### PR TITLE
forkexec: rework

### DIFF
--- a/lxd/include/memory_utils.h
+++ b/lxd/include/memory_utils.h
@@ -51,4 +51,15 @@ static inline void free_disarm_function(void *ptr)
 }
 #define __do_free call_cleaner(free_disarm)
 
+static inline void free_string_list(char **list)
+{
+	if (list) {
+		for (int i = 0; list[i]; i++)
+			free(list[i]);
+		free_disarm(list);
+	}
+}
+define_cleanup_function(char **, free_string_list);
+#define __do_free_string_list call_cleaner(free_string_list)
+
 #endif /* __LXC_MEMORY_UTILS_H */

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5633,15 +5633,16 @@ func (c *lxc) Exec(req api.InstanceExecPost, stdin *os.File, stdout *os.File, st
 	}
 	wStatus.Close()
 
-	attachedPid := -1
-	if err := json.NewDecoder(rStatus).Decode(&attachedPid); err != nil {
-		logger.Errorf("Failed to retrieve PID of executing child process: %s", err)
-		return nil, err
+	attachedPid := shared.ReadPid(rStatus)
+	if attachedPid <= 0 {
+		logger.Errorf("Failed to retrieve PID of executing child process")
+		return nil, fmt.Errorf("Failed to retrieve PID of executing child process")
 	}
+	logger.Debugf("Retrieved PID %d of executing child process", attachedPid)
 
 	instCmd := &lxcCmd{
 		cmd:              &cmd,
-		attachedChildPid: attachedPid,
+		attachedChildPid: int(attachedPid),
 	}
 
 	return instCmd, nil

--- a/lxd/main_forkexec.go
+++ b/lxd/main_forkexec.go
@@ -1,16 +1,236 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"strconv"
-	"strings"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/sys/unix"
-	liblxc "gopkg.in/lxc/go-lxc.v2"
 )
+
+/*
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <limits.h>
+
+#include "include/memory_utils.h"
+#include <lxc/attach_options.h>
+#include <lxc/lxccontainer.h>
+
+extern char *advance_arg(bool required);
+
+static bool write_nointr(int fd, const void *buf, size_t count)
+{
+	ssize_t ret;
+
+	do {
+		ret = write(fd, buf, count);
+	} while (ret < 0 && errno == EINTR);
+
+	if (ret < 0)
+		return false;
+
+	return (size_t)ret == count;
+}
+
+define_cleanup_function(struct lxc_container *, lxc_container_put);
+
+static int wait_for_pid_status_nointr(pid_t pid)
+{
+	int status, ret;
+
+again:
+	ret = waitpid(pid, &status, 0);
+	if (ret == -1) {
+		if (errno == EINTR)
+			goto again;
+
+		return -1;
+	}
+
+	if (ret != pid)
+		goto again;
+
+	return status;
+}
+
+static char *must_copy_string(const char *entry)
+{
+	char *ret;
+
+	if (!entry)
+		return NULL;
+
+	do {
+		ret = strdup(entry);
+	} while (!ret);
+
+	return ret;
+}
+
+static void *must_realloc(void *orig, size_t sz)
+{
+	void *ret;
+
+	do {
+		ret = realloc(orig, sz);
+	} while (!ret);
+
+	return ret;
+}
+
+static int append_null_to_list(void ***list)
+{
+	int newentry = 0;
+
+	if (*list)
+		for (; (*list)[newentry]; newentry++)
+			;
+
+	*list = must_realloc(*list, (newentry + 2) * sizeof(void **));
+	(*list)[newentry + 1] = NULL;
+	return newentry;
+}
+
+static void must_append_string(char ***list, char *entry)
+{
+	int newentry;
+	char *copy;
+
+	newentry = append_null_to_list((void ***)list);
+	copy = must_copy_string(entry);
+	(*list)[newentry] = copy;
+}
+
+// We use a separate function because cleanup macros are called during stack
+// unwinding if I'm not mistaken and if the compiler knows it exits it won't
+// call them. That's not a problem since we're exiting but I just like to be on
+// the safe side in case we ever call this from a different context. We also
+// tell the compiler to not inline us.
+__attribute__ ((noinline)) static int __forkexec(void)
+{
+	__do_close int status_pipe = 6;
+	__do_free_string_list char **argvp = NULL, **envvp = NULL;
+	call_cleaner(lxc_container_put) struct lxc_container *c = NULL;
+	const char *config_path = NULL, *lxcpath = NULL, *name = NULL;
+	char *cwd = NULL;
+	lxc_attach_options_t attach_options = LXC_ATTACH_OPTIONS_DEFAULT;
+	lxc_attach_command_t command = {
+		.program = NULL,
+	};
+	int ret;
+	pid_t pid;
+	uid_t uid;
+	gid_t gid;
+
+	if (geteuid() != 0) {
+		fprintf(stderr, "Error: forkexec requires root privileges\n");
+		return EXIT_FAILURE;
+	}
+
+	name = advance_arg(false);
+	if (name == NULL ||
+	    (strcmp(name, "--help") == 0 ||
+	     strcmp(name, "--version") == 0 || strcmp(name, "-h") == 0))
+		return 0;
+
+	lxcpath = advance_arg(true);
+	config_path = advance_arg(true);
+	cwd = advance_arg(true);
+	uid = atoi(advance_arg(true));
+	if (uid < 0)
+		uid = (uid_t) - 1;
+	gid = atoi(advance_arg(true));
+	if (gid < 0)
+		gid = (gid_t) - 1;
+
+	for (char *arg = NULL, *section = NULL; (arg = advance_arg(false)); ) {
+		if (!strcmp(arg, "--") && (!section || strcmp(section, "cmd"))) {
+			section = NULL;
+			continue;
+		}
+
+		if (!section) {
+			section = arg;
+			continue;
+		}
+
+		if (!strcmp(section, "env")) {
+			if (!strncmp(arg, "HOME=", STRLITERALLEN("HOME=")))
+				attach_options.initial_cwd = arg + STRLITERALLEN("HOME=");
+			must_append_string(&envvp, arg);
+		} else if (!strcmp(section, "cmd")) {
+			must_append_string(&argvp, arg);
+		} else {
+			fprintf(stderr, "Invalid exec section %s\n", section);
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (!argvp || !*argvp) {
+		fprintf(stderr, "No command specified\n");
+		return EXIT_FAILURE;
+	}
+
+	c = lxc_container_new(name, lxcpath);
+	if (!c)
+		return EXIT_FAILURE;
+
+	c->clear_config(c);
+
+	if (!c->load_config(c, config_path))
+		return EXIT_FAILURE;
+
+	if (strcmp(cwd, ""))
+		attach_options.initial_cwd = cwd;
+	attach_options.env_policy = LXC_ATTACH_CLEAR_ENV;
+	attach_options.extra_env_vars = envvp;
+	attach_options.stdin_fd = 3;
+	attach_options.stdout_fd = 4;
+	attach_options.stderr_fd = 5;
+	attach_options.uid = uid;
+	attach_options.gid = gid;
+	command.program = argvp[0];
+	command.argv = argvp;
+
+	ret = c->attach(c, lxc_attach_run_command, &command, &attach_options, &pid);
+	if (ret < 0)
+		return EXIT_FAILURE;
+
+	if (!write_nointr(status_pipe, &pid, sizeof(pid))) {
+		// Kill the child just to be safe.
+		fprintf(stderr, "Failed to send pid %d of executing child to LXD. Killing child\n", pid);
+		kill(pid, SIGKILL);
+	}
+
+	ret = wait_for_pid_status_nointr(pid);
+	if (ret < 0)
+		return EXIT_FAILURE;
+
+	if (WIFEXITED(ret))
+		return WEXITSTATUS(ret);
+
+	if (WIFSIGNALED(ret))
+		return 128 + WTERMSIG(ret);
+
+	return EXIT_FAILURE;
+}
+
+void forkexec(void)
+{
+	_exit(__forkexec());
+}
+*/
+import "C"
 
 type cmdForkexec struct {
 	global *cmdGlobal
@@ -34,122 +254,5 @@ func (c *cmdForkexec) Command() *cobra.Command {
 }
 
 func (c *cmdForkexec) Run(cmd *cobra.Command, args []string) error {
-	// Sanity checks
-	if len(args) < 7 {
-		cmd.Help()
-
-		if len(args) == 0 {
-			return nil
-		}
-
-		return fmt.Errorf("Missing required arguments")
-	}
-
-	// Only root should run this
-	if os.Geteuid() != 0 {
-		return fmt.Errorf("This must be run as root")
-	}
-
-	name := args[0]
-	lxcpath := args[1]
-	configPath := args[2]
-	cwd := args[3]
-	uid, err := strconv.ParseUint(args[4], 10, 32)
-	if err != nil {
-		return err
-	}
-
-	gid, err := strconv.ParseUint(args[5], 10, 32)
-	if err != nil {
-		return err
-	}
-
-	// Get the status
-	fdStatus := os.NewFile(uintptr(6), "attachedPid")
-	defer fdStatus.Close()
-
-	// Load the container
-	d, err := liblxc.NewContainer(name, lxcpath)
-	if err != nil {
-		return fmt.Errorf("Error initializing instance for start: %q", err)
-	}
-
-	err = d.LoadConfigFile(configPath)
-	if err != nil {
-		return fmt.Errorf("Error opening startup config file: %q", err)
-	}
-
-	// Setup attach arguments
-	opts := liblxc.DefaultAttachOptions
-	opts.ClearEnv = true
-	opts.StdinFd = 3
-	opts.StdoutFd = 4
-	opts.StderrFd = 5
-	opts.UID = int(uid)
-	opts.GID = int(gid)
-
-	// Parse the command line
-	env := []string{}
-	command := []string{}
-
-	section := ""
-	for _, arg := range args[6:] {
-		// The "cmd" section must come last as it may contain a --
-		if arg == "--" && section != "cmd" {
-			section = ""
-			continue
-		}
-
-		if section == "" {
-			section = arg
-			continue
-		}
-
-		if section == "env" {
-			fields := strings.SplitN(arg, "=", 2)
-			if len(fields) == 2 && fields[0] == "HOME" {
-				opts.Cwd = fields[1]
-			}
-			env = append(env, arg)
-		} else if section == "cmd" {
-			command = append(command, arg)
-		} else {
-			return fmt.Errorf("Invalid exec section: %s", section)
-		}
-	}
-
-	opts.Env = env
-	if cwd != "" {
-		opts.Cwd = cwd
-	}
-
-	// Exec the command
-	status, err := d.RunCommandNoWait(command, opts)
-	if err != nil {
-		return fmt.Errorf("Failed running command: %q", err)
-	}
-
-	// Send the PID of the executing process.
-	err = json.NewEncoder(fdStatus).Encode(status)
-	if err != nil {
-		return fmt.Errorf("Failed sending PID of executing command: %q", err)
-	}
-
-	// Handle exit code
-	var ws unix.WaitStatus
-	wpid, err := unix.Wait4(status, &ws, 0, nil)
-	if err != nil || wpid != status {
-		return fmt.Errorf("Failed finding process: %q", err)
-	}
-
-	if ws.Exited() {
-		os.Exit(ws.ExitStatus())
-	}
-
-	if ws.Signaled() {
-		// 128 + n == Fatal error signal "n"
-		os.Exit(128 + int(ws.Signal()))
-	}
-
-	return fmt.Errorf("Command failed")
+	return fmt.Errorf("This command should have been intercepted in cgo")
 }

--- a/lxd/main_nsexec.go
+++ b/lxd/main_nsexec.go
@@ -40,6 +40,7 @@ package main
 
 // External functions
 extern void checkfeature();
+extern void forkexec();
 extern void forkfile();
 extern void forksyscall();
 extern void forkmount();
@@ -302,6 +303,8 @@ __attribute__((constructor)) void init(void) {
 	}
 
 	// Intercepts some subcommands
+	if (strcmp(cmdline_cur, "forkexec") == 0)
+		forkexec();
 	if (strcmp(cmdline_cur, "forkfile") == 0)
 		forkfile();
 	else if (strcmp(cmdline_cur, "forksyscall") == 0)

--- a/shared/util_linux_cgo.go
+++ b/shared/util_linux_cgo.go
@@ -119,6 +119,22 @@ again:
 
 	return ret;
 }
+
+static int read_pid(int fd)
+{
+	ssize_t ret;
+	pid_t n = -1;
+
+again:
+	ret = read(fd, &n, sizeof(n));
+	if (ret < 0 && errno == EINTR)
+		goto again;
+
+	if (ret < 0)
+		return -1;
+
+	return n;
+}
 */
 import "C"
 
@@ -438,4 +454,8 @@ func ExecReaderToChannel(r io.Reader, bufferSize int, exited <-chan struct{}, fd
 	}()
 
 	return ch
+}
+
+func ReadPid(r *os.File) int {
+	return int(C.read_pid(C.int(r.Fd())))
 }


### PR DESCRIPTION
This reworks our forkexec logic to switch from go because it's just not working
well with anything that gets close to any libc and their state assumptions.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>