### PR TITLE
lxd/instances: Better use userRequested on Update

### DIFF
--- a/lxd/instance_patch.go
+++ b/lxd/instance_patch.go
@@ -140,7 +140,7 @@ func containerPatch(d *Daemon, r *http.Request) response.Response {
 		Project:      project,
 	}
 
-	err = c.Update(args, false)
+	err = c.Update(args, true)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instance_put.go
+++ b/lxd/instance_put.go
@@ -89,8 +89,7 @@ func containerPut(d *Daemon, r *http.Request) response.Response {
 				Project:      project,
 			}
 
-			// FIXME: should set to true when not migrating
-			err = c.Update(args, false)
+			err = c.Update(args, true)
 			if err != nil {
 				return err
 			}

--- a/lxd/instance_state.go
+++ b/lxd/instance_state.go
@@ -163,7 +163,7 @@ func containerStatePut(d *Daemon, r *http.Request) response.Response {
 				// On function return, set the flag back on
 				defer func() {
 					args.Ephemeral = ephemeral
-					c.Update(args, true)
+					c.Update(args, false)
 				}()
 			}
 

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -2038,6 +2038,7 @@ func updatePoolPropertyForAllObjects(d *Daemon, poolName string, allcontainers [
 
 		err = c.Update(args, false)
 		if err != nil {
+			logger.Warnf("Unable to add pool name to '%s': %v", c.Name(), err)
 			continue
 		}
 	}


### PR DESCRIPTION
This updates all calls to Update() to properly set userRequested to true
if the config change comes through a user request.

If it doesn't, then ignore validation issues as reverting will be just
as broken and there's nothing the user can do at that point anyway.

This also removes the logic checking if `volatile.` keys have been
modified since the check never actually applied to PUT/PATCH requests
due to us having to use that API when handling migrations.

So in practice userRequested was never set to true when a change was
actually requested by the user, making the check useless.

Closes #6661

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>