### PR TITLE
Util: Fixes go vet conversion from int64 to string yields a string of one rune error

### DIFF
--- a/lxd/util/fs.go
+++ b/lxd/util/fs.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"fmt"
+
 	"golang.org/x/sys/unix"
 
 	"github.com/lxc/lxd/shared/logger"
@@ -39,6 +41,6 @@ func FilesystemDetect(path string) (string, error) {
 		return "nfs", nil
 	default:
 		logger.Debugf("Unknown backing filesystem type: 0x%x", fs.Type)
-		return string(fs.Type), nil
+		return fmt.Sprintf("0x%x", fs.Type), nil
 	}
 }


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>