### PR TITLE
instance_exec: don't panic

### DIFF
--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -279,7 +279,7 @@ func (s *execWs) Do(op *operations.Operation) error {
 
 					err = cmd.WindowResize(int(ptys[0].Fd()), winchWidth, winchHeight)
 					if err != nil {
-						logger.Debug("Failed to set window size", winchWidth, winchHeight, log.Ctx{"err": err, "width": winchWidth, "height": winchHeight})
+						logger.Debug("Failed to set window size", log.Ctx{"err": err, "width": winchWidth, "height": winchHeight})
 						continue
 					}
 				} else if command.Command == "signal" {


### PR DESCRIPTION
```
DBUG[05-21|14:59:09] Finished mirroring websocket             instance=f3 PID=623244
DBUG[05-21|14:59:18] Failed to set window size                instance=f3 PID=623244 LOG15_ERROR= LOG15_ERROR= LOG15_ERROR="Normalized odd number of arguments by adding nil"
DBUG[05-21|14:59:18] Interactive child process handler finished instance=f3 PID=623244
panic: interface conversion: interface {} is int, not string

goroutine 3111 [running]:
github.com/lxc/lxd/lxd/events.logContextMap(0xc0005f4fa0, 0xa, 0xa, 0xc000108080)
        /home/brauner/src/go/src/github.com/lxc/lxd/lxd/events/logging.go:42 +0x1ae
github.com/lxc/lxd/lxd/events.Handler.Log(0xc000108080, 0x0, 0x0)
        /home/brauner/src/go/src/github.com/lxc/lxd/lxd/events/logging.go:32 +0x79
github.com/lxc/lxd/shared/log15.MultiHandler.func1(0xc000108080, 0xc000787bf0, 0xc000787c78)
        /home/brauner/src/go/src/github.com/lxc/lxd/shared/log15/handler.go:208 +0x67
github.com/lxc/lxd/shared/log15.funcHandler.Log(0xc00045da60, 0xc000108080, 0x1, 0x1)
        /home/brauner/src/go/src/github.com/lxc/lxd/shared/log15/handler.go:32 +0x30
github.com/lxc/lxd/shared/log15.(*swapHandler).Log(0xc000010880, 0xc000108080, 0x1, 0x1)
        /home/brauner/src/go/src/github.com/lxc/lxd/shared/log15/handler_other.go:17 +0x40
github.com/lxc/lxd/shared/log15.(*swapHandler).Log(...)
        /home/brauner/src/go/src/github.com/lxc/lxd/shared/log15/handler_other.go:17
github.com/lxc/lxd/shared/log15.(*logger).write(0xc000421940, 0x1485978, 0x19, 0x4, 0xc00068c210, 0x3, 0x3)
        /home/brauner/src/go/src/github.com/lxc/lxd/shared/log15/logger.go:111 +0x1cd
github.com/lxc/lxd/shared/log15.(*logger).Debug(0xc000421940, 0x1485978, 0x19, 0xc00068c210, 0x3, 0x3)
        /home/brauner/src/go/src/github.com/lxc/lxd/shared/log15/logger.go:129 +0x66
main.(*execWs).Do.func2(0x7fa4bc3ad1b8, 0xc000421940, 0xc0009e8b00, 0xc0001de720, 0x16f0320, 0xc0006d44c0, 0xc000bac690, 0x1, 0x1)
        /home/brauner/src/go/src/github.com/lxc/lxd/lxd/instance_exec.go:282 +0xa56
created by main.(*execWs).Do
        /home/brauner/src/go/src/github.com/lxc/lxd/lxd/instance_exec.go:211 +0x7e1
```

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>