### PR TITLE
lxd/api: Fail /internal/ready requests made after shutdown has started

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -64,8 +64,8 @@ type lxdHttpServer struct {
 }
 
 func (s *lxdHttpServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	// Set CORS headers, unless this is an internal or gRPC request.
-	if !strings.HasPrefix(req.URL.Path, "/internal") && !strings.HasPrefix(req.URL.Path, "/protocol.SQL") {
+	// Set CORS headers, unless this is an internal request.
+	if !strings.HasPrefix(req.URL.Path, "/internal") {
 		<-s.d.setupChan
 		err := s.d.cluster.Transaction(func(tx *db.ClusterTx) error {
 			config, err := cluster.ConfigLoad(tx)

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -108,6 +108,15 @@ var internalRAFTSnapshotCmd = APIEndpoint{
 }
 
 func internalWaitReady(d *Daemon, r *http.Request) response.Response {
+	// Check that we're not shutting down.
+	var isClosing bool
+	d.clusterMembershipMutex.RLock()
+	isClosing = d.clusterMembershipClosing
+	d.clusterMembershipMutex.RUnlock()
+	if isClosing {
+		return response.Unavailable(fmt.Errorf("LXD daemon is shutting down"))
+	}
+
 	select {
 	case <-d.readyChan:
 	default:

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -97,7 +97,7 @@ type Daemon struct {
 
 	// Serialize changes to cluster membership (joins, leaves, role
 	// changes).
-	clusterMembershipMutex   sync.Mutex
+	clusterMembershipMutex   sync.RWMutex
 	clusterMembershipClosing bool // Prevent further rebalances
 }
 

--- a/lxd/main_daemon.go
+++ b/lxd/main_daemon.go
@@ -85,8 +85,8 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 			containersShutdown(s)
 			networkShutdown(s)
 		} else {
-			d.Kill()
 			logger.Infof("Received '%s signal', exiting", sig)
+			d.Kill()
 		}
 
 	case <-d.shutdownChan:


### PR DESCRIPTION
We need to do this since now we're leaving the endpoints open for a good part of
the shutdown sequence, to allow for cluster membership adjustments.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>