### PR TITLE
Storage: ZFS image volume regeneration when pool volume.size smaller than cached volume

### DIFF
--- a/lxd/storage/drivers/driver_zfs_utils.go
+++ b/lxd/storage/drivers/driver_zfs_utils.go
@@ -55,7 +55,7 @@ func (d *zfs) createDataset(dataset string, options ...string) error {
 }
 
 func (d *zfs) createVolume(dataset string, size int64, options ...string) error {
-	size = (size / 8192) * 8192
+	size = (size / minBlockBoundary) * minBlockBoundary
 
 	args := []string{"create", "-s", "-V", fmt.Sprintf("%d", size)}
 	for _, option := range options {

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -838,7 +838,7 @@ func (d *zfs) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 
 	// Handle volume datasets.
 	if vol.contentType == ContentTypeBlock {
-		sizeBytes = (sizeBytes / 8192) * 8192
+		sizeBytes = (sizeBytes / minBlockBoundary) * minBlockBoundary
 
 		oldSizeBytesStr, err := d.getDatasetProperty(d.dataset(vol, false), "volsize")
 		if err != nil {

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -117,6 +117,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 				}
 			}
 
+			revert.Success()
 			return nil
 		}
 	}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -45,22 +45,80 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 
 	// Look for previously deleted images.
 	if vol.volType == VolumeTypeImage && d.checkDataset(d.dataset(vol, true)) {
-		// Restore the image.
-		_, err := shared.RunCommand("/proc/self/exe", "forkzfs", "--", "rename", d.dataset(vol, true), d.dataset(vol, false))
-		if err != nil {
-			return err
-		}
+		canRestore := true
 
-		if vol.IsVMBlock() {
-			fsVol := vol.NewVMBlockFilesystemVolume()
-
-			_, err := shared.RunCommand("/proc/self/exe", "forkzfs", "--", "rename", d.dataset(fsVol, true), d.dataset(fsVol, false))
+		// For block volumes check if the cached image volume is larger than the current pool volume.size
+		// setting (if so we won't be able to resize the snapshot to that the smaller size later).
+		if vol.contentType == ContentTypeBlock {
+			volSize, err := d.getDatasetProperty(d.dataset(vol, true), "volsize")
 			if err != nil {
 				return err
 			}
+
+			volSizeBytes, err := strconv.ParseInt(volSize, 10, 64)
+			if err != nil {
+				return err
+			}
+
+			poolVolSize := defaultBlockSize
+			if vol.poolConfig["volume.size"] != "" {
+				poolVolSize = vol.poolConfig["volume.size"]
+			}
+
+			poolVolSizeBytes, err := units.ParseByteSizeString(poolVolSize)
+			if err != nil {
+				return err
+			}
+
+			// Round to block boundary.
+			poolVolSizeBytes = (poolVolSizeBytes / minBlockBoundary) * minBlockBoundary
+
+			// If the cached volume is larger than the pool volume size, then we can't use the
+			// deleted cached image volume and instead we will rename it to a random UUID so it can't
+			// be restored in the future and a new cached image volume will be created instead.
+			if volSizeBytes > poolVolSizeBytes {
+				d.logger.Debug("Renaming deleted cached image volume so that regeneration is used")
+				randomVol := NewVolume(d, d.name, vol.volType, vol.contentType, strings.Replace(uuid.NewRandom().String(), "-", "", -1), vol.config, vol.poolConfig)
+
+				_, err := shared.RunCommand("/proc/self/exe", "forkzfs", "--", "rename", d.dataset(vol, true), d.dataset(randomVol, true))
+				if err != nil {
+					return err
+				}
+
+				if vol.IsVMBlock() {
+					fsVol := vol.NewVMBlockFilesystemVolume()
+					randomFsVol := randomVol.NewVMBlockFilesystemVolume()
+
+					_, err := shared.RunCommand("/proc/self/exe", "forkzfs", "--", "rename", d.dataset(fsVol, true), d.dataset(randomFsVol, true))
+					if err != nil {
+						return err
+					}
+				}
+
+				// We have renamed the deleted cached image volume, so we don't want to try and
+				// restore it.
+				canRestore = false
+			}
 		}
 
-		return nil
+		// Restore the image.
+		if canRestore {
+			_, err := shared.RunCommand("/proc/self/exe", "forkzfs", "--", "rename", d.dataset(vol, true), d.dataset(vol, false))
+			if err != nil {
+				return err
+			}
+
+			if vol.IsVMBlock() {
+				fsVol := vol.NewVMBlockFilesystemVolume()
+
+				_, err := shared.RunCommand("/proc/self/exe", "forkzfs", "--", "rename", d.dataset(fsVol, true), d.dataset(fsVol, false))
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		}
 	}
 
 	// After this point we'll have a volume, so setup revert.

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -19,6 +19,8 @@ import (
 	"github.com/lxc/lxd/shared/units"
 )
 
+const minBlockBoundary = 8192
+
 // wipeDirectory empties the contents of a directory, but leaves it in place.
 func wipeDirectory(path string) error {
 	// List all entries.
@@ -320,7 +322,6 @@ func roundVolumeBlockFileSizeBytes(blockSize string) (int64, error) {
 
 	// Qemu requires image files to be in traditional storage block boundaries.
 	// We use 8k here to ensure our images are compatible with all of our backend drivers.
-	const minBlockBoundary = 8192
 	if blockSizeBytes < minBlockBoundary {
 		blockSizeBytes = minBlockBoundary
 	}


### PR DESCRIPTION
When a block backed pool's settings change (such as changing the `volume.size` setting) the old cached image volume (which is set to the old pool's volume.size or default) needs to be deleted and regenerated. 

However some storage drivers have an 'undelete' feature whereby when an image volume is 'deleted', if it is in use as a parent to other volumes, it is only renamed and not actually deleted. Then if a subsequent call to `EnsureImage()` is performed then the existing volume is just 'undeleted' and renamed back to its original name.

This causes problems when we really want to regenerate the volume from fresh, as the old image is still using the old larger size.

This PR introduces driver level detect of deleted image volumes being larger than the pool's `volume.size` setting and then renames them to a random name to avoid them being restored.