### PR TITLE
lxd/device/utils: Do not add the Ceph mon port if already present in /etc/ceph config file

### DIFF
--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -207,7 +207,7 @@ func cephFsConfig(clusterName string, userName string) ([]string, string, error)
 	}
 
 	if len(cephMon) == 0 {
-		return nil, "", fmt.Errorf("Couldn't find a CPEH mon")
+		return nil, "", fmt.Errorf("Couldn't find a CEPH mon")
 	}
 
 	// Parse the CEPH keyring
@@ -256,7 +256,12 @@ func diskCephfsOptions(clusterName string, userName string, fsName string, fsPat
 	fsOptions := fmt.Sprintf("name=%v,secret=%v,mds_namespace=%v", userName, secret, fsName)
 	srcpath := ""
 	for _, monAddress := range monAddresses {
-		srcpath += fmt.Sprintf("%s:6789,", monAddress)
+		// Add the default port to the mon hosts if not already provided
+		if strings.Contains(monAddress, ":6789") {
+			srcpath += fmt.Sprintf("%s,", monAddress)
+		} else {
+			srcpath += fmt.Sprintf("%s:6789,", monAddress)
+		}
 	}
 	srcpath = srcpath[:len(srcpath)-1]
 	srcpath += fmt.Sprintf(":/%s", fsPath)


### PR DESCRIPTION
Hello,

I had a little issue while configuring a CephFS device as described [here](https://lxd.readthedocs.io/en/latest/instances/#devices-configuration):

```
root@ubuntu-focal:~# lxc config device add u1 myfs disk source=cephfs:myfs/ ceph.user_name=admin ceph.cluster_name=ceph path=/cephfs
Error: Failed to start device "myfs": Unable to mount 10.0.0.1:6789:6789,10.0.0.2:6789:6789,10.0.0.3:6789:6789:/ at /var/lib/lxd/devices/u1/disk.myfs.cephfs: invalid argument

root@ubuntu-focal:~# cat /etc/ceph/ceph.conf 
[global]
mon_host = 10.0.0.1:6789,10.0.0.2:6789,10.0.0.3:6789
```

If the `/etc/ceph/$cluster_name.conf` file already has ports configured for the `mon_host` variable, the `diskCephfsOptions` should not append it another time.

This PR checks whether or not the ports should be added.

Thanks,

Léo