### PR TITLE
lxd/storage/zfs: Use TryUnmount

### DIFF
--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1109,7 +1109,7 @@ func (d *zfs) UnmountVolume(vol Volume, op *operations.Operation) (bool, error) 
 	// Check if still mounted.
 	if shared.IsMountPoint(mountPath) {
 		// Unmount the dataset.
-		_, err := shared.RunCommand("zfs", "unmount", dataset)
+		err := TryUnmount(mountPath, 0)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
"zfs unmount" annoyingly wraps errors so just use our own TryUnmount
instead so we can deal with things taking a bit long to unmount.

Closes #7296

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>