### PR TITLE
NIC Bridged: Disables IPv6 on bridged host side interface

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -213,6 +213,13 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 		return nil, err
 	}
 
+	// Disable IPv6 on host-side veth interface (prevents host-side interface getting link-local address)
+	// which isn't needed because the host-side interface is connected to a bridge.
+	err = util.SysctlSet(fmt.Sprintf("net/ipv6/conf/%s/disable_ipv6", saveData["host_name"]), "1")
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
 	// Apply and host-side network filters (uses enriched host_name from networkSetupHostVethDevice).
 	err = d.setupHostFilters(nil)
 	if err != nil {


### PR DESCRIPTION
Prevents host-side interface getting IPv6 link-local address which isn't needed as interface is added to bridge.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>