### PR TITLE
Storage: Take snapshot when backing up BTRFS volumes

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -763,23 +763,23 @@ func (d *btrfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWr
 		}
 	}
 
-	// Make a temporary copy of the container.
+	// Make a temporary copy of the instance.
 	sourceVolume := vol.MountPath()
-	containersPath := GetVolumeMountPath(d.name, vol.volType, "")
+	instancesPath := GetVolumeMountPath(d.name, vol.volType, "")
 
-	tmpContainerMntPoint, err := ioutil.TempDir(containersPath, "backup.")
+	tmpInstanceMntPoint, err := ioutil.TempDir(instancesPath, "backup.")
 	if err != nil {
-		return errors.Wrapf(err, "Failed to create temporary directory under '%s'", containersPath)
+		return errors.Wrapf(err, "Failed to create temporary directory under '%s'", instancesPath)
 	}
-	defer os.RemoveAll(tmpContainerMntPoint)
+	defer os.RemoveAll(tmpInstanceMntPoint)
 
-	err = os.Chmod(tmpContainerMntPoint, 0100)
+	err = os.Chmod(tmpInstanceMntPoint, 0100)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to chmod '%s'", tmpContainerMntPoint)
+		return errors.Wrapf(err, "Failed to chmod '%s'", tmpInstanceMntPoint)
 	}
 
 	// Create the read-only snapshot.
-	targetVolume := fmt.Sprintf("%s/.backup", tmpContainerMntPoint)
+	targetVolume := fmt.Sprintf("%s/.backup", tmpInstanceMntPoint)
 	err = d.snapshotSubvolume(sourceVolume, targetVolume, true, true)
 	if err != nil {
 		return err

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -197,13 +197,13 @@ func (d *btrfs) CreateVolumeFromBackup(vol Volume, snapshots []string, srcData i
 	// Create a temporary directory to unpack the backup into.
 	unpackDir, err := ioutil.TempDir(GetVolumeMountPath(d.name, vol.volType, ""), "backup.")
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "Failed to create temporary directory under '%s'", GetVolumeMountPath(d.name, vol.volType, ""))
+		return nil, nil, errors.Wrapf(err, "Failed to create temporary directory under %q", GetVolumeMountPath(d.name, vol.volType, ""))
 	}
 	defer os.RemoveAll(unpackDir)
 
 	err = os.Chmod(unpackDir, 0100)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "Failed to chmod '%s'", unpackDir)
+		return nil, nil, errors.Wrapf(err, "Failed to chmod %q", unpackDir)
 	}
 
 	// Extract main volume.
@@ -325,13 +325,13 @@ func (d *btrfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, v
 	// Create a temporary directory which will act as the parent directory of the received ro snapshot.
 	tmpVolumesMountPoint, err := ioutil.TempDir(instancesPath, "migration.")
 	if err != nil {
-		return errors.Wrapf(err, "Failed to create temporary directory under '%s'", instancesPath)
+		return errors.Wrapf(err, "Failed to create temporary directory under %q", instancesPath)
 	}
 	defer os.RemoveAll(tmpVolumesMountPoint)
 
 	err = os.Chmod(tmpVolumesMountPoint, 0100)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to chmod '%s'", tmpVolumesMountPoint)
+		return errors.Wrapf(err, "Failed to chmod %q", tmpVolumesMountPoint)
 	}
 
 	wrapper := migration.ProgressWriter(op, "fs_progress", vol.name)
@@ -507,7 +507,7 @@ func (d *btrfs) SetVolumeQuota(vol Volume, size string, op *operations.Operation
 			}
 
 			if id == "" {
-				return fmt.Errorf("Failed to find subvolume id for %s", volPath)
+				return fmt.Errorf("Failed to find subvolume id for %q", volPath)
 			}
 
 			// Create a qgroup.
@@ -607,13 +607,13 @@ func (d *btrfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *m
 	// Create a temporary directory which will act as the parent directory of the read-only snapshot.
 	tmpVolumesMountPoint, err := ioutil.TempDir(instancesPath, "migration.")
 	if err != nil {
-		return errors.Wrapf(err, "Failed to create temporary directory under '%s'", instancesPath)
+		return errors.Wrapf(err, "Failed to create temporary directory under %q", instancesPath)
 	}
 	defer os.RemoveAll(tmpVolumesMountPoint)
 
 	err = os.Chmod(tmpVolumesMountPoint, 0100)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to chmod '%s'", tmpVolumesMountPoint)
+		return errors.Wrapf(err, "Failed to chmod %q", tmpVolumesMountPoint)
 	}
 
 	// Make read-only snapshot of the subvolume as writable subvolumes cannot be sent.
@@ -769,13 +769,13 @@ func (d *btrfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWr
 
 	tmpInstanceMntPoint, err := ioutil.TempDir(instancesPath, "backup.")
 	if err != nil {
-		return errors.Wrapf(err, "Failed to create temporary directory under '%s'", instancesPath)
+		return errors.Wrapf(err, "Failed to create temporary directory under %q", instancesPath)
 	}
 	defer os.RemoveAll(tmpInstanceMntPoint)
 
 	err = os.Chmod(tmpInstanceMntPoint, 0100)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to chmod '%s'", tmpInstanceMntPoint)
+		return errors.Wrapf(err, "Failed to chmod %q", tmpInstanceMntPoint)
 	}
 
 	// Create the read-only snapshot.
@@ -864,7 +864,7 @@ func (d *btrfs) RestoreVolume(vol Volume, snapshotName string, op *operations.Op
 	backupSubvolume := fmt.Sprintf("%s%s", vol.MountPath(), tmpVolSuffix)
 	err := os.Rename(vol.MountPath(), backupSubvolume)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to rename '%s' to '%s'", vol.MountPath(), backupSubvolume)
+		return errors.Wrapf(err, "Failed to rename %q to %q", vol.MountPath(), backupSubvolume)
 	}
 
 	// Setup revert logic.

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1186,7 +1186,7 @@ func (d *zfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mig
 func (d *zfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error {
 	// Handle the non-optimized tarballs through the generic packer.
 	if !optimized {
-		// For block volumes that are exporting snapshots, we need to mount parent volume first so that
+		// For block volumes that are exporting snapshots, we need to activate parent volume first so that
 		// the snapshot volumes can have their devices accessible.
 		if vol.contentType == ContentTypeBlock && snapshots {
 			parent, _, _ := shared.InstanceGetParentAndSnapshotName(vol.Name())

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -61,14 +61,15 @@ var BaseDirectories = map[VolumeType][]string{
 
 // Volume represents a storage volume, and provides functions to mount and unmount it.
 type Volume struct {
-	name        string
-	pool        string
-	poolConfig  map[string]string
-	volType     VolumeType
-	contentType ContentType
-	config      map[string]string
-	driver      Driver
-	keepDevice  bool
+	name            string
+	pool            string
+	poolConfig      map[string]string
+	volType         VolumeType
+	contentType     ContentType
+	config          map[string]string
+	driver          Driver
+	keepDevice      bool
+	customMountPath string
 }
 
 // NewVolume instantiates a new Volume struct.
@@ -121,6 +122,10 @@ func (v Volume) IsSnapshot() bool {
 
 // MountPath returns the path where the volume will be mounted.
 func (v Volume) MountPath() string {
+	if v.customMountPath != "" {
+		return v.customMountPath
+	}
+
 	return GetVolumeMountPath(v.pool, v.volType, v.name)
 }
 


### PR DESCRIPTION
As tarball creation will not create consistent backup when instance is running and files are being modified during backup, we avoid this by creating a read-only snapshot of the main volume.

This is possible because BTRFS allows us to create a snapshot quickly without freezing the main volume.