### PR TITLE
Storage: Fix VM unified image unpack for dir and btrfs drivers

### DIFF
--- a/lxd/rsync/rsync.go
+++ b/lxd/rsync/rsync.go
@@ -19,7 +19,7 @@ import (
 )
 
 // LocalCopy copies a directory using rsync (with the --devices option).
-func LocalCopy(source string, dest string, bwlimit string, xattrs bool) (string, error) {
+func LocalCopy(source string, dest string, bwlimit string, xattrs bool, rsyncArgs ...string) (string, error) {
 	err := os.MkdirAll(dest, 0755)
 	if err != nil {
 		return "", err
@@ -52,10 +52,15 @@ func LocalCopy(source string, dest string, bwlimit string, xattrs bool) (string,
 		args = append(args, "--bwlimit", bwlimit)
 	}
 
+	if len(rsyncArgs) > 0 {
+		args = append(args, rsyncArgs...)
+	}
+
 	args = append(args,
 		rsyncVerbosity,
 		shared.AddSlash(source),
 		dest)
+
 	msg, err := shared.RunCommand("rsync", args...)
 	if err != nil {
 		runError, ok := err.(shared.RunError)

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -514,8 +514,9 @@ func ImageUnpack(imageFile, destPath, destBlockFile string, blockBackend, runnin
 			return errors.Wrapf(err, "Failed to remove %q", imgPath)
 		}
 
-		// Transfer the content.
-		_, err = rsync.LocalCopy(tempDir, destPath, "", true)
+		// Transfer the content excluding the destBlockFile name so that we don't delete the block file
+		// created above if the storage driver stores image files in the same directory as destPath.
+		_, err = rsync.LocalCopy(tempDir, destPath, "", true, "--exclude", filepath.Base(destBlockFile))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Unified image VM unpack was not working for dir and btrfs drivers because the rsync of unpacked config files was removing the generated rootfs block file that was generated.

This was silently failing because subsequently the storage driver attempted to set the generated volume to the correct size, and as it was missing, just generated a new blank image of the correct size.

However the resulting VM was unbootable.