### PR TITLE
db/cluster: Bump the value of sqlite_sequence for storage_volumes

### DIFF
--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -552,5 +552,5 @@ CREATE TABLE storage_volumes_snapshots_config (
     UNIQUE (storage_volume_snapshot_id, key)
 );
 
-INSERT INTO schema (version, updated_at) VALUES (26, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (27, strftime("%s"))
 `

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -63,6 +63,18 @@ var updates = map[int]schema.Update{
 	24: updateFromV23,
 	25: updateFromV24,
 	26: updateFromV25,
+	27: updateFromV26,
+}
+
+// Bump the sqlite_sequence value for storage volumes, to avoid unique
+// constraint violations when inserting new snapshots.
+func updateFromV26(tx *sql.Tx) error {
+	ids, err := query.SelectIntegers(tx, "SELECT coalesce(max(id), 0) FROM storage_volumes_all")
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec("UPDATE sqlite_sequence SET seq = ? WHERE name = 'storage_volumes'", ids[0])
+	return err
 }
 
 // Create new storage snapshot tables and migrate data to them.


### PR DESCRIPTION
Fixes #7024

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>