### PR TITLE
NIC IPVLAN: Add custom policy routing table support

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1017,3 +1017,7 @@ Those are taken from the os-release data on the system.
 ## container\_nic\_routed\_host\_table
 This introduces the `ipv4.host_table` and `ipv6.host_table` NIC config keys that can be used to add static routes
 for the instance's IPs to a custom policy routing table by ID.
+
+## container\_nic\_ipvlan\_host\_table
+This introduces the `ipv4.host_table` and `ipv6.host_table` NIC config keys that can be used to add static routes
+for the instance's IPs to a custom policy routing table by ID.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -371,8 +371,10 @@ mtu                     | integer   | parent MTU        | no        | The MTU of
 hwaddr                  | string    | randomly assigned | no        | The MAC address of the new interface
 ipv4.address            | string    | -                 | no        | Comma delimited list of IPv4 static addresses to add to the instance
 ipv4.gateway            | string    | auto              | no        | Whether to add an automatic default IPv4 gateway, can be "auto" or "none"
+ipv4.host\_table        | integer   | -                 | no        | The custom policy routing table ID to add IPv4 static routes to (in addition to main routing table).
 ipv6.address            | string    | -                 | no        | Comma delimited list of IPv6 static addresses to add to the instance
 ipv6.gateway            | string    | auto              | no        | Whether to add an automatic default IPv6 gateway, can be "auto" or "none"
+ipv6.host\_table        | integer   | -                 | no        | The custom policy routing table ID to add IPv6 static routes to (in addition to main routing table).
 vlan                    | integer   | -                 | no        | The VLAN ID to attach to
 
 #### nictype: p2p

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -206,6 +206,7 @@ var APIExtensions = []string{
 	"resources_cpu_core_die",
 	"api_os",
 	"container_nic_routed_host_table",
+	"container_nic_ipvlan_host_table",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
When using custom policy routing on the host, proxy ARP and proxy NDP will not function unless static routes for the instance's IPs are added to the custom policy routing table (in addition to the host's main routing table).

This PR introduces a new `ipvlan` NIC config setting: `host_table` which can be set to the routing table ID that LXD will add static routes to for each of the instances IPs.

Fixes #7123

Includes https://github.com/lxc/lxd/pull/7192