### PR TITLE
Storage: CEPH Support cached image regeneration

### DIFF
--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -529,24 +529,14 @@ func (d *ceph) rbdListVolumeSnapshots(vol Volume) ([]string, error) {
 	return snapshots, nil
 }
 
-// getRBDSize returns the size the RBD storage volume is supposed to be created with.
-func (d *ceph) getRBDSize(vol Volume) (string, error) {
-	size, ok := vol.config["size"]
-	if !ok {
-		size = vol.poolConfig["volume.size"]
+// volumeSize returns the size to use when creating new RBD volumes.
+func (d *ceph) volumeSize(vol Volume) string {
+	size := vol.ExpandedConfig("size")
+	if size == "" || size == "0" {
+		return defaultBlockSize
 	}
 
-	sz, err := units.ParseByteSizeString(size)
-	if err != nil {
-		return "", err
-	}
-
-	// Safety net: Set to default value.
-	if sz == 0 {
-		sz, _ = units.ParseByteSizeString(defaultBlockSize)
-	}
-
-	return fmt.Sprintf("%dB", sz), nil
+	return size
 }
 
 // getRBDFilesystem returns the filesystem the RBD storage volume is supposed to be created with.

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -22,6 +22,8 @@ import (
 	"github.com/lxc/lxd/shared/units"
 )
 
+const cephVolumeTypeZombieImage = VolumeType("zombie_image")
+
 // osdPoolExists checks whether a given OSD pool exists.
 func (d *ceph) osdPoolExists() bool {
 	_, err := shared.RunCommand(

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -382,7 +382,9 @@ func (d *ceph) rbdMarkVolumeDeleted(vol Volume, newVolumeName string) error {
 // under its original name and the callers maps it under its new name the image
 // will be mapped twice. This will prevent it from being deleted.
 func (d *ceph) rbdRenameVolume(vol Volume, newVolumeName string) error {
-	newVol := NewVolume(d, d.name, vol.volType, vol.contentType, newVolumeName, nil, nil)
+	// Ensure that new volume contains the config from the source volume to maintain filesystem suffix on
+	// new volume name generated in getRBDVolumeName.
+	newVol := NewVolume(d, d.name, vol.volType, vol.contentType, newVolumeName, vol.config, vol.poolConfig)
 
 	_, err := shared.RunCommand(
 		"rbd",
@@ -390,7 +392,8 @@ func (d *ceph) rbdRenameVolume(vol Volume, newVolumeName string) error {
 		"--cluster", d.config["ceph.cluster_name"],
 		"mv",
 		d.getRBDVolumeName(vol, "", false, true),
-		d.getRBDVolumeName(newVol, "", false, true))
+		d.getRBDVolumeName(newVol, "", false, true),
+	)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -767,8 +767,7 @@ func (d *ceph) deleteVolumeSnapshot(vol Volume, snapshotName string) (int, error
 			return -1, err
 		}
 
-		// Only delete the parent image if it is a zombie. If it is not
-		// we know that LXD is still using it.
+		// Only delete the parent image if it is a zombie. If it is not we know that LXD is still using it.
 		if strings.HasPrefix(string(vol.volType), "zombie_") {
 			ret, err := d.deleteVolume(vol)
 			if ret < 0 {

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -1059,11 +1059,12 @@ func (d *ceph) getRBDVolumeName(vol Volume, snapName string, zombie bool, withPo
 	volumeType := string(vol.volType)
 	parentName, snapshotName, isSnapshot := shared.InstanceGetParentAndSnapshotName(vol.name)
 
-	if vol.volType == VolumeTypeImage {
+	// Only use filesystem suffix on filesystem type image volumes (for all content types).
+	if vol.volType == VolumeTypeImage || vol.volType == cephVolumeTypeZombieImage {
 		parentName = fmt.Sprintf("%s_%s", parentName, d.getRBDFilesystem(vol))
 	}
 
-	if (vol.volType == VolumeTypeVM || vol.volType == VolumeTypeImage) && vol.contentType == ContentTypeBlock {
+	if vol.contentType == ContentTypeBlock {
 		parentName = fmt.Sprintf("%s.block", parentName)
 	}
 

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -658,8 +658,7 @@ func (d *ceph) deleteVolume(vol Volume) (int, error) {
 				return -1, err
 			}
 
-			if strings.HasPrefix(vol.name, "zombie_") ||
-				strings.HasPrefix(string(vol.volType), "zombie_") {
+			if strings.HasPrefix(vol.name, "zombie_") || strings.HasPrefix(string(vol.volType), "zombie_") {
 				return 1, nil
 			}
 

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -70,6 +70,11 @@ func (d *ceph) osdDeletePool() error {
 // library and the kernel module are minimized. Otherwise random panics might
 // occur.
 func (d *ceph) rbdCreateVolume(vol Volume, size string) error {
+	sizeBytes, err := units.ParseByteSizeString(size)
+	if err != nil {
+		return err
+	}
+
 	cmd := []string{
 		"--id", d.config["ceph.user.name"],
 		"--image-feature", "layering,",
@@ -82,11 +87,11 @@ func (d *ceph) rbdCreateVolume(vol Volume, size string) error {
 	}
 
 	cmd = append(cmd,
-		"--size", size,
+		"--size", fmt.Sprintf("%dB", sizeBytes),
 		"create",
 		d.getRBDVolumeName(vol, "", false, false))
 
-	_, err := shared.RunCommand("rbd", cmd...)
+	_, err = shared.RunCommand("rbd", cmd...)
 	return err
 }
 

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -528,7 +528,7 @@ func (d *ceph) getRBDSize(vol Volume) (string, error) {
 
 	// Safety net: Set to default value.
 	if sz == 0 {
-		sz, _ = units.ParseByteSizeString("10GB")
+		sz, _ = units.ParseByteSizeString(defaultBlockSize)
 	}
 
 	return fmt.Sprintf("%dB", sz), nil

--- a/lxd/storage/drivers/driver_ceph_utils_test.go
+++ b/lxd/storage/drivers/driver_ceph_utils_test.go
@@ -1,6 +1,9 @@
 package drivers
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func Test_ceph_getRBDVolumeName(t *testing.T) {
 	type args struct {
@@ -109,4 +112,36 @@ func Test_ceph_getRBDVolumeName(t *testing.T) {
 			}
 		})
 	}
+}
+func Example_ceph_parseParent() {
+	d := &ceph{}
+
+	parents := []string{
+		"pool/zombie_image_9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb_ext4.block@readonly",
+		"pool/zombie_image_9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb_ext4.block",
+		"pool/image_9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb_ext4.block@readonly",
+		"pool/zombie_image_9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb_ext4@readonly",
+		"pool/zombie_image_9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb_ext4",
+		"pool/image_9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb_ext4@readonly",
+		"pool/zombie_image_2cfc5a5567b8d74c0986f3d8a77a2a78e58fe22ea9abd2693112031f85afa1a1_xfs@zombie_snapshot_7f6d679b-ee25-419e-af49-bb805cb32088",
+		"pool/container_bar@zombie_snapshot_ce77e971-6c1b-45c0-b193-dba9ec5e7d82",
+		"pool/container_test-project_c4.block",
+		"pool/zombie_container_test-project_c1_28e7a7ab-740a-490c-8118-7caf7810f83b@zombie_snapshot_1027f4ab-de11-4cee-8015-bd532a1fed76",
+	}
+
+	for _, parent := range parents {
+		vol, snapName, err := d.parseParent(parent)
+		fmt.Println(vol.pool, vol.volType, vol.name, vol.config["block.filesystem"], vol.contentType, snapName, err)
+	}
+
+	// Output: pool zombie_image 9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb ext4 block readonly <nil>
+	// pool zombie_image 9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb ext4 block  <nil>
+	// pool image 9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb ext4 block readonly <nil>
+	// pool zombie_image 9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb ext4 fs readonly <nil>
+	// pool zombie_image 9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb ext4 fs  <nil>
+	// pool image 9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb ext4 fs readonly <nil>
+	// pool zombie_image 2cfc5a5567b8d74c0986f3d8a77a2a78e58fe22ea9abd2693112031f85afa1a1 xfs fs zombie_snapshot_7f6d679b-ee25-419e-af49-bb805cb32088 <nil>
+	// pool container bar  fs zombie_snapshot_ce77e971-6c1b-45c0-b193-dba9ec5e7d82 <nil>
+	// pool container test-project_c4  block  <nil>
+	// pool zombie_container test-project_c1_28e7a7ab-740a-490c-8118-7caf7810f83b  fs zombie_snapshot_1027f4ab-de11-4cee-8015-bd532a1fed76 <nil>
 }

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -594,6 +594,10 @@ func (d *ceph) RefreshVolume(vol Volume, srcVol Volume, srcSnapshots []Volume, o
 // DeleteVolume deletes a volume of the storage device. If any snapshots of the volume remain then
 // this function will return an error.
 func (d *ceph) DeleteVolume(vol Volume, op *operations.Operation) error {
+	if !d.HasVolume(vol) {
+		return nil
+	}
+
 	if vol.volType == VolumeTypeImage {
 		// Try to umount but don't fail.
 		d.UnmountVolume(vol, op)
@@ -644,10 +648,6 @@ func (d *ceph) DeleteVolume(vol Volume, op *operations.Operation) error {
 			return err
 		}
 	} else {
-		if !d.HasVolume(vol) {
-			return nil
-		}
-
 		_, err := d.UnmountVolume(vol, op)
 		if err != nil {
 			return err

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -294,7 +294,7 @@ func (d *ceph) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots boo
 	// Copy without snapshots.
 	if !copySnapshots || len(snapshots) == 0 {
 		// If lightweight clone mode isn't enabled, perform a full copy of the volume.
-		if d.config["ceph.rbd.clone_copy"] != "" && !shared.IsTrue(d.config["ceph.rbd.clone_copy"]) && srcVol.volType != VolumeTypeImage {
+		if d.config["ceph.rbd.clone_copy"] != "" && !shared.IsTrue(d.config["ceph.rbd.clone_copy"]) {
 			_, err = shared.RunCommand(
 				"rbd",
 				"--id", d.config["ceph.user.name"],

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -467,15 +467,6 @@ func (d *ceph) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots boo
 		return err
 	}
 
-	ourMount, err := d.MountVolume(vol, op)
-	if err != nil {
-		return err
-	}
-
-	if ourMount {
-		defer d.UnmountVolume(vol, op)
-	}
-
 	revert.Success()
 
 	return nil

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -491,7 +491,7 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 		}
 	}
 
-	// Handle zfs.clone_copy
+	// If zfs.clone_copy is disabled or source volume has snapshots, then use full copy mode.
 	if (d.config["zfs.clone_copy"] != "" && !shared.IsTrue(d.config["zfs.clone_copy"])) || len(snapshots) > 0 {
 		snapName := strings.SplitN(srcSnapshot, "@", 2)[1]
 
@@ -557,6 +557,7 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 			}
 		}
 	} else {
+		// Perform volume clone.
 		args := []string{
 			"clone",
 			srcSnapshot,

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -133,8 +133,7 @@ func VolumeDBCreate(s *state.State, project, poolName, volumeName, volumeDescrip
 		return err
 	}
 
-	// Check that a storage volume of the same storage volume type does not
-	// already exist.
+	// Check that a storage volume of the same storage volume type does not already exist.
 	volumeID, _ := s.Cluster.StoragePoolNodeVolumeGetTypeIDByProject(project, volumeName, volumeType, poolID)
 	if volumeID > 0 {
 		return fmt.Errorf("A storage volume of type %s already exists", volumeTypeName)


### PR DESCRIPTION
This PR is larger than expected as I found a number of bugs and issues along the way:

- Allows regeneration of cached image volume if size is larger than pool's volume size.
- Ensures new volumes have their size set correctly (was previously ignored) when creating from an image volume.
- Always respects setting of `ceph.rbd.clone_copy`.
- Zombie image volumes were always suffixed with `_ext4` even if their filesystem wasn't that.
- Reworks zombie volume management to use volume type consistently rather than a mixture of volume type and volume name.