### PR TITLE
lxd/storage/drivers/btrfs: Fix quota

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -194,7 +194,7 @@ func (d *btrfs) deleteSubvolume(path string, recursion bool) error {
 
 func (d *btrfs) getQGroup(path string) (string, int64, error) {
 	// Try to get the qgroup details.
-	output, err := shared.RunCommand("btrfs", "qgroup", "show", "-e", "-f", path)
+	output, err := shared.RunCommand("btrfs", "qgroup", "show", "-e", "-f", "--raw", path)
 	if err != nil {
 		return "", -1, errBtrfsNoQuota
 	}


### PR DESCRIPTION
This adds the `--raw` flags to `btrfs qgroup show`. The flag is needed
as the sizes in the output are listed with suffixes (KiB, MiB, etc.).
Since `ParseInt` cannot deal with that, it fails and returns -1. Adding
the `--raw` flag removes all suffixes, and returns the correct usage.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>