### PR TITLE
Network: Make setting bridge VLAN filtering & default PVID optional

### DIFF
--- a/lxd/network/network.go
+++ b/lxd/network/network.go
@@ -287,13 +287,13 @@ func (n *Network) setup(oldConfig map[string]string) error {
 	if n.config["bridge.driver"] != "openvswitch" {
 		err = BridgeVLANFilterSetStatus(n.name, "1")
 		if err != nil {
-			return err
+			logger.Warnf("%v", err)
 		}
 
 		// Set the default PVID for new ports to 1.
 		err = BridgeVLANSetDefaultPVID(n.name, "1")
 		if err != nil {
-			return err
+			logger.Warnf("%v", err)
 		}
 	}
 


### PR DESCRIPTION
Warn if setting failed due to host missing VLAN filtering feature.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>