### PR TITLE
VM: Use qemu-img dd mode instead of convert

### DIFF
--- a/lxd/storage/drivers/driver_zfs_utils.go
+++ b/lxd/storage/drivers/driver_zfs_utils.go
@@ -55,7 +55,7 @@ func (d *zfs) createDataset(dataset string, options ...string) error {
 }
 
 func (d *zfs) createVolume(dataset string, size int64, options ...string) error {
-	size = (size / minBlockBoundary) * minBlockBoundary
+	size = (size / MinBlockBoundary) * MinBlockBoundary
 
 	args := []string{"create", "-s", "-V", fmt.Sprintf("%d", size)}
 	for _, option := range options {

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -72,7 +72,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 			}
 
 			// Round to block boundary.
-			poolVolSizeBytes = (poolVolSizeBytes / minBlockBoundary) * minBlockBoundary
+			poolVolSizeBytes = (poolVolSizeBytes / MinBlockBoundary) * MinBlockBoundary
 
 			// If the cached volume is larger than the pool volume size, then we can't use the
 			// deleted cached image volume and instead we will rename it to a random UUID so it can't
@@ -886,7 +886,7 @@ func (d *zfs) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 			return nil
 		}
 
-		sizeBytes = (sizeBytes / minBlockBoundary) * minBlockBoundary
+		sizeBytes = (sizeBytes / MinBlockBoundary) * MinBlockBoundary
 
 		oldSizeBytesStr, err := d.getDatasetProperty(d.dataset(vol, false), "volsize")
 		if err != nil {

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -18,7 +18,8 @@ import (
 	"github.com/lxc/lxd/shared/idmap"
 )
 
-const minBlockBoundary = 8192
+// MinBlockBoundary minimum block boundary size to use.
+const MinBlockBoundary = 8192
 
 // wipeDirectory empties the contents of a directory, but leaves it in place.
 func wipeDirectory(path string) error {

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -317,12 +317,12 @@ func createSparseFile(filePath string, sizeBytes int64) error {
 func roundVolumeBlockFileSizeBytes(sizeBytes int64) (int64, error) {
 	// Qemu requires image files to be in traditional storage block boundaries.
 	// We use 8k here to ensure our images are compatible with all of our backend drivers.
-	if sizeBytes < minBlockBoundary {
-		sizeBytes = minBlockBoundary
+	if sizeBytes < MinBlockBoundary {
+		sizeBytes = MinBlockBoundary
 	}
 
-	// Round the size to closest minBlockBoundary bytes to avoid qemu boundary issues.
-	return int64(sizeBytes/minBlockBoundary) * minBlockBoundary, nil
+	// Round the size to closest MinBlockBoundary bytes to avoid qemu boundary issues.
+	return int64(sizeBytes/MinBlockBoundary) * MinBlockBoundary, nil
 }
 
 // ensureVolumeBlockFile creates new block file or enlarges the raw block file for a volume to the specified size.

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -576,12 +576,6 @@ func ImageUnpack(imageFile string, vol drivers.Volume, destBlockFile string, blo
 		if err != nil {
 			return -1, err
 		}
-
-		// Convert the qcow2 format to a raw block device.
-		_, err = shared.RunCommand("qemu-img", "convert", "-O", "raw", imageRootfsFile, destBlockFile)
-		if err != nil {
-			return -1, fmt.Errorf("Failed converting image to raw at %s: %v", destBlockFile, err)
-		}
 	} else {
 		// Dealing with unified tarballs require an initial unpack to a temporary directory.
 		tempDir, err := ioutil.TempDir(shared.VarPath("images"), "lxd_image_unpack_")


### PR DESCRIPTION
Works around issues unpacking images on loopback files that causes kernel hangs on ZFS and slow downs on LVM.

Includes https://github.com/lxc/lxd/pull/7459