### PR TITLE
Storage: LVM snapshot parsing improvements

### DIFF
--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -743,3 +743,39 @@ func (d *lvm) thinPoolVolumeUsage(volDevPath string) (uint64, uint64, error) {
 
 	return totalSize, usedSize, nil
 }
+
+// parseLogicalVolumeSnapshot parses a raw logical volume name (from lvs command) and checks whether it is a
+// snapshot of the supplied parent volume. Returns unescaped parsed snapshot name if snapshot volume recognised,
+// empty string if not. The parent is required due to limitations in the naming scheme that LXD has historically
+// been used for naming logical volumes meaning that additional context of the parent is required to accurately
+// recognise snapshot volumes that belong to the parent.
+func (d *lvm) parseLogicalVolumeSnapshot(parent Volume, lvmVolName string) string {
+	fullVolName := d.lvmFullVolumeName(parent.volType, parent.contentType, parent.name)
+
+	// If block volume, remove the block suffix ready for comparison with LV list.
+	// Note: Only VM volumes currently support content type block for VMs. Not custom volumes.
+	if parent.IsVMBlock() {
+		if !strings.HasSuffix(lvmVolName, lvmBlockVolSuffix) {
+			return ""
+		}
+
+		// Remove the block suffix so that snapshot names can be compared and extracted without the suffix.
+		fullVolName = strings.TrimSuffix(fullVolName, lvmBlockVolSuffix)
+		lvmVolName = strings.TrimSuffix(lvmVolName, lvmBlockVolSuffix)
+	}
+
+	// Prefix we would expect for a snapshot of the parent volume.
+	snapPrefix := fmt.Sprintf("%s%s", fullVolName, lvmSnapshotSeparator)
+
+	// Prefix used when escaping "-" in volume names. Doesn't indicate a snapshot of parent.
+	badPrefix := fmt.Sprintf("%s%s", fullVolName, lvmEscapedHyphen)
+
+	// Check the volume matches the snapshot prefix, but doesn't match the prefix that indicates a similarly
+	// named volume that just has escaped "-" characters in it.
+	if strings.HasPrefix(lvmVolName, snapPrefix) && !strings.HasPrefix(lvmVolName, badPrefix) {
+		// Remove volume name prefix (including snapshot delimiter) and unescape snapshot name.
+		return strings.Replace(strings.TrimPrefix(lvmVolName, snapPrefix), lvmEscapedHyphen, "-", -1)
+	}
+
+	return ""
+}

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -26,6 +26,9 @@ const lvmBlockVolSuffix = ".block"
 // lvmSnapshotSeparator separator character used between volume name and snaphot name in logical volume names.
 const lvmSnapshotSeparator = "-"
 
+// lvmEscapedHyphen used to escape hyphens in volume names to avoid conflicts with lvmSnapshotSeparator.
+const lvmEscapedHyphen = "--"
+
 var errLVMNotFound = fmt.Errorf("Not found")
 
 // usesThinpool indicates whether the config specifies to use a thin pool or not.
@@ -515,7 +518,7 @@ func (d *lvm) lvmFullVolumeName(volType VolumeType, contentType ContentType, vol
 	}
 
 	// Escape the volume name to a name suitable for using as a logical volume.
-	lvName := strings.Replace(strings.Replace(volName, "-", "--", -1), shared.SnapshotDelimiter, lvmSnapshotSeparator, -1)
+	lvName := strings.Replace(strings.Replace(volName, "-", lvmEscapedHyphen, -1), shared.SnapshotDelimiter, lvmSnapshotSeparator, -1)
 
 	return fmt.Sprintf("%s_%s%s", volTypePrefix, lvName, contentTypeSuffix)
 }

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -23,6 +23,9 @@ import (
 // lvmBlockVolSuffix suffix used for block content type svolumes.
 const lvmBlockVolSuffix = ".block"
 
+// lvmSnapshotSeparator separator character used between volume name and snaphot name in logical volume names.
+const lvmSnapshotSeparator = "-"
+
 var errLVMNotFound = fmt.Errorf("Not found")
 
 // usesThinpool indicates whether the config specifies to use a thin pool or not.
@@ -512,7 +515,7 @@ func (d *lvm) lvmFullVolumeName(volType VolumeType, contentType ContentType, vol
 	}
 
 	// Escape the volume name to a name suitable for using as a logical volume.
-	lvName := strings.Replace(strings.Replace(volName, "-", "--", -1), shared.SnapshotDelimiter, "-", -1)
+	lvName := strings.Replace(strings.Replace(volName, "-", "--", -1), shared.SnapshotDelimiter, lvmSnapshotSeparator, -1)
 
 	return fmt.Sprintf("%s_%s%s", volTypePrefix, lvName, contentTypeSuffix)
 }

--- a/lxd/storage/drivers/driver_lvm_utils_test.go
+++ b/lxd/storage/drivers/driver_lvm_utils_test.go
@@ -1,0 +1,68 @@
+package drivers
+
+import (
+	"fmt"
+)
+
+func Example_lvm_parseLogicalVolumeName() {
+	d := &lvm{}
+	d.name = "pool"
+
+	type testVol struct {
+		lvName string
+		parent Volume
+	}
+
+	parentCT := Volume{
+		contentType: ContentTypeFS,
+		volType:     VolumeTypeContainer,
+		name:        "proj_testct-with-hyphens",
+	}
+
+	parentVM := Volume{
+		contentType: ContentTypeBlock,
+		volType:     VolumeTypeVM,
+		name:        "proj_testvm-with-hyphens",
+	}
+
+	custVol := Volume{
+		contentType: ContentTypeFS,
+		volType:     VolumeTypeCustom,
+		name:        "proj_testvol-with-hyphens.block", // .block ending doesn't indicate a block vol.
+	}
+
+	tests := []testVol{
+		// Test container snapshots.
+		{parent: parentCT, lvName: "containers_proj_testct--with--hyphens"},
+		{parent: parentCT, lvName: "containers_proj_testct--with--hyphens-snap1--with--hyphens"},
+		{parent: parentCT, lvName: "containers_proj_testct--with--hyphens-snap1--with--hyphens.block"},
+		// Test container with name containing snapshot prefix.
+		{parent: parentCT, lvName: "containers_proj_testct--with--hyphens--snap0"},
+		// Test virtual machine snapshots.
+		{parent: parentVM, lvName: "virtual-machines_proj_testvm--with--hyphens.block"},
+		{parent: parentVM, lvName: "virtual-machines_proj_testvm--with--hyphens-snap1--with--hyphens.block"},
+		{parent: parentVM, lvName: "virtual-machines_proj_testvm--with--hyphens-snap1--with--hyphens.block.block"},
+		// Test custom volume filesystem snapshots.
+		{parent: custVol, lvName: "custom_proj_testvol--with--hyphens.block"},
+		{parent: custVol, lvName: "custom_proj_testvol--with--hyphens.block-snap1--with--hyphens.block"},
+	}
+
+	for _, test := range tests {
+		snapName := d.parseLogicalVolumeSnapshot(test.parent, test.lvName)
+		if snapName == "" {
+			fmt.Printf("%s: Unrecognised\n", test.lvName)
+		} else {
+			fmt.Printf("%s: %s\n", test.lvName, snapName)
+		}
+	}
+
+	// Output: containers_proj_testct--with--hyphens: Unrecognised
+	// containers_proj_testct--with--hyphens-snap1--with--hyphens: snap1-with-hyphens
+	// containers_proj_testct--with--hyphens-snap1--with--hyphens.block: snap1-with-hyphens.block
+	// containers_proj_testct--with--hyphens--snap0: Unrecognised
+	// virtual-machines_proj_testvm--with--hyphens.block: Unrecognised
+	// virtual-machines_proj_testvm--with--hyphens-snap1--with--hyphens.block: snap1-with-hyphens
+	// virtual-machines_proj_testvm--with--hyphens-snap1--with--hyphens.block.block: snap1-with-hyphens.block
+	// custom_proj_testvol--with--hyphens.block: Unrecognised
+	// custom_proj_testvol--with--hyphens.block-snap1--with--hyphens.block: snap1-with-hyphens.block
+}

--- a/test/suites/storage_snapshots.sh
+++ b/test/suites/storage_snapshots.sh
@@ -90,6 +90,15 @@ test_storage_volume_snapshots() {
   lxc storage volume detach "${storage_pool}" "${storage_volume}" c1
   lxc delete -f c1
   lxc storage volume delete "${storage_pool}" "${storage_volume}"
+
+  # Check snapshots naming conflicts.
+  lxc storage volume create "${storage_pool}" "vol1"
+  lxc storage volume create "${storage_pool}" "vol1-snap0"
+  lxc storage volume snapshot "${storage_pool}" "vol1" "snap0"
+  lxc storage volume delete "${storage_pool}" "vol1"
+  lxc storage volume delete "${storage_pool}" "vol1-snap0"
+
+
   lxc storage delete "${storage_pool}"
 
   # shellcheck disable=SC2031


### PR DESCRIPTION
Adds LVM volume snapshot parser and unit tests similar to ceph's `parseParent` function.

The intention is to more thoroughly parse LVM volume names to avoid issues like  https://github.com/lxc/lxd/issues/7335.