### PR TITLE
doc/api-extensions: Fix over-escaping

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1102,8 +1102,8 @@ which can be used to set the failure domain of a node.
 ## container\_syscall\_filtering\_allow\_deny\_syntax
 A number of new syscalls related container configuration keys were updated.
 
- * `security.syscalls.deny\_default`
- * `security.syscalls.deny\_compat`
+ * `security.syscalls.deny_default`
+ * `security.syscalls.deny_compat`
  * `security.syscalls.deny`
  * `security.syscalls.allow`
 


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>