### PR TITLE
production-setup: add net.core.bpf_jit_limit and kernel.keys.m…

### DIFF
--- a/doc/production-setup.md
+++ b/doc/production-setup.md
@@ -34,16 +34,18 @@ root    | hard  | nofile  | 1048576   | unset     | maximum number of open files
 
 ### /etc/sysctl.conf
 
-Parameter                           | Value     | Default | Description
-:-----                              | :---      | :---    | :---
-fs.inotify.max\_queued\_events      | 1048576   | 16384   | This specifies an upper limit on the number of events that can be queued to the corresponding inotify instance. [1]
-fs.inotify.max\_user\_instances     | 1048576   | 128     | This specifies an upper limit on the number of inotify instances that can be created per real user ID. [1]
-fs.inotify.max\_user\_watches       | 1048576   | 8192    | This specifies an upper limit on the number of watches that can be created per real user ID. [1]
-vm.max\_map\_count                  | 262144    | 65530   | This file contains the maximum number of memory map areas a process may have. Memory map areas are used as a side-effect of calling malloc, directly by mmap and mprotect, and also when loading shared libraries.
-kernel.dmesg\_restrict              | 1         | 0       | This denies container access to the messages in the kernel ring buffer. Please note that this also will deny access to non-root users on the host system.
-net.ipv4.neigh.default.gc\_thresh3  | 8192      | 1024    | This is the maximum number of entries in ARP table (IPv4). You should increase this if you create over 1024 containers. Otherwise, you will get the error `neighbour: ndisc_cache: neighbor table overflow!` when the ARP table gets full and those containers will not be able to get a network configuration. [2]
-net.ipv6.neigh.default.gc\_thresh3  | 8192      | 1024    | This is the maximum number of entries in ARP table (IPv6). You should increase this if you plan to create over 1024 containers. Otherwise, you will get the error `neighbour: ndisc_cache: neighbor table overflow!` when the ARP table gets full and those containers will not be able to get a network configuration. [2]
-kernel.keys.maxkeys                 | 2000      | 200     | This is the maximum number of keys a non-root user can use, should be higher than the number of containers
+Parameter                           | Value      | Default   | Description
+:-----                              | :---       | :---      | :---
+fs.inotify.max\_queued\_events      | 1048576    | 16384     | This specifies an upper limit on the number of events that can be queued to the corresponding inotify instance. [1]
+fs.inotify.max\_user\_instances     | 1048576    | 128       | This specifies an upper limit on the number of inotify instances that can be created per real user ID. [1]
+fs.inotify.max\_user\_watches       | 1048576    | 8192      | This specifies an upper limit on the number of watches that can be created per real user ID. [1]
+vm.max\_map\_count                  | 262144     | 65530     | This file contains the maximum number of memory map areas a process may have. Memory map areas are used as a side-effect of calling malloc, directly by mmap and mprotect, and also when loading shared libraries.
+kernel.dmesg\_restrict              | 1          | 0         | This denies container access to the messages in the kernel ring buffer. Please note that this also will deny access to non-root users on the host system.
+net.ipv4.neigh.default.gc\_thresh3  | 8192       | 1024      | This is the maximum number of entries in ARP table (IPv4). You should increase this if you create over 1024 containers. Otherwise, you will get the error `neighbour: ndisc_cache: neighbor table overflow!` when the ARP table gets full and those containers will not be able to get a network configuration. [2]
+net.ipv6.neigh.default.gc\_thresh3  | 8192       | 1024      | This is the maximum number of entries in ARP table (IPv6). You should increase this if you plan to create over 1024 containers. Otherwise, you will get the error `neighbour: ndisc_cache: neighbor table overflow!` when the ARP table gets full and those containers will not be able to get a network configuration. [2]
+net.core.bpf_jit_limit              | 3000000000 | 264241152 | This is a limit on the size of eBPF JIT allocations which is usually set to PAGE_SIZE * 40000. When your kernel is compiled with `CONFIG_BPF_JIT_ALWAYS_ON=y` then `/proc/sys/net/core/bpf_jit_enable` is set to `1` and can't be changed. On such kernels the eBPF JIT compiler will treat failure to JIT compile a bpf program such as a `seccomp` filter as fatal when it would continue on another kernel. On such kernels the limit for eBPF jitted programs needs to be increased siginficantly.
+kernel.keys.maxkeys                 | 2000       | 200       | This is the maximum number of keys a non-root user can use, should be higher than the number of containers
+kernel.keys.maxbytes                | 2000000    | 20000     | This is the maximum size of the keyring non-root users can use
 
 Then, reboot the server.
 


### PR DESCRIPTION
…axbytes

/* kernel.keys.maxbytes */
When all containers share the same id mapping they will share a keyring. But
since each container will get their own session key it will be appended to the
keyring which will thus grow quite large. Thus the limit needs to be bumped.

/* net.core.bpf_jit_limit */
This is a limit on the size of eBPF JIT allocations which is usually set to PAGE_SIZE * 40000. When your kernel is compiled with `CONFIG_BPF_JIT_ALWAYS_ON=y` then `/proc/sys/net/core/bpf_jit_enable` is set to `1` and can't be changed. On such kernels the eBPF JIT compiler will treat failure to JIT compile a bpf program such as a `seccomp` filter as fatal when it would continue on another kernel. On such kernels the limit for eBPF jitted programs needs to be increased siginficantly.

Cc: Tobias Schüring <tobias@raidboxes.de>
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>