### PR TITLE
Add go 1.14.x check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ go:
   - 1.11.x
   - 1.12.x
   - 1.13.x
+  - 1.14.x
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
relates to https://github.com/Homebrew/homebrew-core/pull/51206 (brew formula already shipped with go 1.14)