### PR TITLE
lxd/storage/drivers: Bump VM fs size to 100MB

### DIFF
--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -20,7 +20,7 @@ const tmpVolSuffix = ".lxdtmp"
 const defaultBlockSize = "10GB"
 
 // vmBlockFilesystemSize is the size of a VM block volume's associated filesystem volume.
-const vmBlockFilesystemSize = "50MB"
+const vmBlockFilesystemSize = "100MB"
 
 // DefaultFilesystem filesytem to use for block devices by default.
 const DefaultFilesystem = "ext4"


### PR DESCRIPTION
The UEFI nvram on aarch64 is 64MB so wasn't fitting in our previous
value when stored on a block based storage driver.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>