### PR TITLE
lxd: Fix snapshot index retrieval

### DIFF
--- a/lxd/db/storage_pools_test.go
+++ b/lxd/db/storage_pools_test.go
@@ -220,15 +220,23 @@ func TestCreateStoragePoolVolume_Snapshot(t *testing.T) {
 	poolID, err := cluster.CreateStoragePool("p1", "", "dir", nil)
 	require.NoError(t, err)
 
+	poolID1, err := cluster.CreateStoragePool("p2", "", "dir", nil)
+	require.NoError(t, err)
+
 	config := map[string]string{"k": "v"}
 	_, err = cluster.CreateStoragePoolVolume("default", "v1", "", 1, poolID, config)
+	require.NoError(t, err)
+
+	_, err = cluster.CreateStoragePoolVolume("default", "v1", "", 1, poolID1, config)
 	require.NoError(t, err)
 
 	config = map[string]string{"k": "v"}
 	_, err = cluster.CreateStorageVolumeSnapshot("default", "v1/snap0", "", 1, poolID, config, time.Time{})
 	require.NoError(t, err)
 
-	n := cluster.GetNextStorageVolumeSnapshotIndex("v1", 1, "snap%d")
+	n := cluster.GetNextStorageVolumeSnapshotIndex("p1", "v1", 1, "snap%d")
 	assert.Equal(t, n, 1)
 
+	n = cluster.GetNextStorageVolumeSnapshotIndex("p2", "v1", 1, "snap%d")
+	assert.Equal(t, n, 0)
 }

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -662,15 +662,17 @@ func (c *Cluster) GetStorageVolumeDescription(volumeID int64) (string, error) {
 //
 // Note, the code below doesn't deal with snapshots of snapshots.
 // To do that, we'll need to weed out based on # slashes in names
-func (c *Cluster) GetNextStorageVolumeSnapshotIndex(name string, typ int, pattern string) int {
+func (c *Cluster) GetNextStorageVolumeSnapshotIndex(pool, name string, typ int, pattern string) int {
 	q := fmt.Sprintf(`
 SELECT storage_volumes_snapshots.name FROM storage_volumes_snapshots
   JOIN storage_volumes ON storage_volumes_snapshots.storage_volume_id=storage_volumes.id
+  JOIN storage_pools ON storage_volumes.storage_pool_id=storage_pools.id
  WHERE storage_volumes.type=?
    AND storage_volumes.name=?
+   AND storage_pools.name=?
 `)
 	var numstr string
-	inargs := []interface{}{typ, name}
+	inargs := []interface{}{typ, name, pool}
 	outfmt := []interface{}{numstr}
 	results, err := queryScan(c, q, inargs, outfmt)
 	if err != nil {

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -79,7 +79,7 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 
 	// Get a snapshot name.
 	if req.Name == "" {
-		i := d.cluster.GetNextStorageVolumeSnapshotIndex(volumeName, volumeType, "snap%d")
+		i := d.cluster.GetNextStorageVolumeSnapshotIndex(poolName, volumeName, volumeType, "snap%d")
 		req.Name = fmt.Sprintf("snap%d", i)
 	}
 
@@ -766,7 +766,7 @@ func volumeDetermineNextSnapshotName(d *Daemon, volume db.StorageVolumeArgs, def
 	if count > 1 {
 		return "", fmt.Errorf("Snapshot pattern may contain '%%d' only once")
 	} else if count == 1 {
-		i := d.cluster.GetNextStorageVolumeSnapshotIndex(volume.Name, db.StoragePoolVolumeTypeCustom, pattern)
+		i := d.cluster.GetNextStorageVolumeSnapshotIndex(volume.PoolName, volume.Name, db.StoragePoolVolumeTypeCustom, pattern)
 		return strings.Replace(pattern, "%d", strconv.Itoa(i), 1), nil
 	}
 
@@ -814,7 +814,7 @@ func volumeDetermineNextSnapshotName(d *Daemon, volume db.StorageVolumeArgs, def
 	}
 
 	if snapshotExists {
-		i := d.cluster.GetNextStorageVolumeSnapshotIndex(volume.Name, db.StoragePoolVolumeTypeCustom, pattern)
+		i := d.cluster.GetNextStorageVolumeSnapshotIndex(volume.PoolName, volume.Name, db.StoragePoolVolumeTypeCustom, pattern)
 		return strings.Replace(pattern, "%d", strconv.Itoa(i), 1), nil
 	}
 


### PR DESCRIPTION
This changes the snapshot index retrieval to consider the storage pool
as well. Previously, the behaviour would have been:

```
lxc storage create dir1 dir
lxc storage create dir2 dir
lxc storage volume create dir1 vol
lxc storage volume create dir2 vol
lxc storage volume snapshot dir1 vol # creates vol/snap0
lxc storage volume snapshot dir2 vol # creates vol/snap1
```

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
