### PR TITLE
Consider all nodes when looking for the leader, not only voters

### DIFF
--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -684,8 +684,7 @@ func (g *Gateway) init() error {
 
 	g.lock.Lock()
 	g.store.onDisk = client.NewNodeStore(
-		g.db.DB(), "main", "raft_nodes", "address",
-		client.WithNodeStoreWhereClause(fmt.Sprintf("role=%d", db.RaftVoter)))
+		g.db.DB(), "main", "raft_nodes", "address")
 	g.lock.Unlock()
 
 	return nil


### PR DESCRIPTION
This is now safe since dqlite itself will return empty responses
when probing non-voting nodes.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>