### PR TITLE
Storage: ZFS migration improvement

### DIFF
--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1182,10 +1182,8 @@ func (d *zfs) RenameVolume(vol Volume, newVolName string, op *operations.Operati
 func (d *zfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
 	// Handle simple rsync and block_and_rsync through generic.
 	if volSrcArgs.MigrationType.FSType == migration.MigrationFSType_RSYNC || volSrcArgs.MigrationType.FSType == migration.MigrationFSType_BLOCK_AND_RSYNC {
-		// We need to mount the parent volume before calling genericVFSMigrateVolume for two reasons.
-		// 1. In order to get the block device disk path to read from the device must be activated.
-		// 2. If copying snapshots the parent volume must be activated before the snapshot volume's block
-		// device can be made visible.
+		// Before doing a generic volume migration, we need to ensure volume (or snap volume parent) is
+		// activated to avoid issues activating the snapshot volume device.
 		parent, _, _ := shared.InstanceGetParentAndSnapshotName(vol.Name())
 		parentVol := NewVolume(d, d.Name(), vol.volType, vol.contentType, parent, vol.config, vol.poolConfig)
 		ourMount, err := d.MountVolume(parentVol, op)
@@ -1194,18 +1192,6 @@ func (d *zfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mig
 		}
 		if ourMount {
 			defer d.UnmountVolume(parentVol, op)
-		}
-
-		// In addition to above, if the volume we are sending is a snapshot, we also need to mount that
-		// so that genericVFSMigrateVolume can discover its block device (same reason as 1. above).
-		if vol.IsSnapshot() {
-			ourMount, err = d.MountVolumeSnapshot(vol, op)
-			if err != nil {
-				return err
-			}
-			if ourMount {
-				defer d.UnmountVolumeSnapshot(vol, op)
-			}
 		}
 
 		return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)


### PR DESCRIPTION
This PR changes the way that `genericVFSMigrateVolume` detects if a VM root device exists as a disk image in the instance's config filesystem (and needs to be excluded when rsyncing that volume to the target) or whether it exists as a block device outside of the filesystem's mount path.

This allows us to avoid a pre-mount of snapshot volumes, as previously it required thid to activate the volume in order to ascertain whether the root disk was a disk image or a block device.