### PR TITLE
NIC Routed: Host addresses for multiple NIC support

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -975,3 +975,18 @@ This adds a new `size` field to the output of `/1.0/instances/<name>/snapshots/<
 
 ## clustering\_edit\_roles
 This adds a writable endpoint for cluster members, allowing the editing of their roles.
+
+## container\_nic\_routed\_host\_address
+This introduces the `ipv4.host_address` and `ipv6.host_address` NIC config keys that can be used to control the
+host-side veth interface's IP addresses. This can be useful when using multiple routed NICs at the same time and
+needing a predictable next-hop address to use.
+
+This also alters the behaviour of `ipv4.gateway` and `ipv6.gateway` NIC config keys. When they are set to "auto"
+the container will have its default gateway set to the value of `ipv4.host_address` or `ipv6.host_address` respectively.
+
+The default values are:
+
+`ipv4.host_address`: 169.254.0.1
+`ipv6.host_address`: fe80::1
+
+This is backward compatible with the previous default behaviour.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -456,6 +456,10 @@ net.ipv6.conf.all.proxy_ndp=1
 net.ipv6.conf.<parent>.proxy_ndp=1
 ```
 
+Each NIC device can have multiple IP addresses added to them. However it may be desirable to utilise multiple `routed` NIC interfaces.
+In these cases one should set the `ipv4.gateway` and `ipv6.gateway` values to "none" on any subsequent interfaces to avoid default gateway conflicts.
+It may also be useful to specify a different host-side address for these subsequent interfaces using `ipv4.host_address` and `ipv6.host_address` respectively.
+
 Device configuration properties:
 
 Key                     | Type      | Default           | Required  | Description
@@ -467,8 +471,10 @@ mtu                     | integer   | parent MTU        | no        | The MTU of
 hwaddr                  | string    | randomly assigned | no        | The MAC address of the new interface
 ipv4.address            | string    | -                 | no        | Comma delimited list of IPv4 static addresses to add to the instance
 ipv4.gateway            | string    | auto              | no        | Whether to add an automatic default IPv4 gateway, can be "auto" or "none"
+ipv4.host_address       | string    | 169.254.0.1       | no        | The IPv4 address to add to the host-side veth interface.
 ipv6.address            | string    | -                 | no        | Comma delimited list of IPv6 static addresses to add to the instance
 ipv6.gateway            | string    | auto              | no        | Whether to add an automatic default IPv6 gateway, can be "auto" or "none"
+ipv6.host_address       | string    | fe80::1           | no        | The IPv6 address to add to the host-side veth interface.
 vlan                    | integer   | -                 | no        | The VLAN ID to attach to
 
 #### bridged, macvlan or ipvlan for connection to physical network

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -51,6 +51,8 @@ func nicValidationRules(requiredFields []string, optionalFields []string) map[st
 		"boot.priority":           shared.IsUint32,
 		"ipv4.gateway":            NetworkValidGateway,
 		"ipv6.gateway":            NetworkValidGateway,
+		"ipv4.host_address":       NetworkValidAddressV4,
+		"ipv6.host_address":       NetworkValidAddressV6,
 	}
 
 	validators := map[string]func(value string) error{}

--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -115,8 +115,9 @@ _have lxc && {
 
     device_keys="limits.ingress limits.egress ipv4.routes ipv6.routes parent \
       name mtu hwaddr vlan maas.subnet.ipv4 maas.subnet.ipv6 nictype \
-      host_name limits.max ipv4.address ipv6.address security.mac_filtering \
-      security.ipv4_filtering security.ipv6_filtering vlan limits.read \
+      host_name limits.max \
+      ipv4.address ipv6.address ipv4.host_address ipv6.host_address ipv4.gateway ipv6.gateway \
+      security.mac_filtering security.ipv4_filtering security.ipv6_filtering vlan limits.read \
       limits.write path source optional readonly size recursive pool \
       propagation shift major minor uid gid mode required vendorid productid \
       pci id listen connect bind nat proxy_protocol security.uid security.gid \

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -199,6 +199,7 @@ var APIExtensions = []string{
 	"trust_ca_certificates",
 	"snapshot_disk_usage",
 	"clustering_edit_roles",
+	"container_nic_routed_host_address",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This introduces the `ipv4.host_address` and `ipv6.host_address` NIC config keys that can be used to control the host-side veth interface's IP addresses. This can be useful when using multiple routed NICs at the same time and needing a predictable next-hop address to use.

This also alters the behaviour of `ipv4.gateway` and `ipv6.gateway` NIC config keys. When they are set to "auto" the container will have its default gateway set to the value of `ipv4.host_address` or `ipv6.host_address` respectively.

The default values are:

`ipv4.host_address`: 169.254.0.1
`ipv6.host_address`: fe80::1

This is backward compatible with the previous default behaviour.