### PR TITLE
lxd/cluster: Transfer leadership before adjusting roles, not after

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1286,6 +1286,7 @@ func handoverMemberRole(d *Daemon) error {
 	}
 
 	// Find the cluster leader.
+findLeader:
 	leader, err := d.gateway.LeaderAddress()
 	if err != nil {
 		return err
@@ -1295,6 +1296,15 @@ func handoverMemberRole(d *Daemon) error {
 		//
 		// TODO: retry a few times?
 		return nil
+	}
+
+	if leader == address {
+		logger.Info("Transfer leadership")
+		err := d.gateway.TransferLeadership()
+		if err != nil {
+			return errors.Wrapf(err, "Failed to transfer leadership")
+		}
+		goto findLeader
 	}
 
 	cert := d.endpoints.NetworkCert()

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1534,6 +1534,9 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat) {
 
 		if isDegraded || voters < int(maxVoters) || standbys < int(maxStandBy) {
 			go func() {
+				// Wait a little bit, just to avoid spurious
+				// attempts due to nodes being shut down.
+				time.Sleep(5 * time.Second)
 				d.clusterMembershipMutex.Lock()
 				defer d.clusterMembershipMutex.Unlock()
 				err := rebalanceMemberRoles(d)


### PR DESCRIPTION
Although it's possible to hold leadership while being demoted to spare, that
creates a few issues down the line.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>