### PR TITLE
Backup: Adds OptimizedStorage and Type fields to index.yaml

### DIFF
--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -177,11 +177,10 @@ func backupCreate(s *state.State, args db.InstanceBackupArgs, sourceInst instanc
 // backupWriteIndex generates an index.yaml file and then writes it to the root of the backup tarball.
 func backupWriteIndex(sourceInst instance.Instance, pool storagePools.Pool, instanceOnly bool, indexFile string, tarWriter *instancewriter.InstanceTarWriter) error {
 	indexInfo := backup.Info{
-		Name:       sourceInst.Name(),
-		Privileged: sourceInst.IsPrivileged(),
-		Pool:       pool.Name(),
-		Snapshots:  []string{},
-		Backend:    pool.Driver().Info().Name,
+		Name:      sourceInst.Name(),
+		Pool:      pool.Name(),
+		Snapshots: []string{},
+		Backend:   pool.Driver().Info().Name,
 	}
 
 	if !instanceOnly {

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -25,6 +25,7 @@ import (
 	storagePools "github.com/lxc/lxd/lxd/storage"
 	"github.com/lxc/lxd/lxd/task"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/idmap"
 	"github.com/lxc/lxd/shared/instancewriter"
 	log "github.com/lxc/lxd/shared/log15"
@@ -143,7 +144,7 @@ func backupCreate(s *state.State, args db.InstanceBackupArgs, sourceInst instanc
 	// Write index file.
 	indexFile := filepath.Join(tmpDirPath, "index.yaml")
 	logger.Debug("Adding backup index file", log.Ctx{"path": indexFile})
-	err = backupWriteIndex(sourceInst, pool, b.InstanceOnly(), indexFile, tarWriter)
+	err = backupWriteIndex(sourceInst, pool, b.OptimizedStorage(), !b.InstanceOnly(), indexFile, tarWriter)
 	if err != nil {
 		return errors.Wrapf(err, "Error writing backup index file")
 	}
@@ -175,15 +176,17 @@ func backupCreate(s *state.State, args db.InstanceBackupArgs, sourceInst instanc
 }
 
 // backupWriteIndex generates an index.yaml file and then writes it to the root of the backup tarball.
-func backupWriteIndex(sourceInst instance.Instance, pool storagePools.Pool, instanceOnly bool, indexFile string, tarWriter *instancewriter.InstanceTarWriter) error {
+func backupWriteIndex(sourceInst instance.Instance, pool storagePools.Pool, optimized bool, snapshots bool, indexFile string, tarWriter *instancewriter.InstanceTarWriter) error {
 	indexInfo := backup.Info{
-		Name:      sourceInst.Name(),
-		Pool:      pool.Name(),
-		Snapshots: []string{},
-		Backend:   pool.Driver().Info().Name,
+		Name:             sourceInst.Name(),
+		Pool:             pool.Name(),
+		Snapshots:        []string{},
+		Backend:          pool.Driver().Info().Name,
+		Type:             api.InstanceType(sourceInst.Type().String()),
+		OptimizedStorage: &optimized,
 	}
 
-	if !instanceOnly {
+	if snapshots {
 		snaps, err := sourceInst.Snapshots()
 		if err != nil {
 			return err

--- a/lxd/backup/backup.go
+++ b/lxd/backup/backup.go
@@ -29,7 +29,6 @@ type Info struct {
 	Project          string   `json:"project" yaml:"project"`
 	Name             string   `json:"name" yaml:"name"`
 	Backend          string   `json:"backend" yaml:"backend"`
-	Privileged       bool     `json:"privileged" yaml:"privileged"`
 	Pool             string   `json:"pool" yaml:"pool"`
 	Snapshots        []string `json:"snapshots,omitempty" yaml:"snapshots,omitempty"`
 	OptimizedStorage bool     `json:"-" yaml:"-"`

--- a/lxd/backup/backup.go
+++ b/lxd/backup/backup.go
@@ -27,7 +27,7 @@ type Instance interface {
 
 // Info represents exported backup information.
 type Info struct {
-	Project          string           `json:"project" yaml:"project"`
+	Project          string           `json:"-" yaml:"-"` // Project is set during import based on current project.
 	Name             string           `json:"name" yaml:"name"`
 	Backend          string           `json:"backend" yaml:"backend"`
 	Pool             string           `json:"pool" yaml:"pool"`

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -604,7 +604,7 @@ func createFromBackup(d *Daemon, project string, data io.Reader, pool string) re
 		// The storage pool doesn't exist. If backup is in binary format (so we cannot alter
 		// the backup.yaml) or the pool has been specified directly from the user restoring
 		// the backup then we cannot proceed so return an error.
-		if bInfo.OptimizedStorage || pool != "" {
+		if *bInfo.OptimizedStorage || pool != "" {
 			return response.InternalError(errors.Wrap(err, "Storage pool not found"))
 		}
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -476,7 +476,7 @@ func (b *lxdBackend) CreateInstance(inst instance.Instance, op *operations.Opera
 // created in the database to run any storage layer finalisations, and a revert hook that can be
 // run if the instance database load process fails that will remove anything created thus far.
 func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(instance.Instance) error, func(), error) {
-	logger := logging.AddContext(b.logger, log.Ctx{"project": srcBackup.Project, "instance": srcBackup.Name, "snapshots": srcBackup.Snapshots, "optimizedStorage": srcBackup.OptimizedStorage})
+	logger := logging.AddContext(b.logger, log.Ctx{"project": srcBackup.Project, "instance": srcBackup.Name, "snapshots": srcBackup.Snapshots, "optimizedStorage": *srcBackup.OptimizedStorage})
 	logger.Debug("CreateInstanceFromBackup started")
 	defer logger.Debug("CreateInstanceFromBackup finished")
 
@@ -492,7 +492,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 	defer revert.Fail()
 
 	// Unpack the backup into the new storage volume(s).
-	volPostHook, revertHook, err := b.driver.CreateVolumeFromBackup(vol, srcBackup.Snapshots, srcData, srcBackup.OptimizedStorage, op)
+	volPostHook, revertHook, err := b.driver.CreateVolumeFromBackup(vol, srcBackup.Snapshots, srcData, *srcBackup.OptimizedStorage, op)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
 Changes instanceOnly arg to snapshots.
 Removes `privileged` field.
 Adds `optimized` field to indicate if optimized backup format is used.
 Adds `type` field to indicate the instance type being backed up.