### PR TITLE
Firewall: Updates detection to warn when falling back to non-compatible xtables driver

### DIFF
--- a/lxd/firewall/firewall_interface.go
+++ b/lxd/firewall/firewall_interface.go
@@ -9,7 +9,7 @@ import (
 // Firewall represents an LXD firewall.
 type Firewall interface {
 	String() string
-	Compat() (bool, bool)
+	Compat() (bool, error)
 
 	NetworkSetupForwardingPolicy(networkName string, ipVersion uint, allow bool) error
 	NetworkSetupOutboundNAT(networkName string, subnet *net.IPNet, srcIP net.IP, append bool) error

--- a/lxd/firewall/firewall_load.go
+++ b/lxd/firewall/firewall_load.go
@@ -2,6 +2,7 @@ package firewall
 
 import (
 	"github.com/lxc/lxd/lxd/firewall/drivers"
+	"github.com/lxc/lxd/shared/logger"
 )
 
 // New returns an appropriate firewall implementation.
@@ -10,26 +11,40 @@ func New() Firewall {
 	nftables := drivers.Nftables{}
 	xtables := drivers.Xtables{}
 
-	// If nftables is compatible and already in use, then we prefer to use the nftables driver irrespective of
-	// whether xtables is in use or not.
-	nftablesCompat, nftablesInUse := nftables.Compat()
-	if nftablesCompat && nftablesInUse {
+	nftablesInUse, nftablesCompatErr := nftables.Compat()
+	if nftablesCompatErr != nil {
+		logger.Debugf(`Firewall detected "nftables" incompatibility: %v`, nftablesCompatErr)
+	} else if nftablesInUse {
+		// If nftables is compatible and already in use, then we prefer to use the nftables driver
+		// irrespective of whether xtables is in use or not.
 		return nftables
-	} else if !nftablesCompat {
-		// Note: If nftables isn't compatible, we fallback to xtables without considering whether xtables
-		// is itself compatible. This continues the existing behaviour of allowing LXD to start with
-		// potentially an incomplete firewall backend, so that only networks and instances using those
-		// features will fail to start later.
+	}
+
+	xtablesInUse, xtablesCompatErr := xtables.Compat()
+	if xtablesCompatErr != nil {
+		logger.Debugf(`Firewall detected "xtables" incompatibility: %v`, xtablesCompatErr)
+	} else if xtablesInUse {
+		// If xtables is compatible and already in use, then we prefer to stick with the xtables driver
+		// rather than mix the use of firewall drivers on the system.
 		return xtables
 	}
 
-	// If xtables is compatible and already in use, then we prefer to stick with the xtables driver rather than
-	// mix the use of firewall drivers on the system.
-	xtablesCompat, xtablesInUse := xtables.Compat()
-	if xtablesCompat && xtablesInUse {
+	// If nftables is compatible, but not in use, and xtables is not compatible or not in use, use nftables.
+	if nftablesCompatErr == nil {
+		return nftables
+	}
+
+	// If neither nftables nor xtables are compatible, we fallback to xtables.
+	// This continues the existing behaviour of allowing LXD to start with potentially an incomplete firewall
+	// backend, so that only networks and instances using those features may fail to function properly.
+	// The most common scenario for this is when xtables is using nft shim commands but the nft command itself
+	// is not installed. In this case LXD will use the xtables shim commands but with the potential of problems
+	// due to differences between the original xtables commands and the shim commands provided by nft.
+	if nftablesCompatErr != nil && xtablesCompatErr != nil {
+		logger.Warnf(`Firewall failed to detect any compatible driver, falling back to "xtables" (but some features may not work as expected due to: %v)`, xtablesCompatErr)
 		return xtables
 	}
 
-	// Otherwise prefer nftables as default.
-	return nftables
+	// If xtables is compatible, but not in use, and nftables is not compatible, use xtables.
+	return xtables
 }


### PR DESCRIPTION
Warning contains the issue as to why the xtables driver we are using as "last resort" is not fully compatible and may still cause unexpected behaviour.