### PR TITLE
NIC Routed: Add custom policy routing table support

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1013,3 +1013,7 @@ Exposes the die\_id information on each core.
 This introduces two new fields in `/1.0`, `os` and `os\_version`.
 
 Those are taken from the os-release data on the system.
+
+## container\_nic\_routed\_host\_table
+This introduces the `ipv4.host_table` and `ipv6.host_table` NIC config keys that can be used to add static routes
+for the instance's IPs to a custom policy routing table by ID.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -474,9 +474,11 @@ hwaddr                  | string    | randomly assigned | no        | The MAC ad
 ipv4.address            | string    | -                 | no        | Comma delimited list of IPv4 static addresses to add to the instance
 ipv4.gateway            | string    | auto              | no        | Whether to add an automatic default IPv4 gateway, can be "auto" or "none"
 ipv4.host\_address      | string    | 169.254.0.1       | no        | The IPv4 address to add to the host-side veth interface.
+ipv4.host\_table        | integer   | -                 | no        | The custom policy routing table ID to add IPv4 static routes to (in addition to main routing table).
 ipv6.address            | string    | -                 | no        | Comma delimited list of IPv6 static addresses to add to the instance
 ipv6.gateway            | string    | auto              | no        | Whether to add an automatic default IPv6 gateway, can be "auto" or "none"
 ipv6.host\_address      | string    | fe80::1           | no        | The IPv6 address to add to the host-side veth interface.
+ipv6.host\_table        | integer   | -                 | no        | The custom policy routing table ID to add IPv6 static routes to (in addition to main routing table).
 vlan                    | integer   | -                 | no        | The VLAN ID to attach to
 
 #### bridged, macvlan or ipvlan for connection to physical network

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -53,6 +53,8 @@ func nicValidationRules(requiredFields []string, optionalFields []string) map[st
 		"ipv6.gateway":            NetworkValidGateway,
 		"ipv4.host_address":       NetworkValidAddressV4,
 		"ipv6.host_address":       NetworkValidAddressV6,
+		"ipv4.host_table":         shared.IsUint32,
+		"ipv6.host_table":         shared.IsUint32,
 	}
 
 	validators := map[string]func(value string) error{}

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -131,7 +131,8 @@ func (d *nicRouted) validateEnvironment() error {
 			return fmt.Errorf("Error reading net sysctl %s: %v", ipv4FwdPath, err)
 		}
 		if sysctlVal != "1\n" {
-			return fmt.Errorf("Routed mode requires sysctl net.ipv4.conf.%s.forwarding=1", effectiveParentName)
+			// Replace . in parent name with / for sysctl formatting.
+			return fmt.Errorf("Routed mode requires sysctl net.ipv4.conf.%s.forwarding=1", strings.Replace(effectiveParentName, ".", "/", -1))
 		}
 	}
 
@@ -143,7 +144,8 @@ func (d *nicRouted) validateEnvironment() error {
 			return fmt.Errorf("Error reading net sysctl %s: %v", ipv6FwdPath, err)
 		}
 		if sysctlVal != "1\n" {
-			return fmt.Errorf("Routed mode requires sysctl net.ipv6.conf.%s.forwarding=1", effectiveParentName)
+			// Replace . in parent name with / for sysctl formatting.
+			return fmt.Errorf("Routed mode requires sysctl net.ipv6.conf.%s.forwarding=1", strings.Replace(effectiveParentName, ".", "/", -1))
 		}
 
 		ipv6ProxyNdpPath := fmt.Sprintf("net/ipv6/conf/%s/proxy_ndp", effectiveParentName)
@@ -152,7 +154,8 @@ func (d *nicRouted) validateEnvironment() error {
 			return fmt.Errorf("Error reading net sysctl %s: %v", ipv6ProxyNdpPath, err)
 		}
 		if sysctlVal != "1\n" {
-			return fmt.Errorf("Routed mode requires sysctl net.ipv6.conf.%s.proxy_ndp=1", effectiveParentName)
+			// Replace . in parent name with / for sysctl formatting.
+			return fmt.Errorf("Routed mode requires sysctl net.ipv6.conf.%s.proxy_ndp=1", strings.Replace(effectiveParentName, ".", "/", -1))
 		}
 	}
 

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -44,6 +44,8 @@ func (d *nicRouted) validateConfig(instConf instance.ConfigReader) error {
 		"ipv6.gateway",
 		"ipv4.host_address",
 		"ipv6.host_address",
+		"ipv4.host_table",
+		"ipv6.host_table",
 	}
 
 	rules := nicValidationRules(requiredFields, optionalFields)
@@ -294,10 +296,7 @@ func (d *nicRouted) setupParentSysctls(parentName string) error {
 func (d *nicRouted) postStart() error {
 	v := d.volatileGet()
 
-	// If host_name is defined (and it should be), then we add the dummy link-local gateway IPs
-	// to the host end of the veth pair. This ensures that liveness detection of the gateways
-	// inside the instance work and ensure that traffic doesn't periodically halt whilst ARP/NDP
-	// is re-detected.
+	// If volatile host_name is defined (and it should be), then configure the host-side interface.
 	if v["host_name"] != "" {
 		// Attempt to disable IPv6 router advertisement acceptance.
 		err := util.SysctlSet(fmt.Sprintf("net/ipv6/conf/%s/accept_ra", v["host_name"]), "0")
@@ -318,16 +317,50 @@ func (d *nicRouted) postStart() error {
 		}
 
 		if d.config["ipv4.address"] != "" {
+			// Add dummy link-local gateway IPs to the host end of the veth pair. This ensures that
+			// liveness detection of the gateways inside the instance work and ensure that traffic
+			// doesn't periodically halt whilst ARP is re-detected.
 			_, err := shared.RunCommand("ip", "-4", "addr", "add", fmt.Sprintf("%s/32", d.ipv4HostAddress()), "dev", v["host_name"])
 			if err != nil {
 				return err
 			}
+
+			// Add static routes to instance IPs to custom routing tables if specified.
+			// This is in addition to the static route added by liblxc to the main routing table, which
+			// is still critical to ensure that reverse path filtering doesn't kick in blocking traffic
+			// from the instance.
+			if d.config["ipv4.host_table"] != "" {
+				for _, addr := range strings.Split(d.config["ipv4.address"], ",") {
+					addr = strings.TrimSpace(addr)
+					_, err := shared.RunCommand("ip", "-4", "route", "add", "table", d.config["ipv4.host_table"], fmt.Sprintf("%s/32", addr), "dev", v["host_name"])
+					if err != nil {
+						return err
+					}
+				}
+			}
 		}
 
 		if d.config["ipv6.address"] != "" {
+			// Add dummy link-local gateway IPs to the host end of the veth pair. This ensures that
+			// liveness detection of the gateways inside the instance work and ensure that traffic
+			// doesn't periodically halt whilst NDP is re-detected.
 			_, err := shared.RunCommand("ip", "-6", "addr", "add", fmt.Sprintf("%s/128", d.ipv6HostAddress()), "dev", v["host_name"])
 			if err != nil {
 				return err
+			}
+
+			// Add static routes to instance IPs to custom routing tables if specified.
+			// This is in addition to the static route added by liblxc to the main routing table, which
+			// is still critical to ensure that reverse path filtering doesn't kick in blocking traffic
+			// from the instance.
+			if d.config["ipv6.host_table"] != "" {
+				for _, addr := range strings.Split(d.config["ipv6.address"], ",") {
+					addr = strings.TrimSpace(addr)
+					_, err := shared.RunCommand("ip", "-6", "route", "add", "table", d.config["ipv6.host_table"], fmt.Sprintf("%s/128", addr), "dev", v["host_name"])
+					if err != nil {
+						return err
+					}
+				}
 			}
 		}
 	}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -205,6 +205,7 @@ var APIExtensions = []string{
 	"resources_cpu_threads_numa",
 	"resources_cpu_core_die",
 	"api_os",
+	"container_nic_routed_host_table",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/container_devices_nic_routed.sh
+++ b/test/suites/container_devices_nic_routed.sh
@@ -135,8 +135,10 @@ test_container_devices_nic_routed() {
   lxc stop -f "${ctName}2"
   lxc stop -f "${ctName}"
 
-  # Check routed ontop of VLAN parent.
+  # Check routed ontop of VLAN parent with custom routing tables.
   lxc config device set "${ctName}" eth0 vlan 1234
+  lxc config device set "${ctName}" eth0 ipv4.host_table=100
+  lxc config device set "${ctName}" eth0 ipv6.host_table=101
   lxc start "${ctName}"
 
   # Check VLAN interface created
@@ -144,6 +146,10 @@ test_container_devices_nic_routed() {
     echo "vlan interface not created"
     false
   fi
+
+  # Check static routes added to custom routing table
+  ip -4 route show table 100 | grep "192.0.2.1${ipRand}"
+  ip -6 route show table 101 | grep "2001:db8::1${ipRand}"
 
   # Check volatile cleanup on stop.
   lxc stop -f "${ctName}"


### PR DESCRIPTION
When using custom policy routing on the host, proxy ARP and proxy NDP will not function unless static routes for the instance's IPs are added to the custom policy routing table (in addition to the host's main routing table to ensure reverse path filtering doesn't kick in).

This PR introduces new `routed` NIC config settings: `ipv4.host_table` and `ipv6.host_table` which can be set to the routing table ID that LXD will add static routes to for each of the instances IPs.

Fixes https://github.com/lxc/lxd/issues/7152