### PR TITLE
lxd/qemu: Restrict NUMA layout to x86_64

### DIFF
--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -155,6 +155,7 @@ sockets = "{{.cpuSockets}}"
 cores = "{{.cpuCores}}"
 threads = "{{.cpuThreads}}"
 
+{{if eq .architecture "x86_64" -}}
 {{range $index, $element := .cpuNumaNodes}}
 [numa]
 type = "node"
@@ -168,6 +169,7 @@ node-id = "{{.node}}"
 socket-id = "{{.socket}}"
 core-id = "{{.core}}"
 thread-id = "{{.thread}}"
+{{end}}
 {{end}}
 `))
 


### PR DESCRIPTION
At least on aarch64, core_id doesn't appear to be supported.
So this will need more testing and potentially a different approach on
some architectures.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>