### PR TITLE
Decode error

### DIFF
--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -143,7 +143,7 @@ func SetupTrust(cert, targetAddress, targetCert, targetPassword string) error {
 
 	block, _ := pem.Decode([]byte(cert))
 	if block == nil {
-		return errors.Wrap(err, "failed to decode certificate")
+		return fmt.Errorf("failed to decode certificate")
 	}
 
 	certificate := base64.StdEncoding.EncodeToString(block.Bytes)


### PR DESCRIPTION
When attempting invoke setup trust, if the passed in cert fails to
decode there isn't any error to return and will just return nil.

Considering this will always be nil, then the error message will never
be displayed. Change to always return the error and will work as
expected.

Signed-off-by: Simon Richardson simon.richardson@canonical.com