### PR TITLE
lxd/etag: Quote generated etag values

### DIFF
--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -74,7 +74,7 @@ func (r *syncResponse) Render(w http.ResponseWriter) error {
 	if r.etag != nil {
 		etag, err := util.EtagHash(r.etag)
 		if err == nil {
-			w.Header().Set("ETag", etag)
+			w.Header().Set("ETag", fmt.Sprintf("\"%s\"", etag))
 		}
 	}
 

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -64,6 +64,8 @@ func EtagCheck(r *http.Request, data interface{}) error {
 		return nil
 	}
 
+	match = strings.Trim(match, "\"")
+
 	hash, err := EtagHash(data)
 	if err != nil {
 		return err


### PR DESCRIPTION
And accept both quoted and unquoted values in If-Match.

Closes #7068

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>