### PR TITLE
lxc/action: Show usage on missing target

### DIFF
--- a/lxc/action.go
+++ b/lxc/action.go
@@ -255,6 +255,11 @@ func (c *cmdAction) Run(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		names = args
+
+		if len(args) == 0 {
+			cmd.Usage()
+			return nil
+		}
 	}
 
 	if c.flagConsole {


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>