### PR TITLE
Storage: LVM skipactivation patch

### DIFF
--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -97,6 +97,7 @@ var patches = []patch{
 	{name: "storage_create_vm_again", stage: patchPostDaemonStorage, run: patchGenericStorage},
 	{name: "storage_zfs_volmode", stage: patchPostDaemonStorage, run: patchGenericStorage},
 	{name: "storage_rename_custom_volume_add_project", stage: patchPreDaemonStorage, run: patchGenericStorage},
+	{name: "storage_lvm_skipactivation", stage: patchPostDaemonStorage, run: patchGenericStorage},
 }
 
 type patch struct {

--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -34,6 +34,7 @@ func (d *btrfs) load() error {
 		"storage_create_vm_again":                  nil,
 		"storage_zfs_volmode":                      nil,
 		"storage_rename_custom_volume_add_project": nil,
+		"storage_lvm_skipactivation":               nil,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -33,6 +33,7 @@ func (d *ceph) load() error {
 		"storage_create_vm_again":                  nil,
 		"storage_zfs_volmode":                      nil,
 		"storage_rename_custom_volume_add_project": nil,
+		"storage_lvm_skipactivation":               nil,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -32,6 +32,7 @@ func (d *cephfs) load() error {
 		"storage_create_vm_again":                  nil,
 		"storage_zfs_volmode":                      nil,
 		"storage_rename_custom_volume_add_project": nil,
+		"storage_lvm_skipactivation":               nil,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -166,13 +166,13 @@ func (d *common) Config() map[string]string {
 // ApplyPatch looks for a suitable patch and runs it.
 func (d *common) ApplyPatch(name string) error {
 	if d.patches == nil {
-		return fmt.Errorf("The patch mechanism isn't implemented on pool '%s'", d.name)
+		return fmt.Errorf("The patch mechanism isn't implemented on pool %q", d.name)
 	}
 
 	// Locate the patch.
 	patch, ok := d.patches[name]
 	if !ok {
-		return fmt.Errorf("Patch '%s' isn't implemented on pool '%s'", name, d.name)
+		return fmt.Errorf("Patch %q isn't implemented on pool %q", name, d.name)
 	}
 
 	// Handle cases where a patch isn't needed.

--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -25,6 +25,7 @@ func (d *dir) load() error {
 		"storage_create_vm_again":                  nil,
 		"storage_zfs_volmode":                      nil,
 		"storage_rename_custom_volume_add_project": nil,
+		"storage_lvm_skipactivation":               nil,
 	}
 
 	return nil

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -37,6 +37,7 @@ func (d *lvm) load() error {
 		"storage_create_vm_again":                  nil,
 		"storage_zfs_volmode":                      nil,
 		"storage_rename_custom_volume_add_project": nil,
+		"storage_lvm_skipactivation":               d.patchStorageSkipActivation,
 	}
 
 	// Done if previously loaded.

--- a/lxd/storage/drivers/driver_lvm_patches.go
+++ b/lxd/storage/drivers/driver_lvm_patches.go
@@ -1,0 +1,50 @@
+package drivers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/logger"
+)
+
+// patchStorageSkipActivation set skipactivation=y on all LXD LVM logical volumes (excluding thin pool volumes).
+func (d *lvm) patchStorageSkipActivation() error {
+	out, err := shared.RunCommand("lvs", "--noheadings", "-o", "lv_name,lv_attr", d.name)
+	if err != nil {
+		return errors.Wrapf(err, "Error getting LVM logical volume list for storage pool %q", d.name)
+	}
+
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) != 2 {
+			continue
+		}
+
+		volName := fields[0]
+		volAttr := fields[1]
+
+		// Ignore non-LXD prefixes, and thinpool volumes (these should remain auto activated).
+		if !strings.HasPrefix(volName, "images_") && !strings.HasPrefix(volName, "containers_") && !strings.HasPrefix(volName, "virtual-machines_") && !strings.HasPrefix(volName, "custom_") {
+			continue
+		}
+
+		// Skip volumes that already have k flag set, meaning setactivationskip=y.
+		if strings.HasSuffix(volAttr, "k") {
+			logger.Infof("Skipping volume %q that already has skipactivation=y set in pool %q", volName, d.name)
+			continue
+		}
+
+		// Set the --setactivationskip flag enabled on the volume.
+		_, err = shared.RunCommand("lvchange", "--setactivationskip", "y", fmt.Sprintf("%s/%s", d.name, volName))
+		if err != nil {
+			return errors.Wrapf(err, "Error setting setactivationskip=y on LVM logical volume %q for storage pool %q", volName, d.name)
+		}
+
+		logger.Infof("Set setactivationskip=y on volume %q in pool %q", volName, d.name)
+	}
+
+	return nil
+}

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -45,6 +45,7 @@ func (d *zfs) load() error {
 		"storage_create_vm_again":                  nil,
 		"storage_zfs_volmode":                      d.patchStorageZFSVolMode,
 		"storage_rename_custom_volume_add_project": nil,
+		"storage_lvm_skipactivation":               nil,
 	}
 
 	// Done if previously loaded.


### PR DESCRIPTION
Applies the skipactivation=y flag to LXD managed LVM volumes.

This brings existing volumes into line with new volume behaviour introduced in https://github.com/lxc/lxd/pull/7303.