### PR TITLE
Storage: Snapshot usage

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -419,7 +419,7 @@ func (d *btrfs) GetVolumeUsage(vol Volume) (int64, error) {
 	_, usage, err := d.getQGroup(vol.MountPath())
 	if err != nil {
 		if err == errBtrfsNoQuota {
-			return 0, nil
+			return -1, ErrNotSupported
 		}
 
 		return -1, err

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -288,6 +288,11 @@ func (d *cephfs) UpdateVolume(vol Volume, changedConfig map[string]string) error
 
 // GetVolumeUsage returns the disk space usage of a volume.
 func (d *cephfs) GetVolumeUsage(vol Volume) (int64, error) {
+	// Snapshot usage not supported for CephFS.
+	if vol.IsSnapshot() {
+		return -1, ErrNotSupported
+	}
+
 	out, err := shared.RunCommand("getfattr", "-n", "ceph.quota.max_bytes", "--only-values", GetVolumeMountPath(d.name, vol.volType, vol.name))
 	if err != nil {
 		return -1, err

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -213,10 +213,15 @@ func (d *dir) UpdateVolume(vol Volume, changedConfig map[string]string) error {
 
 // GetVolumeUsage returns the disk space used by the volume.
 func (d *dir) GetVolumeUsage(vol Volume) (int64, error) {
+	// Snapshot usage not supported for Dir.
+	if vol.IsSnapshot() {
+		return -1, ErrNotSupported
+	}
+
 	volPath := vol.MountPath()
 	ok, err := quota.Supported(volPath)
 	if err != nil || !ok {
-		return 0, nil
+		return -1, ErrNotSupported
 	}
 
 	// Get the volume ID for the volume to access quota.

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -283,6 +283,11 @@ func (d *lvm) UpdateVolume(vol Volume, changedConfig map[string]string) error {
 
 // GetVolumeUsage returns the disk space used by the volume (this is not currently supported).
 func (d *lvm) GetVolumeUsage(vol Volume) (int64, error) {
+	// Snapshot usage not supported for LVM.
+	if vol.IsSnapshot() {
+		return -1, ErrNotSupported
+	}
+
 	// If volume has a filesystem and is mounted we can ask the filesystem for usage.
 	if vol.contentType == ContentTypeFS && shared.IsMountPoint(vol.MountPath()) {
 		var stat unix.Statfs_t

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -778,7 +778,7 @@ func (d *zfs) GetVolumeUsage(vol Volume) (int64, error) {
 		key = "referenced"
 	}
 
-	// Shortcut for refquota filesystems.
+	// Shortcut for mounted refquota filesystems.
 	if key == "referenced" && vol.contentType == ContentTypeFS && shared.IsMountPoint(vol.MountPath()) {
 		var stat unix.Statfs_t
 		err := unix.Statfs(vol.MountPath(), &stat)


### PR DESCRIPTION
Makes snapshot usage reporting as consistent in meaning as possible (CoW usage as opposed to volume size) and if not possible returns -1/ErrNotSupported.