### PR TITLE
lxd/qemu: Don't use file.locking with rbd

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2038,7 +2038,7 @@ func (vm *qemu) addDriveConfig(sb *strings.Builder, bootIndexes map[string]int, 
 		"bootIndex": bootIndexes[driveConf.DevName],
 		"cacheMode": cacheMode,
 		"aioMode":   aioMode,
-		"shared":    driveConf.TargetPath != "/",
+		"shared":    driveConf.TargetPath != "/" && !strings.HasPrefix(driveConf.DevPath, "rbd:"),
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>