### PR TITLE
Storage: Removes storagePools.RenderSnapshotUsage from RenderFull()

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3119,7 +3119,7 @@ func (c *lxc) RenderFull() (*api.InstanceFull, interface{}, error) {
 	}
 
 	for _, snap := range snaps {
-		render, _, err := snap.Render(storagePools.RenderSnapshotUsage(c.state, c))
+		render, _, err := snap.Render()
 		if err != nil {
 			return nil, nil, err
 		}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3582,7 +3582,7 @@ func (vm *qemu) RenderFull() (*api.InstanceFull, interface{}, error) {
 	}
 
 	for _, snap := range snaps {
-		render, _, err := snap.Render(storagePools.RenderSnapshotUsage(vm.state, vm))
+		render, _, err := snap.Render()
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
To speed up lxc list command.

Fixes #7124

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>