### PR TITLE
Storage: LVM volume activation

### DIFF
--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -501,12 +501,7 @@ func (d *lvm) Mount() (bool, error) {
 			return false, err
 		}
 		defer loopFile.Close()
-	}
-
-	// Activate volume group so that it's device is added to /dev.
-	_, err := shared.TryRunCommand("vgchange", "-ay", d.config["lvm.vg_name"])
-	if err != nil {
-		return false, err
+		return true, nil
 	}
 
 	return false, nil

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -645,6 +645,11 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []Volume, refr
 		// volumes with the same UUID to be mounted at the same time). This should be done before volume
 		// resize as some filesystems will need to mount the filesystem to resize.
 		if renegerateFilesystemUUIDNeeded(d.volumeFilesystem(vol)) {
+			_, err = d.activateVolume(volDevPath)
+			if err != nil {
+				return err
+			}
+
 			d.logger.Debug("Regenerating filesystem UUID", log.Ctx{"dev": volDevPath, "fs": d.volumeFilesystem(vol)})
 			err = regenerateFilesystemUUID(d.volumeFilesystem(vol), volDevPath)
 			if err != nil {

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -427,7 +427,7 @@ func (d *lvm) createLogicalVolumeSnapshot(vgName string, srcVol, snapVol Volume,
 	args := []string{"-n", snapLvName, "-s", srcVolDevPath}
 
 	if isRecent {
-		args = append(args, "-kn")
+		args = append(args, "--setactivationskip", "y")
 	}
 
 	// If the source is not a thin volume the size needs to be specified.
@@ -463,15 +463,6 @@ func (d *lvm) createLogicalVolumeSnapshot(vgName string, srcVol, snapVol Volume,
 	})
 
 	targetVolDevPath := d.lvmDevPath(vgName, snapVol.volType, snapVol.contentType, snapVol.name)
-	if makeThinLv {
-		// Snapshots of thin logical volumes can be directly activated.
-		// Normal snapshots will complain about changing the origin (Which they never do.),
-		// so skip the activation since the logical volume will be automatically activated anyway.
-		_, err := shared.TryRunCommand("lvchange", "-ay", targetVolDevPath)
-		if err != nil {
-			return "", err
-		}
-	}
 
 	revert.Success()
 	return targetVolDevPath, nil

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -779,3 +779,31 @@ func (d *lvm) parseLogicalVolumeSnapshot(parent Volume, lvmVolName string) strin
 
 	return ""
 }
+
+// activateVolume activates an LVM logical volume if not already present. Returns true if activated, false if not.
+func (d *lvm) activateVolume(volDevPath string) (bool, error) {
+	if !shared.PathExists(volDevPath) {
+		_, err := shared.RunCommand("lvchange", "--activate", "y", "--ignoreactivationskip", volDevPath)
+		if err != nil {
+			return false, errors.Wrapf(err, "Failed to activate LVM logical volume %q", volDevPath)
+		}
+		d.logger.Debug("Activated logical volume", log.Ctx{"dev": volDevPath})
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// deactivateVolume deactivates an LVM logical volume if present. Returns true if deactivated, false if not.
+func (d *lvm) deactivateVolume(volDevPath string) (bool, error) {
+	if shared.PathExists(volDevPath) {
+		_, err := shared.RunCommand("lvchange", "--activate", "n", "--ignoreactivationskip", volDevPath)
+		if err != nil {
+			return false, errors.Wrapf(err, "Failed to deactivate LVM logical volume %q", volDevPath)
+		}
+		d.logger.Debug("Deactivated logical volume", log.Ctx{"dev": volDevPath})
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -366,6 +366,15 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 
 	logCtx := log.Ctx{"dev": volDevPath, "size": fmt.Sprintf("%db", sizeBytes)}
 
+	// Activate volume if needed.
+	activated, err := d.activateVolume(volDevPath)
+	if err != nil {
+		return err
+	}
+	if activated {
+		defer d.deactivateVolume(volDevPath)
+	}
+
 	// Resize filesystem if needed.
 	if vol.contentType == ContentTypeFS {
 		if sizeBytes < oldSizeBytes {

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -965,6 +965,11 @@ func (d *lvm) RestoreVolume(vol Volume, snapshotName string, op *operations.Oper
 
 		// If the volume's filesystem needs to have its UUID regenerated to allow mount then do so now.
 		if vol.contentType == ContentTypeFS && renegerateFilesystemUUIDNeeded(d.volumeFilesystem(vol)) {
+			_, err = d.activateVolume(volDevPath)
+			if err != nil {
+				return err
+			}
+
 			d.logger.Debug("Regenerating filesystem UUID", log.Ctx{"dev": volDevPath, "fs": d.volumeFilesystem(vol)})
 			err = regenerateFilesystemUUID(d.volumeFilesystem(vol), volDevPath)
 			if err != nil {


### PR DESCRIPTION
This PR modifies the LVM driver to be more like the ZFS and Ceph drivers in that it will not activate all LXD logical volumes (in so much as entries will not appear in `/dev`) until the volumes are needed, and will deactivate them when they are not needed.

This uses the `--setactivationskip y` option in LVM to mark a volume as one that should not be automatically activated when the volume group is scanned.

For non-thinpool volumes, any snapshots are activated and deactivated by LVM when the parent is activated/deactivated. However LVM does not allow a non-thin snapshot to be activated without the parent already being activated (similar to ZFS) so we also detect this and activate the parent volume when needed.

- [x] Container testing
- [x] VM testing
- [x] Custom volume testing