### PR TITLE
lxd/cluster: If raft node 1 gets remove during recovery, add it back

### DIFF
--- a/lxd/cluster/upgrade.go
+++ b/lxd/cluster/upgrade.go
@@ -142,7 +142,7 @@ func upgradeMembersWithoutRole(gateway *Gateway, members []db.NodeInfo, nodes []
 	for _, member := range members {
 		found := false
 		for _, node := range nodes {
-			if member.ID == 1 || member.Address == node.Address {
+			if member.ID == 1 && node.ID == 1 || member.Address == node.Address {
 				found = true
 				break
 			}


### PR DESCRIPTION
When running lxd cluster recover-from-quorum-loss, if your raft node 1 is still
around it wasn't added back to the raft configuration after recovery.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>