### PR TITLE
lxd/storage/lvm: Always call vgchange on mount

### DIFF
--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -501,8 +501,6 @@ func (d *lvm) Mount() (bool, error) {
 			return false, err
 		}
 		defer loopFile.Close()
-
-		return true, nil
 	}
 
 	// Activate volume group so that it's device is added to /dev.


### PR DESCRIPTION
Otherwise loops stored in the snap may not activate.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>