### PR TITLE
lxd/firewall/drivers: Fix nft syntax

### DIFF
--- a/lxd/firewall/drivers/drivers_nftables.go
+++ b/lxd/firewall/drivers/drivers_nftables.go
@@ -106,7 +106,7 @@ type nftGenericItem struct {
 // nftParseRuleset parses the ruleset and returns the generic parts as a slice of items.
 func (d Nftables) nftParseRuleset() ([]nftGenericItem, error) {
 	// Dump ruleset as JSON. Use -nn flags to avoid doing DNS lookups of IPs mentioned in any rules.
-	cmd := exec.Command("nft", "list", "ruleset", "--json", "-nn")
+	cmd := exec.Command("nft", "--json", "-nn", "list", "ruleset")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes the `nft` syntax, as it causes the following error in LXD:

```
EROR[05-11|18:09:29] Firewall nftables unable to parse existing ruleset:
invalid character '^' looking for beginning of value
```

When running the command in a shell, it says:

```
$ nft list ruleset --json -nn
Error: syntax error, options must be specified before commands
nft list ruleset --json -nn
   ^             ~~
```

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>