### PR TITLE
NIC: Detect and prefer ebtables-legacy command if available

### DIFF
--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -449,31 +449,31 @@ func (d Xtables) generateFilterEbtablesRules(hostName string, hwAddr string, IPv
 	// MAC source filtering rules. Block any packet coming from instance with an incorrect Ethernet source MAC.
 	// This is required for IP filtering too.
 	rules := [][]string{
-		{"ebtables", "-t", "filter", "-A", "INPUT", "-s", "!", hwAddr, "-i", hostName, "-j", "DROP"},
-		{"ebtables", "-t", "filter", "-A", "FORWARD", "-s", "!", hwAddr, "-i", hostName, "-j", "DROP"},
+		{"-t", "filter", "-A", "INPUT", "-s", "!", hwAddr, "-i", hostName, "-j", "DROP"},
+		{"-t", "filter", "-A", "FORWARD", "-s", "!", hwAddr, "-i", hostName, "-j", "DROP"},
 	}
 
 	if IPv4 != nil {
 		if IPv4.String() == FilterIPv4All {
 			rules = append(rules,
-				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "ARP", "-i", hostName, "-j", "DROP"},
-				[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "ARP", "-i", hostName, "-j", "DROP"},
-				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv4", "-i", hostName, "-j", "DROP"},
-				[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "IPv4", "-i", hostName, "-j", "DROP"},
+				[]string{"-t", "filter", "-A", "INPUT", "-p", "ARP", "-i", hostName, "-j", "DROP"},
+				[]string{"-t", "filter", "-A", "FORWARD", "-p", "ARP", "-i", hostName, "-j", "DROP"},
+				[]string{"-t", "filter", "-A", "INPUT", "-p", "IPv4", "-i", hostName, "-j", "DROP"},
+				[]string{"-t", "filter", "-A", "FORWARD", "-p", "IPv4", "-i", hostName, "-j", "DROP"},
 			)
 		} else {
 			rules = append(rules,
 				// Prevent ARP MAC spoofing (prevents the instance poisoning the ARP cache of its neighbours with a MAC address that isn't its own).
-				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "ARP", "-i", hostName, "--arp-mac-src", "!", hwAddr, "-j", "DROP"},
-				[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "ARP", "-i", hostName, "--arp-mac-src", "!", hwAddr, "-j", "DROP"},
+				[]string{"-t", "filter", "-A", "INPUT", "-p", "ARP", "-i", hostName, "--arp-mac-src", "!", hwAddr, "-j", "DROP"},
+				[]string{"-t", "filter", "-A", "FORWARD", "-p", "ARP", "-i", hostName, "--arp-mac-src", "!", hwAddr, "-j", "DROP"},
 				// Prevent ARP IP spoofing (prevents the instance redirecting traffic for IPs that are not its own).
-				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "ARP", "-i", hostName, "--arp-ip-src", "!", IPv4.String(), "-j", "DROP"},
-				[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "ARP", "-i", hostName, "--arp-ip-src", "!", IPv4.String(), "-j", "DROP"},
+				[]string{"-t", "filter", "-A", "INPUT", "-p", "ARP", "-i", hostName, "--arp-ip-src", "!", IPv4.String(), "-j", "DROP"},
+				[]string{"-t", "filter", "-A", "FORWARD", "-p", "ARP", "-i", hostName, "--arp-ip-src", "!", IPv4.String(), "-j", "DROP"},
 				// Allow DHCPv4 to the host only. This must come before the IP source filtering rules below.
-				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv4", "-s", hwAddr, "-i", hostName, "--ip-src", "0.0.0.0", "--ip-dst", "255.255.255.255", "--ip-proto", "udp", "--ip-dport", "67", "-j", "ACCEPT"},
+				[]string{"-t", "filter", "-A", "INPUT", "-p", "IPv4", "-s", hwAddr, "-i", hostName, "--ip-src", "0.0.0.0", "--ip-dst", "255.255.255.255", "--ip-proto", "udp", "--ip-dport", "67", "-j", "ACCEPT"},
 				// IP source filtering rules. Blocks any packet coming from instance with an incorrect IP source address.
-				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv4", "-i", hostName, "--ip-src", "!", IPv4.String(), "-j", "DROP"},
-				[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "IPv4", "-i", hostName, "--ip-src", "!", IPv4.String(), "-j", "DROP"},
+				[]string{"-t", "filter", "-A", "INPUT", "-p", "IPv4", "-i", hostName, "--ip-src", "!", IPv4.String(), "-j", "DROP"},
+				[]string{"-t", "filter", "-A", "FORWARD", "-p", "IPv4", "-i", hostName, "--ip-src", "!", IPv4.String(), "-j", "DROP"},
 			)
 		}
 	}
@@ -481,20 +481,20 @@ func (d Xtables) generateFilterEbtablesRules(hostName string, hwAddr string, IPv
 	if IPv6 != nil {
 		if IPv6.String() == FilterIPv6All {
 			rules = append(rules,
-				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv6", "-i", hostName, "-j", "DROP"},
-				[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "IPv6", "-i", hostName, "-j", "DROP"},
+				[]string{"-t", "filter", "-A", "INPUT", "-p", "IPv6", "-i", hostName, "-j", "DROP"},
+				[]string{"-t", "filter", "-A", "FORWARD", "-p", "IPv6", "-i", hostName, "-j", "DROP"},
 			)
 		} else {
 			rules = append(rules,
 				// Allow DHCPv6 and Router Solicitation to the host only. This must come before the IP source filtering rules below.
-				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv6", "-s", hwAddr, "-i", hostName, "--ip6-src", "fe80::/ffc0::", "--ip6-dst", "ff02::1:2/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "--ip6-proto", "udp", "--ip6-dport", "547", "-j", "ACCEPT"},
-				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv6", "-s", hwAddr, "-i", hostName, "--ip6-src", "fe80::/ffc0::", "--ip6-dst", "ff02::2/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "--ip6-proto", "ipv6-icmp", "--ip6-icmp-type", "router-solicitation", "-j", "ACCEPT"},
+				[]string{"-t", "filter", "-A", "INPUT", "-p", "IPv6", "-s", hwAddr, "-i", hostName, "--ip6-src", "fe80::/ffc0::", "--ip6-dst", "ff02::1:2/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "--ip6-proto", "udp", "--ip6-dport", "547", "-j", "ACCEPT"},
+				[]string{"-t", "filter", "-A", "INPUT", "-p", "IPv6", "-s", hwAddr, "-i", hostName, "--ip6-src", "fe80::/ffc0::", "--ip6-dst", "ff02::2/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "--ip6-proto", "ipv6-icmp", "--ip6-icmp-type", "router-solicitation", "-j", "ACCEPT"},
 				// IP source filtering rules. Blocks any packet coming from instance with an incorrect IP source address.
-				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv6", "-i", hostName, "--ip6-src", "!", fmt.Sprintf("%s/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", IPv6.String()), "-j", "DROP"},
-				[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "IPv6", "-i", hostName, "--ip6-src", "!", fmt.Sprintf("%s/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", IPv6.String()), "-j", "DROP"},
+				[]string{"-t", "filter", "-A", "INPUT", "-p", "IPv6", "-i", hostName, "--ip6-src", "!", fmt.Sprintf("%s/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", IPv6.String()), "-j", "DROP"},
+				[]string{"-t", "filter", "-A", "FORWARD", "-p", "IPv6", "-i", hostName, "--ip6-src", "!", fmt.Sprintf("%s/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", IPv6.String()), "-j", "DROP"},
 				// Block any IPv6 router advertisement packets from instance.
-				[]string{"ebtables", "-t", "filter", "-A", "INPUT", "-p", "IPv6", "-i", hostName, "--ip6-proto", "ipv6-icmp", "--ip6-icmp-type", "router-advertisement", "-j", "DROP"},
-				[]string{"ebtables", "-t", "filter", "-A", "FORWARD", "-p", "IPv6", "-i", hostName, "--ip6-proto", "ipv6-icmp", "--ip6-icmp-type", "router-advertisement", "-j", "DROP"},
+				[]string{"-t", "filter", "-A", "INPUT", "-p", "IPv6", "-i", hostName, "--ip6-proto", "ipv6-icmp", "--ip6-icmp-type", "router-advertisement", "-j", "DROP"},
+				[]string{"-t", "filter", "-A", "FORWARD", "-p", "IPv6", "-i", hostName, "--ip6-proto", "ipv6-icmp", "--ip6-icmp-type", "router-advertisement", "-j", "DROP"},
 			)
 		}
 	}

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -257,10 +257,11 @@ func (d Xtables) instanceDeviceIPTablesComment(projectName string, instanceName 
 // InstanceSetupBridgeFilter sets up the filter rules to apply bridged device IP filtering.
 func (d Xtables) InstanceSetupBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4 net.IP, IPv6 net.IP) error {
 	comment := d.instanceDeviceIPTablesComment(projectName, instanceName, deviceName)
+	ebtablesCmd := d.ebtablesCmd()
 
 	rules := d.generateFilterEbtablesRules(hostName, hwAddr, IPv4, IPv6)
 	for _, rule := range rules {
-		_, err := shared.RunCommand(rule[0], append([]string{"--concurrent"}, rule[1:]...)...)
+		_, err := shared.RunCommand(ebtablesCmd, append([]string{"--concurrent"}, rule...)...)
 		if err != nil {
 			return err
 		}

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -286,6 +286,17 @@ func (d Xtables) InstanceSetupBridgeFilter(projectName string, instanceName stri
 	return nil
 }
 
+// ebtablesCmd detects if the ebtables-legacy command is available, and uses that instead of the nftables ebtables
+// shim command which isn't fully implemented.
+func (d Xtables) ebtablesCmd() string {
+	_, err := exec.LookPath("ebtables-legacy")
+	if err == nil {
+		return "ebtables-legacy"
+	}
+
+	return "ebtables"
+}
+
 // InstanceClearBridgeFilter removes any filter rules that were added to apply bridged device IP filtering.
 func (d Xtables) InstanceClearBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4 net.IP, IPv6 net.IP) error {
 	comment := d.instanceDeviceIPTablesComment(projectName, instanceName, deviceName)

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -9,6 +9,13 @@ test_container_devices_nic_bridged_filtering() {
     false
   fi
 
+  ebtablesCmd="ebtables"
+  if [ "$firewallDriver" = "xtables" ]; then
+        if which "ebtables-legacy"; then
+            ebtablesCmd="ebtables-legacy"
+        fi
+  fi
+
   ctPrefix="nt$$"
   brName="lxdt$$"
 
@@ -61,7 +68,7 @@ test_container_devices_nic_bridged_filtering() {
   # Check MAC filter is present in firewall.
   ctAHost=$(lxc config get "${ctPrefix}A" volatile.eth0.host_name)
   if [ "$firewallDriver" = "xtables" ]; then
-    if ! ebtables --concurrent -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
+    if ! "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
       echo "MAC filter not applied as part of mac_filtering in ebtables"
       false
     fi
@@ -111,7 +118,7 @@ test_container_devices_nic_bridged_filtering() {
   # Stop CT A and check filters are cleaned up.
   lxc stop -f "${ctPrefix}A"
   if [ "$firewallDriver" = "xtables" ]; then
-    if ebtables --concurrent -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
+    if "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
         echo "MAC filter still applied as part of mac_filtering in ebtables"
         false
     fi
@@ -140,11 +147,11 @@ test_container_devices_nic_bridged_filtering() {
   # Check MAC and IPv4 filter is present in firewall.
   ctAHost=$(lxc config get "${ctPrefix}A" volatile.eth0.host_name)
   if [ "$firewallDriver" = "xtables" ]; then
-    if ! ebtables --concurrent -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
+    if ! "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
       echo "MAC filter not applied as part of ipv4_filtering in ebtables"
       false
     fi
-    if ! ebtables --concurrent -L --Lmac2 --Lx | grep -e "192.0.2.2" ; then
+    if ! "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "192.0.2.2" ; then
         echo "IPv4 filter not applied as part of ipv4_filtering in ebtables"
         false
     fi
@@ -199,7 +206,7 @@ test_container_devices_nic_bridged_filtering() {
   # Stop CT A and check filters are cleaned up in firewall.
   lxc stop -f "${ctPrefix}A"
   if [ "$firewallDriver" = "xtables" ]; then
-    if ebtables --concurrent -L --Lmac2 --Lx | grep -e "${ctAHost}" ; then
+    if "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "${ctAHost}" ; then
         echo "IPv4 filter still applied as part of ipv4_filtering in ebtables"
         false
     fi
@@ -278,7 +285,7 @@ test_container_devices_nic_bridged_filtering() {
   macHex=$(echo "${ctAMAC}" |sed "s/://g")
 
   if [ "$firewallDriver" = "xtables" ]; then
-    if ! ebtables --concurrent -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
+    if ! "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
         echo "MAC filter not applied as part of ipv6_filtering in ebtables"
         false
     fi
@@ -296,13 +303,13 @@ test_container_devices_nic_bridged_filtering() {
     fi
 
     # Check IPv6 filter is present in ebtables.
-    if ! ebtables --concurrent -L --Lmac2 --Lx | grep -e "2001:db8::2" ; then
+    if ! "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "2001:db8::2" ; then
         echo "IPv6 filter not applied as part of ipv6_filtering in ebtables"
         false
     fi
 
     # Check IPv6 RA filter is present in ebtables.
-    if ! ebtables --concurrent -L --Lmac2 --Lx | grep -e "-i ${ctAHost} --ip6-proto ipv6-icmp --ip6-icmp-type router-advertisement -j DROP" ; then
+    if ! "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "-i ${ctAHost} --ip6-proto ipv6-icmp --ip6-icmp-type router-advertisement -j DROP" ; then
         echo "IPv6 RA filter not applied as part of ipv6_filtering in ebtables"
         false
     fi
@@ -378,7 +385,7 @@ test_container_devices_nic_bridged_filtering() {
   # Stop CT A and check filters are cleaned up.
   lxc stop -f "${ctPrefix}A"
   if [ "$firewallDriver" = "xtables" ]; then
-    if ebtables --concurrent -L --Lmac2 --Lx | grep -e "${ctAHost}" ; then
+    if "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "${ctAHost}" ; then
         echo "IPv6 filter still applied as part of ipv6_filtering in ebtables"
         false
     fi
@@ -459,7 +466,7 @@ test_container_devices_nic_bridged_filtering() {
 
   if [ "$firewallDriver" = "xtables" ]; then
     # Check MAC filter is present in ebtables.
-    if ! ebtables --concurrent -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
+    if ! "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
         echo "MAC filter not applied as part of ipv4_filtering in ebtables"
         false
     fi
@@ -471,13 +478,13 @@ test_container_devices_nic_bridged_filtering() {
     fi
 
     # Check IPv4 filter is present in ebtables.
-    if ! ebtables --concurrent -L --Lmac2 --Lx | grep -e "192.0.2.2" ; then
+    if ! "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "192.0.2.2" ; then
         echo "IPv4 filter not applied as part of ipv4_filtering in ebtables"
         false
     fi
 
     # Check IPv6 filter is present in ebtables.
-    if ! ebtables --concurrent -L --Lmac2 --Lx | grep -e "2001:db8::2" ; then
+    if ! "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "2001:db8::2" ; then
         echo "IPv6 filter not applied as part of ipv6_filtering in ebtables"
         false
     fi
@@ -529,7 +536,7 @@ test_container_devices_nic_bridged_filtering() {
   # Delete container and check filters are cleaned up.
   lxc delete -f "${ctPrefix}A"
   if [ "$firewallDriver" = "xtables" ]; then
-    if ebtables --concurrent -L --Lmac2 --Lx | grep -e "${ctAHost}" ; then
+    if "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "${ctAHost}" ; then
         echo "ebtables filter still applied after delete"
         false
     fi
@@ -560,7 +567,7 @@ test_container_devices_nic_bridged_filtering() {
   ctAMAC=$(lxc config get "${ctPrefix}A" volatile.eth0.hwaddr)
 
   if [ "$firewallDriver" = "xtables" ]; then
-    if ! ebtables --concurrent -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
+    if ! "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
         echo "MAC ebtables filter not applied as part of mac_filtering in ebtables"
         false
     fi
@@ -589,8 +596,8 @@ test_container_devices_nic_bridged_filtering() {
   # Stop container and check filters are cleaned up.
   lxc stop -f "${ctPrefix}A"
   if [ "$firewallDriver" = "xtables" ]; then
-    if ebtables --concurrent -L --Lmac2 --Lx | grep -e "${ctAHost}" ; then
-        echo "MAC filter still applied as part of mac_filtering in ebtables"
+    if "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "${ctAHost}" ; then
+        echo "MAC filter still applied as part of unmanaged bridge mac_filtering in ebtables"
         false
     fi
   else
@@ -625,12 +632,12 @@ test_container_devices_nic_bridged_filtering() {
   ctAHost=$(lxc config get "${ctPrefix}A" volatile.eth0.host_name)
 
   if [ "$firewallDriver" = "xtables" ]; then
-    ebtables --concurrent -L --Lmac2 --Lx | grep -e "-A INPUT -p ARP -i ${ctAHost} -j DROP"
-    ebtables --concurrent -L --Lmac2 --Lx | grep -e "-A FORWARD -p ARP -i ${ctAHost} -j DROP"
-    ebtables --concurrent -L --Lmac2 --Lx | grep -e "-A INPUT -p IPv4 -i ${ctAHost} -j DROP"
-    ebtables --concurrent -L --Lmac2 --Lx | grep -e "-A FORWARD -p IPv4 -i ${ctAHost} -j DROP"
-    ebtables --concurrent -L --Lmac2 --Lx | grep -e "-A INPUT -p IPv6 -i ${ctAHost} -j DROP"
-    ebtables --concurrent -L --Lmac2 --Lx | grep -e "-A FORWARD -p IPv6 -i ${ctAHost} -j DROP"
+    "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "-A INPUT -p ARP -i ${ctAHost} -j DROP"
+    "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "-A FORWARD -p ARP -i ${ctAHost} -j DROP"
+    "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "-A INPUT -p IPv4 -i ${ctAHost} -j DROP"
+    "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "-A FORWARD -p IPv4 -i ${ctAHost} -j DROP"
+    "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "-A INPUT -p IPv6 -i ${ctAHost} -j DROP"
+    "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "-A FORWARD -p IPv6 -i ${ctAHost} -j DROP"
   else
     for table in "in" "fwd"
     do
@@ -643,7 +650,7 @@ test_container_devices_nic_bridged_filtering() {
   # Delete container and check filters are cleaned up.
   lxc delete -f "${ctPrefix}A"
   if [ "$firewallDriver" = "xtables" ]; then
-    if ebtables --concurrent -L --Lmac2 --Lx | grep -e "${ctAHost}" ; then
+    if "${ebtablesCmd}" --concurrent -L --Lmac2 --Lx | grep -e "${ctAHost}" ; then
         echo "Filters still applied as part of IP filter in ebtables"
         false
     fi


### PR DESCRIPTION
Avoids using the nftables ebtables partially implemented shim command.

Fixes orphaned filter rules being left on Ubuntu Focal default installs that have iptables and ebtables (as an nftables) shim installed by default, and no nftables, meaning LXD uses iptables mode and expects the ebtables command to be fully implemented as per its manpage.