### PR TITLE
lxd/storage/drivers/btrfs: Don't destroy qgroups

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -507,7 +507,7 @@ func (d *btrfs) SetVolumeQuota(vol Volume, size string, op *operations.Operation
 		}
 	} else if qgroup != "" {
 		// Remove the limit.
-		_, err := shared.RunCommand("btrfs", "qgroup", "destroy", qgroup, volPath)
+		_, err := shared.RunCommand("btrfs", "qgroup", "limit", "none", qgroup, volPath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When deleting a qgroup, it's not possible to get the usage of an
instance or volume anymore. Therefore, instead of deleting the qgroup,
we just don't set a limit.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>