### PR TITLE
Storage: Improve failed snapshot create revert cleanup

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1627,8 +1627,7 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 	volStorageName := project.Instance(inst.Project(), inst.Name())
 
 	// Get the volume.
-	// There's no need to pass config as it's not needed when creating volume
-	// snapshots.
+	// There's no need to pass config as it's not needed when creating volume snapshots.
 	vol := b.newVolume(volType, contentType, volStorageName, nil)
 
 	err = b.driver.CreateVolumeSnapshot(vol, op)

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -624,9 +624,9 @@ func (d *ceph) HasVolume(vol Volume) bool {
 		"--id", d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
 		"--pool", d.config["ceph.osd.pool_name"],
-		"image-meta",
-		"list",
-		d.getRBDVolumeName(vol, "", false, false))
+		"info",
+		d.getRBDVolumeName(vol, "", false, false),
+	)
 
 	return err == nil
 }

--- a/shared/subprocess/proc.go
+++ b/shared/subprocess/proc.go
@@ -38,15 +38,18 @@ func (p *Process) GetPid() (int64, error) {
 // Stop will stop the given process object
 func (p *Process) Stop() error {
 	pr, _ := os.FindProcess(int(p.Pid))
+
+	// Check if process exists.
 	err := pr.Signal(syscall.Signal(0))
 	if err == nil {
 		err = pr.Kill()
-		if err != nil {
-			return errors.Wrapf(err, "Could not kill process")
+		if err == nil {
+			return nil // Killed successfully.
 		}
+	}
 
-		return nil
-	} else if strings.Contains(err.Error(), "process already finished") {
+	// Check if either the existence check or the kill resulted in an already finished error.
+	if strings.Contains(err.Error(), "process already finished") {
 		return ErrNotRunning
 	}
 


### PR DESCRIPTION
Addresses failed snapshot creation leaving database records as discussed in https://discuss.linuxcontainers.org/t/not-able-create-snapshot-through-zfs-snapshot-storage-name-containers-containers-name-snapshot-snapshot-name-due-to-invalid-argument-in-its-name/7243