### PR TITLE
Storage: Restore VM generic backups using their original volume size

### DIFF
--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -663,7 +663,7 @@ func createFromBackup(d *Daemon, project string, data io.Reader, pool string) re
 		if err != nil {
 			return errors.Wrap(err, "Create instance from backup")
 		}
-		revert.Add(revertHook)
+		runRevert.Add(revertHook)
 
 		body, err := json.Marshal(&internalImportPost{
 			Name:  bInfo.Name,

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -587,7 +587,17 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 			logger.Debug("Applying volume quota from root disk config", log.Ctx{"size": rootDiskConf["size"]})
 			err = b.driver.SetVolumeQuota(vol, rootDiskConf["size"], op)
 			if err != nil {
-				return err
+				// The restored volume can end up being larger than the root disk config's size
+				// property due to the block boundary rounding some storage drivers use. As such
+				// if the restored volume is larger than the config's size and it cannot be shrunk
+				// to the equivalent size on the target storage driver, don't fail as the backup
+				// has still been restored successfully.
+				if errors.Cause(err) == drivers.ErrCannotBeShrunk {
+					logger.Warn("Could not apply volume quota from root disk config as restored volume cannot be shrunk", log.Ctx{"size": rootDiskConf["size"]})
+
+				} else {
+					return err
+				}
 			}
 		}
 

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -65,8 +65,8 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 			return err
 		}
 
-		// Move the GPT alt header to end of disk if needed.
-		if vol.IsVMBlock() {
+		// Move the GPT alt header to end of disk if needed and if filler specified.
+		if vol.IsVMBlock() && filler != nil && filler.Fill != nil {
 			err = d.moveGPTAltHeader(rootBlockPath)
 			if err != nil {
 				return err

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -461,8 +461,10 @@ func (d *btrfs) SetVolumeQuota(vol Volume, size string, op *operations.Operation
 			return err
 		}
 
-		// Move the GPT alt header to end of disk if needed and resize has taken place.
-		if vol.IsVMBlock() && resized {
+		// Move the GPT alt header to end of disk if needed and resize has taken place (not needed in
+		// unsafe resize mode as it is  expected the caller will do all necessary post resize actions
+		// themselves).
+		if vol.IsVMBlock() && resized && !vol.allowUnsafeResize {
 			err = d.moveGPTAltHeader(rootBlockPath)
 			if err != nil {
 				return err

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -774,50 +774,33 @@ func (d *ceph) SetVolumeQuota(vol Volume, size string, op *operations.Operation)
 	}
 
 	// Resize filesystem if needed.
-	if vol.contentType == ContentTypeFS {
-		if newSizeBytes < oldSizeBytes {
+	if newSizeBytes < oldSizeBytes {
+		if vol.contentType == ContentTypeBlock && !vol.allowUnsafeResize {
+			return errors.Wrap(ErrCannotBeShrunk, "You cannot shrink block volumes")
+		}
+
+		// Shrink the filesystem.
+		if vol.contentType == ContentTypeFS {
 			err = shrinkFileSystem(fsType, RBDDevPath, vol, newSizeBytes)
 			if err != nil {
 				return err
 			}
+		}
 
-			_, err = shared.TryRunCommand(
-				"rbd",
-				"resize",
-				"--allow-shrink",
-				"--id", d.config["ceph.user.name"],
-				"--cluster", d.config["ceph.cluster_name"],
-				"--pool", d.config["ceph.osd.pool_name"],
-				"--size", fmt.Sprintf("%dB", newSizeBytes),
-				d.getRBDVolumeName(vol, "", false, false))
-			if err != nil {
-				return err
-			}
-		} else {
-			// Grow the block device.
-			_, err = shared.TryRunCommand(
-				"rbd",
-				"resize",
-				"--id", d.config["ceph.user.name"],
-				"--cluster", d.config["ceph.cluster_name"],
-				"--pool", d.config["ceph.osd.pool_name"],
-				"--size", fmt.Sprintf("%dB", newSizeBytes),
-				d.getRBDVolumeName(vol, "", false, false))
-			if err != nil {
-				return err
-			}
-
-			// Grow the filesystem.
-			err = growFileSystem(fsType, RBDDevPath, vol)
-			if err != nil {
-				return err
-			}
+		// Shrink the block device.
+		_, err = shared.TryRunCommand(
+			"rbd",
+			"resize",
+			"--allow-shrink",
+			"--id", d.config["ceph.user.name"],
+			"--cluster", d.config["ceph.cluster_name"],
+			"--pool", d.config["ceph.osd.pool_name"],
+			"--size", fmt.Sprintf("%dB", newSizeBytes),
+			d.getRBDVolumeName(vol, "", false, false))
+		if err != nil {
+			return err
 		}
 	} else {
-		if newSizeBytes < oldSizeBytes {
-			return errors.Wrap(ErrCannotBeShrunk, "You cannot shrink block volumes")
-		}
-
 		// Grow the block device.
 		_, err = shared.TryRunCommand(
 			"rbd",
@@ -831,12 +814,21 @@ func (d *ceph) SetVolumeQuota(vol Volume, size string, op *operations.Operation)
 			return err
 		}
 
-		// Move the GPT alt header to end of disk if needed.
-		if vol.IsVMBlock() {
-			err = d.moveGPTAltHeader(RBDDevPath)
+		// Grow the filesystem.
+		if vol.contentType == ContentTypeFS {
+			err = growFileSystem(fsType, RBDDevPath, vol)
 			if err != nil {
 				return err
 			}
+		}
+	}
+
+	// Move the VM GPT alt header to end of disk if needed (not needed in unsafe resize mode as it is
+	// expected the caller will do all necessary post resize actions themselves).
+	if vol.IsVMBlock() && !vol.allowUnsafeResize {
+		err = d.moveGPTAltHeader(RBDDevPath)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -260,8 +260,10 @@ func (d *dir) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 			return err
 		}
 
-		// Move the GPT alt header to end of disk if needed and resize has taken place.
-		if vol.IsVMBlock() && resized {
+		// Move the GPT alt header to end of disk if needed and resize has taken place (not needed in
+		// unsafe resize mode as it is  expected the caller will do all necessary post resize actions
+		// themselves).
+		if vol.IsVMBlock() && resized && !vol.allowUnsafeResize {
 			err = d.moveGPTAltHeader(rootBlockPath)
 			if err != nil {
 				return err

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -914,7 +914,7 @@ func (d *zfs) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 			return nil
 		}
 
-		if sizeBytes < oldVolSizeBytes {
+		if sizeBytes < oldVolSizeBytes && !vol.allowUnsafeResize {
 			return errors.Wrap(ErrCannotBeShrunk, "You cannot shrink block volumes")
 		}
 
@@ -929,8 +929,9 @@ func (d *zfs) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 				return err
 			}
 
-			// Move the GPT alt header to end of disk if needed.
-			if vol.IsVMBlock() {
+			// Move the VM GPT alt header to end of disk if needed (not needed in unsafe resize mode as
+			// it is expected the caller will do all necessary post resize actions themselves).
+			if vol.IsVMBlock() && !vol.allowUnsafeResize {
 				err = d.moveGPTAltHeader(devPath)
 				if err != nil {
 					return err

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -62,15 +62,16 @@ var BaseDirectories = map[VolumeType][]string{
 
 // Volume represents a storage volume, and provides functions to mount and unmount it.
 type Volume struct {
-	name            string
-	pool            string
-	poolConfig      map[string]string
-	volType         VolumeType
-	contentType     ContentType
-	config          map[string]string
-	driver          Driver
-	keepDevice      bool
-	customMountPath string
+	name              string
+	pool              string
+	poolConfig        map[string]string
+	volType           VolumeType
+	contentType       ContentType
+	config            map[string]string
+	driver            Driver
+	keepDevice        bool
+	customMountPath   string
+	allowUnsafeResize bool // Whether to allow potentially destructive unchecked resizing of volume.
 }
 
 // NewVolume instantiates a new Volume struct.


### PR DESCRIPTION
For generic VM backups, restore the original volume sizes rather than the target's default volume size.

In order to accommodate this change, whilst avoiding unnecessary scans of the compressed backup file, I have introduced the concept of a `Volume` setting called `allowUnsafeResize` that allows us to indicate to the storage driver that a we can shrink block volumes (as we do this before unpacking the backup volume).