### PR TITLE
NIC IPVLAN: Adds l2 mode support

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1021,3 +1021,12 @@ for the instance's IPs to a custom policy routing table by ID.
 ## container\_nic\_ipvlan\_host\_table
 This introduces the `ipv4.host_table` and `ipv6.host_table` NIC config keys that can be used to add static routes
 for the instance's IPs to a custom policy routing table by ID.
+
+## container\_nic\_ipvlan\_mode
+This introduces the `mode` NIC config key that can be used to switch the `ipvlan` mode into either `l2` or `l3s`.
+If not specified, the default value is `l3s` (which is the old behavior).
+
+In `l2` mode the `ipv4.address` and `ipv6.address` keys will accept addresses in either CIDR or singular formats.
+If singular format is used, the default subnet size is taken to be /24 and /64 for IPv4 and IPv6 respectively.
+
+In `l2` mode the `ipv4.gateway` and `ipv6.gateway` keys accept only a singular IP address.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -363,19 +363,20 @@ net.ipv6.conf.<parent>.proxy_ndp=1
 
 Device configuration properties:
 
-Key                     | Type      | Default           | Required  | Description
-:--                     | :--       | :--               | :--       | :--
-parent                  | string    | -                 | yes       | The name of the host device
-name                    | string    | kernel assigned   | no        | The name of the interface inside the instance
-mtu                     | integer   | parent MTU        | no        | The MTU of the new interface
-hwaddr                  | string    | randomly assigned | no        | The MAC address of the new interface
-ipv4.address            | string    | -                 | no        | Comma delimited list of IPv4 static addresses to add to the instance
-ipv4.gateway            | string    | auto              | no        | Whether to add an automatic default IPv4 gateway, can be "auto" or "none"
-ipv4.host\_table        | integer   | -                 | no        | The custom policy routing table ID to add IPv4 static routes to (in addition to main routing table).
-ipv6.address            | string    | -                 | no        | Comma delimited list of IPv6 static addresses to add to the instance
-ipv6.gateway            | string    | auto              | no        | Whether to add an automatic default IPv6 gateway, can be "auto" or "none"
-ipv6.host\_table        | integer   | -                 | no        | The custom policy routing table ID to add IPv6 static routes to (in addition to main routing table).
-vlan                    | integer   | -                 | no        | The VLAN ID to attach to
+Key                     | Type      | Default            | Required  | Description
+:--                     | :--       | :--                | :--       | :--
+parent                  | string    | -                  | yes       | The name of the host device
+name                    | string    | kernel assigned    | no        | The name of the interface inside the instance
+mtu                     | integer   | parent MTU         | no        | The MTU of the new interface
+mode                    | string    | l3s                | no        | The IPVLAN mode (either `l2` or `l3s`)
+hwaddr                  | string    | randomly assigned  | no        | The MAC address of the new interface
+ipv4.address            | string    | -                  | no        | Comma delimited list of IPv4 static addresses to add to the instance. In `l2` mode these can be specified as CIDR values or singular addresses (if singular a subnet of /24 is used).
+ipv4.gateway            | string    | auto               | no        | In `l3s` mode, whether to add an automatic default IPv4 gateway, can be `auto` or `none`. In `l2` mode specifies the IPv4 address of the gateway.
+ipv4.host\_table        | integer   | -                  | no        | The custom policy routing table ID to add IPv4 static routes to (in addition to main routing table).
+ipv6.address            | string    | -                  | no        | Comma delimited list of IPv6 static addresses to add to the instance. In `l2` mode these can be specified as CIDR values or singular addresses (if singular a subnet of /64 is used).
+ipv6.gateway            | string    | auto (l3s), - (l2) | no        | In `l3s` mode, whether to add an automatic default IPv6 gateway, can be `auto` or `none`. In `l2` mode specifies the IPv6 address of the gateway.
+ipv6.host\_table        | integer   | -                  | no        | The custom policy routing table ID to add IPv6 static routes to (in addition to main routing table).
+vlan                    | integer   | -                  | no        | The VLAN ID to attach to
 
 #### nictype: p2p
 

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -207,6 +207,7 @@ var APIExtensions = []string{
 	"api_os",
 	"container_nic_routed_host_table",
 	"container_nic_ipvlan_host_table",
+	"container_nic_ipvlan_mode",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Adds l2 mode support for `ipvlan` NIC. This mode allows a container to define its own IPs and avoid the need to use proxy ARP/NDP. Although l2 mode removes the ability for the host to firewall the container traffic.

Adds a new NIC config key `mode`, which can be either `l3s` or `l2` (defaults to `l3s` which is current behaviour).

In `l2` mode, the `ipv4.address` and `ipv6.address` keys allow addresses to be specified in CIDR format, e.g. `192.168.0.1/27` allowing for the container to join the same layer 2 subnet as the wider network. If a singular address is specified, such as `192.168.0.1` then the subnet is assumed to be `/24` for IPv4 and `/64` for IPv6.

In `l2` mode the `ipv4.gateway` and `ipv6.gateway` keys require a specific IP address if used, as the host is not used as a router unlike `l3s` mode.

Fixes https://github.com/lxc/lxd/issues/6964

Includes https://github.com/lxc/lxd/pull/7193