### PR TITLE
VM: Allow up to 8 NIC devices

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1850,9 +1850,8 @@ func (vm *qemu) addNetDevConfig(sb *strings.Builder, nicIndex int, bootIndexes m
 		"devName":      devName,
 		"devHwaddr":    devHwaddr,
 		"bootIndex":    bootIndexes[devName],
+		"nicIndex":     nicIndex,
 		"chassisIndex": 5 + nicIndex,
-		"portIndex":    14 + nicIndex,
-		"pcieAddr":     4 + nicIndex,
 	}
 
 	// Detect MACVTAP interface types and figure out which tap device is being used.

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -248,10 +248,11 @@ var qemuDevTapCommon = template.Must(template.New("qemuDevTapCommon").Parse(`
 {{if ne .architecture "ppc64le" -}}
 [device "qemu_pcie{{.chassisIndex}}"]
 driver = "pcie-root-port"
-port = "0x{{.portIndex}}"
+port = "0x{{.nicIndex}}"
 chassis = "{{.chassisIndex}}"
 bus = "pcie.0"
-addr = "0x2.0x{{.pcieAddr}}"
+addr = "0x4.0x{{.nicIndex}}"
+multifunction = "on"
 {{- end }}
 
 [device "dev-lxd_{{.devName}}"]


### PR DESCRIPTION
Adds NIC devices using a different PCIe addr prefix.

Fixes #7175

E.g.

```
 root@v1:~# lspci -t -vvv
 -[0000:00]-+-00.0  Intel Corporation 82G33/G31/P35/P31 Express DRAM Controller
           +-01.0  Red Hat, Inc. Virtio console
           +-02.0-[01]----00.0  Red Hat, Inc. Virtio SCSI
           +-02.1-[02]----00.0  Red Hat, Inc. Virtio memory balloon
           +-02.2-[03]----00.0  Red Hat, Inc. Virtio RNG
           +-02.3-[04]----00.0  Red Hat, Inc. Device 1053
           +-03.0  Red Hat, Inc. Virtio filesystem
           +-04.0-[05]----00.0  Red Hat, Inc. Virtio network device
           +-04.1-[06]----00.0  Red Hat, Inc. Virtio network device
           +-04.2-[07]----00.0  Red Hat, Inc. Virtio network device
           +-04.3-[08]----00.0  Red Hat, Inc. Virtio network device
           +-04.4-[09]----00.0  Red Hat, Inc. Virtio network device
           +-04.5-[0a]----00.0  Red Hat, Inc. Virtio network device
           +-04.6-[0b]----00.0  Red Hat, Inc. Virtio network device
           +-04.7-[0c]----00.0  Red Hat, Inc. Virtio network device
           +-1f.0  Intel Corporation 82801IB (ICH9) LPC Interface Controller
           +-1f.2  Intel Corporation 82801IR/IO/IH (ICH9R/DO/DH) 6 port SATA Controller [AHCI mode]
           \-1f.3  Intel Corporation 82801I (ICH9 Family) SMBus Controller
```

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>