### PR TITLE
Drop invalid `Managed` field from NetworksPost

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -784,7 +784,6 @@ func clusterInitMember(d, client lxd.InstanceServer, memberConfig []api.ClusterM
 
 		post := api.NetworksPost{
 			NetworkPut: network.NetworkPut,
-			Managed:    true,
 			Name:       network.Name,
 			Type:       network.Type,
 		}

--- a/lxd/main_init_dump.go
+++ b/lxd/main_init_dump.go
@@ -32,7 +32,6 @@ func (c *cmdInit) RunDump(d lxd.InstanceServer) error {
 		networksPost := api.NetworksPost{}
 		networksPost.Config = network.Config
 		networksPost.Description = network.Description
-		networksPost.Managed = network.Managed
 		networksPost.Name = network.Name
 		networksPost.Type = network.Type
 

--- a/shared/api/network.go
+++ b/shared/api/network.go
@@ -6,9 +6,8 @@ package api
 type NetworksPost struct {
 	NetworkPut `yaml:",inline"`
 
-	Managed bool   `json:"managed" yaml:"managed"`
-	Name    string `json:"name" yaml:"name"`
-	Type    string `json:"type" yaml:"type"`
+	Name string `json:"name" yaml:"name"`
+	Type string `json:"type" yaml:"type"`
 }
 
 // NetworkPost represents the fields required to rename a LXD network


### PR DESCRIPTION
This should never have been there in the first place.
`Managed` is a read-only property, you can't create an un-managed network.