### PR TITLE
lxd/sys: Don't fail chmod on unresolvable symlinks

### DIFF
--- a/lxd/sys/fs.go
+++ b/lxd/sys/fs.go
@@ -70,7 +70,7 @@ func (s *OS) initDirs() error {
 			}
 
 			err = os.Chmod(dir.path, dir.mode)
-			if err != nil {
+			if err != nil && !os.IsNotExist(err) {
 				return errors.Wrapf(err, "Failed to chmod dir %s", dir.path)
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>