### PR TITLE
Storage ZFS: Delete volume on error in CreateVolumeFromCopy

### DIFF
--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -514,6 +514,9 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 		if err != nil {
 			return err
 		}
+
+		// Delete on revert.
+		revert.Add(func() { d.DeleteVolume(vol, op) })
 	}
 
 	// Apply the properties.


### PR DESCRIPTION
This was previously relying on the backend_lxd revert logic, but now we need CreateVolumeFromCopy to correctly revert on error so we can call it again if needed.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>