### PR TITLE
Plug go-dqlite roles logic into LXD

### DIFF
--- a/lxd/.dir-locals.el
+++ b/lxd/.dir-locals.el
@@ -1,7 +1,7 @@
 ;;; Directory Local Variables
 ;;; For more information see (info "(emacs) Directory Variables")
 ((go-mode
-  . ((go-test-args . "-tags libsqlite3 -timeout 90s")
+  . ((go-test-args . "-tags libsqlite3 -timeout 120s")
      (eval
       . (set
 	 (make-local-variable 'flycheck-go-build-tags)

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -168,8 +168,8 @@ func SetupTrust(cert, targetAddress, targetCert, targetPassword string) error {
 	return nil
 }
 
-// Probe network connectivity to the member with the given address.
-func hasConnectivity(cert *shared.CertInfo, address string) bool {
+// HasConnectivity probes the member with the given address for connectivity.
+func HasConnectivity(cert *shared.CertInfo, address string) bool {
 	config, err := tlsClientConfig(cert)
 	if err != nil {
 		return false

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -481,7 +481,7 @@ func (g *Gateway) TransferLeadership() error {
 		if err != nil {
 			return err
 		}
-		if !hasConnectivity(g.cert, address) {
+		if !HasConnectivity(g.cert, address) {
 			continue
 		}
 		id = server.ID
@@ -496,6 +496,24 @@ func (g *Gateway) TransferLeadership() error {
 	defer cancel()
 
 	return client.Transfer(ctx, id)
+}
+
+// DemoteOfflineNode force demoting an offline node.
+func (g *Gateway) DemoteOfflineNode(raftID uint64) error {
+	cli, err := g.getClient()
+	if err != nil {
+		return errors.Wrap(err, "Connect to local dqlite node")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = cli.Assign(ctx, raftID, db.RaftSpare)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Shutdown this gateway, stopping the gRPC server and possibly the raft factory.

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -657,6 +657,13 @@ assign:
 		}
 	}
 
+	// Give the Assign operation a bit more budget in case we're promoting
+	// to voter, since that might require a snapshot transfer.
+	if info.Role == db.RaftVoter {
+		ctx, cancel = context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+	}
+
 	err = client.Assign(ctx, info.ID, info.Role)
 	if err != nil {
 		return errors.Wrap(err, "Failed to assign role")

--- a/lxd/cluster/notify.go
+++ b/lxd/cluster/notify.go
@@ -73,7 +73,7 @@ func NewNotifier(state *state.State, cert *shared.CertInfo, policy NotifierPolic
 			// enough, let's try to connect to the node, just in
 			// case the heartbeat is lagging behind for some reason
 			// and the node is actually up.
-			if !hasConnectivity(cert, node.Address) {
+			if !HasConnectivity(cert, node.Address) {
 				switch policy {
 				case NotifyAll:
 					return nil, fmt.Errorf("peer node %s is down", node.Address)


### PR DESCRIPTION
This effectively replaces some of LXD's built-in logic around dqlite roles management with equivalent logic now available downstream in the go-dqlite/app package.

There's no change in behavior, except that the switch also brings in a bug fix, since LXD was previously demoting offline voters to spare, even if no replacement was available (i.e. another spare or stand-by node to be promoted to voter). In that situation it's better to not take away the role from the offline voter node (as otherwise we would be left with a cluster of 2 voters), hoping that the offline voter will come back or a spare/stand-by will become available to replace it.