### PR TITLE
NIC: Bridged device fix openvswitch port leak

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -1197,7 +1197,7 @@ func (d *nicBridged) networkDHCPv6CreateIAAddress(IP net.IP) []byte {
 
 // setupBridgePortVLANs configures the bridge port with the specified VLAN settings in device config.
 func (d *nicBridged) setupBridgePortVLANs(hostName string) error {
-	// Enable vlan_filtering on bridge if needed.
+	// Check vlan_filtering is enabled on bridge if needed.
 	if d.config["vlan"] != "" || d.config["vlan.tagged"] != "" {
 		vlanFilteringStatus, err := network.BridgeVLANFilteringStatus(d.config["parent"])
 		if err != nil {

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -278,6 +278,7 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	revert.Add(func() { network.DetachInterface(d.config["parent"], saveData["host_name"]) })
 
 	// Attempt to disable router advertisement acceptance.
 	err = util.SysctlSet(fmt.Sprintf("net/ipv6/conf/%s/accept_ra", saveData["host_name"]), "0")
@@ -402,10 +403,16 @@ func (d *nicBridged) postStop() error {
 	}
 
 	if d.config["host_name"] != "" && shared.PathExists(fmt.Sprintf("/sys/class/net/%s", d.config["host_name"])) {
-		// Removing host-side end of veth pair will delete the peer end too.
-		err := NetworkRemoveInterface(d.config["host_name"])
+		// Detach host-side end of veth pair from bridge (required for openvswitch particularly).
+		err := network.DetachInterface(d.config["parent"], d.config["host_name"])
 		if err != nil {
-			return fmt.Errorf("Failed to remove interface %s: %s", d.config["host_name"], err)
+			return errors.Wrapf(err, "Failed to detach interface %q from %q", d.config["host_name"], d.config["parent"])
+		}
+
+		// Removing host-side end of veth pair will delete the peer end too.
+		err = NetworkRemoveInterface(d.config["host_name"])
+		if err != nil {
+			return errors.Wrapf(err, "Failed to remove interface %q", d.config["host_name"])
 		}
 	}
 

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -100,6 +100,7 @@ func AttachInterface(netName string, devName string) error {
 			return err
 		}
 	} else {
+		// Check if interface is already connected to a bridge, if not connect it to the specified bridge.
 		_, err := shared.RunCommand("ovs-vsctl", "port-to-br", devName)
 		if err != nil {
 			_, err := shared.RunCommand("ovs-vsctl", "add-port", netName, devName)
@@ -120,6 +121,7 @@ func DetachInterface(netName string, devName string) error {
 			return err
 		}
 	} else {
+		// Check if interface is connected to a bridge, if so, then remove it from the bridge.
 		_, err := shared.RunCommand("ovs-vsctl", "port-to-br", devName)
 		if err == nil {
 			_, err := shared.RunCommand("ovs-vsctl", "del-port", netName, devName)

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -93,9 +93,9 @@ func GetIP(subnet *net.IPNet, host int64) net.IP {
 }
 
 // AttachInterface attaches an interface to a bridge.
-func AttachInterface(netName string, devName string) error {
-	if shared.PathExists(fmt.Sprintf("/sys/class/net/%s/bridge", netName)) {
-		_, err := shared.RunCommand("ip", "link", "set", "dev", devName, "master", netName)
+func AttachInterface(bridgeName string, devName string) error {
+	if shared.PathExists(fmt.Sprintf("/sys/class/net/%s/bridge", bridgeName)) {
+		_, err := shared.RunCommand("ip", "link", "set", "dev", devName, "master", bridgeName)
 		if err != nil {
 			return err
 		}
@@ -103,7 +103,7 @@ func AttachInterface(netName string, devName string) error {
 		// Check if interface is already connected to a bridge, if not connect it to the specified bridge.
 		_, err := shared.RunCommand("ovs-vsctl", "port-to-br", devName)
 		if err != nil {
-			_, err := shared.RunCommand("ovs-vsctl", "add-port", netName, devName)
+			_, err := shared.RunCommand("ovs-vsctl", "add-port", bridgeName, devName)
 			if err != nil {
 				return err
 			}
@@ -114,8 +114,8 @@ func AttachInterface(netName string, devName string) error {
 }
 
 // DetachInterface detaches an interface from a bridge.
-func DetachInterface(netName string, devName string) error {
-	if shared.PathExists(fmt.Sprintf("/sys/class/net/%s/bridge", netName)) {
+func DetachInterface(bridgeName string, devName string) error {
+	if shared.PathExists(fmt.Sprintf("/sys/class/net/%s/bridge", bridgeName)) {
 		_, err := shared.RunCommand("ip", "link", "set", "dev", devName, "nomaster")
 		if err != nil {
 			return err
@@ -124,7 +124,7 @@ func DetachInterface(netName string, devName string) error {
 		// Check if interface is connected to a bridge, if so, then remove it from the bridge.
 		_, err := shared.RunCommand("ovs-vsctl", "port-to-br", devName)
 		if err == nil {
-			_, err := shared.RunCommand("ovs-vsctl", "del-port", netName, devName)
+			_, err := shared.RunCommand("ovs-vsctl", "del-port", bridgeName, devName)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Stopping an instance was not detaching the bridged NIC device from the openvswitch bridge, causing port leaks such as:

```
sudo ovs-vsctl show
84593e35-9a66-45ba-b647-929e396b3a59
    Bridge lxdbr1
        Port lxdbr1
            Interface lxdbr1
                type: internal
        Port veth1d5cd6a9
            Interface veth1d5cd6a9
                error: "could not open network device veth1d5cd6a9 (No such device)"
```

Also includes some other comment/code clarity improvements.