### PR TITLE
lxd/instance/drivers: Fix lxd-agent running order

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1271,7 +1271,7 @@ Documentation=https://linuxcontainers.org/lxd
 ConditionPathExists=/dev/virtio-ports/org.linuxcontainers.lxd
 Requires=lxd-agent-9p.service
 After=lxd-agent-9p.service
-Before=cloud-init.target
+Before=cloud-init.target cloud-init.service cloud-init-local.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
This ensures that the lxd-agent is started before cloud-init.service and
cloud-init-local.service.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>