### PR TITLE
Storage: BTRFS backup subvolume support

### DIFF
--- a/lxd/backup/backup.go
+++ b/lxd/backup/backup.go
@@ -31,7 +31,8 @@ type Info struct {
 	Backend          string           `json:"backend" yaml:"backend"`
 	Pool             string           `json:"pool" yaml:"pool"`
 	Snapshots        []string         `json:"snapshots,omitempty" yaml:"snapshots,omitempty"`
-	OptimizedStorage *bool            `json:"optimized,omitempty" yaml:"optimized,omitempty"` // Optional field to handle older optimized backups that don't have this field.
+	OptimizedStorage *bool            `json:"optimized,omitempty" yaml:"optimized,omitempty"`               // Optional field to handle older optimized backups that don't have this field.
+	OptimizedHeader  *bool            `json:"optimized_header,omitempty" yaml:"optimized_header,omitempty"` // Optional field to handle older optimized backups that don't have this field.
 	Type             api.InstanceType `json:"type" yaml:"type"`
 }
 

--- a/lxd/backup/backup.go
+++ b/lxd/backup/backup.go
@@ -42,8 +42,8 @@ func GetInfo(r io.ReadSeeker) (*Info, error) {
 	hasIndexFile := false
 
 	// Define some bools used to create points for OptimizedStorage field.
-	optimizedStorageTrue := true
 	optimizedStorageFalse := false
+	optimizedHeaderFalse := false
 
 	// Extract
 	r.Seek(0, 0)
@@ -84,6 +84,11 @@ func GetInfo(r io.ReadSeeker) (*Info, error) {
 				result.Type = api.InstanceTypeContainer
 			}
 
+			// Default to no optimized header if not specified.
+			if result.OptimizedHeader == nil {
+				result.OptimizedHeader = &optimizedHeaderFalse
+			}
+
 			if result.OptimizedStorage != nil {
 				// No need to continue looking for optimized storage hint using the presence of the
 				// container.bin file below, as the index.yaml file tells us directly.
@@ -98,6 +103,7 @@ func GetInfo(r io.ReadSeeker) (*Info, error) {
 
 		// If the tarball contains a binary dump of the container, then this is an optimized backup.
 		if hdr.Name == "backup/container.bin" {
+			optimizedStorageTrue := true
 			result.OptimizedStorage = &optimizedStorageTrue
 
 			// Stop read loop if index.yaml already parsed.

--- a/lxd/device/device_utils_generic.go
+++ b/lxd/device/device_utils_generic.go
@@ -4,20 +4,6 @@ import (
 	"strings"
 )
 
-// deviceNameEncode encodes a string to be used as part of a file name in the LXD devices path.
-// The encoding scheme replaces "-" with "--" and then "/" with "-".
-func deviceNameEncode(text string) string {
-	return strings.Replace(strings.Replace(text, "-", "--", -1), "/", "-", -1)
-}
-
-// deviceNameDecode decodes a string used in the LXD devices path back to its original form.
-// The decoding scheme converts "-" back to "/" and "--" back to "-".
-func deviceNameDecode(text string) string {
-	// This converts "--" to the null character "\0" first, to allow remaining "-" chars to be
-	// converted back to "/" before making a final pass to convert "\0" back to original "-".
-	return strings.Replace(strings.Replace(strings.Replace(text, "--", "\000", -1), "-", "/", -1), "\000", "-", -1)
-}
-
 // deviceJoinPath joins together prefix and text delimited by a "." for device path generation.
 func deviceJoinPath(parts ...string) string {
 	return strings.Join(parts, ".")

--- a/lxd/device/device_utils_unix.go
+++ b/lxd/device/device_utils_unix.go
@@ -12,6 +12,7 @@ import (
 
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/state"
+	storageDrivers "github.com/lxc/lxd/lxd/storage/drivers"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/idmap"
 	"github.com/lxc/lxd/shared/logger"
@@ -190,7 +191,7 @@ func UnixDeviceCreate(s *state.State, idmapSet *idmap.IdmapSet, devicesPath stri
 
 	destPath := unixDeviceDestPath(m)
 	relativeDestPath := strings.TrimPrefix(destPath, "/")
-	devName := deviceNameEncode(deviceJoinPath(prefix, relativeDestPath))
+	devName := storageDrivers.PathNameEncode(deviceJoinPath(prefix, relativeDestPath))
 	devPath := filepath.Join(devicesPath, devName)
 
 	// Create the new entry.
@@ -253,7 +254,7 @@ func unixDeviceSetup(s *state.State, devicesPath string, typePrefix string, devi
 
 	// Convert the requested dest path inside the instance to an encoded relative one.
 	ourDestPath := unixDeviceDestPath(m)
-	ourEncRelDestFile := deviceNameEncode(strings.TrimPrefix(ourDestPath, "/"))
+	ourEncRelDestFile := storageDrivers.PathNameEncode(strings.TrimPrefix(ourDestPath, "/"))
 
 	// Load all existing host devices.
 	dents, err := ioutil.ReadDir(devicesPath)
@@ -359,7 +360,7 @@ func unixDeviceSetupBlockNum(s *state.State, devicesPath string, typePrefix stri
 // UnixDeviceExists checks if the unix device already exists in devices path.
 func UnixDeviceExists(devicesPath string, prefix string, path string) bool {
 	relativeDestPath := strings.TrimPrefix(path, "/")
-	devName := fmt.Sprintf("%s.%s", deviceNameEncode(prefix), deviceNameEncode(relativeDestPath))
+	devName := fmt.Sprintf("%s.%s", storageDrivers.PathNameEncode(prefix), storageDrivers.PathNameEncode(relativeDestPath))
 	devPath := filepath.Join(devicesPath, devName)
 
 	return shared.PathExists(devPath)
@@ -384,9 +385,9 @@ func unixDeviceRemove(devicesPath string, typePrefix string, deviceName string, 
 	var ourPrefix string
 	// If a prefix override has been supplied, use that for filtering the devices to remove.
 	if optPrefix != "" {
-		ourPrefix = deviceNameEncode(deviceJoinPath(typePrefix, deviceName, optPrefix))
+		ourPrefix = storageDrivers.PathNameEncode(deviceJoinPath(typePrefix, deviceName, optPrefix))
 	} else {
-		ourPrefix = deviceNameEncode(deviceJoinPath(typePrefix, deviceName))
+		ourPrefix = storageDrivers.PathNameEncode(deviceJoinPath(typePrefix, deviceName))
 	}
 
 	ourDevs := []string{}
@@ -448,7 +449,7 @@ func unixDeviceRemove(devicesPath string, typePrefix string, deviceName string, 
 
 		// Append this device to the mount rules (these will be unmounted).
 		runConf.Mounts = append(runConf.Mounts, deviceConfig.MountEntryItem{
-			TargetPath: deviceNameDecode(ourEncRelDestFile),
+			TargetPath: storageDrivers.PathNameDecode(ourEncRelDestFile),
 		})
 
 		absDevPath := filepath.Join(devicesPath, ourDev)
@@ -474,9 +475,9 @@ func unixDeviceDeleteFiles(s *state.State, devicesPath string, typePrefix string
 	var ourPrefix string
 	// If a prefix override has been supplied, use that for filtering the devices to remove.
 	if optPrefix != "" {
-		ourPrefix = deviceNameEncode(deviceJoinPath(typePrefix, deviceName, optPrefix))
+		ourPrefix = storageDrivers.PathNameEncode(deviceJoinPath(typePrefix, deviceName, optPrefix))
 	} else {
-		ourPrefix = deviceNameEncode(deviceJoinPath(typePrefix, deviceName))
+		ourPrefix = storageDrivers.PathNameEncode(deviceJoinPath(typePrefix, deviceName))
 	}
 
 	// Load all devices.

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -189,7 +189,7 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 // getDevicePath returns the absolute path on the host for this instance and supplied device config.
 func (d *disk) getDevicePath(devName string, devConfig deviceConfig.Device) string {
 	relativeDestPath := strings.TrimPrefix(devConfig["path"], "/")
-	devPath := deviceNameEncode(deviceJoinPath("disk", devName, relativeDestPath))
+	devPath := storageDrivers.PathNameEncode(deviceJoinPath("disk", devName, relativeDestPath))
 	return filepath.Join(d.inst.DevicesPath(), devPath)
 }
 
@@ -1514,7 +1514,7 @@ func (d *disk) getParentBlocks(path string) ([]string, error) {
 // generateVMConfigDrive generates an ISO containing the cloud init config for a VM.
 // Returns the path to the ISO.
 func (d *disk) generateVMConfigDrive() (string, error) {
-	scratchDir := filepath.Join(d.inst.DevicesPath(), deviceNameEncode(d.name))
+	scratchDir := filepath.Join(d.inst.DevicesPath(), storageDrivers.PathNameEncode(d.name))
 
 	// Check we have the mkisofs tool available.
 	mkisofsPath, err := exec.LookPath("mkisofs")

--- a/lxd/device/unix_common.go
+++ b/lxd/device/unix_common.go
@@ -8,6 +8,7 @@ import (
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
+	storageDrivers "github.com/lxc/lxd/lxd/storage/drivers"
 	"github.com/lxc/lxd/shared"
 )
 
@@ -91,7 +92,7 @@ func (d *unixCommon) Register() error {
 		// Derive the host side path for the instance device file.
 		ourPrefix := deviceJoinPath("unix", deviceName)
 		relativeDestPath := strings.TrimPrefix(unixDeviceDestPath(devConfig), "/")
-		devName := deviceNameEncode(deviceJoinPath(ourPrefix, relativeDestPath))
+		devName := storageDrivers.PathNameEncode(deviceJoinPath(ourPrefix, relativeDestPath))
 		devPath := filepath.Join(devicesPath, devName)
 
 		runConf := deviceConfig.RunConfig{}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -509,7 +509,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 	defer revert.Fail()
 
 	// Unpack the backup into the new storage volume(s).
-	volPostHook, revertHook, err := b.driver.CreateVolumeFromBackup(vol, srcBackup.Snapshots, srcData, *srcBackup.OptimizedStorage, op)
+	volPostHook, revertHook, err := b.driver.CreateVolumeFromBackup(vol, srcBackup, srcData, op)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -73,6 +73,7 @@ func (d *btrfs) Info() Info {
 		Version:               btrfsVersion,
 		OptimizedImages:       true,
 		OptimizedBackups:      true,
+		OptimizedBackupHeader: true,
 		PreservesInodes:       !d.state.OS.RunningInUserNS,
 		Remote:                false,
 		VolumeTypes:           []VolumeType{VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},

--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -423,6 +423,7 @@ func (d *btrfs) setSubvolumeReadonlyProperty(path string, readonly bool) error {
 }
 
 // BTRFSSubVolume is the structure used to store information about a subvolume.
+// Note: This is used by both migration and backup subsystems so do not modify without considering both!
 type BTRFSSubVolume struct {
 	Path     string `json:"path" yaml:"path"`         // Path inside the volume where the subvolume belongs (so / is the top of the volume tree).
 	Snapshot string `json:"snapshot" yaml:"snapshot"` // Snapshot name the subvolume belongs to.
@@ -466,6 +467,7 @@ func (d *btrfs) getSubvolumesMetaData(vol Volume) ([]BTRFSSubVolume, error) {
 }
 
 // BTRFSMetaDataHeader is the meta data header about the volumes being sent/stored.
+// Note: This is used by both migration and backup subsystems so do not modify without considering both!
 type BTRFSMetaDataHeader struct {
 	Subvolumes []BTRFSSubVolume `json:"subvolumes" yaml:"subvolumes"` // Sub volumes inside the volume (including the top level ones).
 }

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
+	"github.com/lxc/lxd/lxd/backup"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
@@ -283,8 +284,8 @@ func (d *ceph) getVolumeSize(volumeName string) (int64, error) {
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *ceph) CreateVolumeFromBackup(vol Volume, snapshots []string, srcData io.ReadSeeker, optimizedStorage bool, op *operations.Operation) (func(vol Volume) error, func(), error) {
-	return genericVFSBackupUnpack(d, vol, snapshots, srcData, op)
+func (d *ceph) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
+	return genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/lxc/lxd/lxd/backup"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/rsync"
@@ -58,7 +59,7 @@ func (d *cephfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.O
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *cephfs) CreateVolumeFromBackup(vol Volume, snapshots []string, srcData io.ReadSeeker, optimizedStorage bool, op *operations.Operation) (func(vol Volume) error, func(), error) {
+func (d *cephfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
 	return nil, nil, ErrNotImplemented
 }
 

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/lxc/lxd/lxd/backup"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/revert"
@@ -90,9 +91,9 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *dir) CreateVolumeFromBackup(vol Volume, snapshots []string, srcData io.ReadSeeker, optimizedStorage bool, op *operations.Operation) (func(vol Volume) error, func(), error) {
+func (d *dir) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
 	// Run the generic backup unpacker
-	postHook, revertHook, err := genericVFSBackupUnpack(d.withoutGetVolID(), vol, snapshots, srcData, op)
+	postHook, revertHook, err := genericVFSBackupUnpack(d.withoutGetVolID(), vol, srcBackup.Snapshots, srcData, op)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
+	"github.com/lxc/lxd/lxd/backup"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/revert"
@@ -103,8 +104,8 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *lvm) CreateVolumeFromBackup(vol Volume, snapshots []string, srcData io.ReadSeeker, optimizedStorage bool, op *operations.Operation) (func(vol Volume) error, func(), error) {
-	return genericVFSBackupUnpack(d, vol, snapshots, srcData, op)
+func (d *lvm) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
+	return genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.

--- a/lxd/storage/drivers/driver_types.go
+++ b/lxd/storage/drivers/driver_types.go
@@ -8,6 +8,7 @@ type Info struct {
 	Remote                bool         // Whether the driver uses a remote backing store.
 	OptimizedImages       bool         // Whether driver stores images as separate volume.
 	OptimizedBackups      bool         // Whether driver supports optimized volume backups.
+	OptimizedBackupHeader bool         // Whether driver generates an optimised backup header file in backup.
 	PreservesInodes       bool         // Whether driver preserves inodes when volumes are moved hosts.
 	BlockBacking          bool         // Whether driver uses block devices as backing store.
 	RunningQuotaResize    bool         // Whether quota resize is supported whilst instance running.

--- a/lxd/storage/drivers/drivers_mock.go
+++ b/lxd/storage/drivers/drivers_mock.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"io"
 
+	"github.com/lxc/lxd/lxd/backup"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/shared/api"
@@ -74,7 +75,7 @@ func (d *mock) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *mock) CreateVolumeFromBackup(vol Volume, snapshots []string, srcData io.ReadSeeker, optimizedStorage bool, op *operations.Operation) (func(vol Volume) error, func(), error) {
+func (d *mock) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
 	return nil, nil, nil
 }
 

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"io"
 
+	"github.com/lxc/lxd/lxd/backup"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/state"
@@ -84,5 +85,5 @@ type Driver interface {
 
 	// Backup.
 	BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error
-	CreateVolumeFromBackup(vol Volume, snapshots []string, srcData io.ReadSeeker, optimizedStorage bool, op *operations.Operation) (func(vol Volume) error, func(), error)
+	CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error)
 }

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -753,3 +753,17 @@ func BlockDevSizeBytes(blockDevPath string) (int64, error) {
 
 	return int64(res), nil
 }
+
+// PathNameEncode encodes a path string to be used as part of a file name.
+// The encoding scheme replaces "-" with "--" and then "/" with "-".
+func PathNameEncode(text string) string {
+	return strings.Replace(strings.Replace(text, "-", "--", -1), "/", "-", -1)
+}
+
+// PathNameDecode decodes a string containing an encoded path back to its original form.
+// The decoding scheme converts "-" back to "/" and "--" back to "-".
+func PathNameDecode(text string) string {
+	// This converts "--" to the null character "\0" first, to allow remaining "-" chars to be
+	// converted back to "/" before making a final pass to convert "\0" back to original "-".
+	return strings.Replace(strings.Replace(strings.Replace(text, "--", "\000", -1), "-", "/", -1), "\000", "-", -1)
+}

--- a/test/suites/storage_driver_btrfs.sh
+++ b/test/suites/storage_driver_btrfs.sh
@@ -132,6 +132,20 @@ test_storage_driver_btrfs() {
     lxc exec c2pool1 -- touch /a/b/c/w.txt
     lxc delete -f c2pool1
 
+    # Backup c1pool1 and test subvolumes can be restored.
+    lxc export c1pool1 "${LXD_DIR}/c1pool1.tar.gz" --optimized-storage
+    lxc delete -f c1pool1
+    lxc import "${LXD_DIR}/c1pool1.tar.gz"
+    lxc start c1pool1
+    lxc exec c1pool1 -- stat /a/a1.txt
+    lxc exec c1pool1 -- stat /a/b/b1.txt
+    lxc exec c1pool1 -- stat /a/b/c/c1.txt
+
+    # Test readonly property has been propagated.
+    lxc exec c1pool1 -- touch /a/w.txt
+    ! lxc exec c1pool1 -- touch /a/b/w.txt || false
+    lxc exec c1pool1 -- touch /a/b/c/w.txt
+
     lxc delete -f c1pool1
     lxc profile device remove default root
     lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-pool1"


### PR DESCRIPTION
This PR introduces BTRFS subvolume support for optimized backups.

It introduces a new optional field in the index.yaml file called `optimized_header` which is a boolean.
This is used to indicate to the restorer that we should look for a storage driver specific optimized header file called `optimized_header.yaml` in the backup file next.

e.g.

```
name: c1
backend: btrfs
pool: btrfs
snapshots:
- snap0
optimized: true
optimized_header: true
type: container
```

The BTRFS `optimized_header.yaml` is now always added to optimized tarballs, even if subvolumes haven't been detected. It contains all subvolumes and snapshot subvolumes (even just the root subvolume if no subvolumes have been detected).

e.g.

```
subvolumes:
- path: /
  snapshot: snap0
  readonly: true
- path: /rootfs/a
  snapshot: snap0
  readonly: false
- path: /rootfs/a/b
  snapshot: snap0
  readonly: true
- path: /rootfs/a/b/c
  snapshot: snap0
  readonly: false
- path: /
  snapshot: ""
  readonly: false
- path: /rootfs/a
  snapshot: ""
  readonly: false
- path: /rootfs/a/b
  snapshot: ""
  readonly: true
- path: /rootfs/a/b/c
  snapshot: ""
  readonly: false
```

Each subvolme will be stored in the backup as its own file with the naming format:

```
backup/container.bin (for root subvolume to maintain backwards compatibility with earlier LXD versions).
backup/container_rootfs-a-b-c.bin (subvolume /rootfs/a/b/c encoded as rootfs-a-b-c with leading slash removed, using same encoding technique as we use for unix devices).
backup/snapshots/<snapname>.bin (for root subvolume of snapshot for backwards compat).
backup/snapshots/<snapname>_rootfs-a-b-c.bin (subvolume of /rootfs/a/b/c)
```

The root subvolumes are stored in the backup file using their old names to maintain backwards compatibility with older LXD versions. This means a tarball created on newer LXD can be imported by older LXD versions. However it is is worth noting that old LXD versions will not restore the subvolumes stored inside the backup and so will only be a partial restore.

This PR also introduces a unified BTRFS subvolume receive function used by both backup restore and migration receive subsystems. Rather than guessing that the received subvolume will be called as the previous logic did (based on the context of the volume being received) this new function will ensure the target directory is empty first before receiving, and once receive has finished will return the path to the received subvolume.