### PR TITLE
ethtool: don't report -1 for speed in ethtoolLink()

### DIFF
--- a/lxd/resources/network_ethtool.go
+++ b/lxd/resources/network_ethtool.go
@@ -300,7 +300,10 @@ func ethtoolLink(ethtoolFd int, req *ethtoolReq, info *api.ResourcesNetworkCardP
 		}
 
 		// Link speed
-		info.LinkSpeed = uint64(ethLinkSettings.speed)
+		speed := uint64(ethLinkSettings.speed)
+		if speed < uint64(^uint32(0)) {
+			info.LinkSpeed = speed
+		}
 	}
 
 	// Transceiver


### PR DESCRIPTION
the same way we don't in the legacy part of the interface.

Closes: #7382.
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>