### PR TITLE
Network: Bridge updates to use common driver functionality

### DIFF
--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -240,8 +240,10 @@ func (n *bridge) isRunning() bool {
 }
 
 // Delete deletes a network.
-func (n *bridge) Delete(withDatabase bool) error {
-	// Bring the network down
+func (n *bridge) Delete(clusterNotification bool) error {
+	n.logger.Debug("Delete", log.Ctx{"clusterNotification": clusterNotification})
+
+	// Bring the network down.
 	if n.isRunning() {
 		err := n.Stop()
 		if err != nil {
@@ -249,19 +251,7 @@ func (n *bridge) Delete(withDatabase bool) error {
 		}
 	}
 
-	// If withDatabase is false, this is a cluster notification, and we
-	// don't want to perform any database work.
-	if !withDatabase {
-		return nil
-	}
-
-	// Remove the network from the database
-	err := n.state.Cluster.DeleteNetwork(n.name)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return n.common.delete(clusterNotification)
 }
 
 // Rename renames a network.

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1283,6 +1283,14 @@ func (n *bridge) Stop() error {
 func (n *bridge) Update(newNetwork api.NetworkPut, clusterNotification bool) error {
 	n.logger.Debug("Update", log.Ctx{"clusterNotification": clusterNotification})
 
+	// When switching to a fan bridge, auto-detect the underlay if not specified.
+	if newNetwork.Config["bridge.mode"] == "fan" {
+		if newNetwork.Config["fan.underlay_subnet"] == "" {
+			newNetwork.Config["fan.underlay_subnet"] = "auto"
+		}
+	}
+
+	// Populate auto fields.
 	err := fillAuto(newNetwork.Config)
 	if err != nil {
 		return err

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1281,6 +1281,8 @@ func (n *bridge) Stop() error {
 // Update updates the network. Accepts notification boolean indicating if this update request is coming from a
 // cluster notification, in which case do not update the database, just apply local changes needed.
 func (n *bridge) Update(newNetwork api.NetworkPut, clusterNotification bool) error {
+	n.logger.Debug("Update", log.Ctx{"clusterNotification": clusterNotification})
+
 	err := fillAuto(newNetwork.Config)
 	if err != nil {
 		return err

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -15,11 +15,11 @@ import (
 
 	"github.com/pkg/errors"
 
-	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/daemon"
 	"github.com/lxc/lxd/lxd/dnsmasq"
 	"github.com/lxc/lxd/lxd/node"
+	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -1288,142 +1288,81 @@ func (n *bridge) Stop() error {
 	return nil
 }
 
-// Update updates the network.
-func (n *bridge) Update(newNetwork api.NetworkPut, notify bool) error {
+// Update updates the network. Accepts notification boolean indicating if this update request is coming from a
+// cluster notification, in which case do not update the database, just apply local changes needed.
+func (n *bridge) Update(newNetwork api.NetworkPut, clusterNotification bool) error {
 	err := fillAuto(newNetwork.Config)
 	if err != nil {
 		return err
 	}
-	newConfig := newNetwork.Config
 
-	// Backup the current state
-	oldConfig := map[string]string{}
-	oldDescription := n.description
-	err = shared.DeepCopy(&n.config, &oldConfig)
+	dbUpdateNeeeded, changedKeys, oldNetwork, err := n.common.configChanged(newNetwork)
 	if err != nil {
 		return err
 	}
 
-	// Define a function which reverts everything.  Defer this function
-	// so that it doesn't need to be explicitly called in every failing
-	// return path.  Track whether or not we want to undo the changes
-	// using a closure.
-	undoChanges := true
-	defer func() {
-		if undoChanges {
-			// Revert changes to the struct
-			n.config = oldConfig
-			n.description = oldDescription
+	if !dbUpdateNeeeded {
+		return nil // Nothing changed.
+	}
 
-			// Update the database
-			n.state.Cluster.UpdateNetwork(n.name, n.description, n.config)
+	revert := revert.New()
+	defer revert.Fail()
 
-			// Reset any change that was made to the bridge
-			n.setup(newConfig)
-		}
-	}()
+	// Define a function which reverts everything.
+	revert.Add(func() {
+		// Reset changes to all nodes and database.
+		n.common.update(oldNetwork, clusterNotification)
 
-	// Diff the configurations
-	changedConfig := []string{}
-	userOnly := true
-	for key := range oldConfig {
-		if oldConfig[key] != newConfig[key] {
-			if !strings.HasPrefix(key, "user.") {
-				userOnly = false
-			}
+		// Reset any change that was made to local bridge.
+		n.setup(newNetwork.Config)
+	})
 
-			if !shared.StringInSlice(key, changedConfig) {
-				changedConfig = append(changedConfig, key)
-			}
+	// Bring the bridge down entirely if the driver has changed.
+	if shared.StringInSlice("bridge.driver", changedKeys) && n.isRunning() {
+		err = n.Stop()
+		if err != nil {
+			return err
 		}
 	}
 
-	for key := range newConfig {
-		if oldConfig[key] != newConfig[key] {
-			if !strings.HasPrefix(key, "user.") {
-				userOnly = false
-			}
-
-			if !shared.StringInSlice(key, changedConfig) {
-				changedConfig = append(changedConfig, key)
-			}
-		}
-	}
-
-	// Skip on no change
-	if len(changedConfig) == 0 && newNetwork.Description == n.description {
-		return nil
-	}
-
-	// Update the network
-	if !userOnly {
-		if shared.StringInSlice("bridge.driver", changedConfig) && n.isRunning() {
-			err = n.Stop()
-			if err != nil {
-				return err
-			}
+	// Detach any external interfaces should no longer be attached.
+	if shared.StringInSlice("bridge.external_interfaces", changedKeys) && n.isRunning() {
+		devices := []string{}
+		for _, dev := range strings.Split(newNetwork.Config["bridge.external_interfaces"], ",") {
+			dev = strings.TrimSpace(dev)
+			devices = append(devices, dev)
 		}
 
-		if shared.StringInSlice("bridge.external_interfaces", changedConfig) && n.isRunning() {
-			devices := []string{}
-			for _, dev := range strings.Split(newConfig["bridge.external_interfaces"], ",") {
-				dev = strings.TrimSpace(dev)
-				devices = append(devices, dev)
+		for _, dev := range strings.Split(oldNetwork.Config["bridge.external_interfaces"], ",") {
+			dev = strings.TrimSpace(dev)
+			if dev == "" {
+				continue
 			}
 
-			for _, dev := range strings.Split(oldConfig["bridge.external_interfaces"], ",") {
-				dev = strings.TrimSpace(dev)
-				if dev == "" {
-					continue
-				}
-
-				if !shared.StringInSlice(dev, devices) && shared.PathExists(fmt.Sprintf("/sys/class/net/%s", dev)) {
-					err = DetachInterface(n.name, dev)
-					if err != nil {
-						return err
-					}
+			if !shared.StringInSlice(dev, devices) && shared.PathExists(fmt.Sprintf("/sys/class/net/%s", dev)) {
+				err = DetachInterface(n.name, dev)
+				if err != nil {
+					return err
 				}
 			}
 		}
 	}
 
-	// Apply changes
-	n.config = newConfig
-	n.description = newNetwork.Description
+	// Apply changes to database.
+	err = n.common.update(newNetwork, clusterNotification)
+	if err != nil {
+		return err
+	}
 
-	// Update the database
-	if !notify {
-		// Notify all other nodes to update the network.
-		notifier, err := cluster.NewNotifier(n.state, n.state.Endpoints.NetworkCert(), cluster.NotifyAll)
-		if err != nil {
-			return err
-		}
-
-		err = notifier(func(client lxd.InstanceServer) error {
-			return client.UpdateNetwork(n.name, newNetwork, "")
-		})
-		if err != nil {
-			return err
-		}
-
-		// Update the database.
-		err = n.state.Cluster.UpdateNetwork(n.name, n.description, n.config)
+	// Restart the network if needed.
+	if len(changedKeys) > 0 {
+		err = n.setup(oldNetwork.Config)
 		if err != nil {
 			return err
 		}
 	}
 
-	// Restart the network
-	if !userOnly {
-		err = n.setup(oldConfig)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Success, update the closure to mark that the changes should be kept.
-	undoChanges = false
-
+	revert.Success()
 	return nil
 }
 

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -263,3 +263,17 @@ func (n *common) configChanged(newNetwork api.NetworkPut) (bool, []string, api.N
 
 	return dbUpdateNeeded, changedKeys, oldNetwork, nil
 }
+
+// delete the network from the database if clusterNotification is false.
+func (n *common) delete(clusterNotification bool) error {
+	// Only delete database record if not cluster notification.
+	if !clusterNotification {
+		// Remove the network from the database.
+		err := n.state.Cluster.DeleteNetwork(n.name)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -46,8 +46,8 @@ func (n *common) init(state *state.State, id int64, name string, netType string,
 	n.description = description
 }
 
-// commonRules returns a map of config rules common to all drivers.
-func (n *common) commonRules() map[string]func(string) error {
+// validationRules returns a map of config rules common to all drivers.
+func (n *common) validationRules() map[string]func(string) error {
 	return map[string]func(string) error{}
 }
 
@@ -56,7 +56,7 @@ func (n *common) validate(config map[string]string, driverRules map[string]func(
 	checkedFields := map[string]struct{}{}
 
 	// Get rules common for all drivers.
-	rules := n.commonRules()
+	rules := n.validationRules()
 
 	// Merge driver specific rules into common rules.
 	for field, validator := range driverRules {

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -13,6 +13,9 @@ import (
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	log "github.com/lxc/lxd/shared/log15"
+	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/logging"
 )
 
 // DHCPRange represents a range of IPs from start to end.
@@ -23,19 +26,18 @@ type DHCPRange struct {
 
 // common represents a generic LXD network.
 type common struct {
-	// Properties
+	logger      logger.Logger
 	state       *state.State
 	id          int64
 	name        string
 	netType     string
 	description string
-
-	// config
-	config map[string]string
+	config      map[string]string
 }
 
 // init initialise internal variables.
 func (n *common) init(state *state.State, id int64, name string, netType string, description string, config map[string]string) {
+	n.logger = logging.AddContext(logger.Log, log.Ctx{"driver": netType, "network": name})
 	n.id = id
 	n.name = name
 	n.netType = netType

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -26,7 +26,7 @@ type Network interface {
 	Start() error
 	Stop() error
 	Rename(name string) error
-	Update(newNetwork api.NetworkPut, notify bool) error
+	Update(newNetwork api.NetworkPut, clusterNotification bool) error
 	HandleHeartbeat(heartbeatData *cluster.APIHeartbeat) error
 	Delete(withDatabase bool) error
 }

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -28,5 +28,5 @@ type Network interface {
 	Rename(name string) error
 	Update(newNetwork api.NetworkPut, clusterNotification bool) error
 	HandleHeartbeat(heartbeatData *cluster.APIHeartbeat) error
-	Delete(withDatabase bool) error
+	Delete(clusterNotification bool) error
 }

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -676,7 +676,7 @@ func networkPatch(d *Daemon, r *http.Request) response.Response {
 	return doNetworkUpdate(d, name, dbInfo.Config, req, isClusterNotification(r))
 }
 
-func doNetworkUpdate(d *Daemon, name string, oldConfig map[string]string, req api.NetworkPut, notify bool) response.Response {
+func doNetworkUpdate(d *Daemon, name string, oldConfig map[string]string, req api.NetworkPut, clusterNotification bool) response.Response {
 	// Load the network
 	n, err := network.LoadByName(d.State(), name)
 	if err != nil {
@@ -696,7 +696,7 @@ func doNetworkUpdate(d *Daemon, name string, oldConfig map[string]string, req ap
 		}
 	}
 
-	err = n.Update(req, notify)
+	err = n.Update(req, clusterNotification)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -573,7 +573,7 @@ func networkPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if shared.StringInSlice(req.Name, networks) {
-		return response.Conflict(fmt.Errorf("Network '%s' already exists", req.Name))
+		return response.Conflict(fmt.Errorf("Network %q already exists", req.Name))
 	}
 
 	// Rename it

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -688,13 +688,6 @@ func doNetworkUpdate(d *Daemon, name string, oldConfig map[string]string, req ap
 		return response.BadRequest(err)
 	}
 
-	// When switching to a fan bridge, auto-detect the underlay
-	if req.Config["bridge.mode"] == "fan" {
-		if req.Config["fan.underlay_subnet"] == "" {
-			req.Config["fan.underlay_subnet"] = "auto"
-		}
-	}
-
 	err = n.Update(req, clusterNotification)
 	if err != nil {
 		return response.SmartError(err)

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -214,7 +214,7 @@ func networksPostCluster(d *Daemon, req api.NetworksPost) error {
 	// Check that no node-specific config key has been defined.
 	for key := range req.Config {
 		if shared.StringInSlice(key, db.NodeSpecificNetworkConfig) {
-			return fmt.Errorf("Config key '%s' is node-specific", key)
+			return fmt.Errorf("Config key %q is node-specific", key)
 		}
 	}
 

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -133,9 +133,8 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	resp := response.SyncResponseLocation(true, nil, url)
 
 	if isClusterNotification(r) {
-		// This is an internal request which triggers the actual
-		// creation of the network across all nodes, after they have
-		// been previously defined.
+		// This is an internal request which triggers the actual creation of the network across all nodes
+		// after they have been previously defined.
 		err = doNetworksCreate(d, req, true)
 		if err != nil {
 			return response.SmartError(err)
@@ -165,7 +164,7 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	// Check if we're clustered
+	// Check if we're clustered.
 	count, err := cluster.Count(d.State())
 	if err != nil {
 		return response.SmartError(err)
@@ -180,14 +179,13 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
+	// No targetNode was specified and we're either a single-node cluster or not clustered at all,
+	// so create the network immediately.
 	err = network.FillConfig(&req)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	// No targetNode was specified and we're either a single-node
-	// cluster or not clustered at all, so create the storage
-	// pool immediately.
 	networks, err := networkGetInterfaces(d.cluster)
 	if err != nil {
 		return response.InternalError(err)
@@ -197,13 +195,14 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("The network already exists"))
 	}
 
-	// Create the database entry
+	// Create the database entry.
 	_, err = d.cluster.CreateNetwork(req.Name, req.Description, dbNetType, req.Config)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Error inserting %s into database: %s", req.Name, err))
 	}
 
-	err = doNetworksCreate(d, req, true)
+	// Create network and pass false to clusterNotification so the database record is removed on error.
+	err = doNetworksCreate(d, req, false)
 	if err != nil {
 		return response.SmartError(err)
 	}


### PR DESCRIPTION
- Moving common functionality out of bridge driver and into common driver.
- Adds contextual logging support.
- Unifies and clarifies naming of `notify` and `withDatabase` arguments.

Testing:

- Single node create, update, rename, delete.
- Cluster create (with --target first on each node), update and delete (checking for `clusterNotification` contextual logging).