### PR TITLE
VM agent: Fix 9p mount when relative target path is supplied

### DIFF
--- a/lxd-agent/main_agent.go
+++ b/lxd-agent/main_agent.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -211,10 +212,16 @@ func (c *cmdAgent) mountHostShares() {
 	}
 
 	for _, mount := range agentMounts {
+		// Convert relative mounts to absolute from / otherwise dir creation fails or mount fails.
+		if !strings.HasPrefix(mount.Target, "/") {
+			mount.Target = fmt.Sprintf("/%s", mount.Target)
+		}
+
 		if !shared.PathExists(mount.Target) {
 			err := os.MkdirAll(mount.Target, 0755)
 			if err != nil {
 				logger.Errorf("Failed to create mount target %q", mount.Target)
+				continue // Don't try to mount if mount point can't be created.
 			}
 		}
 


### PR DESCRIPTION
Convert to absolute from /.

Skip if mount point doesn't exist and can't be created.

See https://discuss.linuxcontainers.org/t/lxd-4-2-error-when-attaching-additional-disk-to-vm/8215

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>