### PR TITLE
lxd/instance: Fix expiry check

### DIFF
--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -883,7 +883,9 @@ func pruneExpiredContainerSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 			}
 
 			for _, snapshot := range snapshots {
-				if snapshot.ExpiryDate().IsZero() {
+				// Since zero time causes some issues due to timezones, we check the
+				// unix timestamp instead of IsZero().
+				if snapshot.ExpiryDate().Unix() <= 0 {
 					// Snapshot doesn't expire
 					continue
 				}


### PR DESCRIPTION
This fixes the expiry check for instances. Like with backups, it checks
the unix timestamp instead of `IsZero()` as zero time has caused issues
in the past due to timezones.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>