### PR TITLE
lxd/rsync: Untangle from daemon package

### DIFF
--- a/lxd/main.go
+++ b/lxd/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lxc/lxd/lxd/events"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/response"
+	"github.com/lxc/lxd/lxd/rsync"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/logging"
 	"github.com/lxc/lxd/shared/version"
@@ -48,6 +49,7 @@ func (c *cmdGlobal) Run(cmd *cobra.Command, args []string) error {
 
 	// Set logging global variables
 	daemon.Debug = c.flagLogDebug
+	rsync.Debug = c.flagLogDebug
 	daemon.Verbose = c.flagLogVerbose
 
 	// Set debug for the operations package

--- a/lxd/rsync/rsync.go
+++ b/lxd/rsync/rsync.go
@@ -12,12 +12,14 @@ import (
 
 	"github.com/pborman/uuid"
 
-	"github.com/lxc/lxd/lxd/daemon"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/ioprogress"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/version"
 )
+
+// Debug controls additional debugging in rsync output.
+var Debug bool
 
 // LocalCopy copies a directory using rsync (with the --devices option).
 func LocalCopy(source string, dest string, bwlimit string, xattrs bool, rsyncArgs ...string) (string, error) {
@@ -27,7 +29,7 @@ func LocalCopy(source string, dest string, bwlimit string, xattrs bool, rsyncArg
 	}
 
 	rsyncVerbosity := "-q"
-	if daemon.Debug {
+	if Debug {
 		rsyncVerbosity = "-vi"
 	}
 


### PR DESCRIPTION
As we consume lxd/rsync from lxc-to-lxd and lxd-p2c, trying to keep
dependency chain small.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>