### PR TITLE
VM: Removes duplicated qemu-img call in ImageUnpack

### DIFF
--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -576,12 +576,6 @@ func ImageUnpack(imageFile string, vol drivers.Volume, destBlockFile string, blo
 		if err != nil {
 			return -1, err
 		}
-
-		// Convert the qcow2 format to a raw block device.
-		_, err = shared.RunCommand("qemu-img", "convert", "-O", "raw", imageRootfsFile, destBlockFile)
-		if err != nil {
-			return -1, fmt.Errorf("Failed converting image to raw at %s: %v", destBlockFile, err)
-		}
 	} else {
 		// Dealing with unified tarballs require an initial unpack to a temporary directory.
 		tempDir, err := ioutil.TempDir(shared.VarPath("images"), "lxd_image_unpack_")


### PR DESCRIPTION
Missed removing this when introducing `convertBlockImage` which calls `qemu-img convert`.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>