### PR TITLE
Storage: Removes readonly option from snapshotSubvolume()

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -140,7 +140,7 @@ func (d *btrfs) deleteSubvolume(path string, recursion bool) error {
 		}
 
 		// Attempt to make the subvolume writable.
-		shared.RunCommand("btrfs", "property", "set", path, "ro", "false")
+		d.setSubvolumeReadonlyProperty(path, false)
 
 		// Temporarily change ownership & mode to help with nesting.
 		os.Chmod(path, 0700)

--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -161,6 +161,11 @@ func (d *btrfs) deleteSubvolume(path string, recursion bool) error {
 		}
 		sort.Sort(sort.Reverse(sort.StringSlice(subsubvols)))
 
+		if len(subsubvols) > 0 {
+			// Attempt to make the root subvolume writable so any subvolumes can be removed.
+			d.setSubvolumeReadonlyProperty(path, false)
+		}
+
 		for _, subsubvol := range subsubvols {
 			err := destroy(filepath.Join(path, subsubvol))
 			if err != nil {

--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -390,3 +390,15 @@ func (d *btrfs) volumeSize(vol Volume) string {
 
 	return size
 }
+
+// setSubvolumeReadonlyProperty sets the readonly property on the subvolume to true or false.
+func (d *btrfs) setSubvolumeReadonlyProperty(path string, readonly bool) error {
+	// Silently ignore requests to set subvolume readonly property if running in a user namespace as we won't
+	// be able to change it if it is readonly already, and making it readonly will mean we cannot undo it.
+	if d.state.OS.RunningInUserNS {
+		return nil
+	}
+
+	_, err := shared.RunCommand("btrfs", "property", "set", "-ts", path, "ro", fmt.Sprintf("%t", readonly))
+	return err
+}

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -881,6 +881,22 @@ func (d *btrfs) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) e
 		return err
 	}
 
+	// Set any subvolumes that were readonly in the source also readonly in the snapshot.
+	srcVol := NewVolume(d, d.name, snapVol.volType, snapVol.contentType, parentName, snapVol.config, snapVol.poolConfig)
+	subVols, err := d.getSubvolumesMetaData(srcVol)
+	if err != nil {
+		return err
+	}
+
+	for _, subVol := range subVols {
+		if subVol.Readonly {
+			err = d.setSubvolumeReadonlyProperty(filepath.Join(snapPath, subVol.Path), true)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The `snapshotSubvolume` function used to have a `readonly` argument. However it was not applied when using the `recursion` option.

However fixing the function so that it did apply the `readonly` argument when `recursion` was set to true caused more problems because when snapshotting an instance volume, it is expected that only the root subvolume be marked as readonly and not any subvolumes (so that their write status is preserved in the snapshot in order to correctly backup or migrate the volumes with the same state).

However all subvolumes do need to be set readonly when migrating/exporting (the marking of subvolumes as readonly will follow in a separate PR).

As such we need to do different things in different scenarios and a 'one size fits all' option here doesn't make sense. So I have removed it in place of more fine grained control where its needed.