### PR TITLE
Proxy: Adds hairpin NAT rules

### DIFF
--- a/lxd/device/proxy.go
+++ b/lxd/device/proxy.go
@@ -273,8 +273,9 @@ func (d *proxy) setupNAT() error {
 	}
 
 	var connectIP net.IP
+	var hostName string
 
-	for _, devConfig := range d.inst.ExpandedDevices() {
+	for devName, devConfig := range d.inst.ExpandedDevices() {
 		if devConfig["type"] != "nic" || (devConfig["type"] == "nic" && devConfig.NICType() != "bridged") {
 			continue
 		}
@@ -285,18 +286,22 @@ func (d *proxy) setupNAT() error {
 		if ipFamily == "ipv4" && devConfig["ipv4.address"] != "" {
 			if connectHost == devConfig["ipv4.address"] || connectHost == "0.0.0.0" {
 				connectIP = net.ParseIP(devConfig["ipv4.address"])
-				break
 			}
 		} else if ipFamily == "ipv6" && devConfig["ipv6.address"] != "" {
 			if connectHost == devConfig["ipv6.address"] || connectHost == "::" {
 				connectIP = net.ParseIP(devConfig["ipv6.address"])
-				break
 			}
+		}
+
+		if connectIP != nil {
+			// Get host_name of device so we can enable hairpin mode on bridge port.
+			hostName = d.inst.ExpandedConfig()[fmt.Sprintf("volatile.%s.host_name", devName)]
+			break // Found a match, stop searching.
 		}
 	}
 
 	if connectIP == nil {
-		return fmt.Errorf("Proxy connect IP cannot be used with any NIC static IPs")
+		return fmt.Errorf("Proxy connect IP cannot be used with any of the instance NICs static IPs")
 	}
 
 	// Override the host part of the connectAddr.Addr to the chosen connect IP.
@@ -317,6 +322,18 @@ func (d *proxy) setupNAT() error {
 	err = d.checkBridgeNetfilterEnabled(ipFamily)
 	if err != nil {
 		logger.Warnf("Proxy bridge netfilter not enabled: %v. Instances using the bridge will not be able to connect to the proxy's listen IP", err)
+	} else {
+		if hostName == "" {
+			return fmt.Errorf("Proxy cannot find bridge port host_name to enable hairpin mode")
+		}
+
+		// br_netfilter is enabled, so we need to enable hairpin mode on instance's bridge port otherwise
+		// the instances on the bridge will not be able to connect to the proxy device's listn IP and the
+		// NAT rule added by the firewall below to allow instance <-> instance traffic will also not work.
+		_, err = shared.RunCommand("bridge", "link", "set", "dev", hostName, "hairpin", "on")
+		if err != nil {
+			return errors.Wrapf(err, "Error enabling hairpin mode on bridge port %q", hostName)
+		}
 	}
 
 	err = d.state.Firewall.InstanceSetupProxyNAT(d.inst.Project(), d.inst.Name(), d.name, listenAddr, connectAddr)

--- a/lxd/firewall/drivers/drivers_nftables.go
+++ b/lxd/firewall/drivers/drivers_nftables.go
@@ -376,6 +376,8 @@ func (d Nftables) InstanceSetupProxyNAT(projectName string, instanceName string,
 			"listenHost":  listenHost,
 			"listenPort":  listenPort,
 			"connectDest": connectDest,
+			"connectHost": connectHost,
+			"connectPort": connectPort,
 		})
 	}
 
@@ -399,7 +401,7 @@ func (d Nftables) InstanceSetupProxyNAT(projectName string, instanceName string,
 // InstanceClearProxyNAT remove DNAT rules for proxy devices.
 func (d Nftables) InstanceClearProxyNAT(projectName string, instanceName string, deviceName string) error {
 	deviceLabel := d.instanceDeviceLabel(projectName, instanceName, deviceName)
-	err := d.removeChains([]string{"ip", "ip6"}, deviceLabel, "out", "prert")
+	err := d.removeChains([]string{"ip", "ip6"}, deviceLabel, "out", "prert", "pstrt")
 	if err != nil {
 		return errors.Wrapf(err, "Failed clearing proxy rules for instance device %q", deviceLabel)
 	}

--- a/lxd/firewall/drivers/drivers_nftables.go
+++ b/lxd/firewall/drivers/drivers_nftables.go
@@ -363,19 +363,19 @@ func (d Nftables) InstanceSetupProxyNAT(projectName string, instanceName string,
 
 		// Figure out which IP family we are using and format the destination host/port as appropriate.
 		family := "ip"
-		toDest := fmt.Sprintf("%s:%s", connectHost, connectPort)
+		connectDest := fmt.Sprintf("%s:%s", connectHost, connectPort)
 		connectIP := net.ParseIP(connectHost)
 		if connectIP.To4() == nil {
 			family = "ip6"
-			toDest = fmt.Sprintf("[%s]:%s", connectHost, connectPort)
+			connectDest = fmt.Sprintf("[%s]:%s", connectHost, connectPort)
 		}
 
 		rules = append(rules, map[string]interface{}{
-			"family":     family,
-			"connType":   listen.ConnType,
-			"listenHost": listenHost,
-			"listenPort": listenPort,
-			"toDest":     toDest,
+			"family":      family,
+			"connType":    listen.ConnType,
+			"listenHost":  listenHost,
+			"listenPort":  listenPort,
+			"connectDest": connectDest,
 		})
 	}
 

--- a/lxd/firewall/drivers/drivers_nftables_templates.go
+++ b/lxd/firewall/drivers/drivers_nftables_templates.go
@@ -57,7 +57,7 @@ var nftablesNetProxyNAT = template.Must(template.New("nftablesNetProxyNAT").Pars
 chain prert{{.chainSeparator}}{{.deviceLabel}} {
 	type nat hook prerouting priority -100; policy accept;
 	{{- range .rules}}
-	{{.family}} daddr {{.listenHost}} {{.connType}} dport {{.listenPort}} dnat to {{.toDest}}
+	{{.family}} daddr {{.listenHost}} {{.connType}} dport {{.listenPort}} dnat to {{.connectDest}}
 	{{- end}}
 }
 

--- a/lxd/firewall/drivers/drivers_nftables_templates.go
+++ b/lxd/firewall/drivers/drivers_nftables_templates.go
@@ -61,10 +61,17 @@ chain prert{{.chainSeparator}}{{.deviceLabel}} {
 	{{- end}}
 }
 
-chain out{{.chainSeparator}}{{.deviceLabel}}{
+chain out{{.chainSeparator}}{{.deviceLabel}} {
 	type nat hook output priority -100; policy accept;
 	{{- range .rules}}
-	{{.family}} daddr {{.listenHost}} {{.connType}} dport {{.listenPort}} dnat to {{.toDest}}
+	{{.family}} daddr {{.listenHost}} {{.connType}} dport {{.listenPort}} dnat to {{.connectDest}}
+	{{- end}}
+}
+
+chain pstrt{{.chainSeparator}}{{.deviceLabel}} {
+	type nat hook postrouting priority 100; policy accept;
+	{{- range .rules}}
+	{{.family}} saddr {{.connectHost}} ip daddr {{.connectHost}} {{.connType}} dport {{.connectPort}} masquerade
 	{{- end}}
 }
 `))

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -379,21 +379,21 @@ func (d Xtables) InstanceSetupProxyNAT(projectName string, instanceName string, 
 
 		// Decide if we are using iptables/ip6tables and format the destination host/port as appropriate.
 		ipVersion := uint(4)
-		toDest := fmt.Sprintf("%s:%s", connectHost, connectPort)
+		connectDest := fmt.Sprintf("%s:%s", connectHost, connectPort)
 		connectIP := net.ParseIP(connectHost)
 		if connectIP.To4() == nil {
 			ipVersion = 6
-			toDest = fmt.Sprintf("[%s]:%s", connectHost, connectPort)
+			connectDest = fmt.Sprintf("[%s]:%s", connectHost, connectPort)
 		}
 
 		// outbound <-> instance.
-		err = d.iptablesPrepend(ipVersion, comment, "nat", "PREROUTING", "-p", listen.ConnType, "--destination", listenHost, "--dport", listenPort, "-j", "DNAT", "--to-destination", toDest)
+		err = d.iptablesPrepend(ipVersion, comment, "nat", "PREROUTING", "-p", listen.ConnType, "--destination", listenHost, "--dport", listenPort, "-j", "DNAT", "--to-destination", connectDest)
 		if err != nil {
 			return err
 		}
 
 		// host <-> instance.
-		err = d.iptablesPrepend(ipVersion, comment, "nat", "OUTPUT", "-p", listen.ConnType, "--destination", listenHost, "--dport", listenPort, "-j", "DNAT", "--to-destination", toDest)
+		err = d.iptablesPrepend(ipVersion, comment, "nat", "OUTPUT", "-p", listen.ConnType, "--destination", listenHost, "--dport", listenPort, "-j", "DNAT", "--to-destination", connectDest)
 		if err != nil {
 			return err
 		}

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -397,6 +397,13 @@ func (d Xtables) InstanceSetupProxyNAT(projectName string, instanceName string, 
 		if err != nil {
 			return err
 		}
+
+		// instance <-> instance.
+		// Requires instance's bridge port has hairpin mode enabled when br_netfilter is loaded.
+		err = d.iptablesPrepend(ipVersion, comment, "nat", "POSTROUTING", "-p", listen.ConnType, "--source", connectHost, "--destination", connectHost, "--dport", connectPort, "-j", "MASQUERADE")
+		if err != nil {
+			return err
+		}
 	}
 
 	revert.Success()

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -377,7 +377,7 @@ func (d Xtables) InstanceSetupProxyNAT(projectName string, instanceName string, 
 			return err
 		}
 
-		// Figure out if we are using iptables or ip6tables and format the destination host/port as appropriate.
+		// Decide if we are using iptables/ip6tables and format the destination host/port as appropriate.
 		ipVersion := uint(4)
 		toDest := fmt.Sprintf("%s:%s", connectHost, connectPort)
 		connectIP := net.ParseIP(connectHost)
@@ -386,13 +386,13 @@ func (d Xtables) InstanceSetupProxyNAT(projectName string, instanceName string, 
 			toDest = fmt.Sprintf("[%s]:%s", connectHost, connectPort)
 		}
 
-		// outbound <-> container.
+		// outbound <-> instance.
 		err = d.iptablesPrepend(ipVersion, comment, "nat", "PREROUTING", "-p", listen.ConnType, "--destination", listenHost, "--dport", listenPort, "-j", "DNAT", "--to-destination", toDest)
 		if err != nil {
 			return err
 		}
 
-		// host <-> container.
+		// host <-> instance.
 		err = d.iptablesPrepend(ipVersion, comment, "nat", "OUTPUT", "-p", listen.ConnType, "--destination", listenHost, "--dport", listenPort, "-j", "DNAT", "--to-destination", toDest)
 		if err != nil {
 			return err
@@ -433,7 +433,7 @@ func (d Xtables) InstanceClearProxyNAT(projectName string, instanceName string, 
 
 // generateFilterEbtablesRules returns a customised set of ebtables filter rules based on the device.
 func (d Xtables) generateFilterEbtablesRules(hostName string, hwAddr string, IPv4 net.IP, IPv6 net.IP) [][]string {
-	// MAC source filtering rules. Blocks any packet coming from instance with an incorrect Ethernet source MAC.
+	// MAC source filtering rules. Block any packet coming from instance with an incorrect Ethernet source MAC.
 	// This is required for IP filtering too.
 	rules := [][]string{
 		{"ebtables", "-t", "filter", "-A", "INPUT", "-s", "!", hwAddr, "-i", hostName, "-j", "DROP"},

--- a/test/suites/container_devices_proxy.sh
+++ b/test/suites/container_devices_proxy.sh
@@ -153,7 +153,7 @@ container_devices_proxy_tcp() {
   # enable NAT
   lxc config device set nattest validNAT nat true
   if [ "$firewallDriver" = "xtables" ]; then
-    [ "$(iptables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 2 ]
+    [ "$(iptables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 3 ]
   else
       [ "$(nft -nn list chain ip lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat to ${v4_addr}:1234")" -eq 1 ]
       [ "$(nft -nn list chain ip lxd out.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat to ${v4_addr}:1234")" -eq 1 ]
@@ -169,7 +169,7 @@ container_devices_proxy_tcp() {
 
   lxc config device add nattest validNAT proxy listen="tcp:127.0.0.1:1234-1235" connect="tcp:${v4_addr}:1234" bind=host nat=true
   if [ "$firewallDriver" = "xtables" ]; then
-    [ "$(iptables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 4 ]
+    [ "$(iptables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 5 ]
   else
       [ "$(nft -nn list chain ip lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat to ${v4_addr}:1234")" -eq 1 ]
       [ "$(nft -nn list chain ip lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1235 dnat to ${v4_addr}:1234")" -eq 1 ]
@@ -187,7 +187,7 @@ container_devices_proxy_tcp() {
 
   lxc config device add nattest validNAT proxy listen="tcp:127.0.0.1:1234-1235" connect="tcp:${v4_addr}:1234-1235" bind=host nat=true
   if [ "$firewallDriver" = "xtables" ]; then
-    [ "$(iptables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 4 ]
+    [ "$(iptables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 6 ]
   else
       [ "$(nft -nn list chain ip lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat to ${v4_addr}:1234")" -eq 1 ]
       [ "$(nft -nn list chain ip lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1235 dnat to ${v4_addr}:1235")" -eq 1 ]
@@ -206,7 +206,7 @@ container_devices_proxy_tcp() {
   # IPv6 test
   lxc config device add nattest validNAT proxy listen="tcp:[::1]:1234" connect="tcp:[::]:1234" bind=host nat=true
   if [ "$firewallDriver" = "xtables" ]; then
-    [ "$(ip6tables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 2 ]
+    [ "$(ip6tables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 3 ]
   else
       [ "$(nft -nn list chain ip6 lxd prert.nattest.validNAT | grep -c "ip6 daddr ::1 tcp dport 1234 dnat to \[${v6_addr}\]:1234")" -eq 1 ]
       [ "$(nft -nn list chain ip6 lxd out.nattest.validNAT | grep -c "ip6 daddr ::1 tcp dport 1234 dnat to \[${v6_addr}\]:1234")" -eq 1 ]


### PR DESCRIPTION
Allows instances to access the proxy device's listen IP when using NAT mode.

Fixes https://github.com/lxc/lxd/issues/7205