### PR TITLE
lxd/apparmor/apparmor.go: allow listing of binfmt_misc mount

### DIFF
--- a/lxd/apparmor/apparmor.go
+++ b/lxd/apparmor/apparmor.go
@@ -48,7 +48,7 @@ const profileBase = `
 
   # Handle binfmt
   mount fstype=binfmt_misc -> /proc/sys/fs/binfmt_misc/,
-  deny /proc/sys/fs/binfmt_misc/{,**} rwklx,
+  deny /proc/sys/fs/binfmt_misc/** rwklx,
 
   # Handle cgroupfs
   mount options=(ro, nosuid, nodev, noexec, remount, strictatime) -> /sys/fs/cgroup/,


### PR DESCRIPTION
The information on what files exist there is already available if
you brute force and use stat:

$ stat /proc/sys/fs/binfmt_misc/status
stat: cannot stat ‘/proc/sys/fs/binfmt_misc/statu’: No such file or directory

$ stat /proc/sys/fs/binfmt_misc/status
  File: ‘/proc/sys/fs/binfmt_misc/status’ ...

Since the majority of files that exist in binfmt_misc are well known names, it
doesn't provide any security advantages IMHO.  This does still result in access
denied to the files inside the mount.

Closes: #5688

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>