### PR TITLE
index.md: add PATH env variable to sudo command example

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -150,7 +150,7 @@ Now you can run the daemon (the `--group sudo` bit allows everyone in the `sudo`
 group to talk to LXD; you can create your own group if you want):
 
 ```bash
-sudo -E LD_LIBRARY_PATH=$LD_LIBRARY_PATH $GOPATH/bin/lxd --group sudo
+sudo -E PATH=$PATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH $GOPATH/bin/lxd --group sudo
 ```
 
 ## Security


### PR DESCRIPTION
Tiny detail that makes a big difference: Following README file, at the
moment of machine setup, PATH should be $GOPATH/bin. This PATH contains
the "lxd-agent" binary and, if PATH is not passed by sudo, it won't get
included in machine's 9p config filesystem.

Signed-off-by: Rafael David Tinoco <rafaeldtinoco@ubuntu.com>