### PR TITLE
Cleanup db function names

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -486,7 +486,7 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) response.Response {
 		}
 
 		// Remove our old server certificate from the trust store, since it's not needed anymore.
-		_, err = d.cluster.CertificateGet(fingerprint)
+		_, err = d.cluster.GetCertificate(fingerprint)
 		if err != db.ErrNoSuchObject {
 			if err != nil {
 				return err

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -492,7 +492,7 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) response.Response {
 				return err
 			}
 
-			err := d.cluster.CertDelete(fingerprint)
+			err := d.cluster.DeleteCertificate(fingerprint)
 			if err != nil {
 				return errors.Wrap(err, "Failed to delete joining member's certificate")
 			}

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -584,7 +584,7 @@ func internalImport(d *Daemon, r *http.Request) response.Response {
 
 	if instanceErr == nil {
 		// Remove the storage volume db entry for the instance since force was specified.
-		err := d.cluster.InstanceRemove(projectName, req.Name)
+		err := d.cluster.RemoveInstance(projectName, req.Name)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -690,7 +690,7 @@ func internalImport(d *Daemon, r *http.Request) response.Response {
 		}
 
 		if snapErr == nil {
-			err := d.cluster.InstanceRemove(projectName, snap.Name)
+			err := d.cluster.RemoveInstance(projectName, snap.Name)
 			if err != nil {
 				return response.SmartError(err)
 			}

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -250,7 +250,7 @@ func pruneExpiredContainerBackupsTask(d *Daemon) (task.Func, task.Schedule) {
 
 func pruneExpiredContainerBackups(ctx context.Context, d *Daemon) error {
 	// Get the list of expired backups.
-	backups, err := d.cluster.ContainerBackupsGetExpired()
+	backups, err := d.cluster.GetExpiredInstanceBackups()
 	if err != nil {
 		return errors.Wrap(err, "Unable to retrieve the list of expired instance backups")
 	}

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -62,7 +62,7 @@ func backupCreate(s *state.State, args db.InstanceBackupArgs, sourceInst instanc
 		return errors.Wrap(err, "Insert backup info into database")
 	}
 
-	revert.Add(func() { s.Cluster.InstanceBackupRemove(args.Name) })
+	revert.Add(func() { s.Cluster.DeleteInstanceBackup(args.Name) })
 
 	// Get the backup struct.
 	b, err := instance.BackupLoadByName(s, sourceInst.Project(), args.Name)

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -53,7 +53,7 @@ func backupCreate(s *state.State, args db.InstanceBackupArgs, sourceInst instanc
 	}
 
 	// Create the database entry.
-	err = s.Cluster.InstanceBackupCreate(args)
+	err = s.Cluster.CreateInstanceBackup(args)
 	if err != nil {
 		if err == db.ErrAlreadyDefined {
 			return fmt.Errorf("Backup %q already exists", args.Name)

--- a/lxd/backup/backup.go
+++ b/lxd/backup/backup.go
@@ -199,7 +199,7 @@ func (b *Backup) Rename(newName string) error {
 	}
 
 	// Rename the database record
-	err = b.state.Cluster.ContainerBackupRename(b.name, newName)
+	err = b.state.Cluster.RenameInstanceBackup(b.name, newName)
 	if err != nil {
 		return err
 	}

--- a/lxd/backup/backup.go
+++ b/lxd/backup/backup.go
@@ -247,7 +247,7 @@ func DoBackupDelete(s *state.State, projectName, backupName, containerName strin
 	}
 
 	// Remove the database record
-	err := s.Cluster.InstanceBackupRemove(backupName)
+	err := s.Cluster.DeleteInstanceBackup(backupName)
 	if err != nil {
 		return err
 	}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -47,7 +47,7 @@ func certificatesGet(d *Daemon, r *http.Request) response.Response {
 	if recursion {
 		certResponses := []api.Certificate{}
 
-		baseCerts, err := d.cluster.CertificatesGet()
+		baseCerts, err := d.cluster.GetCertificates()
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -78,7 +78,7 @@ func certificatesGet(d *Daemon, r *http.Request) response.Response {
 func readSavedClientCAList(d *Daemon) {
 	d.clientCerts = map[string]x509.Certificate{}
 
-	dbCerts, err := d.cluster.CertificatesGet()
+	dbCerts, err := d.cluster.GetCertificates()
 	if err != nil {
 		logger.Infof("Error reading certificates from database: %s", err)
 		return

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -327,7 +327,7 @@ func certificateDelete(d *Daemon, r *http.Request) response.Response {
 		return response.NotFound(err)
 	}
 
-	err = d.cluster.CertDelete(certInfo.Fingerprint)
+	err = d.cluster.DeleteCertificate(certInfo.Fingerprint)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -188,7 +188,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 			Certificate: string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})),
 		}
 
-		err = d.cluster.CertSave(&dbCert)
+		err = d.cluster.CreateCertificate(&dbCert)
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -311,7 +311,7 @@ func doCertificateUpdate(d *Daemon, fingerprint string, req api.CertificatePut) 
 		return response.BadRequest(fmt.Errorf("Unknown request type %s", req.Type))
 	}
 
-	err := d.cluster.CertUpdate(fingerprint, req.Name, 1)
+	err := d.cluster.UpdateCertificate(fingerprint, req.Name, 1)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -168,7 +168,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 
 	if !isClusterNotification(r) {
 		// Check if we already have the certificate
-		existingCert, _ := d.cluster.CertificateGet(fingerprint)
+		existingCert, _ := d.cluster.GetCertificate(fingerprint)
 		if existingCert != nil {
 			// Deal with the cache being potentially out of sync
 			_, ok := d.clientCerts[fingerprint]
@@ -232,7 +232,7 @@ func certificateGet(d *Daemon, r *http.Request) response.Response {
 func doCertificateGet(db *db.Cluster, fingerprint string) (api.Certificate, error) {
 	resp := api.Certificate{}
 
-	dbCertInfo, err := db.CertificateGet(fingerprint)
+	dbCertInfo, err := db.GetCertificate(fingerprint)
 	if err != nil {
 		return resp, err
 	}
@@ -322,7 +322,7 @@ func doCertificateUpdate(d *Daemon, fingerprint string, req api.CertificatePut) 
 func certificateDelete(d *Daemon, r *http.Request) response.Response {
 	fingerprint := mux.Vars(r)["fingerprint"]
 
-	certInfo, err := d.cluster.CertificateGet(fingerprint)
+	certInfo, err := d.cluster.GetCertificate(fingerprint)
 	if err != nil {
 		return response.NotFound(err)
 	}

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -69,7 +69,7 @@ func ConnectIfInstanceIsRemote(cluster *db.Cluster, project, name string, cert *
 	var address string // Node address
 	err := cluster.Transaction(func(tx *db.ClusterTx) error {
 		var err error
-		address, err = tx.ContainerNodeAddress(project, name, instanceType)
+		address, err = tx.GetNodeAddressOfInstance(project, name, instanceType)
 		return err
 	})
 	if err != nil {

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -49,12 +49,12 @@ func (c *Cluster) GetCertificates() (certs []*CertInfo, err error) {
 	return certs, nil
 }
 
-// CertificateGet gets an CertBaseInfo object from the database.
+// GetCertificate gets an CertBaseInfo object from the database.
 // The argument fingerprint will be queried with a LIKE query, means you can
 // pass a shortform and will get the full fingerprint.
 // There can never be more than one image with a given fingerprint, as it is
 // enforced by a UNIQUE constraint in the schema.
-func (c *Cluster) CertificateGet(fingerprint string) (cert *CertInfo, err error) {
+func (c *Cluster) GetCertificate(fingerprint string) (cert *CertInfo, err error) {
 	cert = new(CertInfo)
 
 	inargs := []interface{}{fingerprint + "%"}

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -114,8 +114,8 @@ func (c *Cluster) CreateCertificate(cert *CertInfo) error {
 	return err
 }
 
-// CertDelete deletes a certificate from the db.
-func (c *Cluster) CertDelete(fingerprint string) error {
+// DeleteCertificate deletes a certificate from the db.
+func (c *Cluster) DeleteCertificate(fingerprint string) error {
 	err := exec(c.db, "DELETE FROM certificates WHERE fingerprint=?", fingerprint)
 	if err != nil {
 		return err

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -16,8 +16,8 @@ type CertInfo struct {
 	Certificate string
 }
 
-// CertificatesGet returns all certificates from the DB as CertBaseInfo objects.
-func (c *Cluster) CertificatesGet() (certs []*CertInfo, err error) {
+// GetCertificates returns all certificates from the DB as CertBaseInfo objects.
+func (c *Cluster) GetCertificates() (certs []*CertInfo, err error) {
 	err = c.Transaction(func(tx *ClusterTx) error {
 		rows, err := tx.tx.Query(
 			"SELECT id, fingerprint, type, name, certificate FROM certificates",

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -84,9 +84,9 @@ func (c *Cluster) GetCertificate(fingerprint string) (cert *CertInfo, err error)
 	return cert, err
 }
 
-// CertSave stores a CertBaseInfo object in the db,
-// it will ignore the ID field from the CertInfo.
-func (c *Cluster) CertSave(cert *CertInfo) error {
+// CreateCertificate stores a CertInfo object in the db, it will ignore the ID
+// field from the CertInfo.
+func (c *Cluster) CreateCertificate(cert *CertInfo) error {
 	err := c.Transaction(func(tx *ClusterTx) error {
 		stmt, err := tx.tx.Prepare(`
 			INSERT INTO certificates (

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -124,8 +124,8 @@ func (c *Cluster) DeleteCertificate(fingerprint string) error {
 	return nil
 }
 
-// CertUpdate updates the certificate with the given fingerprint.
-func (c *Cluster) CertUpdate(fingerprint string, certName string, certType int) error {
+// UpdateCertificate updates the certificate with the given fingerprint.
+func (c *Cluster) UpdateCertificate(fingerprint string, certName string, certType int) error {
 	err := c.Transaction(func(tx *ClusterTx) error {
 		_, err := tx.tx.Exec("UPDATE certificates SET name=?, type=? WHERE fingerprint=?", certName, certType, fingerprint)
 		return err

--- a/lxd/db/config.go
+++ b/lxd/db/config.go
@@ -25,29 +25,3 @@ func (c *ClusterTx) Config() (map[string]string, error) {
 func (c *ClusterTx) UpdateConfig(values map[string]string) error {
 	return query.UpdateConfig(c.tx, "config", values)
 }
-
-// ConfigValueSet is a convenience to set a cluster-level key/value config pair
-// in a single transaction.
-func ConfigValueSet(c *Cluster, key string, value string) error {
-	err := c.Transaction(func(tx *ClusterTx) error {
-		_, err := tx.tx.Exec("DELETE FROM config WHERE key=?", key)
-		if err != nil {
-			return err
-		}
-
-		if value != "" {
-			str := `INSERT INTO config (key, value) VALUES (?, ?);`
-			stmt, err := tx.tx.Prepare(str)
-			if err != nil {
-				return err
-			}
-			defer stmt.Close()
-			_, err = stmt.Exec(key, value)
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	})
-	return err
-}

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -1224,8 +1224,8 @@ func (c *Cluster) RenameInstanceBackup(oldName, newName string) error {
 	return err
 }
 
-// ContainerBackupsGetExpired returns a list of expired container backups.
-func (c *Cluster) ContainerBackupsGetExpired() ([]InstanceBackupArgs, error) {
+// GetExpiredInstanceBackups returns a list of expired instance backups.
+func (c *Cluster) GetExpiredInstanceBackups() ([]InstanceBackupArgs, error) {
 	var result []InstanceBackupArgs
 	var name string
 	var expiryDate string

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -1065,8 +1065,8 @@ SELECT storage_pools.name FROM storage_pools
 	return poolName, nil
 }
 
-// ContainerBackupID returns the ID of the container backup with the given name.
-func (c *Cluster) ContainerBackupID(name string) (int, error) {
+// Returns the ID of the instance backup with the given name.
+func (c *Cluster) getInstanceBackupID(name string) (int, error) {
 	q := "SELECT id FROM instances_backups WHERE name=?"
 	id := -1
 	arg1 := []interface{}{name}
@@ -1143,7 +1143,7 @@ WHERE projects.name=? AND instances.name=?`
 
 // InstanceBackupCreate creates a new backup.
 func (c *Cluster) InstanceBackupCreate(args InstanceBackupArgs) error {
-	_, err := c.ContainerBackupID(args.Name)
+	_, err := c.getInstanceBackupID(args.Name)
 	if err == nil {
 		return ErrAlreadyDefined
 	}
@@ -1185,7 +1185,7 @@ func (c *Cluster) InstanceBackupCreate(args InstanceBackupArgs) error {
 
 // InstanceBackupRemove removes the container backup with the given name from the database.
 func (c *Cluster) InstanceBackupRemove(name string) error {
-	id, err := c.ContainerBackupID(name)
+	id, err := c.getInstanceBackupID(name)
 	if err != nil {
 		return err
 	}

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -691,9 +691,9 @@ func CreateInstanceConfig(tx *sql.Tx, id int, config map[string]string) error {
 	return nil
 }
 
-// ContainerConfigGet returns the value of the given key in the configuration
-// of the container with the given ID.
-func (c *Cluster) ContainerConfigGet(id int, key string) (string, error) {
+// GetInstanceConfig returns the value of the given key in the configuration
+// of the instance with the given ID.
+func (c *Cluster) GetInstanceConfig(id int, key string) (string, error) {
 	q := "SELECT value FROM instances_config WHERE instance_id=? AND key=?"
 	value := ""
 	arg1 := []interface{}{id, key}

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -390,9 +390,9 @@ func (c *ClusterTx) instanceListExpanded() ([]Instance, error) {
 	return instances, nil
 }
 
-// ContainersByNodeName returns a map associating each container to the name of
-// its node.
-func (c *ClusterTx) ContainersByNodeName(project string, instanceType instancetype.Type) (map[string]string, error) {
+// GetInstanceToNodeMap returns a map associating the name of each
+// instance in the given project to the name of the node hosting the instance.
+func (c *ClusterTx) GetInstanceToNodeMap(project string, instanceType instancetype.Type) (map[string]string, error) {
 	args := make([]interface{}, 0, 2) // Expect up to 2 filters.
 	var filters strings.Builder
 

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -539,9 +539,9 @@ func (c *ClusterTx) GetLocalInstancesInProject(project string, instanceType inst
 	return c.InstanceList(filter)
 }
 
-// ContainerConfigInsert inserts a new config for the container with the given ID.
-func (c *ClusterTx) ContainerConfigInsert(id int, config map[string]string) error {
-	return ContainerConfigInsert(c.tx, id, config)
+// CreateInstanceConfig inserts a new config for the container with the given ID.
+func (c *ClusterTx) CreateInstanceConfig(id int, config map[string]string) error {
+	return CreateInstanceConfig(c.tx, id, config)
 }
 
 // ContainerConfigUpdate inserts/updates/deletes the provided keys
@@ -667,8 +667,8 @@ func ContainerConfigClear(tx *sql.Tx, id int) error {
 	return err
 }
 
-// ContainerConfigInsert inserts a new config for the container with the given ID.
-func ContainerConfigInsert(tx *sql.Tx, id int, config map[string]string) error {
+// CreateInstanceConfig inserts a new config for the instance with the given ID.
+func CreateInstanceConfig(tx *sql.Tx, id int, config map[string]string) error {
 	stmt, err := tx.Prepare("INSERT INTO instances_config (instance_id, key, value) values (?, ?, ?)")
 	if err != nil {
 		return err

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -644,9 +644,9 @@ func (c *Cluster) InstanceID(project, name string) (int, error) {
 	return int(id), err
 }
 
-// ContainerConfigClear removes any config associated with the container with
+// DeleteInstanceConfig removes any config associated with the instance with
 // the given ID.
-func ContainerConfigClear(tx *sql.Tx, id int) error {
+func DeleteInstanceConfig(tx *sql.Tx, id int) error {
 	_, err := tx.Exec("DELETE FROM instances_config WHERE instance_id=?", id)
 	if err != nil {
 		return err

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -522,8 +522,9 @@ func (c *ClusterTx) UpdateInstanceNode(project, oldName, newName, newNode string
 	return nil
 }
 
-// ContainerNodeProjectList returns all container objects on the local node within the given project.
-func (c *ClusterTx) ContainerNodeProjectList(project string, instanceType instancetype.Type) ([]Instance, error) {
+// GetLocalInstancesInProject retuurns all instances of the given type on the
+// local node within the given project.
+func (c *ClusterTx) GetLocalInstancesInProject(project string, instanceType instancetype.Type) ([]Instance, error) {
 	node, err := c.NodeName()
 	if err != nil {
 		return nil, errors.Wrap(err, "Local node name")

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -544,8 +544,8 @@ func (c *ClusterTx) CreateInstanceConfig(id int, config map[string]string) error
 	return CreateInstanceConfig(c.tx, id, config)
 }
 
-// ContainerConfigUpdate inserts/updates/deletes the provided keys
-func (c *ClusterTx) ContainerConfigUpdate(id int, values map[string]string) error {
+// UpdateInstanceConfig inserts/updates/deletes the provided keys
+func (c *ClusterTx) UpdateInstanceConfig(id int, values map[string]string) error {
 	insertSQL := fmt.Sprintf("INSERT OR REPLACE INTO instances_config (instance_id, key, value) VALUES")
 	deleteSQL := "DELETE FROM instances_config WHERE key IN %s AND instance_id=?"
 	return c.configUpdate(id, values, insertSQL, deleteSQL)

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -1198,9 +1198,9 @@ func (c *Cluster) DeleteInstanceBackup(name string) error {
 	return nil
 }
 
-// ContainerBackupRename renames a container backup from the given current name
+// RenameInstanceBackup renames an instance backup from the given current name
 // to the new one.
-func (c *Cluster) ContainerBackupRename(oldName, newName string) error {
+func (c *Cluster) RenameInstanceBackup(oldName, newName string) error {
 	err := c.Transaction(func(tx *ClusterTx) error {
 		str := fmt.Sprintf("UPDATE instances_backups SET name = ? WHERE name = ?")
 		stmt, err := tx.tx.Prepare(str)

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -706,9 +706,9 @@ func (c *Cluster) GetInstanceConfig(id int, key string) (string, error) {
 	return value, err
 }
 
-// ContainerConfigRemove removes the given key from the config of the container
+// DeleteInstanceConfigKey removes the given key from the config of the instance
 // with the given ID.
-func (c *Cluster) ContainerConfigRemove(id int, key string) error {
+func (c *Cluster) DeleteInstanceConfigKey(id int, key string) error {
 	err := exec(c.db, "DELETE FROM instances_config WHERE key=? AND instance_id=?", key, id)
 	return err
 }

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -823,16 +823,17 @@ func (c *Cluster) ResetInstancesPowerState() error {
 	return err
 }
 
-// ContainerSetState sets the the power state of the container with the given ID.
-func (c *Cluster) ContainerSetState(id int, state string) error {
+// UpdateInstancePowerState sets the the power state of the instance with the
+// given ID.
+func (c *Cluster) UpdateInstancePowerState(id int, state string) error {
 	err := c.Transaction(func(tx *ClusterTx) error {
-		return tx.ContainerSetState(id, state)
+		return tx.UpdateInstancePowerState(id, state)
 	})
 	return err
 }
 
-// ContainerSetState sets the the power state of the container with the given ID.
-func (c *ClusterTx) ContainerSetState(id int, state string) error {
+// UpdateInstancePowerState sets the the power state of the container with the given ID.
+func (c *ClusterTx) UpdateInstancePowerState(id int, state string) error {
 	// Set the new value
 	str := fmt.Sprintf("INSERT OR REPLACE INTO instances_config (instance_id, key, value) VALUES (?, 'volatile.last_state.power', ?)")
 	stmt, err := c.tx.Prepare(str)

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -816,8 +816,8 @@ WHERE type=? ORDER BY instances.name, instances_snapshots.name
 	return ret, nil
 }
 
-// ContainersResetState resets the power state of all containers.
-func (c *Cluster) ContainersResetState() error {
+// ResetInstancesPowerState resets the power state of all instances.
+func (c *Cluster) ResetInstancesPowerState() error {
 	// Reset all container states
 	err := exec(c.db, "DELETE FROM instances_config WHERE key='volatile.last_state.power'")
 	return err

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -816,26 +816,6 @@ WHERE type=? ORDER BY instances.name, instances_snapshots.name
 	return ret, nil
 }
 
-// ContainersNodeList returns the names of all the containers of the given type
-// running on the local node.
-func (c *Cluster) ContainersNodeList(instanceType instancetype.Type) ([]string, error) {
-	q := fmt.Sprintf("SELECT name FROM instances WHERE type=? AND node_id=? ORDER BY name")
-	inargs := []interface{}{instanceType, c.nodeID}
-	var container string
-	outfmt := []interface{}{container}
-	result, err := queryScan(c.db, q, inargs, outfmt)
-	if err != nil {
-		return nil, err
-	}
-
-	var ret []string
-	for _, container := range result {
-		ret = append(ret, container[0].(string))
-	}
-
-	return ret, nil
-}
-
 // ContainersResetState resets the power state of all containers.
 func (c *Cluster) ContainersResetState() error {
 	// Reset all container states

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -956,9 +956,9 @@ func (c *ClusterTx) GetInstanceSnapshots(project string, name string) ([]Instanc
 	return instances, nil
 }
 
-// ContainerNextSnapshot returns the index the next snapshot of the container
-// with the given name and pattern should have.
-func (c *Cluster) ContainerNextSnapshot(project string, name string, pattern string) int {
+// GetNextInstanceSnapshotIndex returns the index that the next snapshot of the
+// instance with the given name and pattern should have.
+func (c *Cluster) GetNextInstanceSnapshotIndex(project string, name string, pattern string) int {
 	q := `
 SELECT instances_snapshots.name
   FROM instances_snapshots

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -446,7 +446,7 @@ SELECT instances.name, nodes.name
 func (c *ClusterTx) UpdateInstanceNode(project, oldName, newName, newNode string) error {
 	// First check that the container to be moved is backed by a ceph
 	// volume.
-	poolName, err := c.InstancePool(project, oldName)
+	poolName, err := c.GetInstancePool(project, oldName)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get instance's storage pool name")
 	}
@@ -991,21 +991,21 @@ WHERE projects.name=? AND instances.name=?`
 	return max
 }
 
-// InstancePool returns the storage pool of a given instance.
+// GetInstancePool returns the storage pool of a given instance.
 //
-// This is a non-transactional variant of ClusterTx.InstancePool().
-func (c *Cluster) InstancePool(project, instanceName string) (string, error) {
+// This is a non-transactional variant of ClusterTx.GetInstancePool().
+func (c *Cluster) GetInstancePool(project, instanceName string) (string, error) {
 	var poolName string
 	err := c.Transaction(func(tx *ClusterTx) error {
 		var err error
-		poolName, err = tx.InstancePool(project, instanceName)
+		poolName, err = tx.GetInstancePool(project, instanceName)
 		return err
 	})
 	return poolName, err
 }
 
-// InstancePool returns the storage pool of a given instance.
-func (c *ClusterTx) InstancePool(project, instanceName string) (string, error) {
+// GetInstancePool returns the storage pool of a given instance.
+func (c *ClusterTx) GetInstancePool(project, instanceName string) (string, error) {
 	if strings.Contains(instanceName, shared.SnapshotDelimiter) {
 		return c.instancePoolSnapshot(project, instanceName)
 	}

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -439,11 +439,11 @@ SELECT instances.name, nodes.name
 	return result, nil
 }
 
-// ContainerNodeMove changes the node associated with a container.
+// UpdateInstanceNode changes the node hosting an instance.
 //
-// It's meant to be used when moving a non-running container backed by ceph
+// It's meant to be used when moving a non-running instance backed by ceph
 // from one cluster node to another.
-func (c *ClusterTx) ContainerNodeMove(project, oldName, newName, newNode string) error {
+func (c *ClusterTx) UpdateInstanceNode(project, oldName, newName, newNode string) error {
 	// First check that the container to be moved is backed by a ceph
 	// volume.
 	poolName, err := c.InstancePool(project, oldName)

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -265,14 +265,14 @@ SELECT nodes.id, nodes.address
 	return address, nil
 }
 
-// ContainersListByNodeAddress returns the names of all containers grouped by
+// GetInstanceNamesByNodeAddress returns the names of all containers grouped by
 // cluster node address.
 //
 // The node address of containers running on the local node is set to the empty
 // string, to distinguish it from remote nodes.
 //
 // Containers whose node is down are addeded to the special address "0.0.0.0".
-func (c *ClusterTx) ContainersListByNodeAddress(project string, instanceType instancetype.Type) (map[string][]string, error) {
+func (c *ClusterTx) GetInstanceNamesByNodeAddress(project string, instanceType instancetype.Type) (map[string][]string, error) {
 	offlineThreshold, err := c.NodeOfflineThreshold()
 	if err != nil {
 		return nil, err

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -766,33 +766,6 @@ INSERT INTO instances_profiles (instance_id, profile_id, apply_order)
 	return nil
 }
 
-// ContainerProfiles returns a list of profiles for a given container ID.
-func (c *Cluster) ContainerProfiles(id int) ([]string, error) {
-	var name string
-	var profiles []string
-
-	query := `
-        SELECT name FROM instances_profiles
-        JOIN profiles ON instances_profiles.profile_id=profiles.id
-		WHERE instance_id=?
-        ORDER BY instances_profiles.apply_order`
-	inargs := []interface{}{id}
-	outfmt := []interface{}{name}
-
-	results, err := queryScan(c.db, query, inargs, outfmt)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, r := range results {
-		name = r[0].(string)
-
-		profiles = append(profiles, name)
-	}
-
-	return profiles, nil
-}
-
 // ContainerConfig gets the container configuration map from the DB
 func (c *Cluster) ContainerConfig(id int) (map[string]string, error) {
 	var key, value string

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -885,9 +885,9 @@ func (c *Cluster) UpdateInstanceSnapshotCreationDate(instanceID int, date time.T
 	return err
 }
 
-// ContainerLastUsedUpdate updates the last_use_date field of the container
+// UpdateInstanceLastUsedDate updates the last_use_date field of the instance
 // with the given ID.
-func (c *ClusterTx) ContainerLastUsedUpdate(id int, date time.Time) error {
+func (c *ClusterTx) UpdateInstanceLastUsedDate(id int, date time.Time) error {
 	str := `UPDATE instances SET last_use_date=? WHERE id=?`
 	stmt, err := c.tx.Prepare(str)
 	if err != nil {

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -713,9 +713,9 @@ func (c *Cluster) DeleteInstanceConfigKey(id int, key string) error {
 	return err
 }
 
-// ContainerSetStateful toggles the stateful flag of the container with the
-// given ID.
-func (c *Cluster) ContainerSetStateful(id int, stateful bool) error {
+// UpdateInstanceStatefulFlag toggles the stateful flag of the instance with
+// the given ID.
+func (c *Cluster) UpdateInstanceStatefulFlag(id int, stateful bool) error {
 	statefulInt := 0
 	if stateful {
 		statefulInt = 1

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -179,11 +179,11 @@ SELECT instances.name FROM instances
 	return query.SelectStrings(c.tx, stmt, project, instancetype.Any)
 }
 
-// ContainerNodeAddress returns the address of the node hosting the container
-// with the given name in the given project.
+// GetNodeAddressOfInstance returns the address of the node hosting the
+// instance with the given name in the given project.
 //
 // It returns the empty string if the container is hosted on this node.
-func (c *ClusterTx) ContainerNodeAddress(project string, name string, instanceType instancetype.Type) (string, error) {
+func (c *ClusterTx) GetNodeAddressOfInstance(project string, name string, instanceType instancetype.Type) (string, error) {
 	var stmt string
 
 	args := make([]interface{}, 0, 4) // Expect up to 4 filters.

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -599,8 +599,8 @@ func (c *ClusterTx) configUpdate(id int, values map[string]string, insertSQL, de
 	return nil
 }
 
-// InstanceRemove removes the instance with the given name from the database.
-func (c *Cluster) InstanceRemove(project, name string) error {
+// RemoveInstance removes the instance with the given name from the database.
+func (c *Cluster) RemoveInstance(project, name string) error {
 	if strings.Contains(name, shared.SnapshotDelimiter) {
 		parts := strings.SplitN(name, shared.SnapshotDelimiter, 2)
 		return c.Transaction(func(tx *ClusterTx) error {

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -1183,8 +1183,8 @@ func (c *Cluster) CreateInstanceBackup(args InstanceBackupArgs) error {
 	return err
 }
 
-// InstanceBackupRemove removes the container backup with the given name from the database.
-func (c *Cluster) InstanceBackupRemove(name string) error {
+// DeleteInstanceBackup removes the instance backup with the given name from the database.
+func (c *Cluster) DeleteInstanceBackup(name string) error {
 	id, err := c.getInstanceBackupID(name)
 	if err != nil {
 		return err

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -850,9 +850,9 @@ func (c *ClusterTx) UpdateInstancePowerState(id int, state string) error {
 	return nil
 }
 
-// ContainerUpdate updates the description, architecture and ephemeral flag of
-// the container with the given ID.
-func ContainerUpdate(tx *sql.Tx, id int, description string, architecture int, ephemeral bool,
+// UpdateInstance updates the description, architecture and ephemeral flag of
+// the instance with the given ID.
+func UpdateInstance(tx *sql.Tx, id int, description string, architecture int, ephemeral bool,
 	expiryDate time.Time) error {
 	str := fmt.Sprintf("UPDATE instances SET description=?, architecture=?, ephemeral=?, expiry_date=? WHERE id=?")
 	stmt, err := tx.Prepare(str)

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -1141,8 +1141,8 @@ WHERE projects.name=? AND instances.name=?`
 	return result, nil
 }
 
-// InstanceBackupCreate creates a new backup.
-func (c *Cluster) InstanceBackupCreate(args InstanceBackupArgs) error {
+// CreateInstanceBackup creates a new backup.
+func (c *Cluster) CreateInstanceBackup(args InstanceBackupArgs) error {
 	_, err := c.getInstanceBackupID(args.Name)
 	if err == nil {
 		return ErrAlreadyDefined

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -766,32 +766,6 @@ INSERT INTO instances_profiles (instance_id, profile_id, apply_order)
 	return nil
 }
 
-// ContainerConfig gets the container configuration map from the DB
-func (c *Cluster) ContainerConfig(id int) (map[string]string, error) {
-	var key, value string
-	q := `SELECT key, value FROM instances_config WHERE instance_id=?`
-
-	inargs := []interface{}{id}
-	outfmt := []interface{}{key, value}
-
-	// Results is already a slice here, not db Rows anymore.
-	results, err := queryScan(c.db, q, inargs, outfmt)
-	if err != nil {
-		return nil, err //SmartError will wrap this and make "not found" errors pretty
-	}
-
-	config := map[string]string{}
-
-	for _, r := range results {
-		key = r[0].(string)
-		value = r[1].(string)
-
-		config[key] = value
-	}
-
-	return config, nil
-}
-
 // LegacyContainersList returns the names of all the containers.
 //
 // NOTE: this is a pre-projects legacy API that is used only by patches. Don't

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -725,9 +725,9 @@ func (c *Cluster) UpdateInstanceStatefulFlag(id int, stateful bool) error {
 	return err
 }
 
-// ContainerProfilesInsert associates the container with the given ID with the
+// AddProfilesToInstance associates the instance with the given ID with the
 // profiles with the given names in the given project.
-func ContainerProfilesInsert(tx *sql.Tx, id int, project string, profiles []string) error {
+func AddProfilesToInstance(tx *sql.Tx, id int, project string, profiles []string) error {
 	enabled, err := projectHasProfiles(tx, project)
 	if err != nil {
 		return errors.Wrap(err, "Check if project has profiles")

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -612,9 +612,9 @@ func (c *Cluster) RemoveInstance(project, name string) error {
 	})
 }
 
-// ContainerProjectAndName returns the project and the name of the container
+// GetInstanceProjectAndName returns the project and the name of the instance
 // with the given ID.
-func (c *Cluster) ContainerProjectAndName(id int) (string, string, error) {
+func (c *Cluster) GetInstanceProjectAndName(id int) (string, string, error) {
 	q := `
 SELECT projects.name, instances.name
   FROM instances

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -878,8 +878,8 @@ func UpdateInstance(tx *sql.Tx, id int, description string, architecture int, ep
 	return nil
 }
 
-// InstanceSnapshotCreationUpdate updates the creation_date field of the instance snapshot with ID.
-func (c *Cluster) InstanceSnapshotCreationUpdate(instanceID int, date time.Time) error {
+// UpdateInstanceSnapshotCreationDate updates the creation_date field of the instance snapshot with ID.
+func (c *Cluster) UpdateInstanceSnapshotCreationDate(instanceID int, date time.Time) error {
 	stmt := `UPDATE instances_snapshots SET creation_date=? WHERE id=?`
 	err := exec(c.db, stmt, date, instanceID)
 	return err

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -1079,8 +1079,8 @@ func (c *Cluster) getInstanceBackupID(name string) (int, error) {
 	return id, err
 }
 
-// ContainerGetBackup returns the backup with the given name.
-func (c *Cluster) ContainerGetBackup(project, name string) (InstanceBackupArgs, error) {
+// GetInstanceBackup returns the backup with the given name.
+func (c *Cluster) GetInstanceBackup(project, name string) (InstanceBackupArgs, error) {
 	args := InstanceBackupArgs{}
 	args.Name = name
 
@@ -1118,9 +1118,9 @@ SELECT instances_backups.id, instances_backups.instance_id,
 	return args, nil
 }
 
-// ContainerGetBackups returns the names of all backups of the container
-// with the given name.
-func (c *Cluster) ContainerGetBackups(project, name string) ([]string, error) {
+// GetInstanceBackups returns the names of all backups of the instance with the
+// given name.
+func (c *Cluster) GetInstanceBackups(project, name string) ([]string, error) {
 	var result []string
 
 	q := `SELECT instances_backups.name FROM instances_backups

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -903,9 +903,9 @@ func (c *ClusterTx) UpdateInstanceLastUsedDate(id int, date time.Time) error {
 	return nil
 }
 
-// ContainerGetSnapshots returns the names of all snapshots of the container
+// GetInstanceSnapshotsNames returns the names of all snapshots of the instance
 // in the given project with the given name.
-func (c *Cluster) ContainerGetSnapshots(project, name string) ([]string, error) {
+func (c *Cluster) GetInstanceSnapshotsNames(project, name string) ([]string, error) {
 	result := []string{}
 
 	q := `
@@ -930,8 +930,8 @@ ORDER BY date(instances_snapshots.creation_date)
 	return result, nil
 }
 
-// ContainerGetSnapshotsFull returns all container objects for snapshots of a given container
-func (c *ClusterTx) ContainerGetSnapshotsFull(project string, name string) ([]Instance, error) {
+// GetInstanceSnapshots returns all snapshots of a given instance.
+func (c *ClusterTx) GetInstanceSnapshots(project string, name string) ([]Instance, error) {
 	instance, err := c.InstanceGet(project, name)
 	if err != nil {
 		return nil, err

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -169,8 +169,8 @@ type InstanceBackupArgs struct {
 	CompressionAlgorithm string
 }
 
-// InstanceNames returns the names of all containers the given project.
-func (c *ClusterTx) InstanceNames(project string) ([]string, error) {
+// GetInstanceNames returns the names of all containers the given project.
+func (c *ClusterTx) GetInstanceNames(project string) ([]string, error) {
 	stmt := `
 SELECT instances.name FROM instances
   JOIN projects ON projects.id = instances.project_id

--- a/lxd/db/containers_test.go
+++ b/lxd/db/containers_test.go
@@ -326,8 +326,8 @@ func TestGetInstanceNamesByNodeAddress(t *testing.T) {
 		}, result)
 }
 
-// Containers are associated with their node name.
-func TestContainersByNodeName(t *testing.T) {
+// Instances are associated with their node name.
+func TestGetInstanceToNodeMap(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
@@ -339,7 +339,7 @@ func TestContainersByNodeName(t *testing.T) {
 	addContainer(t, tx, nodeID2, "c1")
 	addContainer(t, tx, nodeID1, "c2")
 
-	result, err := tx.ContainersByNodeName("default", instancetype.Container)
+	result, err := tx.GetInstanceToNodeMap("default", instancetype.Container)
 	require.NoError(t, err)
 	assert.Equal(
 		t,

--- a/lxd/db/containers_test.go
+++ b/lxd/db/containers_test.go
@@ -406,7 +406,7 @@ func TestContainersNodeList(t *testing.T) {
 }
 
 // All containers on a node are loaded in bulk.
-func TestContainerNodeProjectList(t *testing.T) {
+func TestGetLocalInstancesInProject(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
@@ -427,7 +427,7 @@ func TestContainerNodeProjectList(t *testing.T) {
 	addContainerDevice(t, tx, "c2", "eth0", "nic", nil)
 	addContainerDevice(t, tx, "c4", "root", "disk", map[string]string{"x": "y"})
 
-	containers, err := tx.ContainerNodeProjectList("", instancetype.Container)
+	containers, err := tx.GetLocalInstancesInProject("", instancetype.Container)
 	require.NoError(t, err)
 	assert.Len(t, containers, 3)
 

--- a/lxd/db/containers_test.go
+++ b/lxd/db/containers_test.go
@@ -349,7 +349,7 @@ func TestGetInstanceToNodeMap(t *testing.T) {
 		}, result)
 }
 
-func TestInstancePool(t *testing.T) {
+func TestGetInstancePool(t *testing.T) {
 	cluster, cleanup := db.NewTestCluster(t)
 	defer cleanup()
 
@@ -376,7 +376,7 @@ func TestInstancePool(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	poolName, err := cluster.InstancePool("default", "c1")
+	poolName, err := cluster.GetInstancePool("default", "c1")
 	require.NoError(t, err)
 	assert.Equal(t, "default", poolName)
 }

--- a/lxd/db/containers_test.go
+++ b/lxd/db/containers_test.go
@@ -297,7 +297,7 @@ func TestInstanceCreate_Snapshot(t *testing.T) {
 }
 
 // Containers are grouped by node address.
-func TestContainersListByNodeAddress(t *testing.T) {
+func TestGetInstanceNamesByNodeAddress(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
@@ -315,7 +315,7 @@ func TestContainersListByNodeAddress(t *testing.T) {
 	addContainer(t, tx, nodeID3, "c3")
 	addContainer(t, tx, nodeID2, "c4")
 
-	result, err := tx.ContainersListByNodeAddress("default", instancetype.Container)
+	result, err := tx.GetInstanceNamesByNodeAddress("default", instancetype.Container)
 	require.NoError(t, err)
 	assert.Equal(
 		t,

--- a/lxd/db/containers_test.go
+++ b/lxd/db/containers_test.go
@@ -381,30 +381,6 @@ func TestInstancePool(t *testing.T) {
 	assert.Equal(t, "default", poolName)
 }
 
-// Only containers running on the local node are returned.
-func TestContainersNodeList(t *testing.T) {
-	cluster, cleanup := db.NewTestCluster(t)
-	defer cleanup()
-
-	nodeID1 := int64(1) // This is the default local node
-
-	// Add another node
-	var nodeID2 int64
-	err := cluster.Transaction(func(tx *db.ClusterTx) error {
-		var err error
-		nodeID2, err = tx.NodeAdd("node2", "1.2.3.4:666")
-		require.NoError(t, err)
-		addContainer(t, tx, nodeID1, "c1")
-		addContainer(t, tx, nodeID2, "c2")
-		return nil
-	})
-	require.NoError(t, err)
-
-	names, err := cluster.ContainersNodeList(instancetype.Container)
-	require.NoError(t, err)
-	assert.Equal(t, names, []string{"c1"})
-}
-
 // All containers on a node are loaded in bulk.
 func TestGetLocalInstancesInProject(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)

--- a/lxd/db/db_internal_test.go
+++ b/lxd/db/db_internal_test.go
@@ -269,29 +269,6 @@ func (s *dbTestSuite) Test_ImageSourceGetCachedFingerprint_no_match() {
 	s.Equal(err, ErrNoSuchObject)
 }
 
-func (s *dbTestSuite) Test_ContainerConfig() {
-	var err error
-	var result map[string]string
-	var expected map[string]string
-
-	tx, commit := s.CreateTestTx()
-
-	_, err = tx.Exec("INSERT INTO instances_config (instance_id, key, value) VALUES (1, 'something', 'something else');")
-	s.Nil(err)
-
-	commit()
-
-	result, err = s.db.ContainerConfig(1)
-	s.Nil(err)
-
-	expected = map[string]string{"thekey": "thevalue", "something": "something else"}
-
-	for key, value := range expected {
-		s.Equal(result[key], value,
-			fmt.Sprintf("Mismatching value for key %s: %s != %s", key, result[key], value))
-	}
-}
-
 func (s *dbTestSuite) Test_dbProfileConfig() {
 	var err error
 	var result map[string]string

--- a/lxd/db/db_internal_test.go
+++ b/lxd/db/db_internal_test.go
@@ -315,21 +315,6 @@ func (s *dbTestSuite) Test_dbProfileConfig() {
 	}
 }
 
-func (s *dbTestSuite) Test_ContainerProfiles() {
-	var err error
-	var result []string
-	var expected []string
-
-	expected = []string{"theprofile"}
-	result, err = s.db.ContainerProfiles(1)
-	s.Nil(err)
-
-	for i := range expected {
-		s.Equal(expected[i], result[i],
-			fmt.Sprintf("Mismatching contents for profile list: %s != %s", result[i], expected[i]))
-	}
-}
-
 func (s *dbTestSuite) Test_dbDevices_profiles() {
 	var err error
 	var result deviceConfig.Devices

--- a/lxd/db/instances.mapper.go
+++ b/lxd/db/instances.mapper.go
@@ -554,7 +554,7 @@ func (c *ClusterTx) InstanceCreate(object Instance) (int64, error) {
 	}
 
 	// Insert profiles reference.
-	err = ContainerProfilesInsert(c.tx, int(id), object.Project, object.Profiles)
+	err = AddProfilesToInstance(c.tx, int(id), object.Project, object.Profiles)
 	if err != nil {
 		return -1, errors.Wrap(err, "Insert profiles for instance")
 	}

--- a/lxd/db/migration_test.go
+++ b/lxd/db/migration_test.go
@@ -60,7 +60,7 @@ func TestImportPreClusteringData(t *testing.T) {
 	defer cluster.Close()
 
 	// certificates
-	certs, err := cluster.CertificatesGet()
+	certs, err := cluster.GetCertificates()
 	require.NoError(t, err)
 	assert.Len(t, certs, 1)
 	cert := certs[0]

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -625,7 +625,7 @@ func instanceCreateInternal(s *state.State, args db.InstanceArgs) (instance.Inst
 			return
 		}
 
-		s.Cluster.InstanceRemove(dbInst.Project, dbInst.Name)
+		s.Cluster.RemoveInstance(dbInst.Project, dbInst.Name)
 	}()
 
 	// Wipe any existing log for this instance name.

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -682,7 +682,7 @@ func instanceLoadNodeProjectAll(s *state.State, project string, instanceType ins
 	var cts []db.Instance
 	err := s.Cluster.Transaction(func(tx *db.ClusterTx) error {
 		var err error
-		cts, err = tx.ContainerNodeProjectList(project, instanceType)
+		cts, err = tx.GetLocalInstancesInProject(project, instanceType)
 		if err != nil {
 			return err
 		}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -287,7 +287,7 @@ func instanceCreateAsCopy(s *state.State, args db.InstanceArgs, sourceInst insta
 			}
 
 			// Set snapshot creation date to that of the source snapshot.
-			err = s.Cluster.InstanceSnapshotCreationUpdate(snapInst.ID(), srcSnap.CreationDate())
+			err = s.Cluster.UpdateInstanceSnapshotCreationDate(snapInst.ID(), srcSnap.CreationDate())
 			if err != nil {
 				return nil, err
 			}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -941,7 +941,7 @@ func containerDetermineNextSnapshotName(d *Daemon, c instance.Instance, defaultP
 	if count > 1 {
 		return "", fmt.Errorf("Snapshot pattern may contain '%%d' only once")
 	} else if count == 1 {
-		i := d.cluster.ContainerNextSnapshot(c.Project(), c.Name(), pattern)
+		i := d.cluster.GetNextInstanceSnapshotIndex(c.Project(), c.Name(), pattern)
 		return strings.Replace(pattern, "%d", strconv.Itoa(i), 1), nil
 	}
 
@@ -963,7 +963,7 @@ func containerDetermineNextSnapshotName(d *Daemon, c instance.Instance, defaultP
 	// Append '-0', '-1', etc. if the actual pattern/snapshot name already exists
 	if snapshotExists {
 		pattern = fmt.Sprintf("%s-%%d", pattern)
-		i := d.cluster.ContainerNextSnapshot(c.Project(), c.Name(), pattern)
+		i := d.cluster.GetNextInstanceSnapshotIndex(c.Project(), c.Name(), pattern)
 		return strings.Replace(pattern, "%d", strconv.Itoa(i), 1), nil
 	}
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -4372,7 +4372,7 @@ func (c *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 				return err
 
 			}
-			err = db.ContainerConfigInsert(tx, c.id, c.localConfig)
+			err = db.CreateInstanceConfig(tx, c.id, c.localConfig)
 			if err != nil {
 				tx.Rollback()
 				return errors.Wrap(err, "Config insert")
@@ -6251,7 +6251,7 @@ func (c *lxc) FillNetworkDevice(name string, m deviceConfig.Device) (deviceConfi
 			return err
 		}
 
-		err = db.ContainerConfigInsert(tx, c.id, map[string]string{key: value})
+		err = db.CreateInstanceConfig(tx, c.id, map[string]string{key: value})
 		if err != nil {
 			tx.Rollback()
 			return err

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3215,7 +3215,7 @@ func (c *lxc) Snapshots() ([]instance.Instance, error) {
 // Backups returns the backups of the instance.
 func (c *lxc) Backups() ([]backup.Backup, error) {
 	// Get all the backups
-	backupNames, err := c.state.Cluster.ContainerGetBackups(c.project, c.name)
+	backupNames, err := c.state.Cluster.GetInstanceBackups(c.project, c.name)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6650,7 +6650,7 @@ func (c *lxc) StatePath() string {
 
 // StoragePool storage pool name.
 func (c *lxc) StoragePool() (string, error) {
-	poolName, err := c.state.Cluster.InstancePool(c.Project(), c.Name())
+	poolName, err := c.state.Cluster.GetInstancePool(c.Project(), c.Name())
 	if err != nil {
 		return "", err
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3187,7 +3187,7 @@ func (c *lxc) Snapshots() ([]instance.Instance, error) {
 	// Get all the snapshots
 	err := c.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
 		var err error
-		snaps, err = tx.ContainerGetSnapshotsFull(c.Project(), c.name)
+		snaps, err = tx.GetInstanceSnapshots(c.Project(), c.name)
 		if err != nil {
 			return err
 		}
@@ -3585,7 +3585,7 @@ func (c *lxc) Rename(newName string) error {
 
 	if !c.IsSnapshot() {
 		// Rename all the instance snapshot database entries.
-		results, err := c.state.Cluster.ContainerGetSnapshots(c.project, oldName)
+		results, err := c.state.Cluster.GetInstanceSnapshotsNames(c.project, oldName)
 		if err != nil {
 			logger.Error("Failed to get container snapshots", ctxMap)
 			return err

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -4390,7 +4390,7 @@ func (c *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 				return errors.Wrap(err, "Device add")
 			}
 
-			err = db.ContainerUpdate(tx, c.id, c.description, c.architecture, c.ephemeral, c.expiryDate)
+			err = db.UpdateInstance(tx, c.id, c.description, c.architecture, c.ephemeral, c.expiryDate)
 			if err != nil {
 				tx.Rollback()
 				return errors.Wrap(err, "Container update")

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2469,7 +2469,7 @@ func (c *lxc) onStart(_ map[string]string) error {
 		}
 
 		// Remove the volatile key from the DB
-		err := c.state.Cluster.ContainerConfigRemove(c.id, key)
+		err := c.state.Cluster.DeleteInstanceConfigKey(c.id, key)
 		if err != nil {
 			apparmor.Destroy(c.state, c)
 			if ourStart {

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2505,7 +2505,7 @@ func (c *lxc) onStart(_ map[string]string) error {
 	// Database updates
 	err = c.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
 		// Record current state
-		err = tx.ContainerSetState(c.id, "RUNNING")
+		err = tx.UpdateInstancePowerState(c.id, "RUNNING")
 		if err != nil {
 			return errors.Wrap(err, "Error updating container state")
 		}
@@ -2811,7 +2811,7 @@ func (c *lxc) onStop(args map[string]string) error {
 	}
 
 	// Record power state
-	err = c.state.Cluster.ContainerSetState(c.id, "STOPPED")
+	err = c.state.Cluster.UpdateInstancePowerState(c.id, "STOPPED")
 	if err != nil {
 		logger.Error("Failed to set container state", log.Ctx{"container": c.Name(), "err": err})
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6281,7 +6281,7 @@ func (c *lxc) FillNetworkDevice(name string, m deviceConfig.Device) (deviceConfi
 				err := updateKey(configKey, volatileHwaddr)
 				if err != nil {
 					// Check if something else filled it in behind our back
-					value, err1 := c.state.Cluster.ContainerConfigGet(c.id, configKey)
+					value, err1 := c.state.Cluster.GetInstanceConfig(c.id, configKey)
 					if err1 != nil || value == "" {
 						return err
 					}
@@ -6317,7 +6317,7 @@ func (c *lxc) FillNetworkDevice(name string, m deviceConfig.Device) (deviceConfi
 			err = updateKey(configKey, volatileName)
 			if err != nil {
 				// Check if something else filled it in behind our back
-				value, err1 := c.state.Cluster.ContainerConfigGet(c.id, configKey)
+				value, err1 := c.state.Cluster.GetInstanceConfig(c.id, configKey)
 				if err1 != nil || value == "" {
 					return nil, err
 				}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2331,7 +2331,7 @@ func (c *lxc) Start(stateful bool) error {
 		os.RemoveAll(c.StatePath())
 		c.stateful = false
 
-		err = c.state.Cluster.ContainerSetStateful(c.id, false)
+		err = c.state.Cluster.UpdateInstanceStatefulFlag(c.id, false)
 		if err != nil {
 			logger.Error("Failed starting container", ctxMap)
 			return errors.Wrap(err, "Start container")
@@ -2356,7 +2356,7 @@ func (c *lxc) Start(stateful bool) error {
 		}
 
 		c.stateful = false
-		err = c.state.Cluster.ContainerSetStateful(c.id, false)
+		err = c.state.Cluster.UpdateInstanceStatefulFlag(c.id, false)
 		if err != nil {
 			return errors.Wrap(err, "Persist stateful flag")
 		}
@@ -2589,7 +2589,7 @@ func (c *lxc) Stop(stateful bool) error {
 		}
 
 		c.stateful = true
-		err = c.state.Cluster.ContainerSetStateful(c.id, true)
+		err = c.state.Cluster.UpdateInstanceStatefulFlag(c.id, true)
 		if err != nil {
 			op.Done(err)
 			logger.Error("Failed stopping container", ctxMap)

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3519,7 +3519,7 @@ func (c *lxc) Delete() error {
 	}
 
 	// Remove the database record of the instance or snapshot instance.
-	if err := c.state.Cluster.InstanceRemove(c.project, c.Name()); err != nil {
+	if err := c.state.Cluster.RemoveInstance(c.project, c.Name()); err != nil {
 		logger.Error("Failed deleting container entry", log.Ctx{"name": c.Name(), "err": err})
 		return err
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2511,7 +2511,7 @@ func (c *lxc) onStart(_ map[string]string) error {
 		}
 
 		// Update time container last started time
-		err = tx.ContainerLastUsedUpdate(c.id, time.Now().UTC())
+		err = tx.UpdateInstanceLastUsedDate(c.id, time.Now().UTC())
 		if err != nil {
 			return errors.Wrap(err, "Error updating last used")
 		}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -4366,7 +4366,7 @@ func (c *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 				return errors.Wrap(err, "Snapshot update")
 			}
 		} else {
-			err = db.ContainerConfigClear(tx, c.id)
+			err = db.DeleteInstanceConfig(tx, c.id)
 			if err != nil {
 				tx.Rollback()
 				return err

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -4378,7 +4378,7 @@ func (c *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 				return errors.Wrap(err, "Config insert")
 			}
 
-			err = db.ContainerProfilesInsert(tx, c.id, c.project, c.profiles)
+			err = db.AddProfilesToInstance(tx, c.id, c.project, c.profiles)
 			if err != nil {
 				tx.Rollback()
 				return errors.Wrap(err, "Profiles insert")

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3733,7 +3733,7 @@ func (c *lxc) VolatileSet(changes map[string]string) error {
 		})
 	} else {
 		err = c.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
-			return tx.ContainerConfigUpdate(c.id, changes)
+			return tx.UpdateInstanceConfig(c.id, changes)
 		})
 	}
 	if err != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -924,7 +924,7 @@ func (vm *qemu) Start(stateful bool) error {
 		}
 
 		// Update time instance last started time
-		err = tx.ContainerLastUsedUpdate(vm.id, time.Now().UTC())
+		err = tx.UpdateInstanceLastUsedDate(vm.id, time.Now().UTC())
 		if err != nil {
 			err = errors.Wrap(err, "Error updating instance last used")
 			op.Done(err)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2635,7 +2635,7 @@ func (vm *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 				return errors.Wrap(err, "Device add")
 			}
 
-			err = db.ContainerUpdate(tx, vm.id, vm.description, vm.architecture, vm.ephemeral, vm.expiryDate)
+			err = db.UpdateInstance(tx, vm.id, vm.description, vm.architecture, vm.ephemeral, vm.expiryDate)
 			if err != nil {
 				tx.Rollback()
 				return errors.Wrap(err, "Instance update")

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -495,7 +495,7 @@ func (vm *qemu) onStop(target string) error {
 	vm.unmount()
 
 	// Record power state.
-	err := vm.state.Cluster.ContainerSetState(vm.id, "STOPPED")
+	err := vm.state.Cluster.UpdateInstancePowerState(vm.id, "STOPPED")
 	if err != nil {
 		op.Done(err)
 		return err
@@ -916,7 +916,7 @@ func (vm *qemu) Start(stateful bool) error {
 	// Database updates
 	err = vm.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
 		// Record current state
-		err = tx.ContainerSetState(vm.id, "RUNNING")
+		err = tx.UpdateInstancePowerState(vm.id, "RUNNING")
 		if err != nil {
 			err = errors.Wrap(err, "Error updating instance state")
 			op.Done(err)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3284,7 +3284,7 @@ func (vm *qemu) VolatileSet(changes map[string]string) error {
 		})
 	} else {
 		err = vm.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
-			return tx.ContainerConfigUpdate(vm.id, changes)
+			return tx.UpdateInstanceConfig(vm.id, changes)
 		})
 	}
 	if err != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4015,7 +4015,7 @@ func (vm *qemu) StatePath() string {
 
 // StoragePool returns the name of the instance's storage pool.
 func (vm *qemu) StoragePool() (string, error) {
-	poolName, err := vm.state.Cluster.InstancePool(vm.Project(), vm.Name())
+	poolName, err := vm.state.Cluster.GetInstancePool(vm.Project(), vm.Name())
 	if err != nil {
 		return "", err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2611,7 +2611,7 @@ func (vm *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 				return errors.Wrap(err, "Snapshot update")
 			}
 		} else {
-			err = db.ContainerConfigClear(tx, vm.id)
+			err = db.DeleteInstanceConfig(tx, vm.id)
 			if err != nil {
 				tx.Rollback()
 				return err

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2970,7 +2970,7 @@ func (vm *qemu) Delete() error {
 	}
 
 	// Remove the database record of the instance or snapshot instance.
-	if err := vm.state.Cluster.InstanceRemove(vm.Project(), vm.Name()); err != nil {
+	if err := vm.state.Cluster.RemoveInstance(vm.Project(), vm.Name()); err != nil {
 		logger.Error("Failed deleting instance entry", log.Ctx{"project": vm.Project(), "instance": vm.Name(), "err": err})
 		return err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2623,7 +2623,7 @@ func (vm *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 				return errors.Wrap(err, "Config insert")
 			}
 
-			err = db.ContainerProfilesInsert(tx, vm.id, vm.project, vm.profiles)
+			err = db.AddProfilesToInstance(tx, vm.id, vm.project, vm.profiles)
 			if err != nil {
 				tx.Rollback()
 				return errors.Wrap(err, "Profiles insert")

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1367,7 +1367,7 @@ echo "To start it now, unmount this filesystem and run: systemctl start lxd-agen
 		}
 
 		// Remove the volatile key from the DB.
-		err := vm.state.Cluster.ContainerConfigRemove(vm.id, key)
+		err := vm.state.Cluster.DeleteInstanceConfigKey(vm.id, key)
 		if err != nil {
 			return err
 		}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2184,7 +2184,7 @@ func (vm *qemu) Snapshots() ([]instance.Instance, error) {
 	// Get all the snapshots
 	err := vm.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
 		var err error
-		snaps, err = tx.ContainerGetSnapshotsFull(vm.Project(), vm.name)
+		snaps, err = tx.GetInstanceSnapshots(vm.Project(), vm.name)
 		if err != nil {
 			return err
 		}
@@ -2260,7 +2260,7 @@ func (vm *qemu) Rename(newName string) error {
 
 	if !vm.IsSnapshot() {
 		// Rename all the instance snapshot database entries.
-		results, err := vm.state.Cluster.ContainerGetSnapshots(vm.project, oldName)
+		results, err := vm.state.Cluster.GetInstanceSnapshotsNames(vm.project, oldName)
 		if err != nil {
 			logger.Error("Failed to get instance snapshots", ctxMap)
 			return err

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4090,7 +4090,7 @@ func (vm *qemu) FillNetworkDevice(name string, m deviceConfig.Device) (deviceCon
 				err := updateKey(configKey, volatileHwaddr)
 				if err != nil {
 					// Check if something else filled it in behind our back
-					value, err1 := vm.state.Cluster.ContainerConfigGet(vm.id, configKey)
+					value, err1 := vm.state.Cluster.GetInstanceConfig(vm.id, configKey)
 					if err1 != nil || value == "" {
 						return err
 					}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2617,7 +2617,7 @@ func (vm *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 				return err
 
 			}
-			err = db.ContainerConfigInsert(tx, vm.id, vm.localConfig)
+			err = db.CreateInstanceConfig(tx, vm.id, vm.localConfig)
 			if err != nil {
 				tx.Rollback()
 				return errors.Wrap(err, "Config insert")
@@ -4060,7 +4060,7 @@ func (vm *qemu) FillNetworkDevice(name string, m deviceConfig.Device) (deviceCon
 			return err
 		}
 
-		err = db.ContainerConfigInsert(tx, vm.id, map[string]string{key: value})
+		err = db.CreateInstanceConfig(tx, vm.id, map[string]string{key: value})
 		if err != nil {
 			tx.Rollback()
 			return err

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -392,7 +392,7 @@ func ParseRawIdmap(value string) ([]idmap.IdmapEntry, error) {
 // LoadByID loads an instance by ID.
 func LoadByID(s *state.State, id int) (Instance, error) {
 	// Get the DB record
-	project, name, err := s.Cluster.ContainerProjectAndName(id)
+	project, name, err := s.Cluster.GetInstanceProjectAndName(id)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -586,7 +586,7 @@ func LoadNodeAll(s *state.State, instanceType instancetype.Type) ([]Instance, er
 
 // DeleteSnapshots calls the Delete() function on each of the supplied instance's snapshots.
 func DeleteSnapshots(s *state.State, projectName, instanceName string) error {
-	results, err := s.Cluster.ContainerGetSnapshots(projectName, instanceName)
+	results, err := s.Cluster.GetInstanceSnapshotsNames(projectName, instanceName)
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -570,7 +570,7 @@ func LoadNodeAll(s *state.State, instanceType instancetype.Type) ([]Instance, er
 	var insts []db.Instance
 	err := s.Cluster.Transaction(func(tx *db.ClusterTx) error {
 		var err error
-		insts, err = tx.ContainerNodeProjectList("", instanceType)
+		insts, err = tx.GetLocalInstancesInProject("", instanceType)
 		if err != nil {
 			return err
 		}

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -628,7 +628,7 @@ func DeviceNextInterfaceHWAddr() (string, error) {
 // BackupLoadByName load an instance backup from the database.
 func BackupLoadByName(s *state.State, project, name string) (*backup.Backup, error) {
 	// Get the backup database record
-	args, err := s.Cluster.ContainerGetBackup(project, name)
+	args, err := s.Cluster.GetInstanceBackup(project, name)
 	if err != nil {
 		return nil, errors.Wrap(err, "Load backup from database")
 	}

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -179,7 +179,7 @@ func containerPost(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Check if we are migrating a ceph-based container.
-			poolName, err := d.cluster.InstancePool(project, name)
+			poolName, err := d.cluster.GetInstancePool(project, name)
 			if err != nil {
 				err = errors.Wrap(err, "Failed to fetch instance's pool name")
 				return response.SmartError(err)

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -378,7 +378,7 @@ func containerPostClusteringMigrate(d *Daemon, c instance.Instance, oldName, new
 			return errors.Wrap(err, "Failed to get ID of moved instance")
 		}
 
-		err = d.cluster.ContainerConfigRemove(id, "volatile.apply_template")
+		err = d.cluster.DeleteInstanceConfigKey(id, "volatile.apply_template")
 		if err != nil {
 			return errors.Wrap(err, "Failed to remove volatile.apply_template config key")
 		}

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -440,7 +440,7 @@ func containerPostClusteringMigrateWithCeph(d *Daemon, c instance.Instance, proj
 
 		// Re-link the database entries against the new node name.
 		err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
-			err := tx.ContainerNodeMove(projectName, oldName, newName, newNode)
+			err := tx.UpdateInstanceNode(projectName, oldName, newName, newNode)
 			if err != nil {
 				return errors.Wrapf(
 					err, "Move container %s to %s with new name %s", oldName, newNode, newName)

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -81,7 +81,7 @@ func containerPost(d *Daemon, r *http.Request) response.Response {
 			targetNodeOffline = node.IsOffline(config.OfflineThreshold())
 
 			// Load source node.
-			address, err := tx.ContainerNodeAddress(project, name, instanceType)
+			address, err := tx.GetNodeAddressOfInstance(project, name, instanceType)
 			if err != nil {
 				return errors.Wrap(err, "Failed to get address of instance's node")
 			}

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -388,7 +388,7 @@ func containerPostClusteringMigrate(d *Daemon, c instance.Instance, oldName, new
 				"volatile.apply_template": origVolatileApplyTemplate,
 			}
 			err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
-				return tx.ContainerConfigInsert(id, config)
+				return tx.CreateInstanceConfig(id, config)
 			})
 			if err != nil {
 				return errors.Wrap(err, "Failed to set volatile.apply_template config key")

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -512,7 +512,7 @@ func containerPostCreateContainerMountPoint(d *Daemon, project, containerName st
 	if err != nil {
 		return errors.Wrap(err, "Failed get pool name of moved instance on target node")
 	}
-	snapshotNames, err := d.cluster.ContainerGetSnapshots(project, containerName)
+	snapshotNames, err := d.cluster.GetInstanceSnapshotsNames(project, containerName)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create instance snapshot names")
 	}

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -48,7 +48,7 @@ func containerSnapshotsGet(d *Daemon, r *http.Request) response.Response {
 	resultMap := []*api.InstanceSnapshot{}
 
 	if !recursion {
-		snaps, err := d.cluster.ContainerGetSnapshots(projectName, cname)
+		snaps, err := d.cluster.GetInstanceSnapshotsNames(projectName, cname)
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -350,8 +350,8 @@ func containersShutdown(s *state.State) error {
 	sort.Sort(containerStopList(instances))
 
 	if dbAvailable {
-		// Reset all container states
-		err = s.Cluster.ContainersResetState()
+		// Reset all instances states
+		err = s.Cluster.ResetInstancesPowerState()
 		if err != nil {
 			return err
 		}

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -102,7 +102,7 @@ func doContainersGet(d *Daemon, r *http.Request) (interface{}, error) {
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
 		var err error
 
-		result, err = tx.ContainersListByNodeAddress(project, instanceType)
+		result, err = tx.GetInstanceNamesByNodeAddress(project, instanceType)
 		if err != nil {
 			return err
 		}

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -107,7 +107,7 @@ func doContainersGet(d *Daemon, r *http.Request) (interface{}, error) {
 			return err
 		}
 
-		nodes, err = tx.ContainersByNodeName(project, instanceType)
+		nodes, err = tx.GetInstanceToNodeMap(project, instanceType)
 		if err != nil {
 			return err
 		}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -852,7 +852,7 @@ func containersPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		if req.Name == "" {
-			names, err := tx.InstanceNames(project)
+			names, err := tx.GetInstanceNames(project)
 			if err != nil {
 				return err
 			}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -958,7 +958,7 @@ func clusterCopyContainerInternal(d *Daemon, source instance.Instance, project s
 		var err error
 
 		// Load source node.
-		nodeAddress, err = tx.ContainerNodeAddress(project, name, source.Type())
+		nodeAddress, err = tx.GetNodeAddressOfInstance(project, name, source.Type())
 		if err != nil {
 			return errors.Wrap(err, "Failed to get address of instance's node")
 		}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -619,7 +619,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 		}
 
 		// Check if we need to account for snapshots for this container.
-		ctSnapshots, err := d.cluster.ContainerGetSnapshots("default", ct)
+		ctSnapshots, err := d.cluster.GetInstanceSnapshotsNames("default", ct)
 		if err != nil {
 			return err
 		}
@@ -1304,7 +1304,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 		}
 
 		// Check if we need to account for snapshots for this container.
-		ctSnapshots, err := d.cluster.ContainerGetSnapshots("default", ct)
+		ctSnapshots, err := d.cluster.GetInstanceSnapshotsNames("default", ct)
 		if err != nil {
 			return err
 		}
@@ -1763,7 +1763,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 		}
 
 		// Check if we need to account for snapshots for this container.
-		ctSnapshots, err := d.cluster.ContainerGetSnapshots("default", ct)
+		ctSnapshots, err := d.cluster.GetInstanceSnapshotsNames("default", ct)
 		if err != nil {
 			logger.Errorf("Failed to query database")
 			return err

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1170,7 +1170,7 @@ func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *
 	defer revert.Fail()
 
 	// Get any snapshots the instance has in the format <instance name>/<snapshot name>.
-	snapshots, err := b.state.Cluster.ContainerGetSnapshots(inst.Project(), inst.Name())
+	snapshots, err := b.state.Cluster.GetInstanceSnapshotsNames(inst.Project(), inst.Name())
 	if err != nil {
 		return err
 	}
@@ -1283,7 +1283,7 @@ func (b *lxdBackend) DeleteInstance(inst instance.Instance, op *operations.Opera
 	}
 
 	// Get any snapshots the instance has in the format <instance name>/<snapshot name>.
-	snapshots, err := b.state.Cluster.ContainerGetSnapshots(inst.Project(), inst.Name())
+	snapshots, err := b.state.Cluster.GetInstanceSnapshotsNames(inst.Project(), inst.Name())
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/load.go
+++ b/lxd/storage/load.go
@@ -174,7 +174,7 @@ func GetPoolByName(state *state.State, name string) (Pool, error) {
 // If the pool's driver is not recognised then drivers.ErrUnknownDriver is returned. If the pool's
 // driver does not support the instance's type then drivers.ErrNotImplemented is returned.
 func GetPoolByInstance(s *state.State, inst instance.Instance) (Pool, error) {
-	poolName, err := s.Cluster.InstancePool(inst.Project(), inst.Name())
+	poolName, err := s.Cluster.GetInstancePool(inst.Project(), inst.Name())
 	if err != nil {
 		return nil, err
 	}

--- a/shared/generate/db/method.go
+++ b/shared/generate/db/method.go
@@ -732,7 +732,7 @@ func (m *Method) create(buf *file.Buffer) error {
 		if field.Name == "Profiles" {
 			// TODO: get rid of the special case
 			buf.L("// Insert profiles reference. ")
-			buf.L("err = ContainerProfilesInsert(c.tx, int(id), object.Project, object.Profiles)")
+			buf.L("err = AddProfilesToInstance(c.tx, int(id), object.Project, object.Profiles)")
 			buf.L("if err != nil {")
 			buf.L("        return -1, errors.Wrap(err, \"Insert profiles for %s\")", m.entity)
 			buf.L("}")


### PR DESCRIPTION
This is a first batch of renames of db functions, to make them more consistent with current naming conventions in LXD.

Other similar renames will be done progressively in follow-up branches.