### PR TITLE
Cluster: Fix race in HeartbeatNode

### DIFF
--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -125,7 +125,7 @@ func (hbState *APIHeartbeat) Send(ctx context.Context, cert *shared.CertInfo, lo
 
 		err := HeartbeatNode(ctx, address, cert, heartbeatData)
 		if err == nil {
-			hbState.Lock()
+			heartbeatData.Lock()
 			// Ensure only update nodes that exist in Members already.
 			hbNode, existing := hbState.Members[nodeID]
 			if !existing {
@@ -135,8 +135,8 @@ func (hbState *APIHeartbeat) Send(ctx context.Context, cert *shared.CertInfo, lo
 			hbNode.LastHeartbeat = time.Now()
 			hbNode.Online = true
 			hbNode.updated = true
-			hbState.Members[nodeID] = hbNode
-			hbState.Unlock()
+			heartbeatData.Members[nodeID] = hbNode
+			heartbeatData.Unlock()
 			logger.Debugf("Successful heartbeat for %s", address)
 		} else {
 			logger.Debugf("Failed heartbeat for %s: %v", address, err)
@@ -365,7 +365,9 @@ func HeartbeatNode(taskCtx context.Context, address string, cert *shared.CertInf
 	}
 
 	buffer := bytes.Buffer{}
+	heartbeatData.Lock()
 	err = json.NewEncoder(&buffer).Encode(heartbeatData)
+	heartbeatData.Unlock()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Aims to fix crashed caused in https://jenkins.linuxcontainers.org/job/lxd-github-pull-test/1324/arch=amd64,backend=dir,compiler=golang-1.13/console#console-section-1

```
fatal error: concurrent map iteration and map write

goroutine 3542 [running]:
runtime.throw(0x14f00f9, 0x26)
	/lxc-ci/build/tmp.hp8MOZNie4/go/golang/src/runtime/panic.go:774 +0x72 fp=0xc000a79638 sp=0xc000a79608 pc=0x43c3f2
runtime.mapiternext(0xc001e655c0)
	/lxc-ci/build/tmp.hp8MOZNie4/go/golang/src/runtime/map.go:858 +0x579 fp=0xc000a796c0 sp=0xc000a79638 pc=0x41c349
runtime.mapiterinit(0x12e3ee0, 0xc0022a4450, 0xc001e655c0)
	/lxc-ci/build/tmp.hp8MOZNie4/go/golang/src/runtime/map.go:848 +0x1c3 fp=0xc000a796e0 sp=0xc000a796c0 pc=0x41bce3
reflect.mapiterinit(0x12e3ee0, 0xc0022a4450, 0xc0008bbdc0)
	/lxc-ci/build/tmp.hp8MOZNie4/go/golang/src/runtime/map.go:1341 +0x54 fp=0xc000a79710 sp=0xc000a796e0 pc=0x41d314
reflect.Value.MapKeys(0x12e3ee0, 0xc00056d308, 0x195, 0x0, 0x129e900, 0x0)
	/lxc-ci/build/tmp.hp8MOZNie4/go/golang/src/reflect/value.go:1202 +0xc5 fp=0xc000a797a0 sp=0xc000a79710 pc=0x4a7d95
encoding/json.mapEncoder.encode(0xc001e68a50, 0xc00018a690, 0x12e3ee0, 0xc00056d308, 0x195, 0x100)
	/lxc-ci/build/tmp.hp8MOZNie4/go/golang/src/encoding/json/encode.go:690 +0xff fp=0xc000a798e8 sp=0xc000a797a0 pc=0x73da9f
encoding/json.mapEncoder.encode-fm(0xc00018a690, 0x12e3ee0, 0xc00056d308, 0x195, 0x100)
	/lxc-ci/build/tmp.hp8MOZNie4/go/golang/src/encoding/json/encode.go:682 +0x64 fp=0xc000a79928 sp=0xc000a798e8 pc=0x749604
encoding/json.structEncoder.encode(0xc0009da900, 0x4, 0x4, 0xc001e68b40, 0xc00018a690, 0x13f21c0, 0xc00056d300, 0x199, 0x730100)
	/lxc-ci/build/tmp.hp8MOZNie4/go/golang/src/encoding/json/encode.go:664 +0x306 fp=0xc000a799c8 sp=0xc000a79928 pc=0x73d756
encoding/json.structEncoder.encode-fm(0xc00018a690, 0x13f21c0, 0xc00056d300, 0x199, 0xc000560100)
	/lxc-ci/build/tmp.hp8MOZNie4/go/golang/src/encoding/json/encode.go:635 +0x7f fp=0xc000a79a20 sp=0xc000a799c8 pc=0x74957f
encoding/json.ptrEncoder.encode(0xc001e68b70, 0xc00018a690, 0x13926e0, 0xc00056d300, 0x16, 0x1390100)
	/lxc-ci/build/tmp.hp8MOZNie4/go/golang/src/encoding/json/encode.go:810 +0xb1 fp=0xc000a79a68 sp=0xc000a79a20 pc=0x73ebf1
encoding/json.ptrEncoder.encode-fm(0xc00018a690, 0x13926e0, 0xc00056d300, 0x16, 0x100)
	/lxc-ci/build/tmp.hp8MOZNie4/go/golang/src/encoding/json/encode.go:805 +0x64 fp=0xc000a79aa8 sp=0xc000a79a68 pc=0x749784
encoding/json.(*encodeState).reflectValue(0xc00018a690, 0x13926e0, 0xc00056d300, 0x16, 0x100)
	/lxc-ci/build/tmp.hp8MOZNie4/go/golang/src/encoding/json/encode.go:337 +0x82 fp=0xc000a79ae0 sp=0xc000a79aa8 pc=0x73af92
encoding/json.(*encodeState).marshal(0xc00018a690, 0x13926e0, 0xc00056d300, 0xc000060100, 0x0, 0x0)
	/lxc-ci/build/tmp.hp8MOZNie4/go/golang/src/encoding/json/encode.go:309 +0x10b fp=0xc000a79b60 sp=0xc000a79ae0 pc=0x73aa3b
encoding/json.(*Encoder).Encode(0xc000a79db8, 0x13926e0, 0xc00056d300, 0x2, 0x2)
	/lxc-ci/build/tmp.hp8MOZNie4/go/golang/src/encoding/json/stream.go:202 +0x8a fp=0xc000a79bf0 sp=0xc000a79b60 pc=0x7472fa
github.com/lxc/lxd/lxd/cluster.HeartbeatNode(0x1746840, 0xc0000d7740, 0xc0021190b0, 0xf, 0xc00063a5b0, 0xc00056d300, 0x0, 0x0)
	/lxc-ci/build/tmp.hp8MOZNie4/go/src/github.com/lxc/lxd/lxd/cluster/heartbeat.go:368 +0x2dc fp=0xc000a79e18 sp=0xc000a79bf0 pc=0xc70dcc
github.com/lxc/lxd/lxd/cluster.(*APIHeartbeat).Send.func1(0x2, 0xc0021190b0, 0xf, 0xc0022a4400, 0xc00056d300)
	/lxc-ci/build/tmp.hp8MOZNie4/go/src/github.com/lxc/lxd/lxd/cluster/heartbeat.go:126 +0x20c fp=0xc000a79fb8 sp=0xc000a79e18 pc=0xc7f2bc
runtime.goexit()
	/lxc-ci/build/tmp.hp8MOZNie4/go/golang/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc000a79fc0 sp=0xc000a79fb8 pc=0x46c461
created by github.com/lxc/lxd/lxd/cluster.(*APIHeartbeat).Send
	/lxc-ci/build/tmp.hp8MOZNie4/go/src/github.com/lxc/lxd/lxd/cluster/heartbeat.go:161 +0x1da
```

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>