### PR TITLE
VM: Fixes exec read loop when agent not started

### DIFF
--- a/lxd-agent/exec.go
+++ b/lxd-agent/exec.go
@@ -253,7 +253,7 @@ func (s *execWs) Do(op *operations.Operation) error {
 
 	controlExit := make(chan bool, 1)
 	attachedChildIsBorn := make(chan int)
-	attachedChildIsDead := make(chan bool, 1)
+	attachedChildIsDead := make(chan struct{})
 	var wgEOF sync.WaitGroup
 
 	if s.interactive {
@@ -400,7 +400,7 @@ func (s *execWs) Do(op *operations.Operation) error {
 			conn.Close()
 		}
 
-		attachedChildIsDead <- true
+		close(attachedChildIsDead)
 
 		wgEOF.Wait()
 

--- a/shared/netutils/network_linux.go
+++ b/shared/netutils/network_linux.go
@@ -173,7 +173,7 @@ func NetnsGetifaddrs(initPID int32) (map[string]api.InstanceStateNetwork, error)
 }
 
 // WebsocketExecMirror mirrors a websocket connection with a set of Writer/Reader.
-func WebsocketExecMirror(conn *websocket.Conn, w io.WriteCloser, r io.ReadCloser, exited chan bool, fd int) (chan bool, chan bool) {
+func WebsocketExecMirror(conn *websocket.Conn, w io.WriteCloser, r io.ReadCloser, exited chan struct{}, fd int) (chan bool, chan bool) {
 	readDone := make(chan bool, 1)
 	writeDone := make(chan bool, 1)
 

--- a/shared/network.go
+++ b/shared/network.go
@@ -211,7 +211,7 @@ func WebsocketRecvStream(w io.Writer, conn *websocket.Conn) chan bool {
 			}
 
 			if err != nil {
-				logger.Debugf("Got error getting next reader %s, %s", err, w)
+				logger.Debugf("Got error getting next reader %s", err)
 				break
 			}
 

--- a/shared/util_linux_cgo.go
+++ b/shared/util_linux_cgo.go
@@ -289,7 +289,7 @@ again:
 // Extensively commented directly in the code. Please leave the comments!
 // Looking at this in a couple of months noone will know why and how this works
 // anymore.
-func ExecReaderToChannel(r io.Reader, bufferSize int, exited <-chan bool, fd int) <-chan []byte {
+func ExecReaderToChannel(r io.Reader, bufferSize int, exited <-chan struct{}, fd int) <-chan []byte {
 	if bufferSize <= (128 * 1024) {
 		bufferSize = (128 * 1024)
 	}


### PR DESCRIPTION
The websocket read go routines were being started before the instance.Exec process was confirmed to have started.

This was leaking go routines and leaving websocket readers running on closed connections which could result in infinite loops in the websocket reader functions.

Changes made:

1. Re-orders the code so that the websocket mirroring go routines are not started until the process being execed has started.
2. Changes any channels that were used for coodination only (i.e not actually sending any data) from bool to struct{} to indicate that the value has no meaning, and instead using close(ch) to indicate whatever coodination point was needed. This has the added benefit of not needing to use a buffered channel, as channels can be closed with no readers without blocking.
3. Properly uses the finisher() function for returning from the Do() function so that sockets and channels are closed.
4. Improves logging with instance name context.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>