### PR TITLE
Storage: ZFS CreateVolumeFromCopy only set volume size when source is image

### DIFF
--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -594,15 +594,16 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 		}
 	}
 
-	// Resize the new volume and filesystem to the correct size.
-	err := d.SetVolumeQuota(vol, vol.ExpandedConfig("size"), nil)
-	if err != nil {
-		return err
+	// Resize the new volume and filesystem to the correct size if the source was an image.
+	if srcVol.volType == VolumeTypeImage {
+		err := d.SetVolumeQuota(vol, vol.ExpandedConfig("size"), nil)
+		if err != nil {
+			return err
+		}
 	}
 
 	// All done.
 	revert.Success()
-
 	return nil
 }
 


### PR DESCRIPTION

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>