### PR TITLE
Storage: Detect cached image filesystem changes for VM images too

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2041,7 +2041,8 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 
 	// If an existing DB row was found, check if filesystem is the same as the current pool's filesystem.
 	// If not we need to delete the existing cached image volume and re-create using new filesystem.
-	if imgDBVol != nil && contentType == drivers.ContentTypeFS {
+	// We need to do this for VM block images too, as they create a filesystem based config volume too.
+	if imgDBVol != nil {
 		if b.Driver().Info().BlockBacking && imgDBVol.Config["block.filesystem"] != b.poolBlockFilesystem() {
 			logger.Debug("Filesystem of pool has changed since cached image volume created, regenerating image volume")
 			err = b.DeleteImage(fingerprint, op)


### PR DESCRIPTION
They have a filesystem config volume too, so need to also use this check.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>