### PR TITLE
lxd/instance/lxc: Don't crash in setNetworkPriority

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6369,6 +6369,13 @@ func (c *lxc) removeDiskDevices() error {
 
 // Network I/O limits
 func (c *lxc) setNetworkPriority() error {
+	// Load the go-lxc struct.
+	err := c.initLXC(false)
+	if err != nil {
+		return err
+	}
+
+	// Load the cgroup struct.
 	cg, err := c.cgroup(nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>