### PR TITLE
Stop using Driver.SetContextTimeout() which is a no-op

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	dqlitedriver "github.com/canonical/go-dqlite/driver"
 	"github.com/gorilla/mux"
@@ -218,19 +217,11 @@ func clusterPut(d *Daemon, r *http.Request) response.Response {
 
 func clusterPutBootstrap(d *Daemon, req api.ClusterPut) response.Response {
 	run := func(op *operations.Operation) error {
-		// The default timeout when non-clustered is one minute, let's
-		// lower it down now that we'll likely have to make requests
-		// over the network.
-		//
-		// FIXME: this is a workaround for #5234.
-		d.cluster.SetDefaultTimeout(5 * time.Second)
-
 		// Start clustering tasks
 		d.startClusterTasks()
 
 		err := cluster.Bootstrap(d.State(), d.gateway, req.ServerName)
 		if err != nil {
-			d.cluster.SetDefaultTimeout(time.Minute)
 			d.stopClusterTasks()
 			return err
 		}
@@ -468,19 +459,11 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) response.Response {
 			nodes[i].Role = db.RaftRole(node.Role)
 		}
 
-		// The default timeout when non-clustered is one minute, let's
-		// lower it down now that we'll likely have to make requests
-		// over the network.
-		//
-		// FIXME: this is a workaround for #5234.
-		d.cluster.SetDefaultTimeout(5 * time.Second)
-
 		// Start clustering tasks
 		d.startClusterTasks()
 
 		err = cluster.Join(d.State(), d.gateway, cert, req.ServerName, nodes)
 		if err != nil {
-			d.cluster.SetDefaultTimeout(time.Minute)
 			d.stopClusterTasks()
 			return err
 		}

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -324,12 +324,6 @@ func ForLocalInspectionWithPreparedStmts(db *sql.DB) (*Cluster, error) {
 	return c, nil
 }
 
-// SetDefaultTimeout sets the default go-dqlite driver timeout.
-func (c *Cluster) SetDefaultTimeout(timeout time.Duration) {
-	driver := c.db.Driver().(*driver.Driver)
-	driver.SetContextTimeout(timeout)
-}
-
 // Kill should be called upon shutdown, it will prevent retrying failed
 // database queries.
 func (c *Cluster) Kill() {


### PR DESCRIPTION
The Driver.SetContextTimeout() has been a no-op for a while now and should be
dropped.

The functionality has been moved to the WithContextTimeout() option, which we
use when creating the driver object and that sets a 30 seconds timeout for
DB.Begin().

In all other cases we don't actually timeout anymore and rather rely on the
network layer to report a broken connection. So the original #5234 issue can't
happen anymore for non-clustered deployments.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>