### PR TITLE
VM: lxd-agent systemd dependency conflicts

### DIFF
--- a/lxd-agent/main_agent.go
+++ b/lxd-agent/main_agent.go
@@ -50,8 +50,8 @@ func (c *cmdAgent) Run(cmd *cobra.Command, args []string) error {
 	}
 	logger.Log = log
 
-	logger.Info("lxd-agent starting")
-	defer logger.Info("lxd-agent stopped")
+	logger.Info("Starting")
+	defer logger.Info("Stopped")
 
 	// Apply the templated files.
 	files, err := templatesApply("files/")
@@ -85,13 +85,16 @@ func (c *cmdAgent) Run(cmd *cobra.Command, args []string) error {
 
 	// Run cloud-init.
 	if shared.PathExists("/etc/cloud") && shared.StringInSlice("/var/lib/cloud/seed/nocloud-net/meta-data", files) {
-		if shared.PathExists("/run/cloud-init") {
-			err = os.RemoveAll("/run/cloud-init")
+		cloudInitPath := "/run/cloud-init"
+		if shared.PathExists(cloudInitPath) {
+			logger.Info(fmt.Sprintf("Removing %q", cloudInitPath))
+			err = os.RemoveAll(cloudInitPath)
 			if err != nil {
 				return err
 			}
 		}
 
+		logger.Info("Starting cloud-init")
 		shared.RunCommand("systemctl", "daemon-reload")
 		shared.RunCommand("systemctl", "start", "cloud-init.target")
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1277,6 +1277,10 @@ Before=cloud-init.target cloud-init.service cloud-init-local.service
 Type=simple
 WorkingDirectory=/run/lxd_config/9p
 ExecStart=/run/lxd_config/9p/lxd-agent
+Restart=on-failure
+RestartSec=5s
+StartLimitInterval=60
+StartLimitBurst=10
 
 [Install]
 WantedBy=multi-user.target

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1272,6 +1272,7 @@ ConditionPathExists=/dev/virtio-ports/org.linuxcontainers.lxd
 Requires=lxd-agent-9p.service
 After=lxd-agent-9p.service
 Before=cloud-init.target cloud-init.service cloud-init-local.service
+DefaultDependencies=no
 
 [Service]
 Type=simple
@@ -1295,6 +1296,8 @@ WantedBy=multi-user.target
 Description=LXD - agent - 9p mount
 Documentation=https://linuxcontainers.org/lxd
 ConditionPathExists=/dev/virtio-ports/org.linuxcontainers.lxd
+After=local-fs.target
+DefaultDependencies=no
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Was seeing errors like this on ubuntu 18.04 VMs:

```
[    3.304595] systemd[1]: cloud-init-local.service: Found ordering cycle on lxd-agent.service/start
[    3.305700] systemd[1]: cloud-init-local.service: Found dependency on sysinit.target/start
[    3.306768] systemd[1]: cloud-init-local.service: Found dependency on cloud-init.service/start
[    3.307790] systemd[1]: cloud-init-local.service: Found dependency on systemd-networkd-wait-online.service/start
[ SKIP ] Ordering cycle found, skipping LXD - agent
```

This seems to fix it.