### PR TITLE
Storage: Custom volumes in Projects

### DIFF
--- a/doc/projects.md
+++ b/doc/projects.md
@@ -19,6 +19,7 @@ Key                             | Type      | Condition             | Default   
 :--                             | :--       | :--                   | :--                       | :--
 features.images                 | boolean   | -                     | true                      | Separate set of images and image aliases for the project
 features.profiles               | boolean   | -                     | true                      | Separate set of profiles for the project
+features.storage.volumes        | boolean   | -                     | true                      | Separate set of storage volumes for the project
 limits.containers               | integer   | -                     | -                         | Maximum number of containers that can be created in the project
 limits.virtual-machines         | integer   | -                     | -                         | Maximum number of VMs that can be created in the project
 limits.cpu                      | integer   | -                     | -                         | Maximum value for the sum of individual "limits.cpu" configs set on the instances of the project

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -426,12 +426,12 @@ func (c *cmdProjectList) Run(cmd *cobra.Command, args []string) error {
 	data := [][]string{}
 	for _, project := range projects {
 		images := i18n.G("NO")
-		if project.Config["features.images"] == "true" {
+		if shared.IsTrue(project.Config["features.images"]) {
 			images = i18n.G("YES")
 		}
 
 		profiles := i18n.G("NO")
-		if project.Config["features.profiles"] == "true" {
+		if shared.IsTrue(project.Config["features.profiles"]) {
 			profiles = i18n.G("YES")
 		}
 

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -435,13 +435,18 @@ func (c *cmdProjectList) Run(cmd *cobra.Command, args []string) error {
 			profiles = i18n.G("YES")
 		}
 
+		storageVolumes := i18n.G("NO")
+		if shared.IsTrue(project.Config["features.storage.volumes"]) {
+			storageVolumes = i18n.G("YES")
+		}
+
 		name := project.Name
 		if name == currentProject {
 			name = fmt.Sprintf("%s (%s)", name, i18n.G("current"))
 		}
 
 		strUsedBy := fmt.Sprintf("%d", len(project.UsedBy))
-		data = append(data, []string{name, images, profiles, strUsedBy})
+		data = append(data, []string{name, images, profiles, storageVolumes, strUsedBy})
 	}
 	sort.Sort(byName(data))
 
@@ -449,6 +454,7 @@ func (c *cmdProjectList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("NAME"),
 		i18n.G("IMAGES"),
 		i18n.G("PROFILES"),
+		i18n.G("STORAGE VOLUMES"),
 		i18n.G("USED BY"),
 	}
 

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/shared/logger"
 )
@@ -122,11 +123,11 @@ func isClusterNotification(r *http.Request) bool {
 
 // projectParam returns the project query parameter from the given request or "default" if parameter is not set.
 func projectParam(request *http.Request) string {
-	project := queryParam(request, "project")
-	if project == "" {
-		project = "default"
+	projectParam := queryParam(request, "project")
+	if projectParam == "" {
+		projectParam = project.Default
 	}
-	return project
+	return projectParam
 }
 
 // Extract the given query parameter directly from the URL, never from an

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lxc/lxd/lxd/config"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/node"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -182,9 +183,9 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		architectures = append(architectures, architectureName)
 	}
 
-	project := r.FormValue("project")
-	if project == "" {
-		project = "default"
+	projectName := r.FormValue("project")
+	if projectName == "" {
+		projectName = project.Default
 	}
 
 	env := api.ServerEnvironment{
@@ -197,7 +198,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		Kernel:                 uname.Sysname,
 		KernelArchitecture:     uname.Machine,
 		KernelVersion:          uname.Release,
-		Project:                project,
+		Project:                projectName,
 		Server:                 "lxd",
 		ServerPid:              os.Getpid(),
 		ServerVersion:          version.Version,

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -176,7 +176,7 @@ func projectCreateDefaultProfile(tx *db.ClusterTx, project string) error {
 	// Create a default profile
 	profile := db.Profile{}
 	profile.Project = project
-	profile.Name = "default"
+	profile.Name = projecthelpers.Default
 	profile.Description = fmt.Sprintf("Default LXD profile for project %s", project)
 
 	_, err := tx.ProfileCreate(profile)
@@ -348,7 +348,7 @@ func projectChange(d *Daemon, project *api.Project, req api.ProjectPut) response
 	}
 
 	// Sanity checks.
-	if project.Name == "default" && featuresChanged {
+	if project.Name == projecthelpers.Default && featuresChanged {
 		return response.BadRequest(fmt.Errorf("You can't change the features of the default project"))
 	}
 
@@ -382,7 +382,7 @@ func projectChange(d *Daemon, project *api.Project, req api.ProjectPut) response
 				}
 			} else {
 				// Delete the project-specific default profile.
-				err = tx.ProfileDelete(project.Name, "default")
+				err = tx.ProfileDelete(project.Name, projecthelpers.Default)
 				if err != nil {
 					return errors.Wrap(err, "Delete project default profile")
 				}
@@ -411,7 +411,7 @@ func projectPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Sanity checks
-	if name == "default" {
+	if name == projecthelpers.Default {
 		return response.Forbidden(fmt.Errorf("The 'default' project cannot be renamed"))
 	}
 
@@ -470,7 +470,7 @@ func projectDelete(d *Daemon, r *http.Request) response.Response {
 	name := mux.Vars(r)["name"]
 
 	// Sanity checks
-	if name == "default" {
+	if name == projecthelpers.Default {
 		return response.Forbidden(fmt.Errorf("The 'default' project cannot be deleted"))
 	}
 

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -141,7 +141,7 @@ func projectsPost(d *Daemon, r *http.Request) response.Response {
 			return errors.Wrap(err, "Add project to database")
 		}
 
-		if project.Config["features.profiles"] == "true" {
+		if shared.IsTrue(project.Config["features.profiles"]) {
 			err = projectCreateDefaultProfile(tx, project.Name)
 			if err != nil {
 				return err
@@ -375,7 +375,7 @@ func projectChange(d *Daemon, project *api.Project, req api.ProjectPut) response
 		}
 
 		if shared.StringInSlice("features.profiles", configChanged) {
-			if req.Config["features.profiles"] == "true" {
+			if shared.IsTrue(req.Config["features.profiles"]) {
 				err = projectCreateDefaultProfile(tx, project.Name)
 				if err != nil {
 					return err

--- a/lxd/daemon_storage.go
+++ b/lxd/daemon_storage.go
@@ -53,7 +53,7 @@ func daemonStorageMount(s *state.State) error {
 		// Mount volume.
 		_, err = pool.MountCustomVolume(volumeName, nil)
 		if err != nil {
-			return errors.Wrapf(err, "Failed to mount storage volume \"%s\"", source)
+			return errors.Wrapf(err, "Failed to mount storage volume %q", source)
 		}
 
 		return nil
@@ -119,7 +119,7 @@ func daemonStorageValidate(s *state.State, target string) error {
 	// Validate pool exists.
 	poolID, dbPool, err := s.Cluster.StoragePoolGet(poolName)
 	if err != nil {
-		return errors.Wrapf(err, "Unable to load storage pool \"%s\"", poolName)
+		return errors.Wrapf(err, "Unable to load storage pool %q", poolName)
 	}
 
 	// Validate pool driver (can't be CEPH or CEPHFS).
@@ -130,12 +130,12 @@ func daemonStorageValidate(s *state.State, target string) error {
 	// Confirm volume exists.
 	_, _, err = s.Cluster.StoragePoolNodeVolumeGetType(volumeName, db.StoragePoolVolumeTypeCustom, poolID)
 	if err != nil {
-		return errors.Wrapf(err, "Unable to load storage volume \"%s\"", target)
+		return errors.Wrapf(err, "Unable to load storage volume %q", target)
 	}
 
 	snapshots, err := s.Cluster.StoragePoolVolumeSnapshotsGetType(volumeName, db.StoragePoolVolumeTypeCustom, poolID)
 	if err != nil {
-		return errors.Wrapf(err, "Unable to load storage volume snapshots \"%s\"", target)
+		return errors.Wrapf(err, "Unable to load storage volume snapshots %q", target)
 	}
 
 	if len(snapshots) != 0 {
@@ -150,7 +150,7 @@ func daemonStorageValidate(s *state.State, target string) error {
 	// Mount volume.
 	ourMount, err := pool.MountCustomVolume(volumeName, nil)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to mount storage volume \"%s\"", target)
+		return errors.Wrapf(err, "Failed to mount storage volume %q", target)
 	}
 	if ourMount {
 		defer pool.UnmountCustomVolume(volumeName, nil)
@@ -161,7 +161,7 @@ func daemonStorageValidate(s *state.State, target string) error {
 
 	entries, err := ioutil.ReadDir(mountpoint)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to list \"%s\"", mountpoint)
+		return errors.Wrapf(err, "Failed to list %q", mountpoint)
 	}
 
 	for _, entry := range entries {
@@ -171,7 +171,7 @@ func daemonStorageValidate(s *state.State, target string) error {
 			continue
 		}
 
-		return fmt.Errorf("Storage volume \"%s\" isn't empty", target)
+		return fmt.Errorf("Storage volume %q isn't empty", target)
 	}
 
 	return nil
@@ -226,19 +226,19 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 		// Remove the symlink.
 		err = os.Remove(destPath)
 		if err != nil {
-			return errors.Wrapf(err, "Failed to delete storage symlink at \"%s\"", destPath)
+			return errors.Wrapf(err, "Failed to delete storage symlink at %q", destPath)
 		}
 
 		// Re-create as a directory.
 		err = os.MkdirAll(destPath, 0700)
 		if err != nil {
-			return errors.Wrapf(err, "Failed to create directory \"%s\"", destPath)
+			return errors.Wrapf(err, "Failed to create directory %q", destPath)
 		}
 
 		// Move the data across.
 		err = moveContent(sourcePath, destPath)
 		if err != nil {
-			return errors.Wrapf(err, "Failed to move data over to directory \"%s\"", destPath)
+			return errors.Wrapf(err, "Failed to move data over to directory %q", destPath)
 		}
 
 		pool, err := storagePools.GetPoolByName(s, sourcePool)
@@ -249,7 +249,7 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 		// Unmount old volume.
 		_, err = pool.UnmountCustomVolume(sourceVolume, nil)
 		if err != nil {
-			return errors.Wrapf(err, "Failed to umount storage volume \"%s/%s\"", sourcePool, sourceVolume)
+			return errors.Wrapf(err, `Failed to umount storage volume "%s/%s"`, sourcePool, sourceVolume)
 		}
 
 		return nil
@@ -272,7 +272,7 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 	// Mount volume.
 	_, err = pool.MountCustomVolume(volumeName, nil)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to mount storage volume \"%s\"", target)
+		return errors.Wrapf(err, "Failed to mount storage volume %q", target)
 	}
 
 	// Set ownership & mode.
@@ -281,12 +281,12 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 
 	err = os.Chmod(mountpoint, 0700)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to set permissions on \"%s\"", mountpoint)
+		return errors.Wrapf(err, "Failed to set permissions on %q", mountpoint)
 	}
 
 	err = os.Chown(mountpoint, 0, 0)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to set ownership on \"%s\"", mountpoint)
+		return errors.Wrapf(err, "Failed to set ownership on %q", mountpoint)
 	}
 
 	// Handle changes.
@@ -294,19 +294,19 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 		// Remove the symlink.
 		err := os.Remove(shared.VarPath(storageType))
 		if err != nil {
-			return errors.Wrapf(err, "Failed to remove the new symlink at \"%s\"", shared.VarPath(storageType))
+			return errors.Wrapf(err, "Failed to remove the new symlink at %q", shared.VarPath(storageType))
 		}
 
 		// Create the new symlink.
 		err = os.Symlink(destPath, shared.VarPath(storageType))
 		if err != nil {
-			return errors.Wrapf(err, "Failed to create the new symlink at \"%s\"", shared.VarPath(storageType))
+			return errors.Wrapf(err, "Failed to create the new symlink at %q", shared.VarPath(storageType))
 		}
 
 		// Move the data across.
 		err = moveContent(sourcePath, destPath)
 		if err != nil {
-			return errors.Wrapf(err, "Failed to move data over to directory \"%s\"", destPath)
+			return errors.Wrapf(err, "Failed to move data over to directory %q", destPath)
 		}
 
 		pool, err := storagePools.GetPoolByName(s, sourcePool)
@@ -317,7 +317,7 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 		// Unmount old volume.
 		_, err = pool.UnmountCustomVolume(sourceVolume, nil)
 		if err != nil {
-			return errors.Wrapf(err, "Failed to umount storage volume \"%s/%s\"", sourcePool, sourceVolume)
+			return errors.Wrapf(err, `Failed to umount storage volume "%s/%s"`, sourcePool, sourceVolume)
 		}
 
 		return nil
@@ -328,25 +328,25 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 	// Rename the existing storage.
 	err = os.Rename(shared.VarPath(storageType), sourcePath)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to rename existing storage \"%s\"", shared.VarPath(storageType))
+		return errors.Wrapf(err, "Failed to rename existing storage %q", shared.VarPath(storageType))
 	}
 
 	// Create the new symlink.
 	err = os.Symlink(destPath, shared.VarPath(storageType))
 	if err != nil {
-		return errors.Wrapf(err, "Failed to create the new symlink at \"%s\"", shared.VarPath(storageType))
+		return errors.Wrapf(err, "Failed to create the new symlink at %q", shared.VarPath(storageType))
 	}
 
 	// Move the data across.
 	err = moveContent(sourcePath, destPath)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to move data over to directory \"%s\"", destPath)
+		return errors.Wrapf(err, "Failed to move data over to directory %q", destPath)
 	}
 
 	// Remove the old data.
 	err = os.RemoveAll(sourcePath)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to cleanup old directory \"%s\"", sourcePath)
+		return errors.Wrapf(err, "Failed to cleanup old directory %q", sourcePath)
 	}
 
 	return nil

--- a/lxd/daemon_storage.go
+++ b/lxd/daemon_storage.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/node"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/rsync"
 	"github.com/lxc/lxd/lxd/state"
 	storagePools "github.com/lxc/lxd/lxd/storage"
@@ -51,7 +52,7 @@ func daemonStorageMount(s *state.State) error {
 		}
 
 		// Mount volume.
-		_, err = pool.MountCustomVolume(volumeName, nil)
+		_, err = pool.MountCustomVolume(project.Default, volumeName, nil)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to mount storage volume %q", source)
 		}
@@ -148,12 +149,12 @@ func daemonStorageValidate(s *state.State, target string) error {
 	}
 
 	// Mount volume.
-	ourMount, err := pool.MountCustomVolume(volumeName, nil)
+	ourMount, err := pool.MountCustomVolume(project.Default, volumeName, nil)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to mount storage volume %q", target)
 	}
 	if ourMount {
-		defer pool.UnmountCustomVolume(volumeName, nil)
+		defer pool.UnmountCustomVolume(project.Default, volumeName, nil)
 	}
 
 	// Validate volume is empty (ignore lost+found).
@@ -247,7 +248,7 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 		}
 
 		// Unmount old volume.
-		_, err = pool.UnmountCustomVolume(sourceVolume, nil)
+		_, err = pool.UnmountCustomVolume(project.Default, sourceVolume, nil)
 		if err != nil {
 			return errors.Wrapf(err, `Failed to umount storage volume "%s/%s"`, sourcePool, sourceVolume)
 		}
@@ -270,7 +271,7 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 	}
 
 	// Mount volume.
-	_, err = pool.MountCustomVolume(volumeName, nil)
+	_, err = pool.MountCustomVolume(project.Default, volumeName, nil)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to mount storage volume %q", target)
 	}
@@ -315,7 +316,7 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 		}
 
 		// Unmount old volume.
-		_, err = pool.UnmountCustomVolume(sourceVolume, nil)
+		_, err = pool.UnmountCustomVolume(project.Default, sourceVolume, nil)
 		if err != nil {
 			return errors.Wrapf(err, `Failed to umount storage volume "%s/%s"`, sourcePool, sourceVolume)
 		}

--- a/lxd/db/cluster/open.go
+++ b/lxd/db/cluster/open.go
@@ -184,6 +184,7 @@ INSERT INTO nodes(id, name, address, schema, api_extensions, arch) VALUES(1, 'no
 INSERT INTO projects (name, description) VALUES ('default', 'Default LXD project');
 INSERT INTO projects_config (project_id, key, value) VALUES (1, 'features.images', 'true');
 INSERT INTO projects_config (project_id, key, value) VALUES (1, 'features.profiles', 'true');
+INSERT INTO projects_config (project_id, key, value) VALUES (1, 'features.storage.volumes', 'true');
 `
 			_, err = tx.Exec(stmt)
 			if err != nil {

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -348,7 +348,7 @@ func (c *ClusterTx) instanceListExpanded() ([]Instance, error) {
 	// Map to check which projects have the profiles features on.
 	projectHasProfiles := map[string]bool{}
 	for _, project := range projects {
-		projectHasProfiles[project.Name] = project.Config["features.profiles"] == "true"
+		projectHasProfiles[project.Name] = shared.IsTrue(project.Config["features.profiles"])
 	}
 
 	profiles, err := c.ProfileList(ProfileFilter{})

--- a/lxd/db/migration.go
+++ b/lxd/db/migration.go
@@ -125,6 +125,7 @@ INSERT INTO nodes(id, name, address, schema, api_extensions) VALUES(1, 'none', '
 INSERT INTO projects (name, description) VALUES ('default', 'Default LXD project');
 INSERT INTO projects_config (project_id, key, value) VALUES (1, 'features.images', 'true');
 INSERT INTO projects_config (project_id, key, value) VALUES (1, 'features.profiles', 'true');
+INSERT INTO projects_config (project_id, key, value) VALUES (1, 'features.storage.volumes', 'true');
 `
 	_, err = tx.Exec(stmt)
 	if err != nil {

--- a/lxd/db/projects.go
+++ b/lxd/db/projects.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/lxc/lxd/lxd/db/query"
+	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/pkg/errors"
 )
@@ -112,7 +113,7 @@ SELECT projects_config.value
 		return false, nil
 	}
 
-	return values[0] == "true", nil
+	return shared.IsTrue(values[0]), nil
 }
 
 // ProjectHasImages is a helper to check if a project has the images
@@ -123,7 +124,7 @@ func (c *ClusterTx) ProjectHasImages(name string) (bool, error) {
 		return false, errors.Wrap(err, "fetch project")
 	}
 
-	enabled := project.Config["features.images"] == "true"
+	enabled := shared.IsTrue(project.Config["features.images"])
 
 	return enabled, nil
 }

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -799,12 +799,12 @@ func (c *Cluster) storagePoolVolumesGetType(project string, volumeType int, pool
 SELECT storage_volumes_all.name
   FROM storage_volumes_all
   JOIN projects ON projects.id=storage_volumes_all.project_id
- WHERE (projects.name=? OR storage_volumes_all.type=?)
+ WHERE projects.name=?
    AND storage_volumes_all.storage_pool_id=?
    AND storage_volumes_all.node_id=?
    AND storage_volumes_all.type=?
 `
-	inargs := []interface{}{project, StoragePoolVolumeTypeCustom, poolID, nodeID, volumeType}
+	inargs := []interface{}{project, poolID, nodeID, volumeType}
 	outargs := []interface{}{poolName}
 
 	result, err := queryScan(c.db, query, inargs, outargs)

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -862,8 +862,8 @@ SELECT storage_volumes_snapshots.name, storage_volumes_snapshots.description FRO
 
 // StoragePoolNodeVolumesGetType returns all storage volumes attached to a
 // given storage pool of a given volume type, on the current node.
-func (c *Cluster) StoragePoolNodeVolumesGetType(volumeType int, poolID int64) ([]string, error) {
-	return c.storagePoolVolumesGetType("default", volumeType, poolID, c.nodeID)
+func (c *Cluster) StoragePoolNodeVolumesGetType(projectName string, volumeType int, poolID int64) ([]string, error) {
+	return c.storagePoolVolumesGetType(projectName, volumeType, poolID, c.nodeID)
 }
 
 // Return a single storage volume attached to a given storage pool of a given

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -823,7 +823,7 @@ SELECT storage_volumes_all.name
 // StoragePoolVolumeSnapshotsGetType get all snapshots of a storage volume
 // attached to a given storage pool of a given volume type, on the given node.
 // Returns snapshots slice ordered by when they were created, oldest first.
-func (c *Cluster) StoragePoolVolumeSnapshotsGetType(volumeName string, volumeType int, poolID int64) ([]StorageVolumeArgs, error) {
+func (c *Cluster) StoragePoolVolumeSnapshotsGetType(projectName string, volumeName string, volumeType int, poolID int64) ([]StorageVolumeArgs, error) {
 	result := []StorageVolumeArgs{}
 
 	// ORDER BY id is important here as the users of this function can expect that the results
@@ -833,13 +833,15 @@ func (c *Cluster) StoragePoolVolumeSnapshotsGetType(volumeName string, volumeTyp
 	query := `
 SELECT storage_volumes_snapshots.name, storage_volumes_snapshots.description FROM storage_volumes_snapshots
   JOIN storage_volumes ON storage_volumes_snapshots.storage_volume_id = storage_volumes.id
+  JOIN projects ON projects.id=storage_volumes_all.project_id
   WHERE storage_volumes.storage_pool_id=?
     AND storage_volumes.node_id=?
     AND storage_volumes.type=?
     AND storage_volumes.name=?
+    AND projects.name=?
   ORDER BY storage_volumes_snapshots.id
 `
-	inargs := []interface{}{poolID, c.nodeID, volumeType, volumeName}
+	inargs := []interface{}{poolID, c.nodeID, volumeType, volumeName, projectName}
 	typeGuide := StorageVolumeArgs{} // StorageVolume struct used to guide the types expected.
 	outfmt := []interface{}{typeGuide.Name, typeGuide.Description}
 	dbResults, err := queryScan(c.db, query, inargs, outfmt)

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -1152,16 +1152,10 @@ SELECT storage_volumes_all.id
 	return int64(result[0]), nil
 }
 
-// StoragePoolNodeVolumeGetTypeID get the ID of a storage volume on a given
-// storage pool of a given storage volume type, on the current node.
-func (c *Cluster) StoragePoolNodeVolumeGetTypeID(volumeName string, volumeType int, poolID int64) (int64, error) {
-	return c.storagePoolVolumeGetTypeID("default", volumeName, volumeType, poolID, c.nodeID)
-}
-
 // StoragePoolNodeVolumeGetTypeIDByProject gets the ID of a storage volume on a given storage pool
 // of a given storage volume type and project, on the current node.
-func (c *Cluster) StoragePoolNodeVolumeGetTypeIDByProject(project, volumeName string, volumeType int, poolID int64) (int64, error) {
-	return c.storagePoolVolumeGetTypeID(project, volumeName, volumeType, poolID, c.nodeID)
+func (c *Cluster) StoragePoolNodeVolumeGetTypeIDByProject(projectName string, volumeName string, volumeType int, poolID int64) (int64, error) {
+	return c.storagePoolVolumeGetTypeID(projectName, volumeName, volumeType, poolID, c.nodeID)
 }
 
 // XXX: this was extracted from lxd/storage_volume_utils.go, we find a way to

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -907,12 +907,6 @@ func (c *Cluster) storagePoolVolumeGetType(project string, volumeName string, vo
 	return volumeID, &storageVolume, nil
 }
 
-// StoragePoolNodeVolumeGetType gets a single storage volume attached to a
-// given storage pool of a given type, on the current node.
-func (c *Cluster) StoragePoolNodeVolumeGetType(volumeName string, volumeType int, poolID int64) (int64, *api.StorageVolume, error) {
-	return c.StoragePoolNodeVolumeGetTypeByProject("default", volumeName, volumeType, poolID)
-}
-
 // StoragePoolNodeVolumeGetTypeByProject gets a single storage volume attached to a
 // given storage pool of a given type, on the current node in the given project.
 func (c *Cluster) StoragePoolNodeVolumeGetTypeByProject(project, volumeName string, volumeType int, poolID int64) (int64, *api.StorageVolume, error) {

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -833,7 +833,7 @@ func (c *Cluster) StoragePoolVolumeSnapshotsGetType(projectName string, volumeNa
 	query := `
 SELECT storage_volumes_snapshots.name, storage_volumes_snapshots.description FROM storage_volumes_snapshots
   JOIN storage_volumes ON storage_volumes_snapshots.storage_volume_id = storage_volumes.id
-  JOIN projects ON projects.id=storage_volumes_all.project_id
+  JOIN projects ON projects.id=storage_volumes.project_id
   WHERE storage_volumes.storage_pool_id=?
     AND storage_volumes.node_id=?
     AND storage_volumes.type=?

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -767,18 +767,18 @@ func (c *Cluster) StoragePoolNodeVolumesGet(project string, poolID int64, volume
 // Returns all storage volumes attached to a given storage pool on the given
 // node.
 func (c *Cluster) storagePoolVolumesGet(project string, poolID, nodeID int64, volumeTypes []int) ([]*api.StorageVolume, error) {
-	// Get all storage volumes of all types attached to a given storage
-	// pool.
+	// Get all storage volumes of all types attached to a given storage pool.
 	result := []*api.StorageVolume{}
 	for _, volumeType := range volumeTypes {
 		volumeNames, err := c.storagePoolVolumesGetType(project, volumeType, poolID, nodeID)
 		if err != nil && err != sql.ErrNoRows {
-			return nil, errors.Wrap(err, "failed to fetch volume types")
+			return nil, errors.Wrap(err, "Failed to fetch volume types")
 		}
+
 		for _, volumeName := range volumeNames {
 			_, volume, err := c.storagePoolVolumeGetType(project, volumeName, volumeType, poolID, nodeID)
 			if err != nil {
-				return nil, errors.Wrap(err, "failed to fetch volume type")
+				return nil, errors.Wrap(err, "Failed to fetch volume type")
 			}
 			result = append(result, volume)
 		}
@@ -1211,7 +1211,7 @@ func storagePoolVolumeTypeToName(volumeType int) (string, error) {
 		return StoragePoolVolumeTypeNameCustom, nil
 	}
 
-	return "", fmt.Errorf("invalid storage volume type")
+	return "", fmt.Errorf("Invalid storage volume type")
 }
 
 // StoragePoolInsertZfsDriver replaces the driver of all storage pools without

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -867,12 +867,6 @@ func (c *Cluster) StoragePoolNodeVolumesGetType(volumeType int, poolID int64) ([
 // Return a single storage volume attached to a given storage pool of a given
 // type, on the node with the given ID.
 func (c *Cluster) storagePoolVolumeGetType(project string, volumeName string, volumeType int, poolID, nodeID int64) (int64, *api.StorageVolume, error) {
-	// Custom volumes are "global", i.e. they are associated with the
-	// default project.
-	if volumeType == StoragePoolVolumeTypeCustom {
-		project = "default"
-	}
-
 	isSnapshot := strings.Contains(volumeName, shared.SnapshotDelimiter)
 
 	volumeID, err := c.storagePoolVolumeGetTypeID(project, volumeName, volumeType, poolID, nodeID)

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -339,14 +339,14 @@ func findContainerForPid(pid int32, s *state.State) (instance.Container, error) 
 			parts := strings.Split(string(cmdline), " ")
 			name := strings.TrimSuffix(parts[len(parts)-1], "\x00")
 
-			project := "default"
+			projectName := project.Default
 			if strings.Contains(name, "_") {
 				fields := strings.SplitN(name, "_", 2)
-				project = fields[0]
+				projectName = fields[0]
 				name = fields[1]
 			}
 
-			inst, err := instance.LoadByProjectAndName(s, project, name)
+			inst, err := instance.LoadByProjectAndName(s, projectName, name)
 			if err != nil {
 				return nil, err
 			}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1579,7 +1579,7 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 		info.ExpiresAt = req.ExpiresAt
 	}
 
-	// Get profile ids
+	// Get profile IDs
 	if req.Profiles == nil {
 		req.Profiles = []string{"default"}
 	}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -33,6 +33,7 @@ import (
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/operations"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/state"
 	storagePools "github.com/lxc/lxd/lxd/storage"
@@ -1352,7 +1353,7 @@ func pruneExpiredImages(ctx context.Context, d *Daemon) error {
 			}
 		}
 
-		imgID, _, err := d.cluster.ImageGet("default", fp, false, false)
+		imgID, _, err := d.cluster.ImageGet(project.Default, fp, false, false)
 		if err != nil {
 			return errors.Wrapf(err, "Error retrieving image info %s", fp)
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1585,13 +1585,13 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 	}
 	profileIds := make([]int64, len(req.Profiles))
 	for i, profile := range req.Profiles {
-		profileId, _, err := d.cluster.ProfileGet(project, profile)
+		profileID, _, err := d.cluster.ProfileGet(project, profile)
 		if err == db.ErrNoSuchObject {
 			return response.BadRequest(fmt.Errorf("Profile '%s' doesn't exist", profile))
 		} else if err != nil {
 			return response.SmartError(err)
 		}
-		profileIds[i] = profileId
+		profileIds[i] = profileID
 	}
 
 	err = d.cluster.ImageUpdate(id, info.Filename, info.Size, req.Public, req.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, req.Properties, project, profileIds)

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -701,11 +701,6 @@ func instanceConfigureInternal(state *state.State, c instance.Instance) error {
 	return nil
 }
 
-// Legacy interface.
-func instanceLoadAll(s *state.State) ([]instance.Instance, error) {
-	return instance.LoadByProject(s, project.Default)
-}
-
 // Load all instances of this nodes under the given project.
 func instanceLoadNodeProjectAll(s *state.State, project string, instanceType instancetype.Type) ([]instance.Instance, error) {
 	// Get all the container arguments

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/operations"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/state"
 	storagePools "github.com/lxc/lxd/lxd/storage"
 	"github.com/lxc/lxd/lxd/task"
@@ -460,7 +461,7 @@ func instanceCreateAsSnapshot(s *state.State, args db.InstanceArgs, sourceInstan
 func instanceCreateInternal(s *state.State, args db.InstanceArgs) (instance.Instance, error) {
 	// Set default values.
 	if args.Project == "" {
-		args.Project = "default"
+		args.Project = project.Default
 	}
 
 	if args.Profiles == nil {
@@ -702,7 +703,7 @@ func instanceConfigureInternal(state *state.State, c instance.Instance) error {
 
 // Legacy interface.
 func instanceLoadAll(s *state.State) ([]instance.Instance, error) {
-	return instance.LoadByProject(s, "default")
+	return instance.LoadByProject(s, project.Default)
 }
 
 // Load all instances of this nodes under the given project.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3719,7 +3719,7 @@ func (c *lxc) VolatileSet(changes map[string]string) error {
 func (c *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 	// Set sane defaults for unset keys
 	if args.Project == "" {
-		args.Project = "default"
+		args.Project = project.Default
 	}
 
 	if args.Architecture == 0 {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2288,7 +2288,7 @@ func (vm *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 
 	// Set sane defaults for unset keys.
 	if args.Project == "" {
-		args.Project = "default"
+		args.Project = project.Default
 	}
 
 	if args.Architecture == 0 {

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
@@ -296,17 +297,17 @@ func containersOnDisk() (map[string][]string, error) {
 
 	for _, file := range files {
 		name := file.Name()
-		project := "default"
+		projectName := project.Default
 		if strings.Contains(name, "_") {
 			fields := strings.Split(file.Name(), "_")
-			project = fields[0]
+			projectName = fields[0]
 			name = fields[1]
 		}
-		names, ok := containers[project]
+		names, ok := containers[projectName]
 		if !ok {
 			names = []string{}
 		}
-		containers[project] = append(names, name)
+		containers[projectName] = append(names, name)
 	}
 
 	return containers, nil

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/network"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/util"
@@ -414,7 +415,7 @@ func doNetworkGet(d *Daemon, name string) (api.Network, error) {
 		for _, inst := range insts {
 			if network.IsInUse(inst, n.Name) {
 				uri := fmt.Sprintf("/%s/instances/%s", version.APIVersion, inst.Name())
-				if inst.Project() != "default" {
+				if inst.Project() != project.Default {
 					uri += fmt.Sprintf("?project=%s", inst.Project())
 				}
 				n.UsedBy = append(n.UsedBy, uri)

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/operations"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -91,12 +92,12 @@ func operationDelete(d *Daemon, r *http.Request) response.Response {
 	op, err := operations.OperationGetInternal(id)
 	if err == nil {
 		if op.Permission() != "" {
-			project := op.Project()
-			if project == "" {
-				project = "default"
+			projectName := op.Project()
+			if projectName == "" {
+				projectName = project.Default
 			}
 
-			if !d.userHasPermission(r, project, op.Permission()) {
+			if !d.userHasPermission(r, projectName, op.Permission()) {
 				return response.Forbidden(nil)
 			}
 		}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -87,6 +87,7 @@ var patches = []patch{
 	{name: "network_pid_files", run: patchNetworkPIDFiles},
 	{name: "storage_create_vm_again", run: patchGenericStorage},
 	{name: "storage_zfs_volmode", run: patchGenericStorage},
+	{name: "storage_rename_custom_volume_add_project", run: patchGenericStorage},
 }
 
 type patch struct {

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -20,6 +20,7 @@ import (
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/rsync"
 	driver "github.com/lxc/lxd/lxd/storage"
 	storagePools "github.com/lxc/lxd/lxd/storage"
@@ -3038,13 +3039,13 @@ func patchStorageApiPermissions(name string, d *Daemon) error {
 
 			// Run task in anonymous function so as not to stack up defers.
 			err = func() error {
-				ourMount, err := pool.MountCustomVolume(vol, nil)
+				ourMount, err := pool.MountCustomVolume(project.Default, vol, nil)
 				if err != nil {
 					return err
 				}
 
 				if ourMount {
-					defer pool.UnmountCustomVolume(vol, nil)
+					defer pool.UnmountCustomVolume(project.Default, vol, nil)
 				}
 
 				cuMntPoint := driver.GetStoragePoolVolumeMountPoint(poolName, vol)

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -3048,7 +3048,7 @@ func patchStorageApiPermissions(name string, d *Daemon) error {
 					defer pool.UnmountCustomVolume(project.Default, vol, nil)
 				}
 
-				cuMntPoint := driver.GetStoragePoolVolumeMountPoint(poolName, vol)
+				cuMntPoint := storageDrivers.GetVolumeMountPath(poolName, storageDrivers.VolumeTypeCustom, vol)
 				err = os.Chmod(cuMntPoint, 0711)
 				if err != nil && !os.IsNotExist(err) {
 					return err

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -214,7 +214,7 @@ func patchRenameCustomVolumeLVs(name string, d *Daemon) error {
 			continue
 		}
 
-		volumes, err := d.cluster.StoragePoolNodeVolumesGetType(db.StoragePoolVolumeTypeCustom, poolID)
+		volumes, err := d.cluster.StoragePoolNodeVolumesGetType(project.Default, db.StoragePoolVolumeTypeCustom, poolID)
 		if err != nil {
 			return err
 		}
@@ -541,7 +541,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 			return err
 		}
 
-		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(ct, db.StoragePoolVolumeTypeContainer, poolID)
+		_, err = d.cluster.StoragePoolNodeVolumeGetTypeIDByProject(project.Default, ct, db.StoragePoolVolumeTypeContainer, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the container")
 			err := d.cluster.StoragePoolVolumeUpdateByProject("default", ct, db.StoragePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
@@ -629,7 +629,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 				return err
 			}
 
-			_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(cs, db.StoragePoolVolumeTypeContainer, poolID)
+			_, err = d.cluster.StoragePoolNodeVolumeGetTypeIDByProject(project.Default, cs, db.StoragePoolVolumeTypeContainer, poolID)
 			if err == nil {
 				logger.Warnf("Storage volumes database already contains an entry for the snapshot")
 				err := d.cluster.StoragePoolVolumeUpdateByProject("default", cs, db.StoragePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
@@ -710,7 +710,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 			return err
 		}
 
-		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(img, db.StoragePoolVolumeTypeImage, poolID)
+		_, err = d.cluster.StoragePoolNodeVolumeGetTypeIDByProject(project.Default, img, db.StoragePoolVolumeTypeImage, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the image")
 			err := d.cluster.StoragePoolVolumeUpdateByProject("default", img, db.StoragePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
@@ -831,7 +831,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 			return err
 		}
 
-		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(ct, db.StoragePoolVolumeTypeContainer, poolID)
+		_, err = d.cluster.StoragePoolNodeVolumeGetTypeIDByProject(project.Default, ct, db.StoragePoolVolumeTypeContainer, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the container")
 			err := d.cluster.StoragePoolVolumeUpdateByProject("default", ct, db.StoragePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
@@ -948,7 +948,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 			return err
 		}
 
-		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(cs, db.StoragePoolVolumeTypeContainer, poolID)
+		_, err = d.cluster.StoragePoolNodeVolumeGetTypeIDByProject(project.Default, cs, db.StoragePoolVolumeTypeContainer, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the snapshot")
 			err := d.cluster.StoragePoolVolumeUpdateByProject("default", cs, db.StoragePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
@@ -978,7 +978,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 			return err
 		}
 
-		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(img, db.StoragePoolVolumeTypeImage, poolID)
+		_, err = d.cluster.StoragePoolNodeVolumeGetTypeIDByProject(project.Default, img, db.StoragePoolVolumeTypeImage, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the image")
 			err := d.cluster.StoragePoolVolumeUpdateByProject("default", img, db.StoragePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
@@ -1140,7 +1140,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 			return err
 		}
 
-		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(ct, db.StoragePoolVolumeTypeContainer, poolID)
+		_, err = d.cluster.StoragePoolNodeVolumeGetTypeIDByProject(project.Default, ct, db.StoragePoolVolumeTypeContainer, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the container")
 			err := d.cluster.StoragePoolVolumeUpdateByProject("default", ct, db.StoragePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
@@ -1301,7 +1301,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 				return err
 			}
 
-			_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(cs, db.StoragePoolVolumeTypeContainer, poolID)
+			_, err = d.cluster.StoragePoolNodeVolumeGetTypeIDByProject(project.Default, cs, db.StoragePoolVolumeTypeContainer, poolID)
 			if err == nil {
 				logger.Warnf("Storage volumes database already contains an entry for the snapshot")
 				err := d.cluster.StoragePoolVolumeUpdateByProject("default", cs, db.StoragePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
@@ -1484,7 +1484,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 			return err
 		}
 
-		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(img, db.StoragePoolVolumeTypeImage, poolID)
+		_, err = d.cluster.StoragePoolNodeVolumeGetTypeIDByProject(project.Default, img, db.StoragePoolVolumeTypeImage, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the image")
 			err := d.cluster.StoragePoolVolumeUpdateByProject("default", img, db.StoragePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
@@ -1676,7 +1676,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 			return err
 		}
 
-		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(ct, db.StoragePoolVolumeTypeContainer, poolID)
+		_, err = d.cluster.StoragePoolNodeVolumeGetTypeIDByProject(project.Default, ct, db.StoragePoolVolumeTypeContainer, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the container")
 			err := d.cluster.StoragePoolVolumeUpdateByProject("default", ct, db.StoragePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
@@ -1762,7 +1762,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 				return err
 			}
 
-			_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(cs, db.StoragePoolVolumeTypeContainer, poolID)
+			_, err = d.cluster.StoragePoolNodeVolumeGetTypeIDByProject(project.Default, cs, db.StoragePoolVolumeTypeContainer, poolID)
 			if err == nil {
 				logger.Warnf("Storage volumes database already contains an entry for the snapshot")
 				err := d.cluster.StoragePoolVolumeUpdateByProject("default", cs, db.StoragePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
@@ -1818,7 +1818,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 			return err
 		}
 
-		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(img, db.StoragePoolVolumeTypeImage, poolID)
+		_, err = d.cluster.StoragePoolNodeVolumeGetTypeIDByProject(project.Default, img, db.StoragePoolVolumeTypeImage, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the image")
 			err := d.cluster.StoragePoolVolumeUpdateByProject("default", img, db.StoragePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
@@ -3026,7 +3026,7 @@ func patchStorageApiPermissions(name string, d *Daemon) error {
 			return err
 		}
 
-		volumes, err := d.cluster.StoragePoolNodeVolumesGetType(db.StoragePoolVolumeTypeCustom, poolID)
+		volumes, err := d.cluster.StoragePoolNodeVolumesGetType(project.Default, db.StoragePoolVolumeTypeCustom, poolID)
 		if err != nil && err != db.ErrNoSuchObject {
 			return err
 		}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -95,16 +95,16 @@ type patch struct {
 }
 
 func (p *patch) apply(d *Daemon) error {
-	logger.Infof("Applying patch: %s", p.name)
+	logger.Infof("Applying patch %q", p.name)
 
 	err := p.run(p.name, d)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "Failed applying patch %q", p.name)
 	}
 
 	err = d.db.PatchesMarkApplied(p.name)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "Failed marking patch applied %q", p.name)
 	}
 
 	return nil

--- a/lxd/profiles_utils.go
+++ b/lxd/profiles_utils.go
@@ -56,7 +56,7 @@ func doProfileUpdate(d *Daemon, project, name string, id int64, profile *api.Pro
 			// Check what profile the device comes from
 			profiles := container.Profiles
 			for i := len(profiles) - 1; i >= 0; i-- {
-				_, profile, err := d.cluster.ProfileGet("default", profiles[i])
+				_, profile, err := d.cluster.ProfileGet(projecthelpers.Default, profiles[i])
 				if err != nil {
 					return err
 				}

--- a/lxd/project/limits.go
+++ b/lxd/project/limits.go
@@ -292,7 +292,7 @@ func fetchProject(tx *db.ClusterTx, projectName string, skipIfNoLimits bool) (*a
 	// If the project has the profiles feature enabled, we use its own
 	// profiles to expand the instances configs, otherwise we use the
 	// profiles from the default project.
-	if projectName == Default || project.Config["features.profiles"] == "true" {
+	if projectName == Default || shared.IsTrue(project.Config["features.profiles"]) {
 		profilesFilter.Project = projectName
 	} else {
 		profilesFilter.Project = Default

--- a/lxd/project/limits.go
+++ b/lxd/project/limits.go
@@ -292,10 +292,10 @@ func fetchProject(tx *db.ClusterTx, projectName string, skipIfNoLimits bool) (*a
 	// If the project has the profiles feature enabled, we use its own
 	// profiles to expand the instances configs, otherwise we use the
 	// profiles from the default project.
-	if projectName == "default" || project.Config["features.profiles"] == "true" {
+	if projectName == Default || project.Config["features.profiles"] == "true" {
 		profilesFilter.Project = projectName
 	} else {
-		profilesFilter.Project = "default"
+		profilesFilter.Project = Default
 	}
 
 	profiles, err := tx.ProfileList(profilesFilter)

--- a/lxd/project/project.go
+++ b/lxd/project/project.go
@@ -36,3 +36,8 @@ func InstanceParts(projectInstanceName string) (string, string) {
 	// Instance names are not allowed to container the separator value.
 	return projectInstanceName[0:i], projectInstanceName[i+1:]
 }
+
+// StorageVolume adds the "<project>_prefix" to the storage volume name. Even if the project name is "default".
+func StorageVolume(projectName string, storageVolumeName string) string {
+	return fmt.Sprintf("%s%s%s", projectName, separator, storageVolumeName)
+}

--- a/lxd/project/project.go
+++ b/lxd/project/project.go
@@ -41,3 +41,10 @@ func InstanceParts(projectInstanceName string) (string, string) {
 func StorageVolume(projectName string, storageVolumeName string) string {
 	return fmt.Sprintf("%s%s%s", projectName, separator, storageVolumeName)
 }
+
+// StorageVolumeParts takes a project prefixed storage volume name and returns the project and storage volume
+// name as separate variables.
+func StorageVolumeParts(projectStorageVolumeName string) (string, string) {
+	parts := strings.SplitN(projectStorageVolumeName, "_", 2)
+	return parts[0], parts[1]
+}

--- a/lxd/project/project.go
+++ b/lxd/project/project.go
@@ -3,6 +3,12 @@ package project
 import (
 	"fmt"
 	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 )
 
 // Default is the string used for a default project.
@@ -47,4 +53,39 @@ func StorageVolume(projectName string, storageVolumeName string) string {
 func StorageVolumeParts(projectStorageVolumeName string) (string, string) {
 	parts := strings.SplitN(projectStorageVolumeName, "_", 2)
 	return parts[0], parts[1]
+}
+
+// StorageVolumeProject returns the project name to use to for the volume based on the requested project.
+// For custom volume type, if the project specified has the "features.storage.volumes" flag enabled then the
+// project name is returned, otherwise the default project name is returned. For all other volume types the
+// supplied project name is returned.
+func StorageVolumeProject(c *db.Cluster, projectName string, volumeType int) (string, error) {
+	// Non-custom volumes always use the project specified.
+	if volumeType != db.StoragePoolVolumeTypeCustom {
+		return projectName, nil
+	}
+
+	var project *api.Project
+	var err error
+
+	err = c.Transaction(func(tx *db.ClusterTx) error {
+		project, err = tx.ProjectGet(projectName)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to load project %q", projectName)
+	}
+
+	// Custom volumes only use the project specified if the project has the features.storage.volumes feature
+	// enabled, otherwise the legacy behaviour of using the default project for custom volumes is used.
+	if shared.IsTrue(project.Config["features.storage.volumes"]) {
+		return projectName, nil
+	}
+
+	return Default, nil
 }

--- a/lxd/project/project_test.go
+++ b/lxd/project/project_test.go
@@ -34,3 +34,13 @@ func ExampleInstanceParts() {
 	// project_name test
 	// proj test1
 }
+
+func ExampleStorageVolume() {
+	prefixed := project.StorageVolume(project.Default, "test")
+	fmt.Println(prefixed)
+
+	prefixed = project.StorageVolume("project_name", "test1")
+	fmt.Println(prefixed)
+	// Output: default_test
+	// project_name_test1
+}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -650,7 +650,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		// If we are copying snapshots, retrieve a list of snapshots from source volume.
 		snapshotNames := []string{}
 		if snapshots {
-			snapshots, err := VolumeSnapshotsGet(b.state, srcPool.Name(), src.Name(), volDBType)
+			snapshots, err := VolumeSnapshotsGet(b.state, src.Project(), srcPool.Name(), src.Name(), volDBType)
 			if err != nil {
 				return err
 			}
@@ -2165,8 +2165,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, volName stri
 	// If we are copying snapshots, retrieve a list of snapshots from source volume.
 	snapshotNames := []string{}
 	if !srcVolOnly {
-		// tomp TODO shouldnt this use projectName?
-		snapshots, err := VolumeSnapshotsGet(b.state, srcPoolName, srcVolName, db.StoragePoolVolumeTypeCustom)
+		snapshots, err := VolumeSnapshotsGet(b.state, projectName, srcPoolName, srcVolName, db.StoragePoolVolumeTypeCustom)
 		if err != nil {
 			return err
 		}
@@ -2395,8 +2394,7 @@ func (b *lxdBackend) RenameCustomVolume(projectName string, volName string, newV
 	defer revert.Fail()
 
 	// Rename each snapshot to have the new parent volume prefix.
-	// tomp TODO shouldnt this use projectName?
-	snapshots, err := VolumeSnapshotsGet(b.state, b.name, volName, db.StoragePoolVolumeTypeCustom)
+	snapshots, err := VolumeSnapshotsGet(b.state, projectName, b.name, volName, db.StoragePoolVolumeTypeCustom)
 	if err != nil {
 		return err
 	}
@@ -2523,7 +2521,7 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 
 	// Confirm that no instances are running when changing shifted state.
 	if newConfig["security.shifted"] != curVol.Config["security.shifted"] {
-		usingVolume, err := VolumeUsedByInstancesWithProfiles(b.state, b.Name(), volName, db.StoragePoolVolumeTypeNameCustom, true)
+		usingVolume, err := VolumeUsedByRunningInstancesWithProfilesGet(b.state, projectName, b.Name(), volName, db.StoragePoolVolumeTypeNameCustom, true)
 		if err != nil {
 			return err
 		}
@@ -2576,8 +2574,7 @@ func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *
 	}
 
 	// Retrieve a list of snapshots.
-	// tomp TODO shouldnt this be using projectName?
-	snapshots, err := VolumeSnapshotsGet(b.state, b.name, volName, db.StoragePoolVolumeTypeCustom)
+	snapshots, err := VolumeSnapshotsGet(b.state, projectName, b.name, volName, db.StoragePoolVolumeTypeCustom)
 	if err != nil {
 		return err
 	}
@@ -2812,8 +2809,7 @@ func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotNa
 	}
 
 	// Check that the volume isn't in use.
-	// tomp TODO shouldnt this use project?
-	usingVolume, err := VolumeUsedByInstancesWithProfiles(b.state, b.Name(), volName, db.StoragePoolVolumeTypeNameCustom, true)
+	usingVolume, err := VolumeUsedByRunningInstancesWithProfilesGet(b.state, projectName, b.Name(), volName, db.StoragePoolVolumeTypeNameCustom, true)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2013,9 +2013,8 @@ func (b *lxdBackend) DeleteImage(fingerprint string, op *operations.Operation) e
 		contentType = drivers.ContentTypeBlock
 	}
 
-	// Load the storage volume in order to get the volume config which is needed
-	// for some drivers.
-	_, storageVol, err := b.state.Cluster.StoragePoolNodeVolumeGetType(fingerprint, db.StoragePoolVolumeTypeImage, b.ID())
+	// Load the storage volume in order to get the volume config which is needed for some drivers.
+	_, storageVol, err := b.state.Cluster.StoragePoolNodeVolumeGetTypeByProject(project.Default, fingerprint, db.StoragePoolVolumeTypeImage, b.ID())
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -283,7 +283,7 @@ func (b *lxdBackend) ApplyPatch(name string) error {
 
 // ensureInstanceSymlink creates a symlink in the instance directory to the instance's mount path
 // if doesn't exist already.
-func (b *lxdBackend) ensureInstanceSymlink(instanceType instancetype.Type, projectName, instanceName, mountPath string) error {
+func (b *lxdBackend) ensureInstanceSymlink(instanceType instancetype.Type, projectName string, instanceName string, mountPath string) error {
 	if shared.IsSnapshot(instanceName) {
 		return fmt.Errorf("Instance must not be snapshot")
 	}
@@ -308,7 +308,7 @@ func (b *lxdBackend) ensureInstanceSymlink(instanceType instancetype.Type, proje
 }
 
 // removeInstanceSymlink removes a symlink in the instance directory to the instance's mount path.
-func (b *lxdBackend) removeInstanceSymlink(instanceType instancetype.Type, projectName, instanceName string) error {
+func (b *lxdBackend) removeInstanceSymlink(instanceType instancetype.Type, projectName string, instanceName string) error {
 	symlinkPath := InstancePath(instanceType, projectName, instanceName, false)
 
 	if shared.PathExists(symlinkPath) {
@@ -323,7 +323,7 @@ func (b *lxdBackend) removeInstanceSymlink(instanceType instancetype.Type, proje
 
 // ensureInstanceSnapshotSymlink creates a symlink in the snapshot directory to the instance's
 // snapshot path if doesn't exist already.
-func (b *lxdBackend) ensureInstanceSnapshotSymlink(instanceType instancetype.Type, projectName, instanceName string) error {
+func (b *lxdBackend) ensureInstanceSnapshotSymlink(instanceType instancetype.Type, projectName string, instanceName string) error {
 	// Check we can convert the instance to the volume type needed.
 	volType, err := InstanceTypeToVolumeType(instanceType)
 	if err != nil {
@@ -356,7 +356,7 @@ func (b *lxdBackend) ensureInstanceSnapshotSymlink(instanceType instancetype.Typ
 // removeInstanceSnapshotSymlinkIfUnused removes the symlink in the snapshot directory to the
 // instance's snapshot path if the snapshot path is missing. It is expected that the driver will
 // remove the instance's snapshot path after the last snapshot is removed or the volume is deleted.
-func (b *lxdBackend) removeInstanceSnapshotSymlinkIfUnused(instanceType instancetype.Type, projectName, instanceName string) error {
+func (b *lxdBackend) removeInstanceSnapshotSymlinkIfUnused(instanceType instancetype.Type, projectName string, instanceName string) error {
 	// Check we can convert the instance to the volume type needed.
 	volType, err := InstanceTypeToVolumeType(instanceType)
 	if err != nil {
@@ -1943,7 +1943,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 	}
 
 	// Try and load any existing volume config on this storage pool so we can compare filesystems if needed.
-	_, imgDBVol, err := b.state.Cluster.StoragePoolNodeVolumeGetTypeByProject("default", fingerprint, db.StoragePoolVolumeTypeImage, b.ID())
+	_, imgDBVol, err := b.state.Cluster.StoragePoolNodeVolumeGetTypeByProject(project.Default, fingerprint, db.StoragePoolVolumeTypeImage, b.ID())
 	if err != nil {
 		if err != db.ErrNoSuchObject {
 			return err
@@ -1981,7 +1981,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 		return err
 	}
 
-	err = VolumeDBCreate(b.state, "default", b.name, fingerprint, "", db.StoragePoolVolumeTypeNameImage, false, nil)
+	err = VolumeDBCreate(b.state, project.Default, b.name, fingerprint, "", db.StoragePoolVolumeTypeNameImage, false, nil)
 	if err != nil {
 		return err
 	}
@@ -2027,7 +2027,7 @@ func (b *lxdBackend) DeleteImage(fingerprint string, op *operations.Operation) e
 		return err
 	}
 
-	err = b.state.Cluster.StoragePoolVolumeDelete("default", fingerprint, db.StoragePoolVolumeTypeImage, b.ID())
+	err = b.state.Cluster.StoragePoolVolumeDelete(project.Default, fingerprint, db.StoragePoolVolumeTypeImage, b.ID())
 	if err != nil {
 		return err
 	}
@@ -2073,24 +2073,27 @@ func (b *lxdBackend) UpdateImage(fingerprint, newDesc string, newConfig map[stri
 	logger.Debug("UpdateImage started")
 	defer logger.Debug("UpdateImage finished")
 
-	return b.updateVolumeDescriptionOnly("default", fingerprint, db.StoragePoolVolumeTypeImage, newDesc, newConfig)
+	return b.updateVolumeDescriptionOnly(project.Default, fingerprint, db.StoragePoolVolumeTypeImage, newDesc, newConfig)
 }
 
 // CreateCustomVolume creates an empty custom volume.
-func (b *lxdBackend) CreateCustomVolume(volName, desc string, config map[string]string, op *operations.Operation) error {
-	logger := logging.AddContext(b.logger, log.Ctx{"volName": volName, "desc": desc, "config": config})
+func (b *lxdBackend) CreateCustomVolume(projectName string, volName string, desc string, config map[string]string, op *operations.Operation) error {
+	logger := logging.AddContext(b.logger, log.Ctx{"project": projectName, "volName": volName, "desc": desc, "config": config})
 	logger.Debug("CreateCustomVolume started")
 	defer logger.Debug("CreateCustomVolume finished")
 
+	// Get the volume name on storage.
+	volStorageName := project.StorageVolume(projectName, volName)
+
 	// Validate config.
-	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volName, config)
+	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volStorageName, config)
 	err := b.driver.ValidateVolume(vol, false)
 	if err != nil {
 		return err
 	}
 
 	// Create database entry for new storage volume.
-	err = VolumeDBCreate(b.state, "default", b.name, volName, desc, db.StoragePoolVolumeTypeNameCustom, false, vol.Config())
+	err = VolumeDBCreate(b.state, projectName, b.name, volName, desc, db.StoragePoolVolumeTypeNameCustom, false, vol.Config())
 	if err != nil {
 		return err
 	}
@@ -2098,7 +2101,7 @@ func (b *lxdBackend) CreateCustomVolume(volName, desc string, config map[string]
 	revertDB := true
 	defer func() {
 		if revertDB {
-			b.state.Cluster.StoragePoolVolumeDelete("default", volName, db.StoragePoolVolumeTypeCustom, b.ID())
+			b.state.Cluster.StoragePoolVolumeDelete(projectName, volName, db.StoragePoolVolumeTypeCustom, b.ID())
 		}
 	}()
 
@@ -2114,8 +2117,8 @@ func (b *lxdBackend) CreateCustomVolume(volName, desc string, config map[string]
 
 // CreateCustomVolumeFromCopy creates a custom volume from an existing custom volume.
 // It copies the snapshots from the source volume by default, but can be disabled if requested.
-func (b *lxdBackend) CreateCustomVolumeFromCopy(volName, desc string, config map[string]string, srcPoolName, srcVolName string, srcVolOnly bool, op *operations.Operation) error {
-	logger := logging.AddContext(b.logger, log.Ctx{"volName": volName, "desc": desc, "config": config, "srcPoolName": srcPoolName, "srcVolName": srcVolName, "srcVolOnly": srcVolOnly})
+func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, volName string, desc string, config map[string]string, srcPoolName, srcVolName string, srcVolOnly bool, op *operations.Operation) error {
+	logger := logging.AddContext(b.logger, log.Ctx{"project": projectName, "volName": volName, "desc": desc, "config": config, "srcPoolName": srcPoolName, "srcVolName": srcVolName, "srcVolOnly": srcVolOnly})
 	logger.Debug("CreateCustomVolumeFromCopy started")
 	defer logger.Debug("CreateCustomVolumeFromCopy finished")
 
@@ -2140,7 +2143,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(volName, desc string, config map
 	}
 
 	// Check source volume exists and is custom type.
-	_, srcVolRow, err := b.state.Cluster.StoragePoolNodeVolumeGetTypeByProject("default", srcVolName, db.StoragePoolVolumeTypeCustom, srcPool.ID())
+	_, srcVolRow, err := b.state.Cluster.StoragePoolNodeVolumeGetTypeByProject(projectName, srcVolName, db.StoragePoolVolumeTypeCustom, srcPool.ID())
 	if err != nil {
 		if err == db.ErrNoSuchObject {
 			return fmt.Errorf("Source volume doesn't exist")
@@ -2162,6 +2165,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(volName, desc string, config map
 	// If we are copying snapshots, retrieve a list of snapshots from source volume.
 	snapshotNames := []string{}
 	if !srcVolOnly {
+		// tomp TODO shouldnt this use projectName?
 		snapshots, err := VolumeSnapshotsGet(b.state, srcPoolName, srcVolName, db.StoragePoolVolumeTypeCustom)
 		if err != nil {
 			return err
@@ -2183,12 +2187,17 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(volName, desc string, config map
 		defer func() {
 			// Remove any DB volume rows created if we are reverting.
 			for _, volName := range revertDBVolumes {
-				b.state.Cluster.StoragePoolVolumeDelete("default", volName, db.StoragePoolVolumeTypeCustom, b.ID())
+				b.state.Cluster.StoragePoolVolumeDelete(projectName, volName, db.StoragePoolVolumeTypeCustom, b.ID())
 			}
 		}()
 
-		vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volName, config)
-		srcVol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, srcVolName, srcVolRow.Config)
+		// Get the volume name on storage.
+		volStorageName := project.StorageVolume(projectName, volName)
+		vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volStorageName, config)
+
+		// Get the src volume name on storage.
+		srcVolStorageName := project.StorageVolume(projectName, srcVolName)
+		srcVol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, srcVolStorageName, srcVolRow.Config)
 
 		// Check the supplied config and remove any fields not relevant for pool type.
 		err := b.driver.ValidateVolume(vol, true)
@@ -2197,7 +2206,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(volName, desc string, config map
 		}
 
 		// Create database entry for new storage volume.
-		err = VolumeDBCreate(b.state, "default", b.name, volName, desc, db.StoragePoolVolumeTypeNameCustom, false, vol.Config())
+		err = VolumeDBCreate(b.state, projectName, b.name, volName, desc, db.StoragePoolVolumeTypeNameCustom, false, vol.Config())
 		if err != nil {
 			return err
 		}
@@ -2209,7 +2218,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(volName, desc string, config map
 				newSnapshotName := drivers.GetSnapshotVolumeName(volName, snapName)
 
 				// Create database entry for new storage volume snapshot.
-				err = VolumeDBCreate(b.state, "default", b.name, newSnapshotName, desc, db.StoragePoolVolumeTypeNameCustom, true, vol.Config())
+				err = VolumeDBCreate(b.state, projectName, b.name, newSnapshotName, desc, db.StoragePoolVolumeTypeNameCustom, true, vol.Config())
 				if err != nil {
 					return err
 				}
@@ -2296,8 +2305,12 @@ func (b *lxdBackend) MigrateCustomVolume(conn io.ReadWriteCloser, args *migratio
 	logger.Debug("MigrateCustomVolume started")
 	defer logger.Debug("MigrateCustomVolume finished")
 
+	// Get the volume name on storage.
+	// tomp TODO add support for projects in migration.
+	volStorageName := project.StorageVolume(project.Default, args.Name)
+
 	// Volume config not needed to send a volume so set to nil.
-	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, args.Name, nil)
+	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volStorageName, nil)
 	err := b.driver.MigrateVolume(vol, conn, args, op)
 	if err != nil {
 		return err
@@ -2317,19 +2330,23 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(conn io.ReadWriteCloser, ar
 	defer func() {
 		// Remove any DB volume rows created if we are reverting.
 		for _, volName := range revertDBVolumes {
-			b.state.Cluster.StoragePoolVolumeDelete("default", volName, db.StoragePoolVolumeTypeCustom, b.ID())
+			b.state.Cluster.StoragePoolVolumeDelete(project.Default, volName, db.StoragePoolVolumeTypeCustom, b.ID())
 		}
 	}()
 
+	// Get the volume name on storage.
+	// tomp TODO add support for projects in migrations.
+	volStorageName := project.StorageVolume(project.Default, args.Name)
+
 	// Check the supplied config and remove any fields not relevant for destination pool type.
-	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, args.Name, args.Config)
+	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volStorageName, args.Config)
 	err := b.driver.ValidateVolume(vol, true)
 	if err != nil {
 		return err
 	}
 
 	// Create database entry for new storage volume.
-	err = VolumeDBCreate(b.state, "default", b.name, args.Name, args.Description, db.StoragePoolVolumeTypeNameCustom, false, vol.Config())
+	err = VolumeDBCreate(b.state, project.Default, b.name, args.Name, args.Description, db.StoragePoolVolumeTypeNameCustom, false, vol.Config())
 	if err != nil {
 		return err
 	}
@@ -2341,7 +2358,7 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(conn io.ReadWriteCloser, ar
 			newSnapshotName := drivers.GetSnapshotVolumeName(args.Name, snapName)
 
 			// Create database entry for new storage volume snapshot.
-			err = VolumeDBCreate(b.state, "default", b.name, newSnapshotName, args.Description, db.StoragePoolVolumeTypeNameCustom, true, vol.Config())
+			err = VolumeDBCreate(b.state, project.Default, b.name, newSnapshotName, args.Description, db.StoragePoolVolumeTypeNameCustom, true, vol.Config())
 			if err != nil {
 				return err
 			}
@@ -2361,8 +2378,8 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(conn io.ReadWriteCloser, ar
 }
 
 // RenameCustomVolume renames a custom volume and its snapshots.
-func (b *lxdBackend) RenameCustomVolume(volName string, newVolName string, op *operations.Operation) error {
-	logger := logging.AddContext(b.logger, log.Ctx{"volName": volName, "newVolName": newVolName})
+func (b *lxdBackend) RenameCustomVolume(projectName string, volName string, newVolName string, op *operations.Operation) error {
+	logger := logging.AddContext(b.logger, log.Ctx{"project": projectName, "volName": volName, "newVolName": newVolName})
 	logger.Debug("RenameCustomVolume started")
 	defer logger.Debug("RenameCustomVolume finished")
 
@@ -2374,21 +2391,11 @@ func (b *lxdBackend) RenameCustomVolume(volName string, newVolName string, op *o
 		return fmt.Errorf("New volume name cannot be a snapshot")
 	}
 
-	type volRevert struct {
-		oldName string
-		newName string
-	}
-
-	// Create slice to record DB volumes renamed if revert needed later.
-	revertDBVolumes := []volRevert{}
-	defer func() {
-		// Remove any DB volume rows created if we are reverting.
-		for _, vol := range revertDBVolumes {
-			b.state.Cluster.StoragePoolVolumeRename("default", vol.newName, vol.oldName, db.StoragePoolVolumeTypeCustom, b.ID())
-		}
-	}()
+	revert := revert.New()
+	defer revert.Fail()
 
 	// Rename each snapshot to have the new parent volume prefix.
+	// tomp TODO shouldnt this use projectName?
 	snapshots, err := VolumeSnapshotsGet(b.state, b.name, volName, db.StoragePoolVolumeTypeCustom)
 	if err != nil {
 		return err
@@ -2397,37 +2404,38 @@ func (b *lxdBackend) RenameCustomVolume(volName string, newVolName string, op *o
 	for _, srcSnapshot := range snapshots {
 		_, snapName, _ := shared.InstanceGetParentAndSnapshotName(srcSnapshot.Name)
 		newSnapVolName := drivers.GetSnapshotVolumeName(newVolName, snapName)
-		err = b.state.Cluster.StoragePoolVolumeRename("default", srcSnapshot.Name, newSnapVolName, db.StoragePoolVolumeTypeCustom, b.ID())
+		err = b.state.Cluster.StoragePoolVolumeRename(projectName, srcSnapshot.Name, newSnapVolName, db.StoragePoolVolumeTypeCustom, b.ID())
 		if err != nil {
 			return err
 		}
 
-		revertDBVolumes = append(revertDBVolumes, volRevert{
-			newName: newSnapVolName,
-			oldName: srcSnapshot.Name,
+		revert.Add(func() {
+			b.state.Cluster.StoragePoolVolumeRename(projectName, newSnapVolName, srcSnapshot.Name, db.StoragePoolVolumeTypeCustom, b.ID())
 		})
 	}
 
-	err = b.state.Cluster.StoragePoolVolumeRename("default", volName, newVolName, db.StoragePoolVolumeTypeCustom, b.ID())
+	err = b.state.Cluster.StoragePoolVolumeRename(projectName, volName, newVolName, db.StoragePoolVolumeTypeCustom, b.ID())
 	if err != nil {
 		return err
 	}
 
-	revertDBVolumes = append(revertDBVolumes, volRevert{
-		newName: newVolName,
-		oldName: volName,
+	revert.Add(func() {
+		b.state.Cluster.StoragePoolVolumeRename(projectName, newVolName, volName, db.StoragePoolVolumeTypeCustom, b.ID())
 	})
 
-	// There's no need to pass the config as it's not needed when renaming a
-	// volume.
-	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volName, nil)
+	// Get the volume name on storage.
+	volStorageName := project.StorageVolume(projectName, volName)
+	newVolStorageName := project.StorageVolume(projectName, newVolName)
 
-	err = b.driver.RenameVolume(vol, newVolName, op)
+	// There's no need to pass the config as it's not needed when renaming a volume.
+	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volStorageName, nil)
+
+	err = b.driver.RenameVolume(vol, newVolStorageName, op)
 	if err != nil {
 		return err
 	}
 
-	revertDBVolumes = nil
+	revert.Success()
 	return nil
 }
 
@@ -2462,8 +2470,8 @@ func (b *lxdBackend) detectChangedConfig(curConfig, newConfig map[string]string)
 }
 
 // UpdateCustomVolume applies the supplied config to the custom volume.
-func (b *lxdBackend) UpdateCustomVolume(volName, newDesc string, newConfig map[string]string, op *operations.Operation) error {
-	logger := logging.AddContext(b.logger, log.Ctx{"volName": volName, "newDesc": newDesc, "newConfig": newConfig})
+func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+	logger := logging.AddContext(b.logger, log.Ctx{"project": projectName, "volName": volName, "newDesc": newDesc, "newConfig": newConfig})
 	logger.Debug("UpdateCustomVolume started")
 	defer logger.Debug("UpdateCustomVolume finished")
 
@@ -2471,15 +2479,18 @@ func (b *lxdBackend) UpdateCustomVolume(volName, newDesc string, newConfig map[s
 		return fmt.Errorf("Volume name cannot be a snapshot")
 	}
 
+	// Get the volume name on storage.
+	volStorageName := project.StorageVolume(projectName, volName)
+
 	// Validate config.
-	newVol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volName, newConfig)
+	newVol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volStorageName, newConfig)
 	err := b.driver.ValidateVolume(newVol, false)
 	if err != nil {
 		return err
 	}
 
 	// Get current config to compare what has changed.
-	_, curVol, err := b.state.Cluster.StoragePoolNodeVolumeGetTypeByProject("default", volName, db.StoragePoolVolumeTypeCustom, b.ID())
+	_, curVol, err := b.state.Cluster.StoragePoolNodeVolumeGetTypeByProject(projectName, volName, db.StoragePoolVolumeTypeCustom, b.ID())
 	if err != nil {
 		if err == db.ErrNoSuchObject {
 			return fmt.Errorf("Volume doesn't exist")
@@ -2496,7 +2507,7 @@ func (b *lxdBackend) UpdateCustomVolume(volName, newDesc string, newConfig map[s
 			return fmt.Errorf("Custom volume 'block.filesystem' property cannot be changed")
 		}
 
-		curVol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volName, curVol.Config)
+		curVol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volStorageName, curVol.Config)
 		if !userOnly {
 			err = b.driver.UpdateVolume(curVol, changedConfig)
 			if err != nil {
@@ -2530,7 +2541,7 @@ func (b *lxdBackend) UpdateCustomVolume(volName, newDesc string, newConfig map[s
 
 	// Update the database if something changed.
 	if len(changedConfig) != 0 || newDesc != curVol.Description {
-		err = b.state.Cluster.StoragePoolVolumeUpdateByProject("default", volName, db.StoragePoolVolumeTypeCustom, b.ID(), newDesc, newConfig)
+		err = b.state.Cluster.StoragePoolVolumeUpdateByProject(projectName, volName, db.StoragePoolVolumeTypeCustom, b.ID(), newDesc, newConfig)
 		if err != nil {
 			return err
 		}
@@ -2541,8 +2552,8 @@ func (b *lxdBackend) UpdateCustomVolume(volName, newDesc string, newConfig map[s
 
 // UpdateCustomVolumeSnapshot updates the description of a custom volume snapshot.
 // Volume config is not allowd to be updated and will return an error.
-func (b *lxdBackend) UpdateCustomVolumeSnapshot(volName, newDesc string, newConfig map[string]string, op *operations.Operation) error {
-	logger := logging.AddContext(b.logger, log.Ctx{"volName": volName, "newDesc": newDesc, "newConfig": newConfig})
+func (b *lxdBackend) UpdateCustomVolumeSnapshot(projectName string, volName string, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+	logger := logging.AddContext(b.logger, log.Ctx{"project": projectName, "volName": volName, "newDesc": newDesc, "newConfig": newConfig})
 	logger.Debug("UpdateCustomVolumeSnapshot started")
 	defer logger.Debug("UpdateCustomVolumeSnapshot finished")
 
@@ -2550,12 +2561,12 @@ func (b *lxdBackend) UpdateCustomVolumeSnapshot(volName, newDesc string, newConf
 		return fmt.Errorf("Volume must be a snapshot")
 	}
 
-	return b.updateVolumeDescriptionOnly("default", volName, db.StoragePoolVolumeTypeCustom, newDesc, newConfig)
+	return b.updateVolumeDescriptionOnly(projectName, volName, db.StoragePoolVolumeTypeCustom, newDesc, newConfig)
 }
 
 // DeleteCustomVolume removes a custom volume and its snapshots.
-func (b *lxdBackend) DeleteCustomVolume(volName string, op *operations.Operation) error {
-	logger := logging.AddContext(b.logger, log.Ctx{"volName": volName})
+func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *operations.Operation) error {
+	logger := logging.AddContext(b.logger, log.Ctx{"project": projectName, "volName": volName})
 	logger.Debug("DeleteCustomVolume started")
 	defer logger.Debug("DeleteCustomVolume finished")
 
@@ -2565,6 +2576,7 @@ func (b *lxdBackend) DeleteCustomVolume(volName string, op *operations.Operation
 	}
 
 	// Retrieve a list of snapshots.
+	// tomp TODO shouldnt this be using projectName?
 	snapshots, err := VolumeSnapshotsGet(b.state, b.name, volName, db.StoragePoolVolumeTypeCustom)
 	if err != nil {
 		return err
@@ -2572,14 +2584,17 @@ func (b *lxdBackend) DeleteCustomVolume(volName string, op *operations.Operation
 
 	// Remove each snapshot.
 	for _, snapshot := range snapshots {
-		err = b.DeleteCustomVolumeSnapshot(snapshot.Name, op)
+		err = b.DeleteCustomVolumeSnapshot(projectName, snapshot.Name, op)
 		if err != nil {
 			return err
 		}
 	}
 
+	// Get the volume name on storage.
+	volStorageName := project.StorageVolume(projectName, volName)
+
 	// There's no need to pass config as it's not needed when deleting a volume.
-	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volName, nil)
+	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volStorageName, nil)
 
 	// Delete the volume from the storage device. Must come after snapshots are removed.
 	err = b.driver.DeleteVolume(vol, op)
@@ -2588,7 +2603,7 @@ func (b *lxdBackend) DeleteCustomVolume(volName string, op *operations.Operation
 	}
 
 	// Finally, remove the volume record from the database.
-	err = b.state.Cluster.StoragePoolVolumeDelete("default", volName, db.StoragePoolVolumeTypeCustom, b.ID())
+	err = b.state.Cluster.StoragePoolVolumeDelete(projectName, volName, db.StoragePoolVolumeTypeCustom, b.ID())
 	if err != nil {
 		return err
 	}
@@ -2597,49 +2612,55 @@ func (b *lxdBackend) DeleteCustomVolume(volName string, op *operations.Operation
 }
 
 // GetCustomVolumeUsage returns the disk space used by the custom volume.
-func (b *lxdBackend) GetCustomVolumeUsage(volName string) (int64, error) {
-	// There's no need to pass config as it's not needed when getting the volume
-	// usage.
-	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volName, nil)
+func (b *lxdBackend) GetCustomVolumeUsage(projectName, volName string) (int64, error) {
+	// Get the volume name on storage.
+	volStorageName := project.StorageVolume(projectName, volName)
+
+	// There's no need to pass config as it's not needed when getting the volume usage.
+	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volStorageName, nil)
 
 	return b.driver.GetVolumeUsage(vol)
 }
 
 // MountCustomVolume mounts a custom volume.
-func (b *lxdBackend) MountCustomVolume(volName string, op *operations.Operation) (bool, error) {
-	logger := logging.AddContext(b.logger, log.Ctx{"volName": volName})
+func (b *lxdBackend) MountCustomVolume(projectName, volName string, op *operations.Operation) (bool, error) {
+	logger := logging.AddContext(b.logger, log.Ctx{"project": projectName, "volName": volName})
 	logger.Debug("MountCustomVolume started")
 	defer logger.Debug("MountCustomVolume finished")
 
-	_, volume, err := b.state.Cluster.StoragePoolNodeVolumeGetTypeByProject("default", volName, db.StoragePoolVolumeTypeCustom, b.id)
+	_, volume, err := b.state.Cluster.StoragePoolNodeVolumeGetTypeByProject(projectName, volName, db.StoragePoolVolumeTypeCustom, b.id)
 	if err != nil {
 		return false, err
 	}
 
-	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volName, volume.Config)
+	// Get the volume name on storage.
+	volStorageName := project.StorageVolume(projectName, volName)
+	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volStorageName, volume.Config)
 
 	return b.driver.MountVolume(vol, op)
 }
 
 // UnmountCustomVolume unmounts a custom volume.
-func (b *lxdBackend) UnmountCustomVolume(volName string, op *operations.Operation) (bool, error) {
-	logger := logging.AddContext(b.logger, log.Ctx{"volName": volName})
+func (b *lxdBackend) UnmountCustomVolume(projectName, volName string, op *operations.Operation) (bool, error) {
+	logger := logging.AddContext(b.logger, log.Ctx{"project": projectName, "volName": volName})
 	logger.Debug("UnmountCustomVolume started")
 	defer logger.Debug("UnmountCustomVolume finished")
 
-	_, volume, err := b.state.Cluster.StoragePoolNodeVolumeGetTypeByProject("default", volName, db.StoragePoolVolumeTypeCustom, b.id)
+	_, volume, err := b.state.Cluster.StoragePoolNodeVolumeGetTypeByProject(projectName, volName, db.StoragePoolVolumeTypeCustom, b.id)
 	if err != nil {
 		return false, err
 	}
 
-	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volName, volume.Config)
+	// Get the volume name on storage.
+	volStorageName := project.StorageVolume(projectName, volName)
+	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volStorageName, volume.Config)
 
 	return b.driver.UnmountVolume(vol, op)
 }
 
 // CreateCustomVolumeSnapshot creates a snapshot of a custom volume.
-func (b *lxdBackend) CreateCustomVolumeSnapshot(volName string, newSnapshotName string, op *operations.Operation) error {
-	logger := logging.AddContext(b.logger, log.Ctx{"volName": volName, "newSnapshotName": newSnapshotName})
+func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, newSnapshotName string, op *operations.Operation) error {
+	logger := logging.AddContext(b.logger, log.Ctx{"project": projectName, "volName": volName, "newSnapshotName": newSnapshotName})
 	logger.Debug("CreateCustomVolumeSnapshot started")
 	defer logger.Debug("CreateCustomVolumeSnapshot finished")
 
@@ -2654,7 +2675,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(volName string, newSnapshotName 
 	fullSnapshotName := drivers.GetSnapshotVolumeName(volName, newSnapshotName)
 
 	// Check snapshot volume doesn't exist already.
-	_, _, err := b.state.Cluster.StoragePoolNodeVolumeGetTypeByProject("default", fullSnapshotName, db.StoragePoolVolumeTypeCustom, b.ID())
+	_, _, err := b.state.Cluster.StoragePoolNodeVolumeGetTypeByProject(projectName, fullSnapshotName, db.StoragePoolVolumeTypeCustom, b.ID())
 	if err != db.ErrNoSuchObject {
 		if err != nil {
 			return err
@@ -2664,7 +2685,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(volName string, newSnapshotName 
 	}
 
 	// Load parent volume information and check it exists.
-	_, parentVol, err := b.state.Cluster.StoragePoolNodeVolumeGetTypeByProject("default", volName, db.StoragePoolVolumeTypeCustom, b.ID())
+	_, parentVol, err := b.state.Cluster.StoragePoolNodeVolumeGetTypeByProject(projectName, volName, db.StoragePoolVolumeTypeCustom, b.ID())
 	if err != nil {
 		if err == db.ErrNoSuchObject {
 			return fmt.Errorf("Parent volume doesn't exist")
@@ -2674,7 +2695,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(volName string, newSnapshotName 
 	}
 
 	// Create database entry for new storage volume snapshot.
-	err = VolumeDBCreate(b.state, "default", b.name, fullSnapshotName, parentVol.Description, db.StoragePoolVolumeTypeNameCustom, true, parentVol.Config)
+	err = VolumeDBCreate(b.state, projectName, b.name, fullSnapshotName, parentVol.Description, db.StoragePoolVolumeTypeNameCustom, true, parentVol.Config)
 	if err != nil {
 		return err
 	}
@@ -2682,11 +2703,13 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(volName string, newSnapshotName 
 	revertDB := true
 	defer func() {
 		if revertDB {
-			b.state.Cluster.StoragePoolVolumeDelete("default", fullSnapshotName, db.StoragePoolVolumeTypeCustom, b.ID())
+			b.state.Cluster.StoragePoolVolumeDelete(projectName, fullSnapshotName, db.StoragePoolVolumeTypeCustom, b.ID())
 		}
 	}()
 
-	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, fullSnapshotName, parentVol.Config)
+	// Get the volume name on storage.
+	volStorageName := project.StorageVolume(projectName, fullSnapshotName)
+	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volStorageName, parentVol.Config)
 
 	// Create the snapshot on the storage device.
 	err = b.driver.CreateVolumeSnapshot(vol, op)
@@ -2699,8 +2722,8 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(volName string, newSnapshotName 
 }
 
 // RenameCustomVolumeSnapshot renames a custom volume.
-func (b *lxdBackend) RenameCustomVolumeSnapshot(volName string, newSnapshotName string, op *operations.Operation) error {
-	logger := logging.AddContext(b.logger, log.Ctx{"volName": volName, "newSnapshotName": newSnapshotName})
+func (b *lxdBackend) RenameCustomVolumeSnapshot(projectName, volName string, newSnapshotName string, op *operations.Operation) error {
+	logger := logging.AddContext(b.logger, log.Ctx{"project": projectName, "volName": volName, "newSnapshotName": newSnapshotName})
 	logger.Debug("RenameCustomVolumeSnapshot started")
 	defer logger.Debug("RenameCustomVolumeSnapshot finished")
 
@@ -2713,8 +2736,11 @@ func (b *lxdBackend) RenameCustomVolumeSnapshot(volName string, newSnapshotName 
 		return fmt.Errorf("Invalid new snapshot name")
 	}
 
+	// Get the volume name on storage.
+	volStorageName := project.StorageVolume(projectName, volName)
+
 	// There's no need to pass config as it's not needed when renaming a volume.
-	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volName, nil)
+	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volStorageName, nil)
 
 	err := b.driver.RenameVolumeSnapshot(vol, newSnapshotName, op)
 	if err != nil {
@@ -2722,10 +2748,13 @@ func (b *lxdBackend) RenameCustomVolumeSnapshot(volName string, newSnapshotName 
 	}
 
 	newVolName := drivers.GetSnapshotVolumeName(parentName, newSnapshotName)
-	err = b.state.Cluster.StoragePoolVolumeRename("default", volName, newVolName, db.StoragePoolVolumeTypeCustom, b.ID())
+	err = b.state.Cluster.StoragePoolVolumeRename(projectName, volName, newVolName, db.StoragePoolVolumeTypeCustom, b.ID())
 	if err != nil {
+		// Get the volume name on storage.
+		newVolStorageName := project.StorageVolume(projectName, newVolName)
+
 		// Revert rename.
-		newVol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, newVolName, nil)
+		newVol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, newVolStorageName, nil)
 		b.driver.RenameVolumeSnapshot(newVol, oldSnapshotName, op)
 		return err
 	}
@@ -2734,8 +2763,8 @@ func (b *lxdBackend) RenameCustomVolumeSnapshot(volName string, newSnapshotName 
 }
 
 // DeleteCustomVolumeSnapshot removes a custom volume snapshot.
-func (b *lxdBackend) DeleteCustomVolumeSnapshot(volName string, op *operations.Operation) error {
-	logger := logging.AddContext(b.logger, log.Ctx{"volName": volName})
+func (b *lxdBackend) DeleteCustomVolumeSnapshot(projectName, volName string, op *operations.Operation) error {
+	logger := logging.AddContext(b.logger, log.Ctx{"project": projectName, "volName": volName})
 	logger.Debug("DeleteCustomVolumeSnapshot started")
 	defer logger.Debug("DeleteCustomVolumeSnapshot finished")
 
@@ -2745,9 +2774,11 @@ func (b *lxdBackend) DeleteCustomVolumeSnapshot(volName string, op *operations.O
 		return fmt.Errorf("Volume name must be a snapshot")
 	}
 
-	// There's no need to pass config as it's not needed when deleting a volume
-	// snapshot.
-	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volName, nil)
+	// Get the volume name on storage.
+	volStorageName := project.StorageVolume(projectName, volName)
+
+	// There's no need to pass config as it's not needed when deleting a volume snapshot.
+	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volStorageName, nil)
 
 	// Delete the snapshot from the storage device.
 	// Must come before DB StoragePoolVolumeDelete so that the volume ID is still available.
@@ -2757,7 +2788,7 @@ func (b *lxdBackend) DeleteCustomVolumeSnapshot(volName string, op *operations.O
 	}
 
 	// Remove the snapshot volume record from the database.
-	err = b.state.Cluster.StoragePoolVolumeDelete("default", volName, db.StoragePoolVolumeTypeCustom, b.ID())
+	err = b.state.Cluster.StoragePoolVolumeDelete(projectName, volName, db.StoragePoolVolumeTypeCustom, b.ID())
 	if err != nil {
 		return err
 	}
@@ -2766,8 +2797,8 @@ func (b *lxdBackend) DeleteCustomVolumeSnapshot(volName string, op *operations.O
 }
 
 // RestoreCustomVolume restores a custom volume from a snapshot.
-func (b *lxdBackend) RestoreCustomVolume(volName string, snapshotName string, op *operations.Operation) error {
-	logger := logging.AddContext(b.logger, log.Ctx{"volName": volName, "snapshotName": snapshotName})
+func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotName string, op *operations.Operation) error {
+	logger := logging.AddContext(b.logger, log.Ctx{"project": projectName, "volName": volName, "snapshotName": snapshotName})
 	logger.Debug("RestoreCustomVolume started")
 	defer logger.Debug("RestoreCustomVolume finished")
 
@@ -2781,6 +2812,7 @@ func (b *lxdBackend) RestoreCustomVolume(volName string, snapshotName string, op
 	}
 
 	// Check that the volume isn't in use.
+	// tomp TODO shouldnt this use project?
 	usingVolume, err := VolumeUsedByInstancesWithProfiles(b.state, b.Name(), volName, db.StoragePoolVolumeTypeNameCustom, true)
 	if err != nil {
 		return err
@@ -2791,7 +2823,7 @@ func (b *lxdBackend) RestoreCustomVolume(volName string, snapshotName string, op
 	}
 
 	// Get the volume config.
-	_, dbVol, err := b.state.Cluster.StoragePoolNodeVolumeGetTypeByProject("default", volName, db.StoragePoolVolumeTypeCustom, b.ID())
+	_, dbVol, err := b.state.Cluster.StoragePoolNodeVolumeGetTypeByProject(projectName, volName, db.StoragePoolVolumeTypeCustom, b.ID())
 	if err != nil {
 		if err == db.ErrNoSuchObject {
 			return fmt.Errorf("Volume doesn't exist")
@@ -2800,20 +2832,24 @@ func (b *lxdBackend) RestoreCustomVolume(volName string, snapshotName string, op
 		return err
 	}
 
-	err = b.driver.RestoreVolume(b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volName, dbVol.Config), snapshotName, op)
+	// Get the volume name on storage.
+	volStorageName := project.StorageVolume(projectName, volName)
+	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volStorageName, dbVol.Config)
+
+	err = b.driver.RestoreVolume(vol, snapshotName, op)
 	if err != nil {
 		snapErr, ok := err.(drivers.ErrDeleteSnapshots)
 		if ok {
 			// We need to delete some snapshots and try again.
 			for _, snapName := range snapErr.Snapshots {
-				err := b.DeleteCustomVolumeSnapshot(fmt.Sprintf("%s/%s", volName, snapName), op)
+				err := b.DeleteCustomVolumeSnapshot(projectName, fmt.Sprintf("%s/%s", volName, snapName), op)
 				if err != nil {
 					return err
 				}
 			}
 
 			// Now try again.
-			err = b.driver.RestoreVolume(b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volName, dbVol.Config), snapshotName, op)
+			err = b.driver.RestoreVolume(vol, snapshotName, op)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage/backend_lxd_patches.go
+++ b/lxd/storage/backend_lxd_patches.go
@@ -1,17 +1,99 @@
 package storage
 
 import (
+	"github.com/pkg/errors"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/storage/drivers"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/logger"
 )
 
 var lxdEarlyPatches = map[string]func(b *lxdBackend) error{}
 
 var lxdLatePatches = map[string]func(b *lxdBackend) error{
-	"storage_create_vm":       lxdPatchStorageCreateVM,
-	"storage_create_vm_again": lxdPatchStorageCreateVM,
+	"storage_create_vm":                        lxdPatchStorageCreateVM,
+	"storage_create_vm_again":                  lxdPatchStorageCreateVM,
+	"storage_rename_custom_volume_add_project": lxdPatchStorageRenameCustomVolumeAddProject,
 }
 
 // Patches start here.
 func lxdPatchStorageCreateVM(b *lxdBackend) error {
 	return b.createStorageStructure(drivers.GetPoolMountPath(b.name))
+}
+
+// lxdPatchStorageRenameCustomVolumeAddProject renames all custom volumes in the default project (which is all of
+// the custom volumes right now) to have the project prefix added to the storage device volume name.
+// This is so we can added project support to custom volumes and avoid any name collisions.
+func lxdPatchStorageRenameCustomVolumeAddProject(b *lxdBackend) error {
+	// Get all custom volumes in default project on this node.
+	// At this time, all custom volumes are in the default project.
+	volumes, err := b.state.Cluster.StoragePoolNodeVolumesGet(project.Default, b.ID(), []int{db.StoragePoolVolumeTypeCustom})
+	if err != nil && err != db.ErrNoSuchObject {
+		return errors.Wrapf(err, "Failed getting custom volumes for default project")
+	}
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	for _, v := range volumes {
+		// Run inside temporary function to ensure revert has correct volume scope.
+		err = func(curVol *api.StorageVolume) error {
+			// There's no need to pass the config as it's not needed when renaming a volume.
+			oldVol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, curVol.Name, nil)
+
+			// Add default project prefix to current volume name.
+			newVolStorageName := project.StorageVolume(project.Default, curVol.Name)
+
+			// Check if volume is currently mounted.
+			oldMntPath := drivers.GetVolumeMountPath(b.Name(), drivers.VolumeTypeCustom, curVol.Name)
+
+			// If the volume is mounted we need to be careful how we rename it to avoid interrupting a
+			// running instance's attached volumes.
+			ourUnmount := false
+			if shared.IsMountPoint(oldMntPath) {
+				logger.Infof("Lazy unmount custom volume %q in pool %q", curVol.Name, b.Name())
+				err = unix.Unmount(oldMntPath, unix.MNT_DETACH)
+				if err != nil {
+					return err
+				}
+				ourUnmount = true
+			}
+
+			logger.Infof("Renaming custom volume %q in pool %q to %q", curVol.Name, b.Name(), newVolStorageName)
+			err = b.driver.RenameVolume(oldVol, newVolStorageName, nil)
+			if err != nil {
+				return err
+			}
+
+			newVol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, newVolStorageName, nil)
+
+			// Ensure we don't use the wrong volume for revert by using a temporary function.
+			revert.Add(func() {
+				logger.Infof("Reverting rename of custom volume %q in pool %q to %q", newVol.Name(), b.Name(), curVol.Name)
+				b.driver.RenameVolume(newVol, curVol.Name, nil)
+			})
+
+			if ourUnmount {
+				logger.Infof("Mount custom volume %q in pool %q", newVolStorageName, b.Name())
+				_, err = b.driver.MountVolume(newVol, nil)
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		}(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	revert.Success()
+	return nil
 }

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -197,11 +197,11 @@ func (b *mockBackend) DeleteCustomVolume(projectName string, volName string, op 
 	return nil
 }
 
-func (b *mockBackend) MigrateCustomVolume(conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (b *mockBackend) MigrateCustomVolume(projectName string, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error {
 	return nil
 }
 
-func (b *mockBackend) CreateCustomVolumeFromMigration(conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
+func (b *mockBackend) CreateCustomVolumeFromMigration(projectName string, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error {
 	return nil
 }
 

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -177,23 +177,23 @@ func (b *mockBackend) UpdateImage(fingerprint, newDesc string, newConfig map[str
 	return nil
 }
 
-func (b *mockBackend) CreateCustomVolume(volName, desc string, config map[string]string, op *operations.Operation) error {
+func (b *mockBackend) CreateCustomVolume(projectName string, volName string, desc string, config map[string]string, op *operations.Operation) error {
 	return nil
 }
 
-func (b *mockBackend) CreateCustomVolumeFromCopy(volName, desc string, config map[string]string, srcPoolName, srcVolName string, srcVolOnly bool, op *operations.Operation) error {
+func (b *mockBackend) CreateCustomVolumeFromCopy(projectName string, volName string, desc string, config map[string]string, srcPoolName string, srcVolName string, srcVolOnly bool, op *operations.Operation) error {
 	return nil
 }
 
-func (b *mockBackend) RenameCustomVolume(volName string, newName string, op *operations.Operation) error {
+func (b *mockBackend) RenameCustomVolume(projectName string, volName string, newName string, op *operations.Operation) error {
 	return nil
 }
 
-func (b *mockBackend) UpdateCustomVolume(volName, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *mockBackend) UpdateCustomVolume(projectName string, volName string, newDesc string, newConfig map[string]string, op *operations.Operation) error {
 	return ErrNotImplemented
 }
 
-func (b *mockBackend) DeleteCustomVolume(volName string, op *operations.Operation) error {
+func (b *mockBackend) DeleteCustomVolume(projectName string, volName string, op *operations.Operation) error {
 	return nil
 }
 
@@ -205,34 +205,34 @@ func (b *mockBackend) CreateCustomVolumeFromMigration(conn io.ReadWriteCloser, a
 	return nil
 }
 
-func (b *mockBackend) GetCustomVolumeUsage(volName string) (int64, error) {
+func (b *mockBackend) GetCustomVolumeUsage(projectName string, volName string) (int64, error) {
 	return 0, nil
 }
 
-func (b *mockBackend) MountCustomVolume(volName string, op *operations.Operation) (bool, error) {
+func (b *mockBackend) MountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error) {
 	return true, nil
 }
 
-func (b *mockBackend) UnmountCustomVolume(volName string, op *operations.Operation) (bool, error) {
+func (b *mockBackend) UnmountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error) {
 	return true, nil
 }
 
-func (b *mockBackend) CreateCustomVolumeSnapshot(volName string, newSnapshotName string, op *operations.Operation) error {
+func (b *mockBackend) CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, op *operations.Operation) error {
 	return nil
 }
 
-func (b *mockBackend) RenameCustomVolumeSnapshot(volName string, newName string, op *operations.Operation) error {
+func (b *mockBackend) RenameCustomVolumeSnapshot(projectName string, volName string, newName string, op *operations.Operation) error {
 	return nil
 }
 
-func (b *mockBackend) DeleteCustomVolumeSnapshot(volName string, op *operations.Operation) error {
+func (b *mockBackend) DeleteCustomVolumeSnapshot(projectName string, volName string, op *operations.Operation) error {
 	return nil
 }
 
-func (b *mockBackend) UpdateCustomVolumeSnapshot(volName, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+func (b *mockBackend) UpdateCustomVolumeSnapshot(projectName string, volName string, newDesc string, newConfig map[string]string, op *operations.Operation) error {
 	return nil
 }
 
-func (b *mockBackend) RestoreCustomVolume(volName string, snapshotName string, op *operations.Operation) error {
+func (b *mockBackend) RestoreCustomVolume(projectName string, volName string, snapshotName string, op *operations.Operation) error {
 	return nil
 }

--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -29,10 +29,11 @@ type btrfs struct {
 func (d *btrfs) load() error {
 	// Register the patches.
 	d.patches = map[string]func() error{
-		"storage_create_vm":       nil,
-		"storage_zfs_mount":       nil,
-		"storage_create_vm_again": nil,
-		"storage_zfs_volmode":     nil,
+		"storage_create_vm":                        nil,
+		"storage_zfs_mount":                        nil,
+		"storage_create_vm_again":                  nil,
+		"storage_zfs_volmode":                      nil,
+		"storage_rename_custom_volume_add_project": nil,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -28,10 +28,11 @@ type ceph struct {
 func (d *ceph) load() error {
 	// Register the patches.
 	d.patches = map[string]func() error{
-		"storage_create_vm":       nil,
-		"storage_zfs_mount":       nil,
-		"storage_create_vm_again": nil,
-		"storage_zfs_volmode":     nil,
+		"storage_create_vm":                        nil,
+		"storage_zfs_mount":                        nil,
+		"storage_create_vm_again":                  nil,
+		"storage_zfs_volmode":                      nil,
+		"storage_rename_custom_volume_add_project": nil,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -27,10 +27,11 @@ type cephfs struct {
 func (d *cephfs) load() error {
 	// Register the patches.
 	d.patches = map[string]func() error{
-		"storage_create_vm":       nil,
-		"storage_zfs_mount":       nil,
-		"storage_create_vm_again": nil,
-		"storage_zfs_volmode":     nil,
+		"storage_create_vm":                        nil,
+		"storage_zfs_mount":                        nil,
+		"storage_create_vm_again":                  nil,
+		"storage_zfs_volmode":                      nil,
+		"storage_rename_custom_volume_add_project": nil,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -20,10 +20,11 @@ type dir struct {
 func (d *dir) load() error {
 	// Register the patches.
 	d.patches = map[string]func() error{
-		"storage_create_vm":       nil,
-		"storage_zfs_mount":       nil,
-		"storage_create_vm_again": nil,
-		"storage_zfs_volmode":     nil,
+		"storage_create_vm":                        nil,
+		"storage_zfs_mount":                        nil,
+		"storage_create_vm_again":                  nil,
+		"storage_zfs_volmode":                      nil,
+		"storage_rename_custom_volume_add_project": nil,
 	}
 
 	return nil

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -32,10 +32,11 @@ type lvm struct {
 func (d *lvm) load() error {
 	// Register the patches.
 	d.patches = map[string]func() error{
-		"storage_create_vm":       nil,
-		"storage_zfs_mount":       nil,
-		"storage_create_vm_again": nil,
-		"storage_zfs_volmode":     nil,
+		"storage_create_vm":                        nil,
+		"storage_zfs_mount":                        nil,
+		"storage_create_vm_again":                  nil,
+		"storage_zfs_volmode":                      nil,
+		"storage_rename_custom_volume_add_project": nil,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -40,10 +40,11 @@ type zfs struct {
 func (d *zfs) load() error {
 	// Register the patches.
 	d.patches = map[string]func() error{
-		"storage_create_vm":       d.patchStorageCreateVM,
-		"storage_zfs_mount":       d.patchStorageZFSMount,
-		"storage_create_vm_again": nil,
-		"storage_zfs_volmode":     d.patchStorageZFSVolMode,
+		"storage_create_vm":                        d.patchStorageCreateVM,
+		"storage_zfs_mount":                        d.patchStorageZFSMount,
+		"storage_create_vm_again":                  nil,
+		"storage_zfs_volmode":                      d.patchStorageZFSVolMode,
+		"storage_rename_custom_volume_add_project": nil,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -445,13 +445,13 @@ func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64)
 		return fmt.Errorf(`Shrinking not supported for filesystem type "%s". A dump, mkfs, and restore are required`, fsType)
 	case "ext4":
 		return vol.UnmountTask(func(op *operations.Operation) error {
-			output, err := shared.TryRunCommand("e2fsck", "-f", "-y", devPath)
+			output, err := shared.RunCommand("e2fsck", "-f", "-y", devPath)
 			if err != nil {
 				// e2fsck provides some context to errors on stdout.
 				return errors.Wrapf(err, "%s", strings.TrimSpace(output))
 			}
 
-			_, err = shared.TryRunCommand("resize2fs", devPath, strSize)
+			_, err = shared.RunCommand("resize2fs", devPath, strSize)
 			if err != nil {
 				return err
 			}
@@ -460,7 +460,7 @@ func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64)
 		}, nil)
 	case "btrfs":
 		return vol.MountTask(func(mountPath string, op *operations.Operation) error {
-			_, err := shared.TryRunCommand("btrfs", "filesystem", "resize", strSize, mountPath)
+			_, err := shared.RunCommand("btrfs", "filesystem", "resize", strSize, mountPath)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -445,9 +445,10 @@ func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64)
 		return fmt.Errorf(`Shrinking not supported for filesystem type "%s". A dump, mkfs, and restore are required`, fsType)
 	case "ext4":
 		return vol.UnmountTask(func(op *operations.Operation) error {
-			_, err := shared.TryRunCommand("e2fsck", "-f", "-y", devPath)
+			output, err := shared.TryRunCommand("e2fsck", "-f", "-y", devPath)
 			if err != nil {
-				return err
+				// e2fsck provides some context to errors on stdout.
+				return errors.Wrapf(err, "%s", strings.TrimSpace(output))
 			}
 
 			_, err = shared.TryRunCommand("resize2fs", devPath, strSize)

--- a/lxd/storage/load.go
+++ b/lxd/storage/load.go
@@ -45,7 +45,7 @@ func volIDFuncMake(state *state.State, poolID int64) func(volType drivers.Volume
 		volID, _, err := state.Cluster.StoragePoolNodeVolumeGetTypeByProject(projectName, volName, volTypeID, poolID)
 		if err != nil {
 			if err == db.ErrNoSuchObject {
-				return -1, fmt.Errorf("Failed to get volume ID for project '%s', volume '%s', type '%s': Volume doesn't exist", projectName, volName, volType)
+				return -1, fmt.Errorf("Failed to get volume ID for project %q, volume %q, type %q: Volume doesn't exist", projectName, volName, volType)
 			}
 
 			return -1, err

--- a/lxd/storage/load.go
+++ b/lxd/storage/load.go
@@ -33,11 +33,13 @@ func volIDFuncMake(state *state.State, poolID int64) func(volType drivers.Volume
 		// the project is default.
 		projectName := project.Default
 
-		// Currently only Containers and VMs support project level volumes.
+		// Currently only Containers, VMs and custom volumes support project level volumes.
 		// This means that other volume types may have underscores in their names that don't
 		// indicate the project name.
 		if volType == drivers.VolumeTypeContainer || volType == drivers.VolumeTypeVM {
 			projectName, volName = project.InstanceParts(volName)
+		} else if volType == drivers.VolumeTypeCustom {
+			projectName, volName = project.StorageVolumeParts(volName)
 		}
 
 		volID, _, err := state.Cluster.StoragePoolNodeVolumeGetTypeByProject(projectName, volName, volTypeID, poolID)

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -62,24 +62,24 @@ type Pool interface {
 	// Images.
 	EnsureImage(fingerprint string, op *operations.Operation) error
 	DeleteImage(fingerprint string, op *operations.Operation) error
-	UpdateImage(fingerprint, newDesc string, newConfig map[string]string, op *operations.Operation) error
+	UpdateImage(fingerprint string, newDesc string, newConfig map[string]string, op *operations.Operation) error
 
 	// Custom volumes.
-	CreateCustomVolume(volName, desc string, config map[string]string, op *operations.Operation) error
-	CreateCustomVolumeFromCopy(volName, desc string, config map[string]string, srcPoolName, srcVolName string, srcVolOnly bool, op *operations.Operation) error
-	UpdateCustomVolume(volName, newDesc string, newConfig map[string]string, op *operations.Operation) error
-	RenameCustomVolume(volName string, newVolName string, op *operations.Operation) error
-	DeleteCustomVolume(volName string, op *operations.Operation) error
-	GetCustomVolumeUsage(volName string) (int64, error)
-	MountCustomVolume(volName string, op *operations.Operation) (bool, error)
-	UnmountCustomVolume(volName string, op *operations.Operation) (bool, error)
+	CreateCustomVolume(projectName string, volName string, desc string, config map[string]string, op *operations.Operation) error
+	CreateCustomVolumeFromCopy(projectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, srcVolOnly bool, op *operations.Operation) error
+	UpdateCustomVolume(projectName string, volName string, newDesc string, newConfig map[string]string, op *operations.Operation) error
+	RenameCustomVolume(projectName string, volName string, newVolName string, op *operations.Operation) error
+	DeleteCustomVolume(projectName string, volName string, op *operations.Operation) error
+	GetCustomVolumeUsage(projectName string, volName string) (int64, error)
+	MountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error)
+	UnmountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error)
 
 	// Custom volume snapshots.
-	CreateCustomVolumeSnapshot(volName string, newSnapshotName string, op *operations.Operation) error
-	RenameCustomVolumeSnapshot(volName string, newSnapshotName string, op *operations.Operation) error
-	DeleteCustomVolumeSnapshot(volName string, op *operations.Operation) error
-	UpdateCustomVolumeSnapshot(volName, newDesc string, newConfig map[string]string, op *operations.Operation) error
-	RestoreCustomVolume(volName string, snapshotName string, op *operations.Operation) error
+	CreateCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, op *operations.Operation) error
+	RenameCustomVolumeSnapshot(projectName string, volName string, newSnapshotName string, op *operations.Operation) error
+	DeleteCustomVolumeSnapshot(projectName string, volName string, op *operations.Operation) error
+	UpdateCustomVolumeSnapshot(projectName string, volName string, newDesc string, newConfig map[string]string, op *operations.Operation) error
+	RestoreCustomVolume(projectName string, volName string, snapshotName string, op *operations.Operation) error
 
 	// Custom volume migration.
 	MigrationTypes(contentType drivers.ContentType, refresh bool) []migration.Type

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -83,6 +83,6 @@ type Pool interface {
 
 	// Custom volume migration.
 	MigrationTypes(contentType drivers.ContentType, refresh bool) []migration.Type
-	CreateCustomVolumeFromMigration(conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error
-	MigrateCustomVolume(conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error
+	CreateCustomVolumeFromMigration(projectName string, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error
+	MigrateCustomVolume(projectName string, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error
 }

--- a/lxd/storage/storage.go
+++ b/lxd/storage/storage.go
@@ -66,12 +66,6 @@ func GetImageMountPoint(poolName string, fingerprint string) string {
 	return shared.VarPath("storage-pools", poolName, "images", fingerprint)
 }
 
-// GetStoragePoolVolumeMountPoint returns the mountpoint of the given pool volume.
-// ${LXD_DIR}/storage-pools/<pool>/custom/<storage_volume>
-func GetStoragePoolVolumeMountPoint(poolName string, volumeName string) string {
-	return shared.VarPath("storage-pools", poolName, "custom", volumeName)
-}
-
 // GetStoragePoolVolumeSnapshotMountPoint returns the mountpoint of the given pool volume snapshot.
 // ${LXD_DIR}/storage-pools/<pool>/custom-snapshots/<custom volume name>/<snapshot name>
 func GetStoragePoolVolumeSnapshotMountPoint(poolName string, snapshotName string) string {

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -627,8 +627,8 @@ func InstanceContentType(inst instance.Instance) drivers.ContentType {
 }
 
 // VolumeUsedByInstancesGet gets a list of instance names using a volume.
-func VolumeUsedByInstancesGet(s *state.State, project, poolName string, volumeName string) ([]string, error) {
-	insts, err := instance.LoadByProject(s, project)
+func VolumeUsedByInstancesGet(s *state.State, projectName string, poolName string, volumeName string) ([]string, error) {
+	insts, err := instance.LoadByProject(s, projectName)
 	if err != nil {
 		return []string{}, err
 	}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -460,13 +460,13 @@ func VolumeFillDefault(name string, config map[string]string, parentPool *api.St
 }
 
 // VolumeSnapshotsGet returns a list of snapshots of the form <volume>/<snapshot-name>.
-func VolumeSnapshotsGet(s *state.State, pool string, volume string, volType int) ([]db.StorageVolumeArgs, error) {
+func VolumeSnapshotsGet(s *state.State, projectName string, pool string, volume string, volType int) ([]db.StorageVolumeArgs, error) {
 	poolID, err := s.Cluster.StoragePoolGetID(pool)
 	if err != nil {
 		return nil, err
 	}
 
-	snapshots, err := s.Cluster.StoragePoolVolumeSnapshotsGetType(volume, volType, poolID)
+	snapshots, err := s.Cluster.StoragePoolVolumeSnapshotsGetType(projectName, volume, volType, poolID)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -957,9 +957,9 @@ func storagePoolVolumeTypePatch(d *Daemon, r *http.Request, volumeTypeName strin
 		return response.BadRequest(err)
 	}
 
-	// Check that the storage volume type is valid.
-	if !shared.IntInSlice(volumeType, supportedVolumeTypes) {
-		return response.BadRequest(fmt.Errorf("Invalid storage volume type %s", volumeTypeName))
+	// Check that the storage volume type is custom.
+	if volumeType != db.StoragePoolVolumeTypeCustom {
+		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
 	pool, err := storagePools.GetPoolByName(d.State(), poolName)
@@ -1071,12 +1071,7 @@ func storagePoolVolumeTypeDelete(d *Daemon, r *http.Request, volumeTypeName stri
 		return resp
 	}
 
-	switch volumeType {
-	case db.StoragePoolVolumeTypeCustom:
-		// allowed
-	case db.StoragePoolVolumeTypeImage:
-		// allowed
-	default:
+	if volumeType != db.StoragePoolVolumeTypeCustom && volumeType != db.StoragePoolVolumeTypeImage {
 		return response.BadRequest(fmt.Errorf("Storage volumes of type %q cannot be deleted with the storage API", volumeTypeName))
 	}
 

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -170,8 +170,7 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 func storagePoolVolumesTypeGet(d *Daemon, r *http.Request) response.Response {
 	project := projectParam(r)
 
-	// Get the name of the pool the storage volume is supposed to be
-	// attached to.
+	// Get the name of the pool the storage volume is supposed to be attached to.
 	poolName := mux.Vars(r)["name"]
 
 	// Get the name of the volume type.
@@ -184,20 +183,19 @@ func storagePoolVolumesTypeGet(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.BadRequest(err)
 	}
+
 	// Check that the storage volume type is valid.
 	if !shared.IntInSlice(volumeType, supportedVolumeTypes) {
-		return response.BadRequest(fmt.Errorf("Invalid storage volume type %s", volumeTypeName))
+		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
-	// Retrieve ID of the storage pool (and check if the storage pool
-	// exists).
+	// Retrieve ID of the storage pool (and check if the storage pool exists).
 	poolID, err := d.cluster.StoragePoolGetID(poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	// Get the names of all storage volumes of a given volume type currently
-	// attached to the storage pool.
+	// Get the names of all storage volumes of a given volume type currently attached to the storage pool.
 	volumes, err := d.cluster.StoragePoolNodeVolumesGetType(volumeType, poolID)
 	if err != nil {
 		return response.SmartError(err)
@@ -275,8 +273,7 @@ func storagePoolVolumesTypePost(d *Daemon, r *http.Request) response.Response {
 	// storagePoolVolumeTypeCustom. So check, that nothing else was
 	// requested.
 	if req.Type != db.StoragePoolVolumeTypeNameCustom {
-		return response.BadRequest(fmt.Errorf(`Currently not allowed to create `+
-			`storage volumes of type %s`, req.Type))
+		return response.BadRequest(fmt.Errorf(`Currently not allowed to create storage volumes of type %q`, req.Type))
 	}
 
 	poolName := mux.Vars(r)["name"]
@@ -377,8 +374,7 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 	// storagePoolVolumeTypeCustom. So check, that nothing else was
 	// requested.
 	if req.Type != db.StoragePoolVolumeTypeNameCustom {
-		return response.BadRequest(fmt.Errorf(`Currently not allowed to create `+
-			`storage volumes of type %s`, req.Type))
+		return response.BadRequest(fmt.Errorf(`Currently not allowed to create storage volumes of type %q`, req.Type))
 	}
 
 	poolName := mux.Vars(r)["name"]
@@ -405,7 +401,7 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 	case "migration":
 		return doVolumeMigration(d, poolName, &req)
 	default:
-		return response.BadRequest(fmt.Errorf("unknown source type %s", req.Source.Type))
+		return response.BadRequest(fmt.Errorf("Unknown source type %q", req.Source.Type))
 	}
 }
 
@@ -523,7 +519,7 @@ func storagePoolVolumeTypePost(d *Daemon, r *http.Request, volumeTypeName string
 	// We currently only allow to create storage volumes of type storagePoolVolumeTypeCustom.
 	// So check, that nothing else was requested.
 	if volumeTypeName != db.StoragePoolVolumeTypeNameCustom {
-		return response.BadRequest(fmt.Errorf("Renaming storage volumes of type %s is not allowed", volumeTypeName))
+		return response.BadRequest(fmt.Errorf("Renaming storage volumes of type %q is not allowed", volumeTypeName))
 	}
 
 	// Retrieve ID of the storage pool (and check if the storage pool exists).
@@ -752,8 +748,7 @@ func storagePoolVolumeTypeGet(d *Daemon, r *http.Request, volumeTypeName string)
 		return response.BadRequest(err)
 	}
 
-	// Get the name of the storage pool the volume is supposed to be
-	// attached to.
+	// Get the name of the storage pool the volume is supposed to be attached to.
 	poolName := mux.Vars(r)["pool"]
 
 	// Convert the volume type name to our internal integer representation.
@@ -761,13 +756,13 @@ func storagePoolVolumeTypeGet(d *Daemon, r *http.Request, volumeTypeName string)
 	if err != nil {
 		return response.BadRequest(err)
 	}
+
 	// Check that the storage volume type is valid.
 	if !shared.IntInSlice(volumeType, supportedVolumeTypes) {
-		return response.BadRequest(fmt.Errorf("Invalid storage volume type %s", volumeTypeName))
+		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
-	// Get the ID of the storage pool the storage volume is supposed to be
-	// attached to.
+	// Get the ID of the storage pool the storage volume is supposed to be attached to.
 	poolID, err := d.cluster.StoragePoolGetID(poolName)
 	if err != nil {
 		return response.SmartError(err)
@@ -828,8 +823,7 @@ func storagePoolVolumeTypePut(d *Daemon, r *http.Request, volumeTypeName string)
 		return response.BadRequest(err)
 	}
 
-	// Get the name of the storage pool the volume is supposed to be
-	// attached to.
+	// Get the name of the storage pool the volume is supposed to be attached to.
 	poolName := mux.Vars(r)["pool"]
 
 	// Convert the volume type name to our internal integer representation.
@@ -840,7 +834,7 @@ func storagePoolVolumeTypePut(d *Daemon, r *http.Request, volumeTypeName string)
 
 	// Check that the storage volume type is valid.
 	if !shared.IntInSlice(volumeType, supportedVolumeTypes) {
-		return response.BadRequest(fmt.Errorf("Invalid storage volume type %s", volumeTypeName))
+		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
 	pool, err := storagePools.GetPoolByName(d.State(), poolName)
@@ -1046,11 +1040,10 @@ func storagePoolVolumeTypeDelete(d *Daemon, r *http.Request, volumeTypeName stri
 	volumeName := mux.Vars(r)["name"]
 
 	if shared.IsSnapshot(volumeName) {
-		return response.BadRequest(fmt.Errorf("Invalid storage volume %s", volumeName))
+		return response.BadRequest(fmt.Errorf("Invalid storage volume %q", volumeName))
 	}
 
-	// Get the name of the storage pool the volume is supposed to be
-	// attached to.
+	// Get the name of the storage pool the volume is supposed to be attached to.
 	poolName := mux.Vars(r)["pool"]
 
 	// Convert the volume type name to our internal integer representation.
@@ -1060,7 +1053,7 @@ func storagePoolVolumeTypeDelete(d *Daemon, r *http.Request, volumeTypeName stri
 	}
 	// Check that the storage volume type is valid.
 	if !shared.IntInSlice(volumeType, supportedVolumeTypes) {
-		return response.BadRequest(fmt.Errorf("Invalid storage volume type %s", volumeTypeName))
+		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
 	resp := ForwardedResponseIfTargetIsRemote(d, r)
@@ -1109,7 +1102,7 @@ func storagePoolVolumeTypeDelete(d *Daemon, r *http.Request, volumeTypeName stri
 	case db.StoragePoolVolumeTypeImage:
 		err = pool.DeleteImage(volumeName, nil)
 	default:
-		return response.BadRequest(fmt.Errorf(`Storage volumes of type %q cannot be deleted with the storage api`, volumeTypeName))
+		return response.BadRequest(fmt.Errorf(`Storage volumes of type %q cannot be deleted with the storage API`, volumeTypeName))
 	}
 	if err != nil {
 		return response.SmartError(err)

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -319,7 +319,7 @@ func storagePoolVolumesTypePost(d *Daemon, r *http.Request) response.Response {
 	case "copy":
 		return doVolumeCreateOrCopy(d, projectName, poolName, &req)
 	case "migration":
-		return doVolumeMigration(d, poolName, &req)
+		return doVolumeMigration(d, projectName, poolName, &req)
 	default:
 		return response.BadRequest(fmt.Errorf("Unknown source type %q", req.Source.Type))
 	}
@@ -424,13 +424,13 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 	case "copy":
 		return doVolumeCreateOrCopy(d, projectName, poolName, &req)
 	case "migration":
-		return doVolumeMigration(d, poolName, &req)
+		return doVolumeMigration(d, projectName, poolName, &req)
 	default:
 		return response.BadRequest(fmt.Errorf("Unknown source type %q", req.Source.Type))
 	}
 }
 
-func doVolumeMigration(d *Daemon, poolName string, req *api.StorageVolumesPost) response.Response {
+func doVolumeMigration(d *Daemon, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {
 	// Validate migration mode
 	if req.Source.Mode != "pull" && req.Source.Mode != "push" {
 		return response.NotImplemented(fmt.Errorf("Mode '%s' not implemented", req.Source.Mode))
@@ -484,7 +484,7 @@ func doVolumeMigration(d *Daemon, poolName string, req *api.StorageVolumesPost) 
 
 	run := func(op *operations.Operation) error {
 		// And finally run the migration.
-		err = sink.DoStorage(d.State(), poolName, req, op)
+		err = sink.DoStorage(d.State(), projectName, poolName, req, op)
 		if err != nil {
 			logger.Error("Error during migration sink", log.Ctx{"err": err})
 			return fmt.Errorf("Error transferring storage volume: %s", err)

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -150,17 +150,16 @@ func storagePoolVolumeSnapshotsTypeGet(d *Daemon, r *http.Request) response.Resp
 	}
 	// Check that the storage volume type is valid.
 	if !shared.IntInSlice(volumeType, supportedVolumeTypes) {
-		return response.BadRequest(fmt.Errorf("invalid storage volume type %s", volumeTypeName))
+		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
-	// Retrieve ID of the storage pool (and check if the storage pool
-	// exists).
+	// Retrieve ID of the storage pool (and check if the storage pool exists).
 	poolID, err := d.cluster.StoragePoolGetID(poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	// Get the names of all storage volume snapshots of a given volume
+	// Get the names of all storage volume snapshots of a given volume.
 	volumes, err := d.cluster.StoragePoolVolumeSnapshotsGetType(volumeName, volumeType, poolID)
 	if err != nil {
 		return response.SmartError(err)
@@ -244,7 +243,7 @@ func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Resp
 
 	// Check that the storage volume type is valid.
 	if volumeType != db.StoragePoolVolumeTypeCustom {
-		return response.BadRequest(fmt.Errorf("invalid storage volume type %s", volumeTypeName))
+		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
 	resp := ForwardedResponseIfTargetIsRemote(d, r)
@@ -305,7 +304,7 @@ func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Respo
 
 	// Check that the storage volume type is valid.
 	if volumeType != db.StoragePoolVolumeTypeCustom {
-		return response.BadRequest(fmt.Errorf("invalid storage volume type %s", volumeTypeName))
+		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
 	resp := ForwardedResponseIfTargetIsRemote(d, r)
@@ -362,7 +361,7 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 
 	// Check that the storage volume type is valid.
 	if volumeType != db.StoragePoolVolumeTypeCustom {
-		return response.BadRequest(fmt.Errorf("Invalid storage volume type %s", volumeTypeName))
+		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
 	resp := ForwardedResponseIfTargetIsRemote(d, r)
@@ -442,7 +441,7 @@ func storagePoolVolumeSnapshotTypeDelete(d *Daemon, r *http.Request) response.Re
 
 	// Check that the storage volume type is valid.
 	if volumeType != db.StoragePoolVolumeTypeCustom {
-		return response.BadRequest(fmt.Errorf("invalid storage volume type %s", volumeTypeName))
+		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
 	resp := ForwardedResponseIfTargetIsRemote(d, r)

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -58,8 +58,8 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 	}
 
 	// Check that the storage volume type is valid.
-	if !shared.IntInSlice(volumeType, supportedVolumeTypes) {
-		return response.BadRequest(fmt.Errorf("Invalid storage volume type \"%d\"", volumeType))
+	if volumeType != db.StoragePoolVolumeTypeCustom {
+		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
 	// Get a snapshot name.

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -23,8 +23,8 @@ const (
 	storagePoolVolumeAPIEndpointCustom     string = "custom"
 )
 
-var supportedVolumeTypesExceptImages = []int{db.StoragePoolVolumeTypeContainer, db.StoragePoolVolumeTypeVM, db.StoragePoolVolumeTypeCustom}
-var supportedVolumeTypes = append(supportedVolumeTypesExceptImages, db.StoragePoolVolumeTypeImage)
+var supportedVolumeTypes = []int{db.StoragePoolVolumeTypeContainer, db.StoragePoolVolumeTypeVM, db.StoragePoolVolumeTypeCustom, db.StoragePoolVolumeTypeImage}
+var supportedVolumeTypesInstances = []int{db.StoragePoolVolumeTypeContainer, db.StoragePoolVolumeTypeVM}
 
 func init() {
 	storagePools.VolumeUsedByInstancesWithProfiles = storagePoolVolumeUsedByRunningInstancesWithProfilesGet

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/state"
 	storagePools "github.com/lxc/lxd/lxd/storage"
 	"github.com/lxc/lxd/shared"
@@ -136,13 +137,13 @@ func storagePoolVolumeUpdateUsers(d *Daemon, oldPoolName string,
 	}
 
 	// update all profiles
-	profiles, err := s.Cluster.Profiles("default")
+	profiles, err := s.Cluster.Profiles(project.Default)
 	if err != nil {
 		return err
 	}
 
 	for _, pName := range profiles {
-		id, profile, err := s.Cluster.ProfileGet("default", pName)
+		id, profile, err := s.Cluster.ProfileGet(project.Default, pName)
 		if err != nil {
 			return err
 		}
@@ -197,7 +198,7 @@ func storagePoolVolumeUpdateUsers(d *Daemon, oldPoolName string,
 		pUpdate.Config = profile.Config
 		pUpdate.Description = profile.Description
 		pUpdate.Devices = profile.Devices
-		err = doProfileUpdate(d, "default", pName, id, profile, pUpdate)
+		err = doProfileUpdate(d, project.Default, pName, id, profile, pUpdate)
 		if err != nil {
 			return err
 		}
@@ -301,13 +302,13 @@ func storagePoolVolumeUsedByGet(s *state.State, project, poolName string, volume
 func profilesUsingPoolVolumeGetNames(db *db.Cluster, volumeName string, volumeType string) ([]string, error) {
 	usedBy := []string{}
 
-	profiles, err := db.Profiles("default")
+	profiles, err := db.Profiles(project.Default)
 	if err != nil {
 		return usedBy, err
 	}
 
 	for _, pName := range profiles {
-		_, profile, err := db.ProfileGet("default", pName)
+		_, profile, err := db.ProfileGet(project.Default, pName)
 		if err != nil {
 			return usedBy, err
 		}

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/state"
 	storagePools "github.com/lxc/lxd/lxd/storage"
@@ -60,12 +61,10 @@ func storagePoolVolumeTypeToAPIEndpoint(volumeType int) (string, error) {
 	return "", fmt.Errorf("Invalid storage volume type")
 }
 
-func storagePoolVolumeUpdateUsers(d *Daemon, oldPoolName string,
-	oldVolumeName string, newPoolName string, newVolumeName string) error {
-
+func storagePoolVolumeUpdateUsers(d *Daemon, projectName string, oldPoolName string, oldVolumeName string, newPoolName string, newVolumeName string) error {
 	s := d.State()
 	// update all instances
-	insts, err := instanceLoadAll(s)
+	insts, err := instance.LoadByProject(s, projectName)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -42,7 +42,7 @@ func storagePoolVolumeTypeNameToAPIEndpoint(volumeTypeName string) (string, erro
 		return storagePoolVolumeAPIEndpointCustom, nil
 	}
 
-	return "", fmt.Errorf("invalid storage volume type name")
+	return "", fmt.Errorf("Invalid storage volume type name")
 }
 
 func storagePoolVolumeTypeToAPIEndpoint(volumeType int) (string, error) {
@@ -57,7 +57,7 @@ func storagePoolVolumeTypeToAPIEndpoint(volumeType int) (string, error) {
 		return storagePoolVolumeAPIEndpointCustom, nil
 	}
 
-	return "", fmt.Errorf("invalid storage volume type")
+	return "", fmt.Errorf("Invalid storage volume type")
 }
 
 func storagePoolVolumeUpdateUsers(d *Daemon, oldPoolName string,

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -860,8 +860,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -1997,7 +1997,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2011,7 +2011,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2390,7 +2390,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2579,6 +2579,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2665,11 +2669,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2776,7 +2780,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -2951,7 +2955,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3134,7 +3138,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3179,7 +3183,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3274,7 +3278,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3398,7 +3402,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4073,7 +4077,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4125,7 +4129,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4169,7 +4173,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4214,7 +4218,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: 2019-12-12 14:53+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -1044,8 +1044,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -2185,7 +2185,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 #, fuzzy
 msgid "Missing project name"
 msgstr "Profilname kann nicht geändert werden"
@@ -2269,7 +2269,7 @@ msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2283,7 +2283,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2431,7 +2431,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2594,7 +2594,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Project %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -2765,7 +2765,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 #, fuzzy
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -2877,6 +2877,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2967,12 +2971,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -3086,7 +3090,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -3272,7 +3276,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3462,7 +3466,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3510,7 +3514,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3617,7 +3621,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3766,7 +3770,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4561,7 +4565,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4627,7 +4631,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 #, fuzzy
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -4707,7 +4711,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 #, fuzzy
 msgid "switch [<remote>:]<project>"
 msgstr ""
@@ -4827,7 +4831,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 #, fuzzy
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -864,8 +864,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1315,7 +1315,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -1930,7 +1930,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2020,7 +2020,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2400,7 +2400,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2484,7 +2484,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2589,6 +2589,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2675,11 +2679,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2786,7 +2790,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -2961,7 +2965,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3144,7 +3148,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3189,7 +3193,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3284,7 +3288,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3408,7 +3412,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4047,7 +4051,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4083,7 +4087,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4135,7 +4139,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4179,7 +4183,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4224,7 +4228,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -999,8 +999,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1452,7 +1452,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -2070,7 +2070,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nombre del contenedor es: %s"
@@ -2148,7 +2148,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2162,7 +2162,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2306,7 +2306,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2467,7 +2467,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2544,7 +2544,7 @@ msgstr "Refrescando la imagen: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2629,7 +2629,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2735,6 +2735,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2821,11 +2825,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2932,7 +2936,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -3107,7 +3111,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3290,7 +3294,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3335,7 +3339,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3430,7 +3434,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3558,7 +3562,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4214,7 +4218,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4253,7 +4257,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4309,7 +4313,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4357,7 +4361,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 #, fuzzy
 msgid "switch [<remote>:]<project>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4404,7 +4408,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -860,8 +860,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -1997,7 +1997,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2011,7 +2011,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2390,7 +2390,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2579,6 +2579,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2665,11 +2669,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2776,7 +2780,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -2951,7 +2955,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3134,7 +3138,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3179,7 +3183,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3274,7 +3278,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3398,7 +3402,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4073,7 +4077,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4125,7 +4129,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4169,7 +4173,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4214,7 +4218,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -860,8 +860,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -1997,7 +1997,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2011,7 +2011,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2390,7 +2390,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2579,6 +2579,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2665,11 +2669,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2776,7 +2780,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -2951,7 +2955,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3134,7 +3138,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3179,7 +3183,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3274,7 +3278,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3398,7 +3402,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4073,7 +4077,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4125,7 +4129,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4169,7 +4173,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4214,7 +4218,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -1051,8 +1051,8 @@ msgstr "Copie de l'image : %s"
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1536,7 +1536,7 @@ msgstr "Pid : %d"
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -2241,7 +2241,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nom de l'ensemble de stockage"
@@ -2327,7 +2327,7 @@ msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr "NOM"
@@ -2341,7 +2341,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr "NON"
 
@@ -2496,7 +2496,7 @@ msgstr "PID"
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr "PROFILS"
 
@@ -2660,7 +2660,7 @@ msgstr "Profil %s créé"
 msgid "Project %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -2742,7 +2742,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -2831,7 +2831,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 #, fuzzy
 msgid "Rename projects"
 msgstr "Créé : %s"
@@ -2945,6 +2945,11 @@ msgstr "ÉTAT"
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
+#: lxc/project.go:457
+#, fuzzy
+msgid "STORAGE VOLUMES"
+msgstr "ENSEMBLE DE STOCKAGE"
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -3037,12 +3042,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -3159,7 +3164,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show profile configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 #, fuzzy
 msgid "Show project options"
 msgstr "Afficher la configuration étendue"
@@ -3347,7 +3352,7 @@ msgstr "Swap (courant)"
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 #, fuzzy
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -3545,7 +3550,7 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
@@ -3595,7 +3600,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3700,7 +3705,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr "OUI"
 
@@ -3853,7 +3858,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -4705,7 +4710,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4777,7 +4782,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 #, fuzzy
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -4869,7 +4874,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4946,7 +4951,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 #, fuzzy
 msgid "switch [<remote>:]<project>"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -4996,7 +5001,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 #, fuzzy
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -860,8 +860,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -1997,7 +1997,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2011,7 +2011,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2390,7 +2390,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2579,6 +2579,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2665,11 +2669,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2776,7 +2780,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -2951,7 +2955,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3134,7 +3138,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3179,7 +3183,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3274,7 +3278,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3398,7 +3402,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4073,7 +4077,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4125,7 +4129,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4169,7 +4173,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4214,7 +4218,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -860,8 +860,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -1997,7 +1997,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2011,7 +2011,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2390,7 +2390,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2579,6 +2579,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2665,11 +2669,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2776,7 +2780,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -2951,7 +2955,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3134,7 +3138,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3179,7 +3183,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3274,7 +3278,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3398,7 +3402,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4073,7 +4077,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4125,7 +4129,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4169,7 +4173,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4214,7 +4218,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -987,8 +987,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1441,7 +1441,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 #, fuzzy
 msgid "Missing project name"
 msgstr "Il nome del container è: %s"
@@ -2141,7 +2141,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2155,7 +2155,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2299,7 +2299,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2459,7 +2459,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2537,7 +2537,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -2623,7 +2623,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2730,6 +2730,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2816,11 +2820,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2927,7 +2931,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -3104,7 +3108,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3288,7 +3292,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3334,7 +3338,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3429,7 +3433,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3559,7 +3563,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4215,7 +4219,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4254,7 +4258,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4310,7 +4314,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4358,7 +4362,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 #, fuzzy
 msgid "switch [<remote>:]<project>"
 msgstr "Creazione del container in corso"
@@ -4405,7 +4409,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-13 16:28-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: 2020-03-05 09:37+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
-"Language-Team: Japanese <https://hosted.weblate.org/projects/"
-"linux-containers/lxd/ja/>\n"
+"Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
+"containers/lxd/ja/>\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -775,7 +775,9 @@ msgstr "インスタンスをコピーします。スナップショットはコ
 
 #: lxc/copy.go:51
 msgid "Copy the instance without its snapshots (deprecated, use instance-only)"
-msgstr "インスタンスをコピーします。スナップショットはコピーしません (廃止予定、instance-only を使ってください)"
+msgstr ""
+"インスタンスをコピーします。スナップショットはコピーしません (廃止予定、"
+"instance-only を使ってください)"
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
@@ -845,7 +847,8 @@ msgid ""
 msgstr ""
 "インスタンスのスナップショットを作成します\n"
 "\n"
-"--stateful を指定すると、LXD はインスタンスの実行状態（プロセスのメモリ状態、TCPコネクション、など…を含む）を保存しようとします。"
+"--stateful を指定すると、LXD はインスタンスの実行状態（プロセスのメモリ状態、"
+"TCPコネクション、など…を含む）を保存しようとします。"
 
 #: lxc/init.go:39 lxc/init.go:40
 msgid "Create instances from images"
@@ -1000,8 +1003,8 @@ msgstr "ストレージボリュームを削除します"
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1062,7 +1065,9 @@ msgstr "デバイス: %s"
 
 #: lxc/init.go:336
 msgid "Didn't get any affected image, instance or snapshot from server"
-msgstr "サーバから変更されたイメージ、インスタンス、スナップショットを取得できませんでした"
+msgstr ""
+"サーバから変更されたイメージ、インスタンス、スナップショットを取得できません"
+"でした"
 
 #: lxc/image.go:620
 msgid "Directory import is not available on this platform"
@@ -1174,7 +1179,8 @@ msgstr ""
 
 #: lxc/cluster.go:331
 msgid "Enable clustering on a single non-clustered LXD server"
-msgstr "クラスタリングで動作していないLXDサーバ上でクラスタリングを有効にします"
+msgstr ""
+"クラスタリングで動作していないLXDサーバ上でクラスタリングを有効にします"
 
 #: lxc/cluster.go:332
 msgid ""
@@ -1190,7 +1196,8 @@ msgid ""
 "value\n"
 "  for the address if not yet set."
 msgstr ""
-"クラスタリングで動作していない単一動作のLXDインスタンス上でクラスタリングを有効にします\n"
+"クラスタリングで動作していない単一動作のLXDインスタンス上でクラスタリングを有"
+"効にします\n"
 "\n"
 "  このコマンドはクラスタリングで動作していない LXD インスタンスを、\n"
 "  指定した名前の新しい LXD クラスタの最初のメンバーにします。\n"
@@ -1236,14 +1243,15 @@ msgid ""
 msgstr ""
 "インスタンス内でコマンドを実行します\n"
 "\n"
-"このコマンドは exec を使って直接コマンドを実行します。したがって、シェルはなくシェルパターン（変数、ファイルのリダイレクトなど）は理解されません。"
-"\n"
-"シェル環境が必要なら、シェルを実行し、引数でシェルコマンドを渡す必要があります。例えば:\n"
+"このコマンドは exec を使って直接コマンドを実行します。したがって、シェルはな"
+"くシェルパターン（変数、ファイルのリダイレクトなど）は理解されません。\n"
+"シェル環境が必要なら、シェルを実行し、引数でシェルコマンドを渡す必要がありま"
+"す。例えば:\n"
 "\n"
 "  lxc exec <instance> -- sh -c \"cd /tmp && pwd\"\n"
 "\n"
-"デフォルトのモードは non-interactive です。もし標準入出力が両方ともターミナルの場合は interactive モードが選択されます "
-"(標準エラー出力は無視されます)。"
+"デフォルトのモードは non-interactive です。もし標準入出力が両方ともターミナル"
+"の場合は interactive モードが選択されます (標準エラー出力は無視されます)。"
 
 #: lxc/image.go:907
 #, c-format
@@ -1374,15 +1382,19 @@ msgid ""
 "\n"
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
-"クラスタからサーバを強制的に削除するのは最後の手段としてのみ実行してください。\n"
+"クラスタからサーバを強制的に削除するのは最後の手段としてのみ実行してくださ"
+"い。\n"
 "\n"
-"削除されたサーバはこの操作のあとは機能せず、LXD "
-"のフルリセットが必要になります。サーバに存在していた可能性のある残りのインスタンス、イメージ、ストレージボリュームは失われます。\n"
+"削除されたサーバはこの操作のあとは機能せず、LXD のフルリセットが必要になりま"
+"す。サーバに存在していた可能性のある残りのインスタンス、イメージ、ストレージ"
+"ボリュームは失われます。\n"
 "\n"
-"可能なら、適切な手順で削除することをおすすめします。適切な手順で行うには、クラスタから完全にサーバを削除する前に、影響を受けるインスタンス、イメージ、スト"
-"レージボリュームを他のサーバに移動する必要があります。\n"
+"可能なら、適切な手順で削除することをおすすめします。適切な手順で行うには、ク"
+"ラスタから完全にサーバを削除する前に、影響を受けるインスタンス、イメージ、ス"
+"トレージボリュームを他のサーバに移動する必要があります。\n"
 "\n"
-"--force オプションは、サーバが死んだ場合、サーバの再インストール後、他に復旧の見込みがまったくない場合にのみ使用してください。\n"
+"--force オプションは、サーバが死んだ場合、サーバの再インストール後、他に復旧"
+"の見込みがまったくない場合にのみ使用してください。\n"
 "\n"
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
@@ -1483,7 +1495,7 @@ msgstr "ID: %d"
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr "IMAGES"
 
@@ -1549,7 +1561,8 @@ msgstr "イメージの更新が成功しました!"
 
 #: lxc/import.go:28
 msgid "Import backups of instances including their snapshots."
-msgstr "インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
+msgstr ""
+"インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
 
 #: lxc/image.go:605
 msgid ""
@@ -1896,20 +1909,24 @@ msgstr ""
 "Fast モードのカラムレイアウト: nsacPt\n"
 "\n"
 "== フィルタ ==\n"
-"単一の \"web\" のようなキーワードを指定すると、名前が \"web\" ではじまるインスタンスが一覧表示されます。\n"
+"単一の \"web\" のようなキーワードを指定すると、名前が \"web\" ではじまるイン"
+"スタンスが一覧表示されます。\n"
 "インスタンス名の正規表現 (例: .*web.*01$)。\n"
-"設定項目のキーと値。キーの名前空間は一意に識別できる場合は短縮することができます。\n"
+"設定項目のキーと値。キーの名前空間は一意に識別できる場合は短縮することができ"
+"ます。\n"
 "\n"
 "例:\n"
-"  - \"user.blah=abc\" は \"blah\" という user プロパティが \"abc\" "
-"に設定されているインスタンスをすべて一覧表示します。\n"
+"  - \"user.blah=abc\" は \"blah\" という user プロパティが \"abc\" に設定され"
+"ているインスタンスをすべて一覧表示します。\n"
 "  - \"u.blah=abc\" は上記と同じ意味になります。\n"
 "  - \"security.privileged=true\" は特権インスタンスをすべて一覧表示します。\n"
 "  - \"s.privileged=true\" は上記と同じ意味になります。\n"
 "\n"
-"設定項目もしくは値とマッチする正規表現 (例:volatile.eth0.hwaddr=00:16:3e:.*)。\n"
+"設定項目もしくは値とマッチする正規表現 (例:volatile.eth0.hwaddr=00:16:3e:."
+"*)。\n"
 "\n"
-"複数のフィルタを指定した場合は、指定したフィルタが順に追加され、すべてのフィルタを満たすインスタンスが選択されます。\n"
+"複数のフィルタを指定した場合は、指定したフィルタが順に追加され、すべてのフィ"
+"ルタを満たすインスタンスが選択されます。\n"
 "\n"
 "== カラム ==\n"
 "-c オプションには、表形式もしくは csv 形式で表示する際にどのインスタンスの\n"
@@ -1940,9 +1957,10 @@ msgstr ""
 "  F - ベースとなるイメージのフィンガープリント (長い形式)\n"
 "\n"
 "\"[config:|devices:]key[:name][:maxWidth]\" のように指定するカスタムカラム:\n"
-"     KEY: 表示する (拡張された) 設定キー。[config:|devices:] が省略された場合は config "
-"が指定されたものとします\n"
-"    NAME: カラムのヘッダに表示する名前。指定しない場合、もしくは空の場合のデフォルトはキー。\n"
+"     KEY: 表示する (拡張された) 設定キー。[config:|devices:] が省略された場合"
+"は config が指定されたものとします\n"
+"    NAME: カラムのヘッダに表示する名前。指定しない場合、もしくは空の場合のデ"
+"フォルトはキー。\n"
 "\n"
 "MAXWIDTH: カラムの最大幅 (結果がこれより長い場合は切り詰められます)\n"
 "          デフォルトは -1 (制限なし)。0 はカラムのヘッダサイズに制限します。"
@@ -2205,7 +2223,7 @@ msgid "Missing profile name"
 msgstr "プロファイル名を指定する必要があります"
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr "プロジェクト名を指定する必要があります"
 
@@ -2270,7 +2288,9 @@ msgstr "インスタンスを移動します。スナップショットは移動
 
 #: lxc/move.go:54
 msgid "Move the instance without its snapshots (deprecated, use instance-only)"
-msgstr "インスタンスを移動します。スナップショットは移動しません (廃止予定、instance-only を使ってください)"
+msgstr ""
+"インスタンスを移動します。スナップショットは移動しません (廃止予定、instance-"
+"only を使ってください)"
 
 #: lxc/storage_volume.go:365
 #, c-format
@@ -2286,7 +2306,7 @@ msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr "NAME"
@@ -2300,7 +2320,7 @@ msgid "NICs:"
 msgstr "NICs:"
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr "NO"
 
@@ -2444,7 +2464,7 @@ msgstr "PID"
 msgid "PROCESSES"
 msgstr "PROCESSES"
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr "PROFILES"
 
@@ -2602,7 +2622,7 @@ msgstr "プロジェクト %s を作成しました"
 msgid "Project %s deleted"
 msgstr "プロジェクト %s を削除しました"
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr "プロジェクト名 %s を %s に変更しました"
@@ -2679,7 +2699,7 @@ msgstr "イメージの更新中: %s"
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2763,7 +2783,7 @@ msgstr "ネットワーク名を変更します"
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
@@ -2875,6 +2895,11 @@ msgstr "STATUS"
 msgid "STORAGE POOL"
 msgstr "STORAGE POOL"
 
+#: lxc/project.go:457
+#, fuzzy
+msgid "STORAGE VOLUMES"
+msgstr "STORAGE POOL"
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr "直接リクエスト (raw query) を LXD に送ります"
@@ -2981,11 +3006,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr "プロジェクトの設定項目を設定します"
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -3104,7 +3129,7 @@ msgstr "ネットワークの設定を表示します"
 msgid "Show profile configurations"
 msgstr "プロファイルの設定を表示します"
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr "プロジェクトの設定を表示します"
 
@@ -3279,7 +3304,7 @@ msgstr "Swap (現在値)"
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
@@ -3325,7 +3350,9 @@ msgstr "インスタンスは実行中です。先に停止させるか、--forc
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
-msgstr "インスタンスは現在実行中です。停止して、再起動するために --force を使用してください"
+msgstr ""
+"インスタンスは現在実行中です。停止して、再起動するために --force を使用してく"
+"ださい"
 
 #: lxc/init.go:394
 msgid "The instance you are starting doesn't have any network attached to it."
@@ -3378,11 +3405,15 @@ msgid ""
 "To easily setup a local LXD server in a virtual machine, consider using: "
 "https://multipass.run"
 msgstr ""
-"このクライアントは、まだリモートの LXD サーバを使うようには設定されていません。\n"
-"お使いのプラットフォームでは、ネイティブな Linux インスタンスは実行できませんので、リモートの LXD サーバに接続しなければなりません。\n"
+"このクライアントは、まだリモートの LXD サーバを使うようには設定されていませ"
+"ん。\n"
+"お使いのプラットフォームでは、ネイティブな Linux インスタンスは実行できません"
+"ので、リモートの LXD サーバに接続しなければなりません。\n"
 "\n"
-"すでにリモートサーバを追加しているのであれば、\"lxc remote switch NAME\" のようにデフォルトを設定してください。\n"
-"仮想マシン上にローカルな LXD サーバを簡単にセットアップするには、https://multipass.run の使用を検討してください。"
+"すでにリモートサーバを追加しているのであれば、\"lxc remote switch NAME\" のよ"
+"うにデフォルトを設定してください。\n"
+"仮想マシン上にローカルな LXD サーバを簡単にセットアップするには、https://"
+"multipass.run の使用を検討してください。"
 
 #: lxc/info.go:291
 msgid "Threads:"
@@ -3398,7 +3429,9 @@ msgstr "タイムスタンプ:"
 
 #: lxc/init.go:396
 msgid "To attach a network to an instance, use: lxc network attach"
-msgstr "インスタンスにネットワークを接続するには、lxc network attach を使用してください"
+msgstr ""
+"インスタンスにネットワークを接続するには、lxc network attach を使用してくださ"
+"い"
 
 #: lxc/init.go:395
 msgid "To create a new network, use: lxc network create"
@@ -3411,7 +3444,9 @@ msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
 #: lxc/main.go:345
 msgid "To start your first instance, try: lxc launch ubuntu:18.04"
-msgstr "初めてインスタンスを起動するには、\"lxc launch ubuntu:18.04\" と実行してみてください"
+msgstr ""
+"初めてインスタンスを起動するには、\"lxc launch ubuntu:18.04\" と実行してみて"
+"ください"
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:568 lxc/config.go:649
 #: lxc/copy.go:116 lxc/info.go:310 lxc/network.go:759 lxc/storage.go:420
@@ -3475,7 +3510,7 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr "USED BY"
@@ -3520,7 +3555,7 @@ msgstr "ネットワークの設定を削除します"
 msgid "Unset profile configuration keys"
 msgstr "プロファイルの設定を削除します"
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr "プロジェクトの設定を削除します"
 
@@ -3614,14 +3649,16 @@ msgstr "スナップショットを含めずにインスタンスのみをバッ
 msgid ""
 "Whether or not to restore the instance's running state from snapshot (if "
 "available)"
-msgstr "スナップショットからインスタンスの稼動状態をリストアするかどうか (取得可能な場合)"
+msgstr ""
+"スナップショットからインスタンスの稼動状態をリストアするかどうか (取得可能な"
+"場合)"
 
 #: lxc/snapshot.go:34
 msgid "Whether or not to snapshot the instance's running state"
 msgstr "インスタンスの稼動状態のスナップショットを取得するかどうか"
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr "YES"
 
@@ -3635,7 +3672,8 @@ msgstr "--mode と同時に -t または -T は指定できません"
 
 #: lxc/copy.go:82
 msgid "You must specify a destination instance name when using --target"
-msgstr "--target オプションを使うときはコピー先のインスタンス名を指定してください"
+msgstr ""
+"--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
 #: lxc/copy.go:77 lxc/move.go:220
 msgid "You must specify a source instance name"
@@ -3749,7 +3787,7 @@ msgstr "create [<remote>:]<profile>"
 msgid "create [<remote>:]<project>"
 msgstr "create [<remote>:]<project>"
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr "現在値"
 
@@ -3778,8 +3816,8 @@ msgid ""
 "delete [<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/"
 "<snapshot>]...]"
 msgstr ""
-"delete [<remote>:]<instance>[/<snapshot>] "
-"[[<remote>:]<instance>[/<snapshot>]...]"
+"delete [<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/"
+"<snapshot>]...]"
 
 #: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
@@ -4099,7 +4137,8 @@ msgid ""
 "directory."
 msgstr ""
 "lxc file pull foo/etc/hosts .\n"
-"   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーします。"
+"   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
+"ます。"
 
 #: lxc/file.go:409
 msgid ""
@@ -4107,7 +4146,8 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
-"   /etc/hosts ファイルを、インスタンス \"foo\" 内 (の /etc/hosts) にコピーします。"
+"   /etc/hosts ファイルを、インスタンス \"foo\" 内 (の /etc/hosts) にコピーし"
+"ます。"
 
 #: lxc/image.go:323
 msgid ""
@@ -4182,11 +4222,12 @@ msgid ""
 "lxc list -c ns,user.comment:comment\n"
 "  List images with their running state and user comment."
 msgstr ""
-"lxc list -c "
-"nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
-"  \"NAME\"、\"BASE IMAGE\"、\"STATE\"、\"IPV4\"、\"IPV6\"、\"MAC\" "
-"カラムを使ってインスタンスを一覧表示します。\n"
-"  \"BASE IMAGE\" と \"MAC\" と \"IMAGE OS\" はインスタンスの設定から生成したカスタムカラムです。\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
+"  \"NAME\"、\"BASE IMAGE\"、\"STATE\"、\"IPV4\"、\"IPV6\"、\"MAC\" カラムを"
+"使ってインスタンスを一覧表示します。\n"
+"  \"BASE IMAGE\" と \"MAC\" と \"IMAGE OS\" はインスタンスの設定から生成した"
+"カスタムカラムです。\n"
 "  \"ETHP\" はデバイスの設定から生成したカスタムカラムです。\n"
 "\n"
 "lxc list -c ns,user.comment:comment\n"
@@ -4225,9 +4266,10 @@ msgid ""
 "lxc move <instance>/<old snapshot name> <instance>/<new snapshot name>\n"
 "    Rename a snapshot."
 msgstr ""
-"lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] "
-"[--instance-only]\n"
-"    2 つのホスト間でインスタンスを移動します。コピー先の名前が元と違う場合は\n"
+"lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
+"instance-only]\n"
+"    2 つのホスト間でインスタンスを移動します。コピー先の名前が元と違う場合"
+"は\n"
 "    同時にリネームされます。\n"
 "\n"
 "lxc move <old name> <new name> [--instance-only]\n"
@@ -4436,8 +4478,8 @@ msgid ""
 "push <source path> [<remote>:]<instance>/<path> [[<remote>:]<instance>/"
 "<path>...]"
 msgstr ""
-"push <source path> [<remote>:]<instance>/<path> "
-"[[<remote>:]<instance>/<path>...]"
+"push <source path> [<remote>:]<instance>/<path> [[<remote>:]<instance>/"
+"<path>...]"
 
 #: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
@@ -4511,7 +4553,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr "rename [<remote>:]<profile> <new-name>"
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr "rename [<remote>:]<project> <new-name>"
 
@@ -4547,7 +4589,7 @@ msgstr "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr "set [<remote>:]<profile> <key><value>..."
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr "set [<remote>:]<project> <key>=<value>..."
 
@@ -4599,7 +4641,7 @@ msgstr "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgid "show [<remote>:]<profile>"
 msgstr "show [<remote>:]<profile>"
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr "show [<remote>:]<project>"
 
@@ -4643,7 +4685,7 @@ msgstr "storage"
 msgid "switch <remote>"
 msgstr "switch <remote>"
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr "switch [<remote>:] <project>"
 
@@ -4688,7 +4730,7 @@ msgstr "unset [<remote>:]<pool> <volume> <key>"
 msgid "unset [<remote>:]<profile> <key>"
 msgstr "unset [<remote>:]<profile> <key>"
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr "unset [<remote>:]<project> <key>"
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -860,8 +860,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -1997,7 +1997,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2011,7 +2011,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2390,7 +2390,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2579,6 +2579,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2665,11 +2669,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2776,7 +2780,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -2951,7 +2955,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3134,7 +3138,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3179,7 +3183,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3274,7 +3278,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3398,7 +3402,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4073,7 +4077,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4125,7 +4129,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4169,7 +4173,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4214,7 +4218,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2020-03-06 14:16+0100\n"
+        "POT-Creation-Date: 2020-03-06 14:23+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -797,7 +797,7 @@ msgstr  ""
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:147 lxc/cluster.go:197 lxc/cluster.go:247 lxc/cluster.go:332 lxc/config.go:31 lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:612 lxc/config.go:731 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327 lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513 lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28 lxc/config_metadata.go:53 lxc/config_metadata.go:175 lxc/config_template.go:29 lxc/config_template.go:66 lxc/config_template.go:109 lxc/config_template.go:151 lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29 lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194 lxc/console.go:31 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:40 lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:605 lxc/image.go:833 lxc/image.go:968 lxc/image.go:1266 lxc/image.go:1345 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50 lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32 lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326 lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669 lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961 lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584 lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31 lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455 lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651 lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139 lxc/storage_volume.go:218 lxc/storage_volume.go:301 lxc/storage_volume.go:462 lxc/storage_volume.go:539 lxc/storage_volume.go:615 lxc/storage_volume.go:697 lxc/storage_volume.go:778 lxc/storage_volume.go:978 lxc/storage_volume.go:1069 lxc/storage_volume.go:1142 lxc/storage_volume.go:1173 lxc/storage_volume.go:1286 lxc/storage_volume.go:1362 lxc/storage_volume.go:1461 lxc/storage_volume.go:1492 lxc/storage_volume.go:1563 lxc/version.go:22
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:147 lxc/cluster.go:197 lxc/cluster.go:247 lxc/cluster.go:332 lxc/config.go:31 lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:612 lxc/config.go:731 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327 lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513 lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28 lxc/config_metadata.go:53 lxc/config_metadata.go:175 lxc/config_template.go:29 lxc/config_template.go:66 lxc/config_template.go:109 lxc/config_template.go:151 lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29 lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194 lxc/console.go:31 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:40 lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:605 lxc/image.go:833 lxc/image.go:968 lxc/image.go:1266 lxc/image.go:1345 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50 lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32 lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326 lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669 lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961 lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590 lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31 lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455 lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651 lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139 lxc/storage_volume.go:218 lxc/storage_volume.go:301 lxc/storage_volume.go:462 lxc/storage_volume.go:539 lxc/storage_volume.go:615 lxc/storage_volume.go:697 lxc/storage_volume.go:778 lxc/storage_volume.go:978 lxc/storage_volume.go:1069 lxc/storage_volume.go:1142 lxc/storage_volume.go:1173 lxc/storage_volume.go:1286 lxc/storage_volume.go:1362 lxc/storage_volume.go:1461 lxc/storage_volume.go:1492 lxc/storage_volume.go:1563 lxc/version.go:22
 msgid   "Description"
 msgstr  ""
 
@@ -1211,7 +1211,7 @@ msgstr  ""
 msgid   "ID: %s"
 msgstr  ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid   "IMAGES"
 msgstr  ""
 
@@ -1789,7 +1789,7 @@ msgstr  ""
 msgid   "Missing profile name"
 msgstr  ""
 
-#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358 lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358 lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid   "Missing project name"
 msgstr  ""
 
@@ -1862,7 +1862,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620 lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558 lxc/storage_volume.go:1118
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620 lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558 lxc/storage_volume.go:1118
 msgid   "NAME"
 msgstr  ""
 
@@ -1874,7 +1874,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428 lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428 lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid   "NO"
 msgstr  ""
 
@@ -2018,7 +2018,7 @@ msgstr  ""
 msgid   "PROCESSES"
 msgstr  ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid   "PROFILES"
 msgstr  ""
 
@@ -2174,7 +2174,7 @@ msgstr  ""
 msgid   "Project %s deleted"
 msgstr  ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid   "Project %s renamed to %s"
 msgstr  ""
@@ -2251,7 +2251,7 @@ msgstr  ""
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667 lxc/remote.go:705
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667 lxc/remote.go:705
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
@@ -2333,7 +2333,7 @@ msgstr  ""
 msgid   "Rename profiles"
 msgstr  ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid   "Rename projects"
 msgstr  ""
 
@@ -2436,6 +2436,10 @@ msgstr  ""
 msgid   "STORAGE POOL"
 msgstr  ""
 
+#: lxc/project.go:457
+msgid   "STORAGE VOLUMES"
+msgstr  ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid   "Send a raw query to LXD"
 msgstr  ""
@@ -2512,11 +2516,11 @@ msgid   "Set profile configuration keys\n"
         "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr  ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid   "Set project configuration keys"
 msgstr  ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid   "Set project configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -2617,7 +2621,7 @@ msgstr  ""
 msgid   "Show profile configurations"
 msgstr  ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid   "Show project options"
 msgstr  ""
 
@@ -2792,7 +2796,7 @@ msgstr  ""
 msgid   "Swap (peak)"
 msgstr  ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid   "Switch the current project"
 msgstr  ""
 
@@ -2965,7 +2969,7 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567 lxc/storage_volume.go:1120
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567 lxc/storage_volume.go:1120
 msgid   "USED BY"
 msgstr  ""
 
@@ -3009,7 +3013,7 @@ msgstr  ""
 msgid   "Unset profile configuration keys"
 msgstr  ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid   "Unset project configuration keys"
 msgstr  ""
 
@@ -3097,7 +3101,7 @@ msgstr  ""
 msgid   "Whether or not to snapshot the instance's running state"
 msgstr  ""
 
-#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430 lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430 lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid   "YES"
 msgstr  ""
 
@@ -3217,7 +3221,7 @@ msgstr  ""
 msgid   "create [<remote>:]<project>"
 msgstr  ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid   "current"
 msgstr  ""
 
@@ -3804,7 +3808,7 @@ msgstr  ""
 msgid   "rename [<remote>:]<profile> <new-name>"
 msgstr  ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid   "rename [<remote>:]<project> <new-name>"
 msgstr  ""
 
@@ -3840,7 +3844,7 @@ msgstr  ""
 msgid   "set [<remote>:]<profile> <key><value>..."
 msgstr  ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid   "set [<remote>:]<project> <key>=<value>..."
 msgstr  ""
 
@@ -3892,7 +3896,7 @@ msgstr  ""
 msgid   "show [<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid   "show [<remote>:]<project>"
 msgstr  ""
 
@@ -3936,7 +3940,7 @@ msgstr  ""
 msgid   "switch <remote>"
 msgstr  ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid   "switch [<remote>:]<project>"
 msgstr  ""
 
@@ -3981,7 +3985,7 @@ msgstr  ""
 msgid   "unset [<remote>:]<profile> <key>"
 msgstr  ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid   "unset [<remote>:]<project> <key>"
 msgstr  ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -860,8 +860,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -1997,7 +1997,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2011,7 +2011,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2390,7 +2390,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2579,6 +2579,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2665,11 +2669,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2776,7 +2780,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -2951,7 +2955,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3134,7 +3138,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3179,7 +3183,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3274,7 +3278,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3398,7 +3402,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4073,7 +4077,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4125,7 +4129,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4169,7 +4173,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4214,7 +4218,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -977,8 +977,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -2038,7 +2038,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -2114,7 +2114,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2128,7 +2128,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2272,7 +2272,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2430,7 +2430,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2591,7 +2591,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2696,6 +2696,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2782,11 +2786,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2893,7 +2897,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -3068,7 +3072,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3251,7 +3255,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3296,7 +3300,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3391,7 +3395,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3515,7 +3519,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4154,7 +4158,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4190,7 +4194,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4242,7 +4246,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4286,7 +4290,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4331,7 +4335,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -860,8 +860,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -1997,7 +1997,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2011,7 +2011,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2390,7 +2390,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2579,6 +2579,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2665,11 +2669,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2776,7 +2780,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -2951,7 +2955,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3134,7 +3138,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3179,7 +3183,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3274,7 +3278,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3398,7 +3402,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4073,7 +4077,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4125,7 +4129,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4169,7 +4173,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4214,7 +4218,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -987,8 +987,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1435,7 +1435,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -2048,7 +2048,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -2124,7 +2124,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2138,7 +2138,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2282,7 +2282,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2440,7 +2440,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2517,7 +2517,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2601,7 +2601,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2706,6 +2706,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2792,11 +2796,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2903,7 +2907,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -3078,7 +3082,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3261,7 +3265,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3306,7 +3310,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3401,7 +3405,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3525,7 +3529,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4164,7 +4168,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4200,7 +4204,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4252,7 +4256,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4341,7 +4345,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -1020,8 +1020,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1480,7 +1480,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -2175,7 +2175,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2189,7 +2189,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2333,7 +2333,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2495,7 +2495,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2658,7 +2658,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2763,6 +2763,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2851,12 +2855,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2968,7 +2972,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -3144,7 +3148,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3327,7 +3331,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3375,7 +3379,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3471,7 +3475,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3595,7 +3599,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4234,7 +4238,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4270,7 +4274,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4322,7 +4326,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4366,7 +4370,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4411,7 +4415,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: 2018-06-22 15:57+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1009,8 +1009,8 @@ msgstr "Копирование образа: %s"
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1466,7 +1466,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -2096,7 +2096,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 #, fuzzy
 msgid "Missing project name"
 msgstr "Имя контейнера: %s"
@@ -2175,7 +2175,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2189,7 +2189,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2335,7 +2335,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2493,7 +2493,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2571,7 +2571,7 @@ msgstr "Копирование образа: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2657,7 +2657,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2766,6 +2766,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2852,11 +2856,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2965,7 +2969,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -3144,7 +3148,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3327,7 +3331,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3372,7 +3376,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3467,7 +3471,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3612,7 +3616,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4387,7 +4391,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4451,7 +4455,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 #, fuzzy
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -4527,7 +4531,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4591,7 +4595,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 #, fuzzy
 msgid "switch [<remote>:]<project>"
 msgstr ""
@@ -4644,7 +4648,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 #, fuzzy
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -860,8 +860,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -1997,7 +1997,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2011,7 +2011,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2390,7 +2390,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2579,6 +2579,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2665,11 +2669,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2776,7 +2780,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -2951,7 +2955,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3134,7 +3138,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3179,7 +3183,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3274,7 +3278,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3398,7 +3402,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4073,7 +4077,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4125,7 +4129,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4169,7 +4173,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4214,7 +4218,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -860,8 +860,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -1997,7 +1997,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2011,7 +2011,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2390,7 +2390,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2579,6 +2579,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2665,11 +2669,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2776,7 +2780,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -2951,7 +2955,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3134,7 +3138,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3179,7 +3183,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3274,7 +3278,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3398,7 +3402,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4073,7 +4077,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4125,7 +4129,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4169,7 +4173,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4214,7 +4218,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -860,8 +860,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -1997,7 +1997,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2011,7 +2011,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2390,7 +2390,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2579,6 +2579,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2665,11 +2669,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2776,7 +2780,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -2951,7 +2955,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3134,7 +3138,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3179,7 +3183,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3274,7 +3278,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3398,7 +3402,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4073,7 +4077,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4125,7 +4129,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4169,7 +4173,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4214,7 +4218,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -860,8 +860,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -1997,7 +1997,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2011,7 +2011,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2390,7 +2390,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2579,6 +2579,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2665,11 +2669,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2776,7 +2780,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -2951,7 +2955,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3134,7 +3138,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3179,7 +3183,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3274,7 +3278,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3398,7 +3402,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4073,7 +4077,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4125,7 +4129,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4169,7 +4173,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4214,7 +4218,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -860,8 +860,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -1997,7 +1997,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2011,7 +2011,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2390,7 +2390,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2579,6 +2579,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2665,11 +2669,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2776,7 +2780,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -2951,7 +2955,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3134,7 +3138,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3179,7 +3183,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3274,7 +3278,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3398,7 +3402,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4073,7 +4077,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4125,7 +4129,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4169,7 +4173,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4214,7 +4218,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -860,8 +860,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -1997,7 +1997,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2011,7 +2011,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2390,7 +2390,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2579,6 +2579,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2665,11 +2669,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2776,7 +2780,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -2951,7 +2955,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3134,7 +3138,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3179,7 +3183,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3274,7 +3278,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3398,7 +3402,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4073,7 +4077,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4125,7 +4129,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4169,7 +4173,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4214,7 +4218,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-02-26 08:16-0500\n"
+"POT-Creation-Date: 2020-03-06 14:23+0000\n"
 "PO-Revision-Date: 2018-09-11 19:15+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -863,8 +863,8 @@ msgstr ""
 #: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
 #: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
 #: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
-#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
-#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/project.go:384 lxc/project.go:475 lxc/project.go:530 lxc/project.go:590
+#: lxc/project.go:619 lxc/project.go:672 lxc/publish.go:35 lxc/query.go:31
 #: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
 #: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
@@ -1311,7 +1311,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:450
+#: lxc/project.go:455
 msgid "IMAGES"
 msgstr ""
 
@@ -1924,7 +1924,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
+#: lxc/project.go:499 lxc/project.go:557 lxc/project.go:643
 msgid "Missing project name"
 msgstr ""
 
@@ -2000,7 +2000,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
-#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
+#: lxc/project.go:454 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2014,7 +2014,7 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
-#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
+#: lxc/project.go:433 lxc/project.go:438 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2158,7 +2158,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:430 lxc/project.go:451
+#: lxc/list.go:430 lxc/project.go:456
 msgid "PROFILES"
 msgstr ""
 
@@ -2316,7 +2316,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:508
+#: lxc/project.go:514
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2393,7 +2393,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/project.go:699 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
 #: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2477,7 +2477,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:468 lxc/project.go:469
+#: lxc/project.go:474 lxc/project.go:475
 msgid "Rename projects"
 msgstr ""
 
@@ -2582,6 +2582,10 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
+#: lxc/project.go:457
+msgid "STORAGE VOLUMES"
+msgstr ""
+
 #: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
@@ -2668,11 +2672,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:529
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:524
+#: lxc/project.go:530
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2779,7 +2783,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:612 lxc/project.go:613
+#: lxc/project.go:618 lxc/project.go:619
 msgid "Show project options"
 msgstr ""
 
@@ -2954,7 +2958,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:665 lxc/project.go:666
+#: lxc/project.go:671 lxc/project.go:672
 msgid "Switch the current project"
 msgstr ""
 
@@ -3137,7 +3141,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:458 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3182,7 +3186,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:583 lxc/project.go:584
+#: lxc/project.go:589 lxc/project.go:590
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3277,7 +3281,7 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
-#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
+#: lxc/project.go:435 lxc/project.go:440 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3401,7 +3405,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:440
+#: lxc/project.go:445
 msgid "current"
 msgstr ""
 
@@ -4040,7 +4044,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:466
+#: lxc/project.go:472
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4076,7 +4080,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:528
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4128,7 +4132,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:611
+#: lxc/project.go:617
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4172,7 +4176,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4217,7 +4221,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:582
+#: lxc/project.go:588
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -130,7 +130,7 @@ _have lxc && {
       ipv6.dhcp.stateful ipv6.firewall ipv6.nat ipv6.nat.address ipv6.nat.order \
       ipv6.routes ipv6.routing raw.dnsmasq"
 
-    project_keys="features.images features.profiles"
+    project_keys="features.images features.profiles features.storage.volumes"
 
     storage_pool_keys="source size btrfs.mount_options ceph.cluster_name \
       ceph.osd.force_reuse ceph.osd.pg_num ceph.osd.pool_name ceph.osd.data_pool_name \

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -428,7 +428,7 @@ test_projects_storage() {
 
   lxc storage volume create "${pool}" vol
 
-  lxc project create foo
+  lxc project create foo -c features.storage.volumes=false
   lxc project switch foo
 
   lxc storage volume list "${pool}" | grep custom | grep -q vol
@@ -439,6 +439,22 @@ test_projects_storage() {
 
   ! lxc storage volume list "${pool}" | grep custom | grep -q vol || false
 
+  lxc project set foo features.storage.volumes=true
+  lxc storage volume create "${pool}" vol
+  lxc project switch foo
+  ! lxc storage volume list "${pool}" | grep custom | grep -q vol
+
+  lxc storage volume create "${pool}" vol
+  lxc storage volume delete "${pool}" vol
+
+  lxc storage volume create "${pool}" vol2
+  lxc project switch default
+  ! lxc storage volume list "${pool}" | grep custom | grep -q vol2
+
+  lxc project switch foo
+  lxc storage volume delete "${pool}" vol2
+
+  lxc project switch default
   lxc project delete foo
 }
 

--- a/test/suites/storage_volume_attach.sh
+++ b/test/suites/storage_volume_attach.sh
@@ -47,7 +47,7 @@ test_storage_volume_attach() {
 
   # Attach to a single privileged container
   lxc storage volume attach "lxdtest-$(basename "${LXD_DIR}")" testvolume c1 testvolume
-  PATH_TO_CHECK="${LXD_DIR}/storage-pools/lxdtest-$(basename "${LXD_DIR}")/custom/testvolume"
+  PATH_TO_CHECK="${LXD_DIR}/storage-pools/lxdtest-$(basename "${LXD_DIR}")/custom/default_testvolume"
   [ "$(stat -c %u:%g "${PATH_TO_CHECK}")" = "0:0" ]
 
   # make container unprivileged


### PR DESCRIPTION
Allows projects to have their own custom volumes (as previously all custom volumes were in the default project).

Introduces a new project feature flag: `features.storage.volumes` that defaults to `true` on new project that means that custom volumes created will be associated with the active project.

Existing projects will have the `features.storage.volumes` property set to `false` and so existing custom volumes will continue to be associated with the `default` project and visible in existing projects.

In order to avoid naming collisions with storage volumes across projects, this PR includes a storage patch that will *rename* all custom volumes in the `default` project on the storage devices to have the project prefix added.

Fixes https://github.com/lxc/lxd/issues/6171