### PR TITLE
Storage: Regenerate cached image volumes when cannot be shrunk

### DIFF
--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -815,7 +815,7 @@ func (d *ceph) SetVolumeQuota(vol Volume, size string, op *operations.Operation)
 		}
 	} else {
 		if newSizeBytes < oldSizeBytes {
-			return fmt.Errorf("You cannot shrink block volumes")
+			return errors.Wrap(ErrCannotBeShrunk, "You cannot shrink block volumes")
 		}
 
 		// Grow the block device.

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -382,7 +382,7 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 		}
 	} else {
 		if newSizeBytes < oldSizeBytes {
-			return fmt.Errorf("You cannot shrink block volumes")
+			return errors.Wrap(ErrCannotBeShrunk, "You cannot shrink block volumes")
 		}
 
 		err = d.resizeLogicalVolume(volDevPath, newSizeBytes)

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -853,7 +853,7 @@ func (d *zfs) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 		}
 
 		if sizeBytes < oldVolSizeBytes {
-			return fmt.Errorf("You cannot shrink block volumes")
+			return errors.Wrap(ErrCannotBeShrunk, "You cannot shrink block volumes")
 		}
 
 		err = d.setDatasetProperties(d.dataset(vol, false), fmt.Sprintf("volsize=%d", sizeBytes))

--- a/lxd/storage/drivers/errors.go
+++ b/lxd/storage/drivers/errors.go
@@ -13,6 +13,9 @@ var ErrUnknownDriver = fmt.Errorf("Unknown driver")
 // ErrNotSupported is the "Not supported" error
 var ErrNotSupported = fmt.Errorf("Not supported")
 
+// ErrCannotBeShrunk is the "Cannot be shrunk" error
+var ErrCannotBeShrunk = fmt.Errorf("Cannot be shrunk")
+
 // ErrDeleteSnapshots is a special error used to tell the backend to delete more recent snapshots
 type ErrDeleteSnapshots struct {
 	Snapshots []string

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -781,7 +781,7 @@ func genericVFSResizeBlockFile(filePath, size string) (bool, error) {
 	}
 
 	if newSizeBytes < oldSizeBytes {
-		return false, fmt.Errorf("You cannot shrink block volumes")
+		return false, errors.Wrap(ErrCannotBeShrunk, "You cannot shrink block volumes")
 	}
 
 	if newSizeBytes == oldSizeBytes {

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -462,7 +462,7 @@ func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64)
 	case "": // if not specified, default to ext4.
 		fallthrough
 	case "xfs":
-		return fmt.Errorf(`Shrinking not supported for filesystem type "%s". A dump, mkfs, and restore are required`, fsType)
+		return errors.Wrapf(ErrCannotBeShrunk, `Shrinking not supported for filesystem type "%s". A dump, mkfs, and restore are required`, fsType)
 	case "ext4":
 		return vol.UnmountTask(func(op *operations.Operation) error {
 			output, err := shared.RunCommand("e2fsck", "-f", "-y", devPath)
@@ -488,7 +488,7 @@ func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64)
 			return nil
 		}, nil)
 	default:
-		return fmt.Errorf(`Shrinking not supported for filesystem type "%s"`, fsType)
+		return errors.Wrapf(ErrCannotBeShrunk, `Shrinking not supported for filesystem type "%s"`, fsType)
 	}
 }
 


### PR DESCRIPTION
When creating containers on a block backed pool or creating a VM that supports optimized images, a cached image volume is created that contains the unpacked image using the `volume.size` property of the pool (or the default block size). This is used to speed up subsequent image creations by creating a snapshot of the cached image volume.

However if the `volume.size` property of a pool is changed *after* the initial cached block volume is created, subsequent instance creates will notice this an attempt to resize the new volume to the correct size.

A problem occurs if the new `volume.size` is smaller than the cached image volume size, as some filesystems used by containers don't support shrinking, and no VM volumes allow for shrinking currently.

This PR allows the storage pool driver to advise via a custom error that the volume cannot be shrunk, and if the instance is being created from a cached image copy then the cached image copy is deleted and re-created using the current storage pool settings.