### PR TITLE
VM: Adds cephfs disk support

### DIFF
--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -245,6 +245,7 @@ func cephFsConfig(clusterName string, userName string) ([]string, string, error)
 	return cephMon, cephSecret, nil
 }
 
+// diskCephfsOptions returns the mntSrcPath and fsOptions to use for mounting a cephfs share.
 func diskCephfsOptions(clusterName string, userName string, fsName string, fsPath string) (string, string, error) {
 	// Get the credentials and host
 	monAddresses, secret, err := cephFsConfig(clusterName, userName)


### PR DESCRIPTION
Testing done:

```
lxc storage create cephfs cephfs source=persist-cephfs/persist-edfu
lxc config device add c1 testvol disk source=cephfs:persist-cephfs/persist-edfu path=/mnt
lxc start v1

mount
[2001:470:b0f8:1015:5054:ff:fe5e:ea44]:6789,[2001:470:b0f8:1015:5054:ff:fe0a:750f]:6789,[2001:470:b0f8:1015:5054:ff:fe5e:4c7b]:6789:/persist-edfu/test on /var/lib/lxd/devices/v1/disk.testvol.mnt- type ceph (ro,relatime,name=admin,secret=<hidden>,acl,mds_namespace=persist-cephfs,wsize=33554432)

lxc exec c1 mount
lxd_testvol on /mnt type 9p (rw,relatime,sync,dirsync,access=client,trans=virtio)
lxc stop v1

mount on host gone.
```
