### PR TITLE
Storage: Don't reset custom volume root permissions on mount for DIR and BTRFS

### DIFF
--- a/test/suites/storage_volume_attach.sh
+++ b/test/suites/storage_volume_attach.sh
@@ -90,6 +90,13 @@ test_storage_volume_attach() {
   # attach second container
   lxc storage volume attach "lxdtest-$(basename "${LXD_DIR}")" testvolume c2 testvolume
 
+  # check that setting perms on the root of the custom volume persists after a reboot.
+  lxc exec c2 -- stat -c '%a' /testvolume | grep 711
+  lxc exec c2 -- chmod 0700 /testvolume
+  lxc exec c2 -- stat -c '%a' /testvolume | grep 700
+  lxc restart --force c2
+  lxc exec c2 -- stat -c '%a' /testvolume | grep 700
+
   # delete containers
   lxc delete -f c1
   lxc delete -f c2


### PR DESCRIPTION
This PR fixes an issue where for DIR and BTRFS drivers, if the custom volume root permission was modified inside the instance, it was then modified on restart back to the default value of `0711`.

Also fixes an issue with the created permissions on ceph volumes.

This issue was reported here https://discuss.linuxcontainers.org/t/secondary-disk-rights-issue/7679/