### PR TITLE
Resolve both core.https_address and cluster.https_address when comparing IPs

### DIFF
--- a/lxd/util/net.go
+++ b/lxd/util/net.go
@@ -167,6 +167,18 @@ func IsAddressCovered(address1, address2 string) bool {
 		return false
 	}
 
+	// If address1 contains a host name, let's try to resolve it, in order
+	// to compare the actual IPs.
+	if host1 != "" {
+		ip1 := net.ParseIP(host1)
+		if ip1 == nil {
+			ips, err := net.LookupHost(host1)
+			if err == nil && len(ips) > 0 {
+				host1 = ips[0]
+			}
+		}
+	}
+
 	// If address2 contains a host name, let's try to resolve it, in order
 	// to compare the actual IPs.
 	if host2 != "" {

--- a/lxd/util/net_test.go
+++ b/lxd/util/net_test.go
@@ -72,6 +72,7 @@ func TestIsAddressCovered(t *testing.T) {
 		{":8443", "[::]:8443", true},
 		{"0.0.0.0:8443", "[::]:8443", true},
 		{"10.30.0.8:8443", "[::]", true},
+		{"localhost:8443", "127.0.0.1:8443", true},
 	}
 
 	// Test some localhost cases too


### PR DESCRIPTION
Closes #7265.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>