### PR TITLE
NIC Routed: Adds support for multiple interfaces

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -942,3 +942,10 @@ hugetlb cgroup. This means the hugetlb cgroup needs to be available. Note, that
 limiting hugepages is recommended when intercepting the mount syscall for the
 hugetlbfs filesystem to avoid allowing the container to exhaust the host's
 hugepages resources.
+
+## container\_nic\_routed\_gateway
+This introduces the `ipv4.gateway` and `ipv6.gateway` NIC config keys that can take a value of either "auto" or
+"none". The default value for the key if unspecified is "auto". This will cause the current behaviour of a default
+gateway being added inside the container and the same gateway address being added to the host-side interface.
+If the value is set to "none" then no default gateway nor will the address be added to the host-side interface.
+This allows multiple routed NIC devices to be added to a container.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -466,7 +466,9 @@ host\_name              | string    | randomly assigned | no        | The name o
 mtu                     | integer   | parent MTU        | no        | The MTU of the new interface
 hwaddr                  | string    | randomly assigned | no        | The MAC address of the new interface
 ipv4.address            | string    | -                 | no        | Comma delimited list of IPv4 static addresses to add to the instance
+ipv4.gateway            | string    | auto              | no        | Whether to add an automatic default IPv4 gateway, can be "auto" or "none"
 ipv6.address            | string    | -                 | no        | Comma delimited list of IPv6 static addresses to add to the instance
+ipv6.gateway            | string    | auto              | no        | Whether to add an automatic default IPv6 gateway, can be "auto" or "none"
 vlan                    | integer   | -                 | no        | The VLAN ID to attach to
 
 #### bridged, macvlan or ipvlan for connection to physical network

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -462,6 +462,7 @@ Key                     | Type      | Default           | Required  | Descriptio
 :--                     | :--       | :--               | :--       | :--
 parent                  | string    | -                 | no        | The name of the host device to join the instance to
 name                    | string    | kernel assigned   | no        | The name of the interface inside the instance
+host\_name              | string    | randomly assigned | no        | The name of the interface inside the host
 mtu                     | integer   | parent MTU        | no        | The MTU of the new interface
 hwaddr                  | string    | randomly assigned | no        | The MAC address of the new interface
 ipv4.address            | string    | -                 | no        | Comma delimited list of IPv4 static addresses to add to the instance

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -683,6 +683,15 @@ func NetworkValidNetworkV6List(value string) error {
 	return nil
 }
 
+// NetworkValidGateway validates the gateway value.
+func NetworkValidGateway(value string) error {
+	if shared.StringInSlice(value, []string{"none", "auto"}) {
+		return nil
+	}
+
+	return fmt.Errorf("Invalid gateway: %s", value)
+}
+
 // networkParsePortRange validates a port range in the form n-n.
 func networkParsePortRange(r string) (int64, int64, error) {
 	entries := strings.Split(r, "-")

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -49,6 +49,8 @@ func nicValidationRules(requiredFields []string, optionalFields []string) map[st
 		"ipv4.routes":             NetworkValidNetworkV4List,
 		"ipv6.routes":             NetworkValidNetworkV6List,
 		"boot.priority":           shared.IsUint32,
+		"ipv4.gateway":            NetworkValidGateway,
+		"ipv6.gateway":            NetworkValidGateway,
 	}
 
 	validators := map[string]func(value string) error{}
@@ -93,4 +95,14 @@ func nicValidationRules(requiredFields []string, optionalFields []string) map[st
 	}
 
 	return validators
+}
+
+// nicHasAutoGateway takes the value of the "ipv4.gateway" or "ipv6.gateway" config keys and returns whether they
+// specify whether the gateway mode is automatic or not
+func nicHasAutoGateway(value string) bool {
+	if value == "" || value == "auto" {
+		return true
+	}
+
+	return false
 }

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -192,6 +192,7 @@ var APIExtensions = []string{
 	"projects_limits",
 	"container_syscall_intercept_hugetlbfs",
 	"limits_hugepages",
+	"container_nic_routed_gateway",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Adds support for multiple interfaces by allowing the disabling of the automatic default gateway being added using the NIC config keys `ipv4.gateway=none` and `ipv6.gateway=none` respectively.

 Fixes https://github.com/lxc/lxd/issues/6965