### PR TITLE
lxd/vm: Centralize port generation

### DIFF
--- a/lxd/device/config/devices_sort.go
+++ b/lxd/device/config/devices_sort.go
@@ -19,6 +19,18 @@ func (devices DevicesSortable) Less(i, j int) bool {
 
 	// First sort by types.
 	if a.Config["type"] != b.Config["type"] {
+		// In VMs, network interface names are derived from PCI
+		// location. As a result of that, we must ensure that nic devices will
+		// always show up at the same spot regardless of what other devices may be
+		// added. Easiest way to do this is to always have them show up first.
+		if a.Config["type"] == "nic" {
+			return true
+		}
+
+		if b.Config["type"] == "nic" {
+			return false
+		}
+
 		return a.Config["type"] < b.Config["type"]
 	}
 

--- a/lxd/device/config/devices_test.go
+++ b/lxd/device/config/devices_test.go
@@ -14,10 +14,10 @@ func TestSortableDevices(t *testing.T) {
 	}
 
 	expectedSorted := DevicesSortable{
-		DeviceNamed{Name: "dev4", Config: Device{"type": "disk", "path": "/foo"}},
-		DeviceNamed{Name: "dev3", Config: Device{"type": "disk", "path": "/foo/bar"}},
 		DeviceNamed{Name: "dev1", Config: Device{"type": "nic"}},
 		DeviceNamed{Name: "dev2", Config: Device{"type": "nic"}},
+		DeviceNamed{Name: "dev4", Config: Device{"type": "disk", "path": "/foo"}},
+		DeviceNamed{Name: "dev3", Config: Device{"type": "disk", "path": "/foo/bar"}},
 	}
 
 	result := devices.Sorted()
@@ -26,10 +26,10 @@ func TestSortableDevices(t *testing.T) {
 	}
 
 	expectedReversed := DevicesSortable{
-		DeviceNamed{Name: "dev2", Config: Device{"type": "nic"}},
-		DeviceNamed{Name: "dev1", Config: Device{"type": "nic"}},
 		DeviceNamed{Name: "dev3", Config: Device{"type": "disk", "path": "/foo/bar"}},
 		DeviceNamed{Name: "dev4", Config: Device{"type": "disk", "path": "/foo"}},
+		DeviceNamed{Name: "dev2", Config: Device{"type": "nic"}},
+		DeviceNamed{Name: "dev1", Config: Device{"type": "nic"}},
 	}
 
 	result = devices.Reversed()

--- a/lxd/instance/drivers/qmp/monitor.go
+++ b/lxd/instance/drivers/qmp/monitor.go
@@ -77,7 +77,7 @@ func (m *Monitor) run() error {
 	go func() {
 		for {
 			// Read the ringbuffer.
-			resp, err := m.qmp.Run([]byte(fmt.Sprintf(`{"execute": "ringbuf-read", "arguments": {"device": "vserial", "size": %d, "format": "utf8"}}`, RingbufSize)))
+			resp, err := m.qmp.Run([]byte(fmt.Sprintf(`{"execute": "ringbuf-read", "arguments": {"device": "qemu_serial-chardev", "size": %d, "format": "utf8"}}`, RingbufSize)))
 			if err != nil {
 				m.Disconnect()
 				return


### PR DESCRIPTION
This adds a new helper function within the config generation logic that
automatically figures out the best PCI config to minimize the use of
bridge ports and devices by using multi-function devices when possible.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>