### PR TITLE
Storage: Fix intermittent BTRFS optimized restore errors

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -452,6 +452,7 @@ func (d *btrfs) loadOptimizedBackupHeader(r io.ReadSeeker) (*BTRFSMetaDataHeader
 				return nil, errors.Wrapf(err, "Error parsing optimized backup header file")
 			}
 
+			cancelFunc()
 			return &header, nil
 		}
 	}

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -208,6 +208,7 @@ func (d *btrfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcDat
 					return "", err
 				}
 
+				cancelFunc()
 				return subVolRecvPath, nil
 			}
 		}


### PR DESCRIPTION
This PR fixes the intermittent BTRFS optimized import errors seen in jenkins.

The `context.cancelFunc` returned by `CompressedTarReader()` just cancelled context (which kills the unpacker process), however the `cancelFunc` does not wait until the process has finished, it just signals it to end.

This means after cancelling the tar reader when finding a file we want, and the immediately moving onto rewinding the same io.Reader and reading it again causes unexpected io.EOF and concurrent readers of the same stream.

Instead, once the unpacker process has started, we now return a custom `context.cancelFunc` that wraps the internal `cancelFunc` passed to the unpacker process, with one that calls the `cancelFunc` to signal the process to end, and then waits for it to end before returning.

This should prevent callers from returning before the unpacker has finished.
