### PR TITLE
lxd/init: Improve error messages when failing to bind an address

### DIFF
--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -124,7 +124,7 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer) error
 			}
 			listener, err := net.Listen("tcp", address)
 			if err != nil {
-				return fmt.Errorf("Can't bind address %q", address)
+				return fmt.Errorf("Can't bind address %q: %v", address, err)
 			}
 			listener.Close()
 			return nil
@@ -656,7 +656,7 @@ they otherwise would.
 			address := fmt.Sprintf("%s:%d", netAddr, netPort)
 			listener, err := net.Listen("tcp", address)
 			if err != nil {
-				return fmt.Errorf("Can't bind address %q", address)
+				return fmt.Errorf("Can't bind address %q: %v", address, err)
 			}
 			listener.Close()
 			return nil


### PR DESCRIPTION
Note for reviewers (especially @stgraber): I realized that now that we try to listen to the configured network address in `lxd init`, the behavior is not idempotent anymore. If you try to run again `lxd init` and use the same network address you'll get an error. Not sure if we care about this.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>