### PR TITLE
terminals: update terminology again

### DIFF
--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -959,7 +959,7 @@ Input (run bash):
     "environment": {},              // Optional extra environment variables to set
     "wait-for-websocket": false,    // Whether to wait for a connection before starting the process
     "record-output": false,         // Whether to store stdout and stderr (only valid with wait-for-websocket=false) (requires API extension container_exec_recording)
-    "interactive": true,            // Whether to allocate a pts device instead of PIPEs
+    "interactive": true,            // Whether to allocate a pty device instead of PIPEs
     "width": 80,                    // Initial width of the terminal (optional)
     "height": 25,                   // Initial height of the terminal (optional)
     "user": 1000,                   // User to run the command as (optional)
@@ -977,7 +977,7 @@ stderr. That's unless record-output is set to true, in which case,
 stdout and stderr will be redirected to a log file.
 
 If interactive is set to true, a single websocket is returned and is mapped to a
-pts device for stdin, stdout and stderr of the execed process.
+pty device for stdin, stdout and stderr of the execed process.
 
 If interactive is set to false (default), three pipes will be setup, one
 for each of stdin, stdout and stderr.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5556,7 +5556,7 @@ func (c *lxc) Console() (*os.File, chan error, error) {
 		rootUID, rootGID = idmapset.ShiftIntoNs(0, 0)
 	}
 
-	ptmx, pts, err := shared.OpenPty(rootUID, rootGID)
+	ptx, pty, err := shared.OpenPty(rootUID, rootGID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -5564,9 +5564,9 @@ func (c *lxc) Console() (*os.File, chan error, error) {
 	cmd := exec.Cmd{}
 	cmd.Path = c.state.OS.ExecPath
 	cmd.Args = args
-	cmd.Stdin = pts
-	cmd.Stdout = pts
-	cmd.Stderr = pts
+	cmd.Stdin = pty
+	cmd.Stdout = pty
+	cmd.Stderr = pty
 
 	err = cmd.Start()
 	if err != nil {
@@ -5575,8 +5575,8 @@ func (c *lxc) Console() (*os.File, chan error, error) {
 
 	go func() {
 		err = cmd.Wait()
-		ptmx.Close()
-		pts.Close()
+		ptx.Close()
+		pty.Close()
 	}()
 
 	go func() {
@@ -5584,7 +5584,7 @@ func (c *lxc) Console() (*os.File, chan error, error) {
 		cmd.Process.Kill()
 	}()
 
-	return ptmx, chDisconnect, nil
+	return ptx, chDisconnect, nil
 }
 
 // ConsoleLog returns console log.

--- a/lxd/instance/drivers/qmp/monitor.go
+++ b/lxd/instance/drivers/qmp/monitor.go
@@ -227,14 +227,14 @@ func (m *Monitor) Console(target string) (*os.File, error) {
 	// Look for the requested console.
 	for _, v := range respDecoded.Return {
 		if v.Label == target {
-			ptsPath := strings.TrimPrefix(v.Filename, "pty:")
+			ptyPath := strings.TrimPrefix(v.Filename, "pty:")
 
-			if !shared.PathExists(ptsPath) {
+			if !shared.PathExists(ptyPath) {
 				continue
 			}
 
 			// Open the PTS device
-			console, err := os.OpenFile(ptsPath, os.O_RDWR, 0600)
+			console, err := os.OpenFile(ptyPath, os.O_RDWR, 0600)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
The ptmx and pts abbreviations contain their problematic terminology.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>