### PR TITLE
DB: Tweaks LEFT JOIN to just JOIN in NodeIsEmpty()

### DIFF
--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -508,7 +508,7 @@ SELECT fingerprint, node_id FROM images JOIN images_nodes ON images.id=images_no
 
 	// Check if the node has any custom volumes.
 	volumes, err := query.SelectStrings(
-		c.tx, "SELECT storage_volumes.name FROM storage_volumes LEFT JOIN storage_pools ON storage_volumes.storage_pool_id=storage_pools.id WHERE storage_volumes.node_id=? AND storage_volumes.type=? AND storage_pools.driver NOT IN ('ceph', 'cephfs')",
+		c.tx, "SELECT storage_volumes.name FROM storage_volumes JOIN storage_pools ON storage_volumes.storage_pool_id=storage_pools.id WHERE storage_volumes.node_id=? AND storage_volumes.type=? AND storage_pools.driver NOT IN ('ceph', 'cephfs')",
 		id, StoragePoolVolumeTypeCustom)
 	if err != nil {
 		return "", errors.Wrapf(err, "Failed to get custom volumes for node %d", id)


### PR DESCRIPTION
So that NULL handling isn't needed.

As discussed in https://github.com/lxc/lxd/pull/7049

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>

