### PR TITLE
NIC IPVlan: Adds support for multiple NIC devices

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -990,3 +990,10 @@ The default values are:
 `ipv6.host_address`: fe80::1
 
 This is backward compatible with the previous default behaviour.
+
+## container\_nic\_ipvlan\_gateway
+This introduces the `ipv4.gateway` and `ipv6.gateway` NIC config keys that can take a value of either "auto" or
+"none". The default value for the key if unspecified is "auto". This will cause the current behaviour of a default
+gateway being added inside the container and the same gateway address being added to the host-side interface.
+If the value is set to "none" then no default gateway nor will the address be added to the host-side interface.
+This allows multiple ipvlan NIC devices to be added to a container.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -370,7 +370,9 @@ name                    | string    | kernel assigned   | no        | The name o
 mtu                     | integer   | parent MTU        | no        | The MTU of the new interface
 hwaddr                  | string    | randomly assigned | no        | The MAC address of the new interface
 ipv4.address            | string    | -                 | no        | Comma delimited list of IPv4 static addresses to add to the instance
+ipv4.gateway            | string    | auto              | no        | Whether to add an automatic default IPv4 gateway, can be "auto" or "none"
 ipv6.address            | string    | -                 | no        | Comma delimited list of IPv6 static addresses to add to the instance
+ipv6.gateway            | string    | auto              | no        | Whether to add an automatic default IPv6 gateway, can be "auto" or "none"
 vlan                    | integer   | -                 | no        | The VLAN ID to attach to
 
 #### nictype: p2p

--- a/lxd/device/nic_ipvlan.go
+++ b/lxd/device/nic_ipvlan.go
@@ -32,6 +32,8 @@ func (d *nicIPVLAN) validateConfig(instConf instance.ConfigReader) error {
 		"mtu",
 		"hwaddr",
 		"vlan",
+		"ipv4.gateway",
+		"ipv6.gateway",
 	}
 
 	rules := nicValidationRules(requiredFields, optionalFields)
@@ -167,7 +169,9 @@ func (d *nicIPVLAN) Start() (*deviceConfig.RunConfig, error) {
 			nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv4.address", Value: fmt.Sprintf("%s/32", addr)})
 		}
 
-		nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv4.gateway", Value: "dev"})
+		if nicHasAutoGateway(d.config["ipv4.gateway"]) {
+			nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv4.gateway", Value: "dev"})
+		}
 	}
 
 	if d.config["ipv6.address"] != "" {
@@ -176,7 +180,9 @@ func (d *nicIPVLAN) Start() (*deviceConfig.RunConfig, error) {
 			nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv6.address", Value: fmt.Sprintf("%s/128", addr)})
 		}
 
-		nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv6.gateway", Value: "dev"})
+		if nicHasAutoGateway(d.config["ipv6.gateway"]) {
+			nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv6.gateway", Value: "dev"})
+		}
 	}
 
 	runConf.NetworkInterface = nic

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -200,6 +200,7 @@ var APIExtensions = []string{
 	"snapshot_disk_usage",
 	"clustering_edit_roles",
 	"container_nic_routed_host_address",
+	"container_nic_ipvlan_gateway",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Using the `ipv4.gateway` and `ipv6.gateway` settings set to "none" to avoid conflicting default gateway routes being added to the container and preventing startup.