### PR TITLE
VM: Adds trans=virtio to 9p mounts

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1912,6 +1912,11 @@ func (vm *qemu) addDriveDirConfig(sb *strings.Builder, bus *qemuBus, fdFiles *[]
 		FSType: driveConf.FSType,
 	}
 
+	// If mount type is 9p, we need to specify to use the virtio transport to support more VM guest OSes.
+	if agentMount.FSType == "9p" {
+		agentMount.Options = append(agentMount.Options, "trans=virtio")
+	}
+
 	// Indicate to agent to mount this readonly. Note: This is purely to indicate to VM guest that this is
 	// readonly, it should *not* be used as a security measure, as the VM guest could remount it R/W.
 	if shared.StringInSlice("ro", driveConf.Opts) {


### PR DESCRIPTION
Otherwise CentOS 7 VM guests can't mount 9p shares.

See https://discuss.linuxcontainers.org/t/lxd-attach-volume-to-qemu-vm/7273/16

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>