### PR TITLE
lxd: Updates snapshotProtobufToInstanceArgs to support instance type

### DIFF
--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -885,7 +885,7 @@ func (c *migrationSink) Do(state *state.State, migrateOp *operations.Operation) 
 			volTargetArgs.Snapshots = make([]string, 0, len(args.Snapshots))
 			for _, snap := range args.Snapshots {
 				volTargetArgs.Snapshots = append(volTargetArgs.Snapshots, *snap.Name)
-				snapArgs := snapshotProtobufToInstanceArgs(args.Instance.Project(), args.Instance.Name(), snap)
+				snapArgs := snapshotProtobufToInstanceArgs(args.Instance, snap)
 
 				// Ensure that snapshot and parent container have the same
 				// storage pool in their local root disk device. If the root

--- a/lxd/storage_migration.go
+++ b/lxd/storage_migration.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/lxc/lxd/lxd/db"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
-	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/shared"
 )
 
-func snapshotProtobufToInstanceArgs(project string, containerName string, snap *migration.Snapshot) db.InstanceArgs {
+func snapshotProtobufToInstanceArgs(inst instance.Instance, snap *migration.Snapshot) db.InstanceArgs {
 	config := map[string]string{}
 
 	for _, ent := range snap.LocalConfig {
@@ -27,18 +27,17 @@ func snapshotProtobufToInstanceArgs(project string, containerName string, snap *
 		devices[ent.GetName()] = props
 	}
 
-	name := containerName + shared.SnapshotDelimiter + snap.GetName()
 	args := db.InstanceArgs{
 		Architecture: int(snap.GetArchitecture()),
 		Config:       config,
-		Type:         instancetype.Container,
+		Type:         inst.Type(),
 		Snapshot:     true,
 		Devices:      devices,
 		Ephemeral:    snap.GetEphemeral(),
-		Name:         name,
+		Name:         inst.Name() + shared.SnapshotDelimiter + snap.GetName(),
 		Profiles:     snap.Profiles,
 		Stateful:     snap.GetStateful(),
-		Project:      project,
+		Project:      inst.Project(),
 	}
 
 	if snap.GetCreationDate() != 0 {


### PR DESCRIPTION
Although I don't believe that instance type in snapshots is used by the database layer anymore, it shouldn't be hardcoded to container in case the struct is used in other places in the future.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>