### PR TITLE
lxd/qemu: Match basic NUMA layout

### DIFF
--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -154,6 +154,21 @@ cpus = "{{.cpuCount}}"
 sockets = "{{.cpuSockets}}"
 cores = "{{.cpuCores}}"
 threads = "{{.cpuThreads}}"
+
+{{range $index, $element := .cpuNumaNodes}}
+[numa]
+type = "node"
+nodeid = "{{$element}}"
+{{end}}
+
+{{range .cpuNumaMapping}}
+[numa]
+type = "cpu"
+node-id = "{{.node}}"
+socket-id = "{{.socket}}"
+core-id = "{{.core}}"
+thread-id = "{{.thread}}"
+{{end}}
 `))
 
 var qemuControlSocket = template.Must(template.New("qemuControlSocket").Parse(`


### PR DESCRIPTION
This now mimics the NUMA layout of the host in the guest for cases where
specific CPUs have been pinned.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>