### PR TITLE
share/usbid: Don't print error when missing

### DIFF
--- a/shared/usbid/load.go
+++ b/shared/usbid/load.go
@@ -31,7 +31,9 @@ var (
 func init() {
 	usbids, err := os.Open("/usr/share/misc/usb.ids")
 	if err != nil {
-		log.Printf("usbid: failed to load: %s", err)
+		if !os.IsNotExist(err) {
+			log.Printf("usbid: failed to load: %s", err)
+		}
 		return
 	}
 	defer usbids.Close()


### PR DESCRIPTION
It's always missing during `lxd init` when run from the snap, even if
the daemon itself has access to it.

Closes #7256

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>