### PR TITLE
Backup: Only read up to original size of file during export

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -4592,7 +4592,7 @@ func (c *lxc) Export(w io.Writer, properties map[string]string) error {
 			return err
 		}
 
-		err = tarWriter.WriteFile(path[offset:], path, fi)
+		err = tarWriter.WriteFile(path[offset:], path, fi, false)
 		if err != nil {
 			logger.Debugf("Error tarring up %s: %s", path, err)
 			return err
@@ -4666,7 +4666,7 @@ func (c *lxc) Export(w io.Writer, properties map[string]string) error {
 		}
 
 		tmpOffset := len(path.Dir(fnam)) + 1
-		if err := tarWriter.WriteFile(fnam[tmpOffset:], fnam, fi); err != nil {
+		if err := tarWriter.WriteFile(fnam[tmpOffset:], fnam, fi, false); err != nil {
 			tarWriter.Close()
 			logger.Debugf("Error writing to tarfile: %s", err)
 			logger.Error("Failed exporting instance", ctxMap)
@@ -4728,9 +4728,9 @@ func (c *lxc) Export(w io.Writer, properties map[string]string) error {
 
 		if properties != nil {
 			tmpOffset := len(path.Dir(fnam)) + 1
-			err = tarWriter.WriteFile(fnam[tmpOffset:], fnam, fi)
+			err = tarWriter.WriteFile(fnam[tmpOffset:], fnam, fi, false)
 		} else {
-			err = tarWriter.WriteFile(fnam[offset:], fnam, fi)
+			err = tarWriter.WriteFile(fnam[offset:], fnam, fi, false)
 		}
 		if err != nil {
 			tarWriter.Close()

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2997,7 +2997,7 @@ func (vm *qemu) Export(w io.Writer, properties map[string]string) error {
 			return err
 		}
 
-		err = tarWriter.WriteFile(path[offset:], path, fi)
+		err = tarWriter.WriteFile(path[offset:], path, fi, false)
 		if err != nil {
 			logger.Debugf("Error tarring up %s: %s", path, err)
 			return err
@@ -3072,7 +3072,7 @@ func (vm *qemu) Export(w io.Writer, properties map[string]string) error {
 		}
 
 		tmpOffset := len(filepath.Dir(fnam)) + 1
-		if err := tarWriter.WriteFile(fnam[tmpOffset:], fnam, fi); err != nil {
+		if err := tarWriter.WriteFile(fnam[tmpOffset:], fnam, fi, false); err != nil {
 			tarWriter.Close()
 			logger.Error("Failed exporting instance", ctxMap)
 			return err
@@ -3133,9 +3133,9 @@ func (vm *qemu) Export(w io.Writer, properties map[string]string) error {
 
 		if properties != nil {
 			tmpOffset := len(filepath.Dir(fnam)) + 1
-			err = tarWriter.WriteFile(fnam[tmpOffset:], fnam, fi)
+			err = tarWriter.WriteFile(fnam[tmpOffset:], fnam, fi, false)
 		} else {
-			err = tarWriter.WriteFile(fnam[offset:], fnam, fi)
+			err = tarWriter.WriteFile(fnam[offset:], fnam, fi, false)
 		}
 		if err != nil {
 			tarWriter.Close()
@@ -3175,7 +3175,7 @@ func (vm *qemu) Export(w io.Writer, properties map[string]string) error {
 	}
 
 	imgOffset := len(tmpPath) + 1
-	err = tarWriter.WriteFile(fPath[imgOffset:], fPath, fi)
+	err = tarWriter.WriteFile(fPath[imgOffset:], fPath, fi, false)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -684,7 +684,7 @@ func (d *btrfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWr
 			return err
 		}
 
-		err = tarWriter.WriteFile(fileName, tmpFile.Name(), tmpFileInfo)
+		err = tarWriter.WriteFile(fileName, tmpFile.Name(), tmpFileInfo, false)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1246,7 +1246,7 @@ func (d *zfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWrit
 			return err
 		}
 
-		err = tarWriter.WriteFile(fileName, tmpFile.Name(), tmpFileInfo)
+		err = tarWriter.WriteFile(fileName, tmpFile.Name(), tmpFileInfo, false)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -486,7 +486,7 @@ func genericVFSBackupVolume(d Driver, vol Volume, tarWriter *instancewriter.Inst
 					}
 
 					name := filepath.Join(prefix, strings.TrimPrefix(srcPath, mountPath))
-					err = tarWriter.WriteFile(name, srcPath, fi)
+					err = tarWriter.WriteFile(name, srcPath, fi, false)
 					if err != nil {
 						return errors.Wrapf(err, "Error adding %q as %q to tarball", srcPath, name)
 					}
@@ -524,7 +524,11 @@ func genericVFSBackupVolume(d Driver, vol Volume, tarWriter *instancewriter.Inst
 					}
 
 					name := filepath.Join(prefix, strings.TrimPrefix(srcPath, mountPath))
-					err = tarWriter.WriteFile(name, srcPath, fi)
+
+					// Write the file to the tarball with ignoreGrowth enabled so that if the
+					// source file grows during copy we only copy up to the original size.
+					// This means that the file in the tarball may be inconsistent.
+					err = tarWriter.WriteFile(name, srcPath, fi, true)
 					if err != nil {
 						return errors.Wrapf(err, "Error adding %q as %q to tarball", srcPath, name)
 					}


### PR DESCRIPTION
This restores old behaviour and prevents `lxc export` failing when files are being modified inside a running container.

Addresses https://discuss.linuxcontainers.org/t/lxd-export-fails-with-archive-tar-write-too-long/7207