### PR TITLE
test: Updates udhcpd args to ensure process quits one lease acquired

### DIFF
--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -325,7 +325,7 @@ test_container_devices_nic_bridged() {
   lxc launch testimage "${ctName}" -p "${ctName}"
 
   # Request DHCPv4 lease with custom name (to check managed name is allocated instead).
-  lxc exec "${ctName}" -- udhcpc -i eth0 -F "${ctName}custom"
+  lxc exec "${ctName}" -- udhcpc -i eth0 -n -q -F "${ctName}custom"
 
   # Check DHCPv4 lease is allocated.
   if ! grep -i "${ctMAC}" "${LXD_DIR}/networks/${brName}/dnsmasq.leases" ; then
@@ -346,7 +346,7 @@ test_container_devices_nic_bridged() {
   fi
 
   if [ "$busyboxUdhcpc6" = "1" ]; then
-        lxc exec "${ctName}" -- udhcpc6 -i eth0
+        lxc exec "${ctName}" -- udhcpc6 -i eth0 -n -q
   fi
 
   # Delete container, check LXD releases lease.
@@ -404,7 +404,7 @@ test_container_devices_nic_bridged() {
   # Check dnsmasq leases file removed if DHCP disabled and that device can be removed.
   lxc config device add "${ctName}" eth0 nic nictype=bridged parent="${brName}" name=eth0
   lxc start "${ctName}"
-  lxc exec "${ctName}" -- udhcpc -i eth0
+  lxc exec "${ctName}" -- udhcpc -i eth0 -n -q
   lxc network unset "${brName}" ipv4.address
   lxc network unset "${brName}" ipv6.address
 

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -172,7 +172,7 @@ test_container_devices_nic_bridged_filtering() {
 
   # Check DHCPv4 allocation still works.
   lxc exec "${ctPrefix}A" -- ip link set dev eth0 address "${ctAMAC}" up
-  lxc exec "${ctPrefix}A" -- udhcpc -i eth0 -n
+  lxc exec "${ctPrefix}A" -- udhcpc -i eth0 -n -q
   lxc exec "${ctPrefix}A" -- ip a flush dev eth0
   lxc exec "${ctPrefix}A" -- ip a add 192.0.2.2/24 dev eth0
 
@@ -348,7 +348,7 @@ test_container_devices_nic_bridged_filtering() {
   fi
 
   if [ "$busyboxUdhcpc6" = "1" ]; then
-      lxc exec "${ctPrefix}A" -- udhcpc6 -i eth0 -n
+      lxc exec "${ctPrefix}A" -- udhcpc6 -i eth0 -n -q
   fi
 
   lxc exec "${ctPrefix}A" -- ip -6 a flush dev eth0


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>