### PR TITLE
Storage: Updates volume size treatment to be consistent across drivers

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -378,3 +378,15 @@ func (d *btrfs) receiveSubvolume(path string, targetPath string, conn io.ReadWri
 
 	return nil
 }
+
+// volumeSize returns the size to use when creating new a volume.
+func (d *btrfs) volumeSize(vol Volume) string {
+	size := vol.ExpandedConfig("size")
+
+	// Block images always need a size.
+	if vol.contentType == ContentTypeBlock && (size == "" || size == "0") {
+		return defaultBlockSize
+	}
+
+	return size
+}

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -529,7 +529,7 @@ func (d *ceph) rbdListVolumeSnapshots(vol Volume) ([]string, error) {
 	return snapshots, nil
 }
 
-// volumeSize returns the size to use when creating new RBD volumes.
+// volumeSize returns the size to use when creating new a volume.
 func (d *ceph) volumeSize(vol Volume) string {
 	size := vol.ExpandedConfig("size")
 	if size == "" || size == "0" {

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -313,9 +313,9 @@ func (d *ceph) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots boo
 		// This is so the pool default volume size isn't take into account for volume copies.
 		volSize := vol.config["size"]
 
-		// If source is an image then use expanded config so that we take into account pool volume size.
+		// If source is an image then take into account default volume sizes if not specified.
 		if srcVol.volType == VolumeTypeImage {
-			volSize = vol.ExpandedConfig("size")
+			volSize = d.volumeSize(vol)
 		}
 
 		err = d.SetVolumeQuota(vol, volSize, op)

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -802,7 +802,19 @@ func (d *ceph) GetVolumeUsage(vol Volume) (int64, error) {
 }
 
 // SetVolumeQuota applies a size limit on volume.
+// Does nothing if supplied with an empty/zero size.
 func (d *ceph) SetVolumeQuota(vol Volume, size string, op *operations.Operation) error {
+	// Convert to bytes.
+	sizeBytes, err := units.ParseByteSizeString(size)
+	if err != nil {
+		return err
+	}
+
+	// Do nothing if size isn't specified.
+	if sizeBytes <= 0 {
+		return nil
+	}
+
 	fsType := d.getRBDFilesystem(vol)
 
 	RBDDevPath, err := d.getRBDMappedDevPath(vol)
@@ -822,26 +834,20 @@ func (d *ceph) SetVolumeQuota(vol Volume, size string, op *operations.Operation)
 		return errors.Wrapf(err, "Error getting current size")
 	}
 
-	newSizeBytes, err := units.ParseByteSizeString(size)
-	if err != nil {
-		return err
-	}
-
-	// The right disjunct just means that someone unset the size property in the instance's config.
-	// We obviously cannot resize to 0.
-	if oldSizeBytes == newSizeBytes || newSizeBytes == 0 {
+	// Do nothing is volume is already specified size.
+	if oldSizeBytes == sizeBytes {
 		return nil
 	}
 
 	// Resize filesystem if needed.
-	if newSizeBytes < oldSizeBytes {
+	if sizeBytes < oldSizeBytes {
 		if vol.contentType == ContentTypeBlock && !vol.allowUnsafeResize {
 			return errors.Wrap(ErrCannotBeShrunk, "You cannot shrink block volumes")
 		}
 
 		// Shrink the filesystem.
 		if vol.contentType == ContentTypeFS {
-			err = shrinkFileSystem(fsType, RBDDevPath, vol, newSizeBytes)
+			err = shrinkFileSystem(fsType, RBDDevPath, vol, sizeBytes)
 			if err != nil {
 				return err
 			}
@@ -855,7 +861,7 @@ func (d *ceph) SetVolumeQuota(vol Volume, size string, op *operations.Operation)
 			"--id", d.config["ceph.user.name"],
 			"--cluster", d.config["ceph.cluster_name"],
 			"--pool", d.config["ceph.osd.pool_name"],
-			"--size", fmt.Sprintf("%dB", newSizeBytes),
+			"--size", fmt.Sprintf("%dB", sizeBytes),
 			d.getRBDVolumeName(vol, "", false, false))
 		if err != nil {
 			return err
@@ -868,7 +874,7 @@ func (d *ceph) SetVolumeQuota(vol Volume, size string, op *operations.Operation)
 			"--id", d.config["ceph.user.name"],
 			"--cluster", d.config["ceph.cluster_name"],
 			"--pool", d.config["ceph.osd.pool_name"],
-			"--size", fmt.Sprintf("%dB", newSizeBytes),
+			"--size", fmt.Sprintf("%dB", sizeBytes),
 			d.getRBDVolumeName(vol, "", false, false))
 		if err != nil {
 			return err

--- a/lxd/storage/drivers/driver_dir_utils.go
+++ b/lxd/storage/drivers/driver_dir_utils.go
@@ -48,7 +48,7 @@ func (d *dir) setupInitialQuota(vol Volume) (func(), error) {
 	revert.Add(revertFunc)
 
 	// Set the quota.
-	err = d.setQuota(volPath, volID, vol.ExpandedConfig("size"))
+	err = d.setQuota(volPath, volID, d.volumeSize(vol))
 	if err != nil {
 		return nil, err
 	}
@@ -148,4 +148,16 @@ func (d *dir) setQuota(path string, volID int64, size string) error {
 	}
 
 	return quota.SetProjectQuota(path, d.quotaProjectID(volID), sizeBytes)
+}
+
+// volumeSize returns the size to use when creating new a volume.
+func (d *dir) volumeSize(vol Volume) string {
+	size := vol.ExpandedConfig("size")
+
+	// Block images always need a size.
+	if vol.contentType == ContentTypeBlock && (size == "" || size == "0") {
+		return defaultBlockSize
+	}
+
+	return size
 }

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -249,20 +249,27 @@ func (d *dir) GetVolumeUsage(vol Volume) (int64, error) {
 }
 
 // SetVolumeQuota sets the quota on the volume.
+// Does nothing if supplied with an empty/zero size for block volumes, and for filesystem volumes removes quota.
 func (d *dir) SetVolumeQuota(vol Volume, size string, op *operations.Operation) error {
+	// Convert to bytes.
+	sizeBytes, err := units.ParseByteSizeString(size)
+	if err != nil {
+		return err
+	}
+
 	// For VM block files, resize the file if needed.
 	if vol.contentType == ContentTypeBlock {
+		// Do nothing if size isn't specified.
+		if sizeBytes <= 0 {
+			return nil
+		}
+
 		rootBlockPath, err := d.GetVolumeDiskPath(vol)
 		if err != nil {
 			return err
 		}
 
-		// If size not specified in volume config, then use pool's default block size.
-		if size == "" || size == "0" {
-			size = defaultBlockSize
-		}
-
-		resized, err := genericVFSResizeBlockFile(rootBlockPath, size)
+		resized, err := genericVFSResizeBlockFile(rootBlockPath, sizeBytes)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/instancewriter"
 	log "github.com/lxc/lxd/shared/log15"
+	"github.com/lxc/lxd/shared/units"
 )
 
 // CreateVolume creates an empty volume and can optionally fill it by executing the supplied
@@ -64,7 +65,13 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 	// If we are creating a block volume, resize it to the requested size or the default.
 	// We expect the filler function to have converted the qcow2 image to raw into the rootBlockPath.
 	if vol.contentType == ContentTypeBlock {
-		err := ensureVolumeBlockFile(rootBlockPath, vol.ExpandedConfig("size"))
+		// Convert to bytes.
+		sizeBytes, err := units.ParseByteSizeString(d.volumeSize(vol))
+		if err != nil {
+			return err
+		}
+
+		err = ensureVolumeBlockFile(rootBlockPath, sizeBytes)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -54,7 +54,7 @@ func (d *lvm) volumeFilesystem(vol Volume) string {
 	return DefaultFilesystem
 }
 
-// volumeSize returns the size to use when creating new logical volumes.
+// volumeSize returns the size to use when creating new a volume.
 func (d *lvm) volumeSize(vol Volume) string {
 	size := vol.ExpandedConfig("size")
 	if size == "" || size == "0" {
@@ -654,9 +654,9 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []Volume, refr
 	// This is so the pool default volume size isn't take into account for volume copies.
 	volSize := vol.config["size"]
 
-	// If source is an image then use expanded config so that we take into account pool default volume size.
+	// If source is an image then take into account default volume sizes if not specified.
 	if srcVol.volType == VolumeTypeImage {
-		volSize = vol.ExpandedConfig("size")
+		volSize = d.volumeSize(vol)
 	}
 
 	err = d.SetVolumeQuota(vol, volSize, nil)

--- a/lxd/storage/drivers/driver_zfs_utils.go
+++ b/lxd/storage/drivers/driver_zfs_utils.go
@@ -316,3 +316,15 @@ func (d *zfs) receiveDataset(dataset string, conn io.ReadWriteCloser, writeWrapp
 
 	return nil
 }
+
+// volumeSize returns the size to use when creating new a volume.
+func (d *zfs) volumeSize(vol Volume) string {
+	size := vol.ExpandedConfig("size")
+
+	// Block images always need a size.
+	if vol.contentType == ContentTypeBlock && (size == "" || size == "0") {
+		return defaultBlockSize
+	}
+
+	return size
+}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -590,9 +590,9 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 	// This is so the pool default volume size isn't take into account for volume copies.
 	volSize := vol.config["size"]
 
-	// If source is an image then use expanded config so that we take into account pool default volume size.
+	// If source is an image then take into account default volume sizes if not specified.
 	if srcVol.volType == VolumeTypeImage {
-		volSize = vol.ExpandedConfig("size")
+		volSize = d.volumeSize(vol)
 	}
 
 	err := d.SetVolumeQuota(vol, volSize, op)

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -133,21 +133,12 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 		}
 
 		// Apply the size limit.
-		size := vol.ExpandedConfig("size")
-		if size != "" {
-			err := d.SetVolumeQuota(vol, size, op)
-			if err != nil {
-				return err
-			}
+		err = d.SetVolumeQuota(vol, d.volumeSize(vol), op)
+		if err != nil {
+			return err
 		}
 	} else {
-		// Convert the size.
-		size := vol.ExpandedConfig("size")
-		if size == "" {
-			size = defaultBlockSize
-		}
-
-		sizeBytes, err := units.ParseByteSizeString(size)
+		sizeBytes, err := units.ParseByteSizeString(d.volumeSize(vol))
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -779,8 +779,8 @@ func genericVFSBackupUnpack(d Driver, vol Volume, snapshots []string, srcData io
 // genericVFSResizeBlockFile resizes an existing block file to the specified size. Returns true if resize took
 // place, false if not. Both requested size and existing file size are rounded to nearest block size using
 // roundVolumeBlockFileSizeBytes() before decision whether to resize is taken.
-func genericVFSResizeBlockFile(filePath, size string) (bool, error) {
-	if size == "" || size == "0" {
+func genericVFSResizeBlockFile(filePath string, sizeBytes int64) (bool, error) {
+	if sizeBytes <= 0 {
 		return false, fmt.Errorf("Size cannot be zero")
 	}
 
@@ -792,7 +792,7 @@ func genericVFSResizeBlockFile(filePath, size string) (bool, error) {
 	oldSizeBytes := fi.Size()
 
 	// Round the supplied size the same way the block files created are so its accurate comparison.
-	newSizeBytes, err := roundVolumeBlockFileSizeBytes(size)
+	newSizeBytes, err := roundVolumeBlockFileSizeBytes(sizeBytes)
 	if err != nil {
 		return false, err
 	}
@@ -806,7 +806,7 @@ func genericVFSResizeBlockFile(filePath, size string) (bool, error) {
 	}
 
 	// Resize block file.
-	err = ensureVolumeBlockFile(filePath, size)
+	err = ensureVolumeBlockFile(filePath, sizeBytes)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Updates dir, btrfs, lvm, zfs and ceph drivers to behave in a consistent way in terms of setting volume size (be it block volume size or quota).

Ensures that:

- `SetVolumeQuota()` function does nothing when supplied with a "0" or "" size argument for block volumes and removes quota if driver uses quotas.
- `volumeSize()` function returns the value of `vol.ExpandedConfig("size")` (which takes the size from volume config or pool config) and if not specified in either will return the `defaultBlockSize` if relevant for the driver (i.e for block backed drivers always return it, and for non-block-backed drivers only return it if creating a block volume).

Tested:

- [x] btrfs
- [x] ceph
- [x] dir
- [x] lvm
- [x] zfs
