### PR TITLE
Storage: Unifies LVM and Ceph filesystem mount option logic

### DIFF
--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -524,26 +524,6 @@ func (d *ceph) rbdListVolumeSnapshots(vol Volume) ([]string, error) {
 	return snapshots, nil
 }
 
-// getRBDMountOptions returns the mount options the storage volume is supposed to be mounted with
-// the option string that is returned needs to be passed to the approriate
-// helper (currently named "LXDResolveMountoptions") which will take on the job
-// of splitting it into appropriate flags and string options.
-func (d *ceph) getRBDMountOptions(vol Volume) string {
-	if vol.config["block.mount_options"] != "" {
-		return vol.config["block.mount_options"]
-	}
-
-	if vol.poolConfig["volume.block.mount_options"] != "" {
-		return vol.poolConfig["volume.block.mount_options"]
-	}
-
-	if vol.ConfigBlockFilesystem() == "btrfs" {
-		return "user_subvol_rm_allowed,discard"
-	}
-
-	return "discard"
-}
-
 // copyWithSnapshots creates a non-sparse copy of a container including its snapshots.
 // This does not introduce a dependency relation between the source RBD storage
 // volume and the target RBD storage volume.

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -537,7 +537,7 @@ func (d *ceph) getRBDMountOptions(vol Volume) string {
 		return vol.poolConfig["volume.block.mount_options"]
 	}
 
-	if d.getRBDFilesystem(vol) == "btrfs" {
+	if vol.ConfigBlockFilesystem() == "btrfs" {
 		return "user_subvol_rm_allowed,discard"
 	}
 
@@ -1032,7 +1032,7 @@ func (d *ceph) getRBDVolumeName(vol Volume, snapName string, zombie bool, withPo
 
 	// Only use filesystem suffix on filesystem type image volumes (for all content types).
 	if vol.volType == VolumeTypeImage || vol.volType == cephVolumeTypeZombieImage {
-		parentName = fmt.Sprintf("%s_%s", parentName, d.getRBDFilesystem(vol))
+		parentName = fmt.Sprintf("%s_%s", parentName, vol.ConfigBlockFilesystem())
 	}
 
 	if vol.contentType == ContentTypeBlock {

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -524,19 +524,6 @@ func (d *ceph) rbdListVolumeSnapshots(vol Volume) ([]string, error) {
 	return snapshots, nil
 }
 
-// getRBDFilesystem returns the filesystem the RBD storage volume is supposed to be created with.
-func (d *ceph) getRBDFilesystem(vol Volume) string {
-	if vol.config["block.filesystem"] != "" {
-		return vol.config["block.filesystem"]
-	}
-
-	if vol.poolConfig["volume.block.filesystem"] != "" {
-		return vol.poolConfig["volume.block.filesystem"]
-	}
-
-	return "ext4"
-}
-
 // getRBDMountOptions returns the mount options the storage volume is supposed to be mounted with
 // the option string that is returned needs to be passed to the approriate
 // helper (currently named "LXDResolveMountoptions") which will take on the job

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -139,7 +139,7 @@ func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 	revert.Add(func() { d.rbdUnmapVolume(vol, true) })
 
 	// Get filesystem.
-	RBDFilesystem := d.getRBDFilesystem(vol)
+	RBDFilesystem := vol.ConfigBlockFilesystem()
 
 	if vol.contentType == ContentTypeFS {
 		_, err = makeFSType(RBDDevPath, RBDFilesystem, nil)
@@ -311,7 +311,7 @@ func (d *ceph) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots boo
 		if vol.contentType == ContentTypeFS {
 			// Re-generate the UUID. Do this first as ensuring permissions and setting quota can
 			// rely on being able to mount the volume.
-			err = d.generateUUID(d.getRBDFilesystem(v), RBDDevPath)
+			err = d.generateUUID(v.ConfigBlockFilesystem(), RBDDevPath)
 			if err != nil {
 				return err
 			}
@@ -587,7 +587,7 @@ func (d *ceph) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vo
 	defer d.rbdUnmapVolume(vol, true)
 
 	// Re-generate the UUID.
-	err = d.generateUUID(d.getRBDFilesystem(vol), RBDDevPath)
+	err = d.generateUUID(vol.ConfigBlockFilesystem(), RBDDevPath)
 	if err != nil {
 		return err
 	}
@@ -824,7 +824,7 @@ func (d *ceph) SetVolumeQuota(vol Volume, size string, op *operations.Operation)
 		return nil
 	}
 
-	fsType := d.getRBDFilesystem(vol)
+	fsType := vol.ConfigBlockFilesystem()
 
 	RBDDevPath, err := d.getRBDMappedDevPath(vol)
 	if err != nil {
@@ -928,7 +928,7 @@ func (d *ceph) MountVolume(vol Volume, op *operations.Operation) (bool, error) {
 			return false, err
 		}
 
-		RBDFilesystem := d.getRBDFilesystem(vol)
+		RBDFilesystem := vol.ConfigBlockFilesystem()
 		mountFlags, mountOptions := resolveMountOptions(d.getRBDMountOptions(vol))
 		err = TryMount(RBDDevPath, mountPath, RBDFilesystem, mountFlags, mountOptions)
 		if err != nil {
@@ -1311,7 +1311,7 @@ func (d *ceph) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bo
 			return false, nil
 		}
 
-		RBDFilesystem := d.getRBDFilesystem(snapVol)
+		RBDFilesystem := snapVol.ConfigBlockFilesystem()
 		mountFlags, mountOptions := resolveMountOptions(d.getRBDMountOptions(snapVol))
 
 		if renegerateFilesystemUUIDNeeded(RBDFilesystem) {
@@ -1453,7 +1453,7 @@ func (d *ceph) RestoreVolume(vol Volume, snapshotName string, op *operations.Ope
 	defer d.rbdUnmapVolume(snapVol, true)
 
 	// Re-generate the UUID.
-	err = d.generateUUID(d.getRBDFilesystem(snapVol), RBDDevPath)
+	err = d.generateUUID(snapVol.ConfigBlockFilesystem(), RBDDevPath)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -929,7 +929,7 @@ func (d *ceph) MountVolume(vol Volume, op *operations.Operation) (bool, error) {
 		}
 
 		RBDFilesystem := vol.ConfigBlockFilesystem()
-		mountFlags, mountOptions := resolveMountOptions(d.getRBDMountOptions(vol))
+		mountFlags, mountOptions := resolveMountOptions(vol.ConfigBlockMountOptions())
 		err = TryMount(RBDDevPath, mountPath, RBDFilesystem, mountFlags, mountOptions)
 		if err != nil {
 			return false, err
@@ -1312,7 +1312,7 @@ func (d *ceph) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bo
 		}
 
 		RBDFilesystem := snapVol.ConfigBlockFilesystem()
-		mountFlags, mountOptions := resolveMountOptions(d.getRBDMountOptions(snapVol))
+		mountFlags, mountOptions := resolveMountOptions(snapVol.ConfigBlockMountOptions())
 
 		if renegerateFilesystemUUIDNeeded(RBDFilesystem) {
 			if RBDFilesystem == "xfs" {

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -49,20 +49,6 @@ func (d *lvm) thinpoolName() string {
 	return "LXDThinPool"
 }
 
-// mountOptions returns the mount options for volumes.
-func (d *lvm) volumeMountOptions(vol Volume) string {
-	if d.config["block.mount_options"] != "" {
-		return d.config["block.mount_options"]
-	}
-
-	// Use some special options if the filesystem for the volume is BTRFS.
-	if vol.ConfigBlockFilesystem() == "btrfs" {
-		return "user_subvol_rm_allowed,discard"
-	}
-
-	return "discard"
-}
-
 // openLoopFile opens a loopback file and disable auto detach.
 func (d *lvm) openLoopFile(source string) (*os.File, error) {
 	if source == "" {

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -454,7 +454,7 @@ func (d *lvm) MountVolume(vol Volume, op *operations.Operation) (bool, error) {
 			return false, err
 		}
 
-		mountFlags, mountOptions := resolveMountOptions(d.volumeMountOptions(vol))
+		mountFlags, mountOptions := resolveMountOptions(vol.ConfigBlockMountOptions())
 		err = TryMount(volDevPath, mountPath, vol.ConfigBlockFilesystem(), mountFlags, mountOptions)
 		if err != nil {
 			return false, errors.Wrapf(err, "Failed to mount LVM logical volume")
@@ -722,7 +722,7 @@ func (d *lvm) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) (boo
 		// Default to mounting the original snapshot directly. This may be changed below if a temporary
 		// snapshot needs to be taken.
 		mountVol := snapVol
-		mountFlags, mountOptions := resolveMountOptions(d.volumeMountOptions(mountVol))
+		mountFlags, mountOptions := resolveMountOptions(mountVol.ConfigBlockMountOptions())
 
 		// Regenerate filesystem UUID if needed. This is because some filesystems do not allow mounting
 		// multiple volumes that share the same UUID. As snapshotting a volume will copy its UUID we need

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -25,6 +25,9 @@ const vmBlockFilesystemSize = "50MB"
 // DefaultFilesystem filesytem to use for block devices by default.
 const DefaultFilesystem = "ext4"
 
+// defaultFilesystemMountOpts mount options to use for filesystem block devices by default.
+const defaultFilesystemMountOptions = "discard"
+
 // volIDQuotaSkip is used to indicate to drivers that quotas should not be setup, used during backup import.
 const volIDQuotaSkip = int64(-1)
 
@@ -347,6 +350,22 @@ func (v Volume) ConfigBlockFilesystem() string {
 	}
 
 	return DefaultFilesystem
+}
+
+// ConfigBlockMountOptions returns the filesystem mount options to use for block volumes. Returns config value
+// "block.mount_options" if defined in volume or pool's volume config, otherwise defaultFilesystemMountOptions.
+func (v Volume) ConfigBlockMountOptions() string {
+	fs := v.ExpandedConfig("block.mount_options")
+	if fs != "" {
+		return fs
+	}
+
+	// Use some special options if the filesystem for the volume is BTRFS.
+	if v.ConfigBlockFilesystem() == "btrfs" {
+		return "user_subvol_rm_allowed,discard"
+	}
+
+	return defaultFilesystemMountOptions
 }
 
 // ConfigSize returns the size to use when creating new a volume. Returns config value "size" if defined in volume


### PR DESCRIPTION
Fixes LVM driver that wasn't reading volume's `block.mount_options` when mounting.

Addresses an issue discovered in https://discuss.linuxcontainers.org/t/volume-block-mount-options-not-working/8049