### PR TITLE
Storage: LVM CreateVolumeFromCopy only set volume size when source is image

### DIFF
--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -650,10 +650,12 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []Volume, refr
 		}
 	}
 
-	// Resize the new volume and filesystem to the correct size.
-	err = d.SetVolumeQuota(vol, d.volumeSize(vol), nil)
-	if err != nil {
-		return err
+	// Resize the new volume and filesystem to the correct size if the source was an image.
+	if srcVol.volType == VolumeTypeImage {
+		err = d.SetVolumeQuota(vol, d.volumeSize(vol), nil)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Finally clean up original volumes left that were renamed with a tmpVolSuffix suffix.


### PR DESCRIPTION

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>