### PR TITLE
VM: Backup

### DIFF
--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -38,10 +38,6 @@ func backupCreate(s *state.State, args db.InstanceBackupArgs, sourceInst instanc
 	logger.Debug("Instance backup started")
 	defer logger.Debug("Instance backup finished")
 
-	if sourceInst.Type() != instancetype.Container {
-		return fmt.Errorf("Instance type must be container")
-	}
-
 	revert := revert.New()
 	defer revert.Fail()
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3037,8 +3037,13 @@ func (b *lxdBackend) CheckInstanceBackupFileSnapshots(backupConf *backup.Instanc
 	// Get the volume name on storage.
 	volStorageName := project.Instance(projectName, backupConf.Container.Name)
 
+	contentType := drivers.ContentTypeFS
+	if volType == drivers.VolumeTypeVM {
+		contentType = drivers.ContentTypeBlock
+	}
+
 	// We don't need to use the volume's config for mounting so set to nil.
-	vol := b.newVolume(volType, drivers.ContentTypeFS, volStorageName, nil)
+	vol := b.newVolume(volType, contentType, volStorageName, nil)
 
 	// Get a list of snapshots that exist on storage device.
 	driverSnapshots, err := vol.Snapshots(op)
@@ -3078,7 +3083,7 @@ func (b *lxdBackend) CheckInstanceBackupFileSnapshots(backupConf *backup.Instanc
 			return nil, errors.Wrapf(err, "Failed to delete snapshot %q", driverSnapOnly)
 		}
 
-		logger.Debug("Deleted snapshot as not present in backup config", log.Ctx{"snapshot": driverSnapOnly})
+		logger.Warn("Deleted snapshot as not present in backup config", log.Ctx{"snapshot": driverSnapOnly})
 	}
 
 	// Check the snapshots in backup config exist on storage device.
@@ -3100,7 +3105,7 @@ func (b *lxdBackend) CheckInstanceBackupFileSnapshots(backupConf *backup.Instanc
 				return nil, errors.Wrapf(ErrBackupSnapshotsMismatch, "Snapshot %q exists in backup config but not on storage device", backupFileSnapOnly)
 			}
 
-			logger.Debug("Skipped snapshot in backup config as not present on storage device", log.Ctx{"snapshot": backupFileSnap})
+			logger.Warn("Skipped snapshot in backup config as not present on storage device", log.Ctx{"snapshot": backupFileSnap})
 			continue // Skip snapshots missing on storage device.
 		}
 

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -649,7 +649,7 @@ func (d *btrfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWr
 		defer os.Remove(tmpFile.Name())
 
 		// Write the subvolume to the file.
-		d.logger.Debug("Generating optimized volume file", log.Ctx{"sourcePath": path, "file": tmpFile.Name()})
+		d.logger.Debug("Generating optimized volume file", log.Ctx{"sourcePath": path, "file": tmpFile.Name(), "name": fileName})
 		err = shared.RunCommandWithFds(nil, tmpFile, "btrfs", args...)
 		if err != nil {
 			return err
@@ -690,9 +690,17 @@ func (d *btrfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWr
 			cur := GetVolumeMountPath(d.name, vol.volType, fullSnapshotName)
 
 			// Make a binary btrfs backup.
-			name := fmt.Sprintf("backup/snapshots/%s.bin", snap)
+			prefix := "snapshots"
+			fileName := fmt.Sprintf("%s.bin", snap)
+			if vol.volType == VolumeTypeVM {
+				prefix = "virtual-machine-snapshots"
+				if vol.contentType == ContentTypeFS {
+					fileName = fmt.Sprintf("%s-config.bin", snap)
+				}
+			}
 
-			err := sendToFile(cur, parent, name)
+			target := fmt.Sprintf("backup/%s/%s", prefix, fileName)
+			err := sendToFile(cur, parent, target)
 			if err != nil {
 				return err
 			}
@@ -725,7 +733,17 @@ func (d *btrfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWr
 	defer d.deleteSubvolume(targetVolume, true)
 
 	// Dump the container to a file.
-	err = sendToFile(targetVolume, finalParent, "backup/container.bin")
+	fileName := "container.bin"
+	if vol.volType == VolumeTypeVM {
+		if vol.contentType == ContentTypeFS {
+			fileName = "virtual-machine-config.bin"
+		} else {
+			fileName = "virtual-machine.bin"
+		}
+	}
+
+	// Dump the container to a file.
+	err = sendToFile(targetVolume, finalParent, fmt.Sprintf("backup/%s", fileName))
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -105,6 +105,10 @@ func (d *btrfs) CreateVolumeFromBackup(vol Volume, snapshots []string, srcData i
 		return genericVFSBackupUnpack(d, vol, snapshots, srcData, op)
 	}
 
+	if d.HasVolume(vol) {
+		return nil, nil, fmt.Errorf("Cannot restore volume, already exists on target")
+	}
+
 	revert := revert.New()
 	defer revert.Fail()
 

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -649,7 +649,7 @@ func (d *btrfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWr
 		defer os.Remove(tmpFile.Name())
 
 		// Write the subvolume to the file.
-		d.logger.Debug("Generating optimized volume file", log.Ctx{"src": path, "file": tmpFile.Name()})
+		d.logger.Debug("Generating optimized volume file", log.Ctx{"sourcePath": path, "file": tmpFile.Name()})
 		err = shared.RunCommandWithFds(nil, tmpFile, "btrfs", args...)
 		if err != nil {
 			return err

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -912,7 +912,7 @@ func (d *zfs) MountVolume(vol Volume, op *operations.Operation) (bool, error) {
 	mountPath := vol.MountPath()
 	dataset := d.dataset(vol, false)
 
-	// Check if already mounted.
+	// Check if filesystem volume already mounted.
 	if vol.contentType == ContentTypeFS && !shared.IsMountPoint(mountPath) {
 		// Mount the dataset.
 		_, err = shared.RunCommand("zfs", "mount", dataset)
@@ -926,6 +926,7 @@ func (d *zfs) MountVolume(vol Volume, op *operations.Operation) (bool, error) {
 
 	var ourMountBlock, ourMountFs bool
 
+	// For block devices, we make them appear.
 	if vol.contentType == ContentTypeBlock {
 		// Check if already active.
 		current, err := d.getDatasetProperty(d.dataset(vol, false), "volmode")
@@ -948,7 +949,6 @@ func (d *zfs) MountVolume(vol Volume, op *operations.Operation) (bool, error) {
 		}
 	}
 
-	// For block devices, we make them appear.
 	if vol.IsVMBlock() {
 		// For VMs, also mount the filesystem dataset.
 		fsVol := vol.NewVMBlockFilesystemVolume()

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -204,6 +204,10 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, snapshots []string, srcData io.
 		return genericVFSBackupUnpack(d, vol, snapshots, srcData, op)
 	}
 
+	if d.HasVolume(vol) {
+		return nil, nil, fmt.Errorf("Cannot restore volume, already exists on target")
+	}
+
 	// Restore VM config volumes first.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1174,7 +1174,7 @@ func (d *zfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWrit
 		defer os.Remove(tmpFile.Name())
 
 		// Write the subvolume to the file.
-		d.logger.Debug("Generating optimized volume file", log.Ctx{"src": path, "file": tmpFile.Name()})
+		d.logger.Debug("Generating optimized volume file", log.Ctx{"sourcePath": path, "file": tmpFile.Name()})
 
 		// Write the subvolume to the file.
 		err = shared.RunCommandWithFds(nil, tmpFile, "zfs", args...)


### PR DESCRIPTION
Adds support for virtual machine backups:

- [x] Generic backup create (streams block devices/image files into tarball).
- [x] Optimised backup create (creates temporary files of binary volume dumps and adds them to tarball).
- [x] Generic backup restore
- [x] Optimised backup restore

**Generic tarball output:**

Stores primary volume as a `backup/virtual-machine.img` and the associated config file system volume in `backup/virtual-machine/` directory.

Similarly, snapshots volumes are stored as `backup/virtual-machine-snapshots/<snapName>.img` and its associated config file system volume in `backup/virtual-machine-snapshots/<snapName>/` directory.

**Optimised tarball output:**

For optimised output, the primary volume will store the storage driver specific volume dump file as `backup/virtual-machine.bin` and, for ZFS only, the associated config file system volume in `backup/virtual-machine-config.bin`.

Similarly, snapshots volume dump files are stored as `backup/virtual-machine-snapshots/<snapName>.bin` and, for ZFs only, its associated config file system volume in `backup/virtual-machine-snapshots/<snapName>-config.bin` directory.