### PR TITLE
forkfile: port to using pidfds

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -606,6 +606,13 @@ func (d *Daemon) init() error {
 		logger.Infof(" - netnsid-based network retrieval: no")
 	}
 
+	d.os.PidFds = canUsePidFds()
+	if d.os.PidFds {
+		logger.Infof(" - pidfds: yes")
+	} else {
+		logger.Infof(" - pidfds: no")
+	}
+
 	d.os.UeventInjection = canUseUeventInjection()
 	if d.os.UeventInjection {
 		logger.Infof(" - uevent injection: yes")

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -597,6 +597,23 @@ func (d *Daemon) init() error {
 		}
 	}
 
+	// Detect LXC features
+	d.os.LXCFeatures = map[string]bool{}
+	lxcExtensions := []string{
+		"mount_injection_file",
+		"seccomp_notify",
+		"network_ipvlan",
+		"network_l2proxy",
+		"network_gateway_device_route",
+		"network_phys_macvlan_mtu",
+		"network_veth_router",
+		"cgroup2",
+		"pidfd",
+	}
+	for _, extension := range lxcExtensions {
+		d.os.LXCFeatures[extension] = liblxc.HasApiExtension(extension)
+	}
+
 	// Look for kernel features
 	logger.Infof("Kernel features:")
 	d.os.NetnsGetifaddrs = canUseNetnsGetifaddrs()
@@ -606,7 +623,9 @@ func (d *Daemon) init() error {
 		logger.Infof(" - netnsid-based network retrieval: no")
 	}
 
-	d.os.PidFds = canUsePidFds()
+	if canUsePidFds() && d.os.LXCFeatures["pidfd"] {
+		d.os.PidFds = true
+	}
 	if d.os.PidFds {
 		logger.Infof(" - pidfds: yes")
 	} else {
@@ -660,22 +679,6 @@ func (d *Daemon) init() error {
 		} else {
 			logger.Infof(" - shiftfs support: no")
 		}
-	}
-
-	// Detect LXC features
-	d.os.LXCFeatures = map[string]bool{}
-	lxcExtensions := []string{
-		"mount_injection_file",
-		"seccomp_notify",
-		"network_ipvlan",
-		"network_l2proxy",
-		"network_gateway_device_route",
-		"network_phys_macvlan_mtu",
-		"network_veth_router",
-		"cgroup2",
-	}
-	for _, extension := range lxcExtensions {
-		d.os.LXCFeatures[extension] = liblxc.HasApiExtension(extension)
 	}
 
 	// Validate the devices storage.

--- a/lxd/include/compiler.h
+++ b/lxd/include/compiler.h
@@ -72,4 +72,8 @@
 
 #define __cgfsng_ops
 
+#ifndef __returns_twice
+#define __returns_twice __attribute__((returns_twice))
+#endif
+
 #endif /* __LXC_COMPILER_H */

--- a/lxd/include/macro.h
+++ b/lxd/include/macro.h
@@ -268,4 +268,8 @@ enum {
 		__internal_ret__;                             \
 	})
 
+#ifndef P_PIDFD
+#define P_PIDFD 3
+#endif
+
 #endif /* __LXC_MACRO_H */

--- a/lxd/include/process_utils.h
+++ b/lxd/include/process_utils.h
@@ -1,0 +1,193 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
+#ifndef __LXD_PROCESS_UTILS_H
+#define __LXD_PROCESS_UTILS_H
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+#include <linux/sched.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "compiler.h"
+#include "syscall_numbers.h"
+
+#ifndef CSIGNAL
+#define CSIGNAL 0x000000ff /* signal mask to be sent at exit */
+#endif
+
+#ifndef CLONE_VM
+#define CLONE_VM 0x00000100 /* set if VM shared between processes */
+#endif
+
+#ifndef CLONE_FS
+#define CLONE_FS 0x00000200 /* set if fs info shared between processes */
+#endif
+
+#ifndef CLONE_FILES
+#define CLONE_FILES 0x00000400 /* set if open files shared between processes */
+#endif
+
+#ifndef CLONE_SIGHAND
+#define CLONE_SIGHAND 0x00000800 /* set if signal handlers and blocked signals shared */
+#endif
+
+#ifndef CLONE_PIDFD
+#define CLONE_PIDFD 0x00001000 /* set if a pidfd should be placed in parent */
+#endif
+
+#ifndef CLONE_PTRACE
+#define CLONE_PTRACE 0x00002000 /* set if we want to let tracing continue on the child too */
+#endif
+
+#ifndef CLONE_VFORK
+#define CLONE_VFORK 0x00004000 /* set if the parent wants the child to wake it up on mm_release */
+#endif
+
+#ifndef CLONE_PARENT
+#define CLONE_PARENT 0x00008000 /* set if we want to have the same parent as the cloner */
+#endif
+
+#ifndef CLONE_THREAD
+#define CLONE_THREAD 0x00010000 /* Same thread group? */
+#endif
+
+#ifndef CLONE_NEWNS
+#define CLONE_NEWNS 0x00020000 /* New mount namespace group */
+#endif
+
+#ifndef CLONE_SYSVSEM
+#define CLONE_SYSVSEM 0x00040000 /* share system V SEM_UNDO semantics */
+#endif
+
+#ifndef CLONE_SETTLS
+#define CLONE_SETTLS 0x00080000 /* create a new TLS for the child */
+#endif
+
+#ifndef CLONE_PARENT_SETTID
+#define CLONE_PARENT_SETTID 0x00100000 /* set the TID in the parent */
+#endif
+
+#ifndef CLONE_CHILD_CLEARTID
+#define CLONE_CHILD_CLEARTID 0x00200000 /* clear the TID in the child */
+#endif
+
+#ifndef CLONE_DETACHED
+#define CLONE_DETACHED 0x00400000 /* Unused, ignored */
+#endif
+
+#ifndef CLONE_UNTRACED
+#define CLONE_UNTRACED 0x00800000 /* set if the tracing process can't force CLONE_PTRACE on this clone */
+#endif
+
+#ifndef CLONE_CHILD_SETTID
+#define CLONE_CHILD_SETTID 0x01000000 /* set the TID in the child */
+#endif
+
+#ifndef CLONE_NEWCGROUP
+#define CLONE_NEWCGROUP 0x02000000 /* New cgroup namespace */
+#endif
+
+#ifndef CLONE_NEWUTS
+#define CLONE_NEWUTS 0x04000000 /* New utsname namespace */
+#endif
+
+#ifndef CLONE_NEWIPC
+#define CLONE_NEWIPC 0x08000000 /* New ipc namespace */
+#endif
+
+#ifndef CLONE_NEWUSER
+#define CLONE_NEWUSER 0x10000000 /* New user namespace */
+#endif
+
+#ifndef CLONE_NEWPID
+#define CLONE_NEWPID 0x20000000 /* New pid namespace */
+#endif
+
+#ifndef CLONE_NEWNET
+#define CLONE_NEWNET 0x40000000 /* New network namespace */
+#endif
+
+#ifndef CLONE_IO
+#define CLONE_IO 0x80000000 /* Clone io context */
+#endif
+
+/* Flags for the clone3() syscall. */
+#ifndef CLONE_CLEAR_SIGHAND
+#define CLONE_CLEAR_SIGHAND 0x100000000ULL /* Clear any signal handler and reset to SIG_DFL. */
+#endif
+
+#ifndef CLONE_INTO_CGROUP
+#define CLONE_INTO_CGROUP 0x200000000ULL /* Clone into a specific cgroup given the right permissions. */
+#endif
+
+/*
+ * cloning flags intersect with CSIGNAL so can be used with unshare and clone3
+ * syscalls only:
+ */
+#ifndef CLONE_NEWTIME
+#define CLONE_NEWTIME 0x00000080 /* New time namespace */
+#endif
+
+/* waitid */
+#ifndef P_PIDFD
+#define P_PIDFD 3
+#endif
+
+#ifndef CLONE_ARGS_SIZE_VER0
+#define CLONE_ARGS_SIZE_VER0 64 /* sizeof first published struct */
+#endif
+
+#ifndef CLONE_ARGS_SIZE_VER1
+#define CLONE_ARGS_SIZE_VER1 80 /* sizeof second published struct */
+#endif
+
+#ifndef CLONE_ARGS_SIZE_VER2
+#define CLONE_ARGS_SIZE_VER2 88 /* sizeof third published struct */
+#endif
+
+#ifndef ptr_to_u64
+#define ptr_to_u64(ptr) ((__u64)((uintptr_t)(ptr)))
+#endif
+#ifndef u64_to_ptr
+#define u64_to_ptr(x) ((void *)(uintptr_t)x)
+#endif
+
+struct lxd_clone_args {
+	__aligned_u64 flags;
+	__aligned_u64 pidfd;
+	__aligned_u64 child_tid;
+	__aligned_u64 parent_tid;
+	__aligned_u64 exit_signal;
+	__aligned_u64 stack;
+	__aligned_u64 stack_size;
+	__aligned_u64 tls;
+	__aligned_u64 set_tid;
+	__aligned_u64 set_tid_size;
+	__aligned_u64 cgroup;
+};
+
+__returns_twice static inline pid_t lxd_clone3(struct lxd_clone_args *args, size_t size)
+{
+	return syscall(__NR_clone3, args, size);
+}
+
+static inline int pidfd_open(pid_t pid, unsigned int flags)
+{
+	return syscall(__NR_pidfd_open, pid, flags);
+}
+
+static inline int pidfd_send_signal(int pidfd, int sig, siginfo_t *info,
+				    unsigned int flags)
+{
+	return syscall(__NR_pidfd_send_signal, pidfd, sig, info, flags);
+}
+
+#endif /* __LXD_PROCESS_UTILS_H */
+

--- a/lxd/include/syscall_numbers.h
+++ b/lxd/include/syscall_numbers.h
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+#ifndef __LXD_SYSCALL_NUMBERS_H
+#define __LXD_SYSCALL_NUMBERS_H
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+#include <asm/unistd.h>
+#include <errno.h>
+#include <linux/keyctl.h>
+#include <sched.h>
+#include <stdint.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifndef __NR_pidfd_open
+	#if defined __alpha__
+		#define __NR_pidfd_open 544
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_pidfd_open 4434
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_pidfd_open 6434
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_pidfd_open 5434
+		#endif
+	#else
+		#define __NR_pidfd_open 424
+	#endif
+#endif
+
+#ifndef __NR_pidfd_send_signal
+	#if defined __alpha__
+		#define __NR_pidfd_send_signal 534
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_pidfd_send_signal 4424
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_pidfd_send_signal 6424
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_pidfd_send_signal 5424
+		#endif
+	#else
+		#define __NR_pidfd_send_signal 424
+	#endif
+#endif
+
+#endif /* __LXD_SYSCALL_NUMBERS_H */

--- a/lxd/include/syscall_numbers.h
+++ b/lxd/include/syscall_numbers.h
@@ -50,4 +50,24 @@
 	#endif
 #endif
 
+#ifndef __NR_clone3
+	#if defined __alpha__
+		#define __NR_clone3 545
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_clone3 4435
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_clone3 6435
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_clone3 5435
+		#endif
+	#elif defined __ia64__
+		#define __NR_clone3 (435 + 1024)
+	#else
+		#define __NR_clone3 435
+	#endif
+#endif
+
 #endif /* __LXD_SYSCALL_NUMBERS_H */

--- a/lxd/include/syscall_numbers.h
+++ b/lxd/include/syscall_numbers.h
@@ -27,6 +27,8 @@
 		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
 			#define __NR_pidfd_open 5434
 		#endif
+	#elif defined __ia64__
+		#define __NR_clone3 (424 + 1024)
 	#else
 		#define __NR_pidfd_open 424
 	#endif
@@ -45,6 +47,8 @@
 		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
 			#define __NR_pidfd_send_signal 5424
 		#endif
+	#elif defined __ia64__
+		#define __NR_pidfd_send_signal (424 + 1024)
 	#else
 		#define __NR_pidfd_send_signal 424
 	#endif

--- a/lxd/main_checkfeature.go
+++ b/lxd/main_checkfeature.go
@@ -26,19 +26,24 @@ import (
 #include <linux/filter.h>
 #include <linux/audit.h>
 #include <sys/ptrace.h>
+#include <sys/wait.h>
 
 #include "../shared/netutils/netns_getifaddrs.c"
 #include "include/compiler.h"
 #include "include/lxd_seccomp.h"
 #include "include/memory_utils.h"
+#include "include/syscall_numbers.h"
 
 __ro_after_init bool netnsid_aware = false;
+__ro_after_init bool pidfd_aware = false;
 __ro_after_init bool uevent_aware = false;
 __ro_after_init int seccomp_notify_aware = 0;
 __ro_after_init char errbuf[4096];
 
 extern int can_inject_uevent(const char *uevent, size_t len);
 extern int wait_for_pid(pid_t pid);
+extern int pidfd_open(pid_t pid, unsigned int flags);
+extern int pidfd_send_signal(int pidfd, int sig, siginfo_t *info, unsigned int flags);
 
 static int netns_set_nsid(int fd)
 {
@@ -291,11 +296,40 @@ static void is_seccomp_notify_aware(void)
 
 }
 
+static void is_pidfd_aware(void)
+{
+	__do_close int pidfd = -EBADF;
+	int ret;
+
+	pidfd = pidfd_open(getpid(), 0);
+	if (pidfd < 0)
+		return;
+
+	// We don't care whether or not children were in a waitable state. We
+	// just care whether waitid() recognizes P_PIDFD.
+	ret = waitid(P_PIDFD, pidfd, NULL,
+		    // Type of children to wait for.
+		    __WALL |
+		    // How to wait for them.
+		    WNOHANG | WNOWAIT |
+		    // What state to wait for.
+		    WEXITED | WSTOPPED | WCONTINUED);
+	if (ret < 0 && errno != ECHILD)
+		return;
+
+	ret = pidfd_send_signal(pidfd, 0, NULL, 0);
+	if (ret)
+		return;
+
+	pidfd_aware = true;
+}
+
 void checkfeature(void)
 {
 	__do_close int hostnetns_fd = -EBADF, newnetns_fd = -EBADF;
 
 	is_netnsid_aware(&hostnetns_fd, &newnetns_fd);
+	is_pidfd_aware();
 	is_uevent_aware();
 	is_seccomp_notify_aware();
 
@@ -329,4 +363,8 @@ func canUseSeccompListener() bool {
 
 func canUseSeccompListenerContinue() bool {
 	return bool(C.seccomp_notify_aware == 2)
+}
+
+func canUsePidFds() bool {
+	return bool(C.pidfd_aware)
 }

--- a/lxd/main_checkfeature.go
+++ b/lxd/main_checkfeature.go
@@ -32,6 +32,7 @@ import (
 #include "include/compiler.h"
 #include "include/lxd_seccomp.h"
 #include "include/memory_utils.h"
+#include "include/process_utils.h"
 #include "include/syscall_numbers.h"
 
 __ro_after_init bool netnsid_aware = false;
@@ -42,8 +43,6 @@ __ro_after_init char errbuf[4096];
 
 extern int can_inject_uevent(const char *uevent, size_t len);
 extern int wait_for_pid(pid_t pid);
-extern int pidfd_open(pid_t pid, unsigned int flags);
-extern int pidfd_send_signal(int pidfd, int sig, siginfo_t *info, unsigned int flags);
 
 static int netns_set_nsid(int fd)
 {

--- a/lxd/main_forkfile.go
+++ b/lxd/main_forkfile.go
@@ -15,6 +15,7 @@ import (
 #include <fcntl.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <signal.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/lxd/main_forksyscall.go
+++ b/lxd/main_forksyscall.go
@@ -32,6 +32,7 @@ import (
 extern void attach_userns(int pid);
 extern char* advance_arg(bool required);
 extern int dosetns(int pid, char *nstype);
+extern bool setnsat(int ns_fd, const char *ns);
 
 static inline bool same_fsinfo(struct stat *s1, struct stat *s2,
 			       struct statfs *sfs1, struct statfs *sfs2)
@@ -206,17 +207,6 @@ static void mknod_emulate(void)
 #endif
 
 const char *ns_names[] = { "user", "pid", "uts", "ipc", "net", "cgroup", NULL };
-
-static bool setnsat(int ns_fd, const char *ns)
-{
-	__do_close int fd = -EBADF;
-
-	fd = openat(ns_fd, ns, O_RDONLY | O_CLOEXEC);
-	if (fd < 0)
-		return false;
-
-	return setns(fd, 0) == 0;
-}
 
 static bool change_creds(int ns_fd, cap_t caps, uid_t nsuid, gid_t nsgid, uid_t nsfsuid, gid_t nsfsgid)
 {

--- a/lxd/main_nsexec.go
+++ b/lxd/main_nsexec.go
@@ -37,6 +37,7 @@ package main
 #include <unistd.h>
 
 #include "include/memory_utils.h"
+#include "include/syscall_numbers.h"
 
 // External functions
 extern void checkfeature();
@@ -137,9 +138,12 @@ int dosetns_file(char *file, char *nstype) {
 	return 0;
 }
 
-static int preserve_ns(const int pid, const char *ns)
+static int preserve_ns(pid_t pid, int ns_fd, const char *ns)
 {
 	int ret;
+	if (ns_fd >= 0)
+		return openat(ns_fd, ns, O_RDONLY | O_CLOEXEC);
+
 // 5 /proc + 21 /int_as_str + 3 /ns + 20 /NS_NAME + 1 \0
 #define __NS_PATH_LEN 50
 	char path[__NS_PATH_LEN];
@@ -158,21 +162,22 @@ static int preserve_ns(const int pid, const char *ns)
 }
 
 // in_same_namespace - Check whether two processes are in the same namespace.
-// @pid1 - PID of the first process.
-// @pid2 - PID of the second process.
+// @pid1	- PID of the first process.
+// @pid2	- PID of the second process.
+// @ns_fd2	- ns_fd @pid2.
 // @ns   - Name of the namespace to check. Must correspond to one of the names
 //         for the namespaces as shown in /proc/<pid/ns/
 //
 // If the two processes are not in the same namespace returns an fd to the
 // namespace of the second process identified by @pid2. If the two processes are
 // in the same namespace returns -EINVAL, -1 if an error occurred.
-static int in_same_namespace(pid_t pid1, pid_t pid2, const char *ns)
+static int in_same_namespace(pid_t pid1, pid_t pid2, int ns_fd_pid2, const char *ns)
 {
 	__do_close int ns_fd1 = -EBADF, ns_fd2 = -EBADF;
 	int ret = -1;
 	struct stat ns_st1, ns_st2;
 
-	ns_fd1 = preserve_ns(pid1, ns);
+	ns_fd1 = preserve_ns(pid1, -EBADF, ns);
 	if (ns_fd1 < 0) {
 		// The kernel does not support this namespace. This is not an
 		// error.
@@ -182,7 +187,7 @@ static int in_same_namespace(pid_t pid1, pid_t pid2, const char *ns)
 		return -1;
 	}
 
-	ns_fd2 = preserve_ns(pid2, ns);
+	ns_fd2 = preserve_ns(pid2, ns_fd_pid2, ns);
 	if (ns_fd2 < 0)
 		return -1;
 
@@ -202,11 +207,12 @@ static int in_same_namespace(pid_t pid1, pid_t pid2, const char *ns)
 	return move_fd(ns_fd2);
 }
 
-void attach_userns(int pid) {
+static void __attach_userns(int pid, int ns_fd)
+{
 	__do_close int userns_fd = -EBADF;
 	int ret;
 
-	userns_fd = in_same_namespace(getpid(), pid, "user");
+	userns_fd = in_same_namespace(getpid(), pid, ns_fd, "user");
 	if (userns_fd < 0) {
 		if (userns_fd == -EINVAL)
 			return;
@@ -237,6 +243,62 @@ void attach_userns(int pid) {
 		fprintf(stderr, "Failed setgroups to container root groups: %s\n", strerror(errno));
 		_exit(1);
 	}
+}
+
+void attach_userns(int pid)
+{
+	return __attach_userns(pid, -EBADF);
+}
+
+void attach_userns_fd(int ns_fd)
+{
+	return __attach_userns(-1, ns_fd);
+}
+
+int pidfd_open(pid_t pid, unsigned int flags)
+{
+	return syscall(__NR_pidfd_open, pid, flags);
+}
+
+int pidfd_send_signal(int pidfd, int sig, siginfo_t *info, unsigned int flags)
+{
+	return syscall(__NR_pidfd_send_signal, pidfd, sig, info, flags);
+}
+
+int pidfd_nsfd(int pidfd, pid_t pid)
+{
+	__do_close int ns_fd = -EBADF;
+	int ret;
+	char path[100];
+
+	ret = snprintf(path, sizeof(path), "/proc/%d/ns", pid);
+	if (ret < 0 || (size_t)ret >= sizeof(path))
+		return -E2BIG;
+
+	ns_fd = open(path, O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+	if (ns_fd < 0)
+		return -errno;
+
+	if (pidfd >= 0) {
+		// Verify that the pid has not been recycled and our /proc/<pid> handle
+		// is still valid.
+		ret = pidfd_send_signal(pidfd, 0, NULL, 0);
+		if (ret && errno != EPERM)
+			return -errno;
+	}
+
+	return move_fd(ns_fd);
+}
+
+bool setnsat(int ns_fd, const char *ns)
+{
+	__do_close int fd = -EBADF;
+
+	fd = openat(ns_fd, ns, O_RDONLY | O_CLOEXEC);
+	if (fd < 0)
+		return false;
+
+	return setns(fd, 0) == 0;
 }
 
 static ssize_t lxc_read_nointr(int fd, void *buf, size_t count)

--- a/lxd/main_nsexec.go
+++ b/lxd/main_nsexec.go
@@ -37,6 +37,7 @@ package main
 #include <unistd.h>
 
 #include "include/memory_utils.h"
+#include "include/process_utils.h"
 #include "include/syscall_numbers.h"
 
 // External functions
@@ -253,16 +254,6 @@ void attach_userns(int pid)
 void attach_userns_fd(int ns_fd)
 {
 	return __attach_userns(-1, ns_fd);
-}
-
-int pidfd_open(pid_t pid, unsigned int flags)
-{
-	return syscall(__NR_pidfd_open, pid, flags);
-}
-
-int pidfd_send_signal(int pidfd, int sig, siginfo_t *info, unsigned int flags)
-{
-	return syscall(__NR_pidfd_send_signal, pidfd, sig, info, flags);
 }
 
 int pidfd_nsfd(int pidfd, pid_t pid)

--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -877,11 +877,20 @@ func CallForkmknod(c Instance, dev deviceConfig.Device, requestPID int) int {
 		return int(-C.EPERM)
 	}
 
-	_, stderr, err := shared.RunCommandSplit(nil, util.GetExecPath(),
-		"forksyscall", "mknod", dev["pid"], dev["path"],
-		dev["mode_t"], dev["dev_t"],
-		fmt.Sprintf("%d", uid), fmt.Sprintf("%d", gid),
-		fmt.Sprintf("%d", fsuid), fmt.Sprintf("%d", fsgid))
+	_, stderr, err := shared.RunCommandSplit(
+		nil,
+		nil,
+		util.GetExecPath(),
+		"forksyscall",
+		"mknod",
+		dev["pid"],
+		dev["path"],
+		dev["mode_t"],
+		dev["dev_t"],
+		fmt.Sprintf("%d", uid),
+		fmt.Sprintf("%d", gid),
+		fmt.Sprintf("%d", fsuid),
+		fmt.Sprintf("%d", fsgid))
 	if err != nil {
 		errno, err := strconv.Atoi(stderr)
 		if err != nil || errno == C.ENOANO {
@@ -1155,7 +1164,10 @@ func (s *Server) HandleSetxattrSyscall(c Instance, siov *Iovec) int {
 		return 0
 	}
 
-	_, stderr, err := shared.RunCommandSplit(nil, util.GetExecPath(),
+	_, stderr, err := shared.RunCommandSplit(
+		nil,
+		nil,
+		util.GetExecPath(),
 		"forksyscall",
 		"setxattr",
 		fmt.Sprintf("%d", args.pid),
@@ -1435,7 +1447,10 @@ func (s *Server) HandleMountSyscall(c Instance, siov *Iovec) int {
 		ctx["fuse_source"] = fuseSource
 		ctx["fuse_target"] = args.target
 		ctx["fuse_opts"] = fuseOpts
-		_, _, err = shared.RunCommandSplit(nil, util.GetExecPath(),
+		_, _, err = shared.RunCommandSplit(
+			nil,
+			nil,
+			util.GetExecPath(),
 			"forksyscall",
 			"mount",
 			fmt.Sprintf("%d", args.pid),
@@ -1448,7 +1463,10 @@ func (s *Server) HandleMountSyscall(c Instance, siov *Iovec) int {
 			fmt.Sprintf("%s", args.target),
 			fmt.Sprintf("%s", fuseOpts))
 	} else {
-		_, _, err = shared.RunCommandSplit(nil, util.GetExecPath(),
+		_, _, err = shared.RunCommandSplit(
+			nil,
+			nil,
+			util.GetExecPath(),
 			"forksyscall",
 			"mount",
 			fmt.Sprintf("%d", args.pid),

--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -465,6 +465,20 @@ func InstanceNeedsIntercept(s *state.State, c Instance) (bool, error) {
 	return needed, nil
 }
 
+// InheritInitPidFd prepares a pidfd to inherit for the init process of the container.
+func inheritPidFd(pid int, s *state.State) (int, *os.File) {
+	if s.OS.PidFds {
+		pidFdFile, err := shared.PidFdOpen(pid, 0)
+		if err != nil {
+			return -1, nil
+		}
+
+		return 3, pidFdFile
+	}
+
+	return -1, nil
+}
+
 func seccompGetPolicyContent(s *state.State, c Instance) (string, error) {
 	config := c.ExpandedConfig()
 
@@ -871,19 +885,25 @@ func TaskIDs(pid int) (int64, int64, int64, int64, error) {
 }
 
 // CallForkmknod executes fork mknod.
-func CallForkmknod(c Instance, dev deviceConfig.Device, requestPID int) int {
+func CallForkmknod(c Instance, dev deviceConfig.Device, requestPID int, s *state.State) int {
 	uid, gid, fsuid, fsgid, err := TaskIDs(requestPID)
 	if err != nil {
 		return int(-C.EPERM)
 	}
 
+	pidFdNr, pidFd := inheritPidFd(requestPID, s)
+	if pidFdNr >= 0 {
+		defer pidFd.Close()
+	}
+
 	_, stderr, err := shared.RunCommandSplit(
 		nil,
-		nil,
+		[]*os.File{pidFd},
 		util.GetExecPath(),
 		"forksyscall",
 		"mknod",
 		dev["pid"],
+		fmt.Sprintf("%d", pidFdNr),
 		dev["path"],
 		dev["mode_t"],
 		dev["dev_t"],
@@ -930,7 +950,7 @@ func (s *Server) doDeviceSyscall(c Instance, args *MknodArgs, siov *Iovec) int {
 	dev["mode_t"] = fmt.Sprintf("%d", args.cMode)
 	dev["dev_t"] = fmt.Sprintf("%d", args.cDev)
 
-	errno := CallForkmknod(c, dev, int(args.cPid))
+	errno := CallForkmknod(c, dev, int(args.cPid), s.s)
 	if errno != int(-C.ENOMEDIUM) {
 		return errno
 	}
@@ -1081,6 +1101,12 @@ func (s *Server) HandleSetxattrSyscall(c Instance, siov *Iovec) int {
 	args := SetxattrArgs{}
 
 	args.pid = int(siov.req.pid)
+
+	pidFdNr, pidFd := inheritPidFd(args.pid, s.s)
+	if pidFdNr >= 0 {
+		defer pidFd.Close()
+	}
+
 	uid, gid, fsuid, fsgid, err := TaskIDs(args.pid)
 	if err != nil {
 		if s.s.OS.SeccompListenerContinue {
@@ -1166,11 +1192,12 @@ func (s *Server) HandleSetxattrSyscall(c Instance, siov *Iovec) int {
 
 	_, stderr, err := shared.RunCommandSplit(
 		nil,
-		nil,
+		[]*os.File{pidFd},
 		util.GetExecPath(),
 		"forksyscall",
 		"setxattr",
 		fmt.Sprintf("%d", args.pid),
+		fmt.Sprintf("%d", pidFdNr),
 		fmt.Sprintf("%d", args.nsuid),
 		fmt.Sprintf("%d", args.nsgid),
 		fmt.Sprintf("%d", args.nsfsuid),
@@ -1347,6 +1374,11 @@ func (s *Server) HandleMountSyscall(c Instance, siov *Iovec) int {
 		shift: s.MountSyscallShift(c),
 	}
 
+	pidFdNr, pidFd := inheritPidFd(args.pid, s.s)
+	if pidFdNr >= 0 {
+		defer pidFd.Close()
+	}
+
 	// const char *source
 	args.source = ""
 	if siov.req.data.args[0] != 0 {
@@ -1449,11 +1481,12 @@ func (s *Server) HandleMountSyscall(c Instance, siov *Iovec) int {
 		ctx["fuse_opts"] = fuseOpts
 		_, _, err = shared.RunCommandSplit(
 			nil,
-			nil,
+			[]*os.File{pidFd},
 			util.GetExecPath(),
 			"forksyscall",
 			"mount",
 			fmt.Sprintf("%d", args.pid),
+			fmt.Sprintf("%d", pidFdNr),
 			fmt.Sprintf("%d", 1),
 			fmt.Sprintf("%d", nsuid),
 			fmt.Sprintf("%d", nsgid),
@@ -1465,11 +1498,12 @@ func (s *Server) HandleMountSyscall(c Instance, siov *Iovec) int {
 	} else {
 		_, _, err = shared.RunCommandSplit(
 			nil,
-			nil,
+			[]*os.File{pidFd},
 			util.GetExecPath(),
 			"forksyscall",
 			"mount",
 			fmt.Sprintf("%d", args.pid),
+			fmt.Sprintf("%d", pidFdNr),
 			fmt.Sprintf("%d", 0),
 			fmt.Sprintf("%s", args.source),
 			fmt.Sprintf("%s", args.target),

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -64,6 +64,7 @@ type OS struct {
 
 	// Kernel features
 	NetnsGetifaddrs         bool
+	PidFds                  bool
 	SeccompListener         bool
 	SeccompListenerContinue bool
 	Shiftfs                 bool

--- a/shared/util.go
+++ b/shared/util.go
@@ -892,6 +892,15 @@ func RunCommand(name string, arg ...string) (string, error) {
 	return stdout, err
 }
 
+// RunCommandInheritFds runs a command with optional arguments and passes a set
+// of file descriptors to the newly created process, returning stdout. If the
+// command fails to start or returns a non-zero exit code then an error is
+// returned containing the output of stderr.
+func RunCommandInheritFds(filesInherit []*os.File, name string, arg ...string) (string, error) {
+	stdout, _, err := RunCommandSplit(nil, filesInherit, name, arg...)
+	return stdout, err
+}
+
 // RunCommandCLocale runs a command with a LANG=C.UTF-8 environment set with optional arguments and
 // returns stdout. If the command fails to start or returns a non-zero exit code then an error is
 // returned containing the output of stderr.

--- a/shared/util.go
+++ b/shared/util.go
@@ -855,11 +855,15 @@ func (e RunError) Error() string {
 // resulting stdout and stderr output as separate variables. If the supplied environment is nil then
 // the default environment is used. If the command fails to start or returns a non-zero exit code
 // then an error is returned containing the output of stderr too.
-func RunCommandSplit(env []string, name string, arg ...string) (string, string, error) {
+func RunCommandSplit(env []string, filesInherit []*os.File, name string, arg ...string) (string, string, error) {
 	cmd := exec.Command(name, arg...)
 
 	if env != nil {
 		cmd.Env = env
+	}
+
+	if filesInherit != nil {
+		cmd.ExtraFiles = filesInherit
 	}
 
 	var stdout bytes.Buffer
@@ -884,7 +888,7 @@ func RunCommandSplit(env []string, name string, arg ...string) (string, string, 
 // RunCommand runs a command with optional arguments and returns stdout. If the command fails to
 // start or returns a non-zero exit code then an error is returned containing the output of stderr.
 func RunCommand(name string, arg ...string) (string, error) {
-	stdout, _, err := RunCommandSplit(nil, name, arg...)
+	stdout, _, err := RunCommandSplit(nil, nil, name, arg...)
 	return stdout, err
 }
 
@@ -892,7 +896,7 @@ func RunCommand(name string, arg ...string) (string, error) {
 // returns stdout. If the command fails to start or returns a non-zero exit code then an error is
 // returned containing the output of stderr.
 func RunCommandCLocale(name string, arg ...string) (string, error) {
-	stdout, _, err := RunCommandSplit(append(os.Environ(), "LANG=C.UTF-8"), name, arg...)
+	stdout, _, err := RunCommandSplit(append(os.Environ(), "LANG=C.UTF-8"), nil, name, arg...)
 	return stdout, err
 }
 


### PR DESCRIPTION
This ports all of the forkfile() handlers to verify the validity of the target
process via pidfds. This hardens our codebase and specifically means that we
can't accidently operate on a wrong process when under heavy contention.

I'm going to port all subcommand but want to do so step by step to minimize the
risk of subtle breakages. Once they're all switched over I will do another
cleanup sweep.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>