### PR TITLE
Storage: Support VM image unpack size greater than volume size

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1004,6 +1004,15 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 		}
 
 		imgVol := b.newVolume(drivers.VolumeTypeImage, contentType, fingerprint, imgDBVol.Config)
+
+		// Derive size to use for new volume from source (and check it doesn't exceed volume size limits).
+		volSize, err := vol.ConfigSizeFromSource(imgVol)
+		if err != nil {
+			return err
+		}
+
+		vol.SetConfigSize(volSize)
+
 		err = b.driver.CreateVolumeFromCopy(vol, imgVol, false, op)
 
 		// If the driver returns ErrCannotBeShrunk, this means that the cached volume is larger than the

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -594,7 +594,6 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 				// has still been restored successfully.
 				if errors.Cause(err) == drivers.ErrCannotBeShrunk {
 					logger.Warn("Could not apply volume quota from root disk config as restored volume cannot be shrunk", log.Ctx{"size": rootDiskConf["size"]})
-
 				} else {
 					return err
 				}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -932,8 +932,8 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 // imageFiller returns a function that can be used as a filler function with CreateVolume().
 // The function returned will unpack the specified image archive into the specified mount path
 // provided, and for VM images, a raw root block path is required to unpack the qcow2 image into.
-func (b *lxdBackend) imageFiller(fingerprint string, op *operations.Operation) func(mountPath, rootBlockPath string) error {
-	return func(mountPath, rootBlockPath string) error {
+func (b *lxdBackend) imageFiller(fingerprint string, op *operations.Operation) func(vol drivers.Volume, rootBlockPath string) error {
+	return func(vol drivers.Volume, rootBlockPath string) error {
 		var tracker *ioprogress.ProgressTracker
 		if op != nil { // Not passed when being done as part of pre-migration setup.
 			metadata := make(map[string]interface{})
@@ -944,7 +944,7 @@ func (b *lxdBackend) imageFiller(fingerprint string, op *operations.Operation) f
 				}}
 		}
 		imageFile := shared.VarPath("images", fingerprint)
-		return ImageUnpack(imageFile, mountPath, rootBlockPath, b.driver.Info().BlockBacking, b.state.OS.RunningInUserNS, tracker)
+		return ImageUnpack(imageFile, vol, rootBlockPath, b.driver.Info().BlockBacking, b.state.OS.RunningInUserNS, tracker)
 	}
 }
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -932,8 +932,8 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 // imageFiller returns a function that can be used as a filler function with CreateVolume().
 // The function returned will unpack the specified image archive into the specified mount path
 // provided, and for VM images, a raw root block path is required to unpack the qcow2 image into.
-func (b *lxdBackend) imageFiller(fingerprint string, op *operations.Operation) func(vol drivers.Volume, rootBlockPath string) error {
-	return func(vol drivers.Volume, rootBlockPath string) error {
+func (b *lxdBackend) imageFiller(fingerprint string, op *operations.Operation) func(vol drivers.Volume, rootBlockPath string) (int64, error) {
+	return func(vol drivers.Volume, rootBlockPath string) (int64, error) {
 		var tracker *ioprogress.ProgressTracker
 		if op != nil { // Not passed when being done as part of pre-migration setup.
 			metadata := make(map[string]interface{})

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -69,7 +69,9 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 		}
 
 		_, err = ensureVolumeBlockFile(rootBlockPath, sizeBytes)
-		if err != nil {
+
+		// Ignore ErrCannotBeShrunk as this just means the filler has needed to increase the volume size.
+		if err != nil && errors.Cause(err) != ErrCannotBeShrunk {
 			return err
 		}
 

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -54,12 +54,9 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 		}
 	}
 
-	// Run the volume filler function if supplied.
-	if filler != nil && filler.Fill != nil {
-		err = filler.Fill(vol, rootBlockPath)
-		if err != nil {
-			return err
-		}
+	err = d.runFiller(vol, rootBlockPath, filler)
+	if err != nil {
+		return err
 	}
 
 	// If we are creating a block volume, resize it to the requested size or the default.

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -354,16 +354,9 @@ func (d *btrfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bo
 		}
 	}
 
-	// Default to non-expanded config, so we only use user specified volume size.
-	// This is so the pool default volume size isn't take into account for volume copies.
-	volSize := vol.config["size"]
-
-	// If source is an image then take into account default volume sizes if not specified.
-	if srcVol.volType == VolumeTypeImage {
-		volSize = vol.ConfigSize()
-	}
-
-	err = d.SetVolumeQuota(vol, volSize, op)
+	// Resize volume to the size specified. Only uses volume "size" property and does not use pool/defaults
+	// to give the caller more control over the size being used.
+	err = d.SetVolumeQuota(vol, vol.config["size"], nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -56,7 +56,7 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 
 	// Run the volume filler function if supplied.
 	if filler != nil && filler.Fill != nil {
-		err = filler.Fill(volPath, rootBlockPath)
+		err = filler.Fill(vol, rootBlockPath)
 		if err != nil {
 			return err
 		}
@@ -667,7 +667,7 @@ func (d *btrfs) SetVolumeQuota(vol Volume, size string, op *operations.Operation
 		}
 
 		// Move the GPT alt header to end of disk if needed and resize has taken place (not needed in
-		// unsafe resize mode as it is  expected the caller will do all necessary post resize actions
+		// unsafe resize mode as it is expected the caller will do all necessary post resize actions
 		// themselves).
 		if vol.IsVMBlock() && resized && !vol.allowUnsafeResize {
 			err = d.moveGPTAltHeader(rootBlockPath)

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -165,7 +165,7 @@ func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 	err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
 		if filler != nil && filler.Fill != nil {
 			if vol.contentType == ContentTypeFS {
-				return filler.Fill(mountPath, "")
+				return filler.Fill(vol, "")
 			}
 
 			devPath, err := d.GetVolumeDiskPath(vol)
@@ -173,7 +173,7 @@ func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 				return err
 			}
 
-			err = filler.Fill(mountPath, devPath)
+			err = filler.Fill(vol, devPath)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -325,16 +325,9 @@ func (d *ceph) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots boo
 			}
 		}
 
-		// Default to non-expanded config, so we only use user specified volume size.
-		// This is so the pool default volume size isn't take into account for volume copies.
-		volSize := vol.config["size"]
-
-		// If source is an image then take into account default volume sizes if not specified.
-		if srcVol.volType == VolumeTypeImage {
-			volSize = vol.ConfigSize()
-		}
-
-		err = d.SetVolumeQuota(vol, volSize, op)
+		// Resize volume to the size specified. Only uses volume "size" property and does not use
+		// pool/defaults to give the caller more control over the size being used.
+		err = d.SetVolumeQuota(vol, vol.config["size"], nil)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -831,7 +831,7 @@ func (d *ceph) SetVolumeQuota(vol Volume, size string, op *operations.Operation)
 		return err
 	}
 
-	oldSizeBytes, err := BlockDevSizeBytes(RBDDevPath)
+	oldSizeBytes, err := BlockDiskSizeBytes(RBDDevPath)
 	if err != nil {
 		return errors.Wrapf(err, "Error getting current size")
 	}

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -16,7 +16,6 @@ import (
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/instancewriter"
 	"github.com/lxc/lxd/shared/ioprogress"
-	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/units"
 )
 
@@ -46,12 +45,9 @@ func (d *cephfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.O
 	}()
 
 	// Fill the volume.
-	if filler != nil && filler.Fill != nil {
-		d.logger.Debug("Running filler function", log.Ctx{"path": volPath})
-		err = filler.Fill(vol, "")
-		if err != nil {
-			return err
-		}
+	err = d.runFiller(vol, "", filler)
+	if err != nil {
+		return err
 	}
 
 	revertPath = false

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -48,7 +48,7 @@ func (d *cephfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.O
 	// Fill the volume.
 	if filler != nil && filler.Fill != nil {
 		d.logger.Debug("Running filler function", log.Ctx{"path": volPath})
-		err = filler.Fill(volPath, "")
+		err = filler.Fill(vol, "")
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -216,3 +216,19 @@ func (d *common) moveGPTAltHeader(devPath string) error {
 
 	return err
 }
+
+// runFiller runs the supplied filler, and setting the returned volume size back into filler.
+func (d *common) runFiller(vol Volume, devPath string, filler *VolumeFiller) error {
+	if filler == nil || filler.Fill == nil {
+		return nil
+	}
+
+	vol.driver.Logger().Debug("Running filler function", log.Ctx{"dev": devPath, "path": vol.MountPath()})
+	volSize, err := filler.Fill(vol, devPath)
+	if err != nil {
+		return err
+	}
+
+	filler.Size = volSize
+	return nil
+}

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -69,7 +69,9 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 		}
 
 		_, err = ensureVolumeBlockFile(rootBlockPath, sizeBytes)
-		if err != nil {
+
+		// Ignore ErrCannotBeShrunk as this just means the filler has needed to increase the volume size.
+		if err != nil && errors.Cause(err) != ErrCannotBeShrunk {
 			return err
 		}
 

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -15,7 +15,6 @@ import (
 	"github.com/lxc/lxd/lxd/storage/quota"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/instancewriter"
-	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/units"
 )
 
@@ -55,12 +54,9 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 	}
 
 	// Run the volume filler function if supplied.
-	if filler != nil && filler.Fill != nil {
-		d.logger.Debug("Running filler function", log.Ctx{"path": volPath})
-		err = filler.Fill(vol, rootBlockPath)
-		if err != nil {
-			return err
-		}
+	err = d.runFiller(vol, rootBlockPath, filler)
+	if err != nil {
+		return err
 	}
 
 	// If we are creating a block volume, resize it to the requested size or the default.

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -57,7 +57,7 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 	// Run the volume filler function if supplied.
 	if filler != nil && filler.Fill != nil {
 		d.logger.Debug("Running filler function", log.Ctx{"path": volPath})
-		err = filler.Fill(volPath, rootBlockPath)
+		err = filler.Fill(vol, rootBlockPath)
 		if err != nil {
 			return err
 		}
@@ -281,7 +281,7 @@ func (d *dir) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 		}
 
 		// Move the GPT alt header to end of disk if needed and resize has taken place (not needed in
-		// unsafe resize mode as it is  expected the caller will do all necessary post resize actions
+		// unsafe resize mode as it is expected the caller will do all necessary post resize actions
 		// themselves).
 		if vol.IsVMBlock() && resized && !vol.allowUnsafeResize {
 			err = d.moveGPTAltHeader(rootBlockPath)

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -393,7 +393,7 @@ func (d *lvm) createLogicalVolume(vgName, thinPoolName string, vol Volume, makeT
 }
 
 // createLogicalVolumeSnapshot creates a snapshot of a logical volume.
-func (d *lvm) createLogicalVolumeSnapshot(vgName string, srcVol, snapVol Volume, readonly bool, makeThinLv bool) (string, error) {
+func (d *lvm) createLogicalVolumeSnapshot(vgName string, srcVol Volume, snapVol Volume, readonly bool, makeThinLv bool) (string, error) {
 	srcVolDevPath := d.lvmDevPath(vgName, srcVol.volType, srcVol.contentType, srcVol.name)
 	isRecent, err := d.lvmVersionIsAtLeast(lvmVersion, "2.02.99")
 	if err != nil {

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -644,16 +644,9 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []Volume, refr
 		}
 	}
 
-	// Default to non-expanded config, so we only use user specified volume size.
-	// This is so the pool default volume size isn't take into account for volume copies.
-	volSize := vol.config["size"]
-
-	// If source is an image then take into account default volume sizes if not specified.
-	if srcVol.volType == VolumeTypeImage {
-		volSize = vol.ConfigSize()
-	}
-
-	err = d.SetVolumeQuota(vol, volSize, nil)
+	// Resize volume to the size specified. Only uses volume "size" property and does not use pool/defaults
+	// to give the caller more control over the size being used.
+	err = d.SetVolumeQuota(vol, vol.config["size"], nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -56,7 +56,7 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 		if filler != nil && filler.Fill != nil {
 			if vol.contentType == ContentTypeFS {
 				d.logger.Debug("Running filler function", log.Ctx{"path": volPath})
-				err = filler.Fill(mountPath, "")
+				err = filler.Fill(vol, "")
 				if err != nil {
 					return err
 				}
@@ -69,7 +69,7 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 
 				// Run the filler.
 				d.logger.Debug("Running filler function", log.Ctx{"dev": devPath, "path": volPath})
-				err = filler.Fill(mountPath, devPath)
+				err = filler.Fill(vol, devPath)
 				if err != nil {
 					return err
 				}

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -53,33 +53,30 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 	}
 
 	err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
+		// Run the volume filler function if supplied.
 		if filler != nil && filler.Fill != nil {
-			if vol.contentType == ContentTypeFS {
-				d.logger.Debug("Running filler function", log.Ctx{"path": volPath})
-				err = filler.Fill(vol, "")
-				if err != nil {
-					return err
-				}
-			} else {
+			var err error
+			var devPath string
+
+			if vol.contentType == ContentTypeBlock {
 				// Get the device path.
-				devPath, err := d.GetVolumeDiskPath(vol)
+				devPath, err = d.GetVolumeDiskPath(vol)
 				if err != nil {
 					return err
 				}
+			}
 
-				// Run the filler.
-				d.logger.Debug("Running filler function", log.Ctx{"dev": devPath, "path": volPath})
-				err = filler.Fill(vol, devPath)
+			// Run the filler.
+			err = d.runFiller(vol, devPath, filler)
+			if err != nil {
+				return err
+			}
+
+			// Move the GPT alt header to end of disk if needed.
+			if vol.IsVMBlock() {
+				err = d.moveGPTAltHeader(devPath)
 				if err != nil {
 					return err
-				}
-
-				// Move the GPT alt header to end of disk if needed.
-				if vol.IsVMBlock() {
-					err = d.moveGPTAltHeader(devPath)
-					if err != nil {
-						return err
-					}
 				}
 			}
 		}

--- a/lxd/storage/drivers/driver_types.go
+++ b/lxd/storage/drivers/driver_types.go
@@ -19,7 +19,7 @@ type Info struct {
 
 // VolumeFiller provides a struct for filling a volume.
 type VolumeFiller struct {
-	Fill func(mountPath, rootBlockPath string) error // Function to fill the volume.
+	Fill func(vol Volume, rootBlockPath string) error // Function to fill the volume.
 
 	Fingerprint string // If the Filler will unpack an image, it should be this fingerprint.
 }

--- a/lxd/storage/drivers/driver_types.go
+++ b/lxd/storage/drivers/driver_types.go
@@ -19,7 +19,8 @@ type Info struct {
 
 // VolumeFiller provides a struct for filling a volume.
 type VolumeFiller struct {
-	Fill func(vol Volume, rootBlockPath string) error // Function to fill the volume.
+	Fill func(vol Volume, rootBlockPath string) (int64, error) // Function to fill the volume.
+	Size int64                                                 // Size of the unpacked volume in bytes.
 
 	Fingerprint string // If the Filler will unpack an image, it should be this fingerprint.
 }

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -176,7 +176,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 		if filler != nil && filler.Fill != nil {
 			if vol.contentType == ContentTypeFS {
 				// Run the filler.
-				err := filler.Fill(mountPath, "")
+				err := filler.Fill(vol, "")
 				if err != nil {
 					return err
 				}
@@ -188,7 +188,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 				}
 
 				// Run the filler.
-				err = filler.Fill(mountPath, devPath)
+				err = filler.Fill(vol, devPath)
 				if err != nil {
 					return err
 				}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -584,16 +584,9 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 		}
 	}
 
-	// Default to non-expanded config, so we only use user specified volume size.
-	// This is so the pool default volume size isn't take into account for volume copies.
-	volSize := vol.config["size"]
-
-	// If source is an image then take into account default volume sizes if not specified.
-	if srcVol.volType == VolumeTypeImage {
-		volSize = vol.ConfigSize()
-	}
-
-	err := d.SetVolumeQuota(vol, volSize, op)
+	// Resize volume to the size specified. Only uses volume "size" property and does not use pool/defaults
+	// to give the caller more control over the size being used.
+	err := d.SetVolumeQuota(vol, vol.config["size"], nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -458,20 +458,13 @@ func genericVFSBackupVolume(d Driver, vol Volume, tarWriter *instancewriter.Inst
 				var blockDiskSize int64
 				var exclude []string
 
-				if shared.IsBlockdevPath(blockPath) {
-					// Get size of disk block device for tarball header.
-					blockDiskSize, err = BlockDevSizeBytes(blockPath)
-					if err != nil {
-						return errors.Wrapf(err, "Error getting block device size %q", blockPath)
-					}
-				} else {
-					// Get size of disk image file for tarball header.
-					fi, err := os.Lstat(blockPath)
-					if err != nil {
-						return errors.Wrapf(err, "Error getting block file size %q", blockPath)
-					}
-					blockDiskSize = fi.Size()
+				// Get size of disk block device for tarball header.
+				blockDiskSize, err = BlockDiskSizeBytes(blockPath)
+				if err != nil {
+					return errors.Wrapf(err, "Error getting block device size %q", blockPath)
+				}
 
+				if !shared.IsBlockdevPath(blockPath) {
 					// Exclude the VM root disk path from the config volume backup part.
 					// We will read it as a block device later instead.
 					exclude = append(exclude, blockPath)

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -324,7 +324,7 @@ func roundVolumeBlockFileSizeBytes(sizeBytes int64) (int64, error) {
 	return int64(sizeBytes/minBlockBoundary) * minBlockBoundary, nil
 }
 
-// ensureVolumeBlockFile creates new block file or resizes the raw block file for a volume to the specified size.
+// ensureVolumeBlockFile creates new block file or enlarges the raw block file for a volume to the specified size.
 // Returns true if resize took place, false if not. Requested size is rounded to nearest block size using
 // roundVolumeBlockFileSizeBytes() before decision whether to resize is taken.
 func ensureVolumeBlockFile(path string, sizeBytes int64) (bool, error) {

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -333,6 +333,11 @@ func (v Volume) SetQuota(size string, op *operations.Operation) error {
 	return v.driver.SetVolumeQuota(v, size, op)
 }
 
+// SetConfigSize sets the size config property on the Volume (does not resize volume).
+func (v Volume) SetConfigSize(size string) {
+	v.config["size"] = size
+}
+
 // ConfigBlockFilesystem returns the filesystem to use for block volumes. Returns config value "block.filesystem"
 // if defined in volume or pool's volume config, otherwise the DefaultFilesystem.
 func (v Volume) ConfigBlockFilesystem() string {

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/storage/locking"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/units"
 )
 
 // tmpVolSuffix Suffix to use for any temporary volumes created by LXD.
@@ -357,4 +358,65 @@ func (v Volume) ConfigSize() string {
 
 	// Return defined size or empty string if not defined.
 	return size
+}
+
+// ConfigSizeFromSource derives the volume size to use for a new volume when copying from a source volume.
+// Where possible (if the source volume has a volatile.rootfs.size property), it checks that the source volume
+// isn't larger than the volume's "size" setting and the pool's "volume.size" setting.
+func (v Volume) ConfigSizeFromSource(srcVol Volume) (string, error) {
+	// If source is not an image, then only use volume specified size. This is so the pool volume size isn't
+	// taken into account for non-image volume copies.
+	if srcVol.volType != VolumeTypeImage {
+		return v.config["size"], nil
+	}
+
+	// VM config filesystem volumes should always have a fixed specified size, so just return volume size.
+	if v.volType == VolumeTypeVM && v.contentType == ContentTypeFS {
+		return v.config["size"], nil
+	}
+
+	// If the source image doesn't have any size information, then use volume/pool/default size in that order.
+	if srcVol.config["volatile.rootfs.size"] == "" {
+		return v.ConfigSize(), nil
+	}
+
+	imgSizeBytes, err := units.ParseByteSizeString(srcVol.config["volatile.rootfs.size"])
+	if err != nil {
+		return "", err
+	}
+
+	// If volume/pool size is specified (excluding default size), then check it against the image minimum size.
+	volSize := v.ExpandedConfig("size")
+	if volSize != "" && volSize != "0" {
+		volSizeBytes, err := units.ParseByteSizeString(volSize)
+		if err != nil {
+			return volSize, err
+		}
+
+		// The volume/pool specified size is smaller than image minimum size. We must not continue as
+		// these specified sizes provide protection against unpacking a massive image and filling the pool.
+		if volSizeBytes < imgSizeBytes {
+			return "", fmt.Errorf("Source image size (%d) exceeds specified volume size (%d)", imgSizeBytes, volSizeBytes)
+		}
+
+		// Use the specified volume size.
+		return volSize, nil
+	}
+
+	// If volume/pool size is not specified, then fallback to default volume size if relevant and compare.
+	volSize = v.ConfigSize()
+	if volSize != "" && volSize != "0" {
+		volSizeBytes, err := units.ParseByteSizeString(volSize)
+		if err != nil {
+			return "", err
+		}
+
+		// Use image minimum size as volSize if the default volume size is smaller.
+		if volSizeBytes < imgSizeBytes {
+			return srcVol.config["volatile.rootfs.size"], nil
+		}
+	}
+
+	// Use the default volume size.
+	return volSize, nil
 }

--- a/lxd/storage/drivers/volume_test.go
+++ b/lxd/storage/drivers/volume_test.go
@@ -1,0 +1,112 @@
+package drivers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test Volume_ConfigSizeFromSource
+func Test_Volume_ConfigSizeFromSource(t *testing.T) {
+	nonBlockBackedDriver := dir{}
+	blockBackedDriver := lvm{}
+
+	tests := []struct {
+		vol    Volume
+		srcVol Volume
+		err    error
+		size   string
+	}{
+		{
+			// Check the volume's size is used when empty non-image source volume used.
+			vol:    Volume{driver: &nonBlockBackedDriver, volType: VolumeTypeContainer, config: map[string]string{"size": "1GB"}},
+			srcVol: Volume{},
+			err:    nil,
+			size:   "1GB",
+		},
+		{
+			// Check the volume's pool volume.size isn't used when empty non-image source volume used.
+			vol:    Volume{driver: &nonBlockBackedDriver, volType: VolumeTypeContainer, poolConfig: map[string]string{"volume.size": "2GB"}},
+			srcVol: Volume{},
+			err:    nil,
+			size:   "",
+		},
+		{
+			// Check the volume's pool volume.size is used when volume size not specified and empty
+			// image source volume used.
+			vol:    Volume{driver: &nonBlockBackedDriver, volType: VolumeTypeContainer, poolConfig: map[string]string{"volume.size": "2GB"}},
+			srcVol: Volume{volType: VolumeTypeImage},
+			err:    nil,
+			size:   "2GB",
+		},
+		{
+			// Check the volume's default block disk size is used when volume is a block type and
+			// neighter volume or pool volume size is specified and empty image source volume used.
+			vol:    Volume{driver: &nonBlockBackedDriver, volType: VolumeTypeVM, contentType: ContentTypeBlock},
+			srcVol: Volume{volType: VolumeTypeImage},
+			err:    nil,
+			size:   defaultBlockSize,
+		},
+		{
+			// Check that the volume's smaller size than source image's rootfs size causes error.
+			vol:    Volume{driver: &nonBlockBackedDriver, volType: VolumeTypeContainer, config: map[string]string{"size": "1GB"}},
+			srcVol: Volume{volType: VolumeTypeImage, config: map[string]string{"volatile.rootfs.size": "15GB"}},
+			err:    fmt.Errorf("Source image size (15000000000) exceeds specified volume size (1000000000)"),
+			size:   "",
+		},
+		{
+			// Check that the volume's larger size than source image's rootfs size overrides.
+			vol:    Volume{driver: &nonBlockBackedDriver, volType: VolumeTypeContainer, config: map[string]string{"size": "20GB"}},
+			srcVol: Volume{volType: VolumeTypeImage, config: map[string]string{"volatile.rootfs.size": "15GB"}},
+			err:    nil,
+			size:   "20GB",
+		},
+		{
+			// Check returned size is empty when the container volume/pool doesn't specify a size and
+			// the pool is not block backed and the volume is container & fs.
+			vol:    Volume{driver: &nonBlockBackedDriver, volType: VolumeTypeContainer, contentType: ContentTypeFS, config: map[string]string{}},
+			srcVol: Volume{volType: VolumeTypeImage, config: map[string]string{"volatile.rootfs.size": "15GB"}},
+			err:    nil,
+			size:   "",
+		},
+		{
+			// Check returned size is empty when the container volume/pool doesn't specify a size and
+			// the pool is not block backed and the volume is VM & block.
+			vol:    Volume{driver: &nonBlockBackedDriver, volType: VolumeTypeVM, contentType: ContentTypeBlock, config: map[string]string{}},
+			srcVol: Volume{volType: VolumeTypeImage, config: map[string]string{"volatile.rootfs.size": "15GB"}},
+			err:    nil,
+			size:   "15GB",
+		},
+		{
+			// Check returned size is source size when the VM volume/pool doesn't specify a size and
+			// the pool is block backed, and the source size is larger than default block disk size.
+			vol:    Volume{driver: &blockBackedDriver, volType: VolumeTypeVM, config: map[string]string{}},
+			srcVol: Volume{volType: VolumeTypeImage, config: map[string]string{"volatile.rootfs.size": "15GB"}},
+			err:    nil,
+			size:   "15GB",
+		},
+		{
+			// Check returned size is default block disk size when the VM volume/pool doesn't specify a
+			// size and the pool is block backed, and the source size is smaller than default block
+			// disk size.
+			vol:    Volume{driver: &blockBackedDriver, volType: VolumeTypeVM, config: map[string]string{}},
+			srcVol: Volume{volType: VolumeTypeImage, config: map[string]string{"volatile.rootfs.size": "5GB"}},
+			err:    nil,
+			size:   defaultBlockSize,
+		},
+		{
+			// Check volume's size is used when VM filesystem volume is supplied with image source.
+			vol:    Volume{driver: &nonBlockBackedDriver, volType: VolumeTypeVM, contentType: ContentTypeFS, config: map[string]string{"size": "50MB"}},
+			srcVol: Volume{volType: VolumeTypeImage},
+			err:    nil,
+			size:   "50MB",
+		},
+	}
+
+	for _, test := range tests {
+		size, err := test.vol.ConfigSizeFromSource(test.srcVol)
+		assert.Equal(t, test.size, size)
+		assert.Equal(t, test.err, err)
+	}
+}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -527,9 +527,9 @@ func ImageUnpack(imageFile string, vol drivers.Volume, destBlockFile string, blo
 		}
 
 		if shared.PathExists(dstPath) {
-			volSizeBytes, err := drivers.BlockDevSizeBytes(dstPath)
+			volSizeBytes, err := drivers.BlockDiskSizeBytes(dstPath)
 			if err != nil {
-				return -1, errors.Wrapf(err, "Error getting current size")
+				return -1, errors.Wrapf(err, "Error getting current size of %q", dstPath)
 			}
 
 			if volSizeBytes < imgInfo.VirtualSize {

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -528,6 +528,18 @@ func ImageUnpack(imageFile string, vol drivers.Volume, destBlockFile string, blo
 			}
 
 			if volSizeBytes < imgInfo.VirtualSize {
+				// Create a partial image volume struct and then use it to check that target
+				// volume size can be increased as needed.
+				imgVolConfig := map[string]string{
+					"volatile.rootfs.size": fmt.Sprintf("%d", imgInfo.VirtualSize),
+				}
+				imgVol := drivers.NewVolume(nil, "", drivers.VolumeTypeImage, drivers.ContentTypeBlock, "", imgVolConfig, nil)
+
+				_, err = vol.ConfigSizeFromSource(imgVol)
+				if err != nil {
+					return -1, err
+				}
+
 				logger.Debugf("Increasing %q volume size from %d to %d to accomomdate image %q unpack", dstPath, volSizeBytes, imgInfo.VirtualSize, imgPath)
 				err = vol.SetQuota(fmt.Sprintf("%d", imgInfo.VirtualSize), nil)
 				if err != nil {

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -764,19 +764,9 @@ func InstanceDiskBlockSize(pool Pool, inst instance.Instance, op *operations.Ope
 		return -1, err
 	}
 
-	var blockDiskSize int64
-
-	if shared.IsBlockdevPath(rootDrivePath) {
-		blockDiskSize, err = drivers.BlockDevSizeBytes(rootDrivePath)
-		if err != nil {
-			return -1, errors.Wrapf(err, "Error getting block device size %q", rootDrivePath)
-		}
-	} else {
-		fi, err := os.Lstat(rootDrivePath)
-		if err != nil {
-			return -1, errors.Wrapf(err, "Error getting block file size %q", rootDrivePath)
-		}
-		blockDiskSize = fi.Size()
+	blockDiskSize, err := drivers.BlockDiskSizeBytes(rootDrivePath)
+	if err != nil {
+		return -1, errors.Wrapf(err, "Error getting block disk size %q", rootDrivePath)
 	}
 
 	return blockDiskSize, nil

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -435,6 +435,11 @@ func validateVolumeCommonRules(vol drivers.Volume) map[string]func(string) error
 		rules["security.unmapped"] = shared.IsBool
 	}
 
+	// volatile.rootfs.size is only used for image volumes.
+	if vol.Type() == drivers.VolumeTypeImage {
+		rules["volatile.rootfs.size"] = shared.IsInt64
+	}
+
 	return rules
 }
 


### PR DESCRIPTION
This PR allows images larger than the default 10GB block disk size to be used.

Fixes https://github.com/lxc/lxd/issues/7346 

Create a VM image larger than the default 10GB block disk size:
```
lxc init images:ubuntu/focal/cloud v1 --vm
lxc config device override v1 root size=15GB // Enlarge beyond default 10GB block disk size
lxc start v1  // Wait for boot and cloud init to resize rootfs inside guest
lxc exec v1 -- df -h  | grep /dev/sda2
/dev/sda2        14G  796M   13G   6% /
lxc stop v1
lxc publish v1 --alias myvm
lxc delete v1
```

Now check we can create new VM from the image when the storage pool has no `volume.size` set.
```
lxc init myvm v1
sudo zfs get volsize default/images/f037ad0b451277b594d9f5d80f518f77a6f1a7184a2c7d55939946192ee9a896.block
NAME                                                                                   PROPERTY  VALUE    SOURCE
default/images/f037ad0b451277b594d9f5d80f518f77a6f1a7184a2c7d55939946192ee9a896.block  volsize   14.0G    local
sudo zfs get volsize default/virtual-machines/v1.block
NAME                               PROPERTY  VALUE    SOURCE
default/virtual-machines/v1.block  volsize   14.0G    local
```

Now check that this fails if `volume.size` is set on the pool smaller than the image size when the larger optimized snapshot volume already exists.
```
lxc delete v1
lxc storage set default volume.size 9GB
lxc init myvm v1
Creating v1
Error: Create instance from image: Source image size (14999994368) exceeds specified volume size (9000000000)
```

Now check the optimized snapshot volume creation fails for the same reason:

```
lxc storage volume delete default image/f037ad0b451277b594d9f5d80f518f77a6f1a7184a2c7d55939946192ee9a896
lxc init myvm v1
Creating v1
Error: Create instance from image: Source image size (14999994368) exceeds specified volume size (9000000000)
```

Now check we can set pool's `volume.size` larger than image and optimized snapshot and resulting instance volume use the larger size.

```
lxc storage set default volume.size 16GB
lxc init myvm v1
sudo zfs get volsize default/images/f037ad0b451277b594d9f5d80f518f77a6f1a7184a2c7d55939946192ee9a896.block
NAME                                                                                   PROPERTY  VALUE    SOURCE
default/images/f037ad0b451277b594d9f5d80f518f77a6f1a7184a2c7d55939946192ee9a896.block  volsize   14.9G    local
sudo zfs get volsize default/virtual-machines/v1.block
NAME                               PROPERTY  VALUE    SOURCE
default/virtual-machines/v1.block  volsize   14.9G    local
```

Now check we can reduce the pool's `volume.size` back to minimum image size then create new instance, causing old larger optimized volume to be regenerated.

```
lxc delete v1
lxc storage set default volume.size 15GB
lxc init myvm v1
sudo zfs get volsize default/images/f037ad0b451277b594d9f5d80f518f77a6f1a7184a2c7d55939946192ee9a896.block
NAME                                                                                   PROPERTY  VALUE    SOURCE
default/images/f037ad0b451277b594d9f5d80f518f77a6f1a7184a2c7d55939946192ee9a896.block  volsize   14.0G    local
sudo zfs get volsize default/virtual-machines/v1.block
NAME                               PROPERTY  VALUE    SOURCE
default/virtual-machines/v1.block  volsize   14.0G    local
```