### PR TITLE
Network: Pushes FillConfig logic down into network driver

### DIFF
--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -86,8 +86,8 @@ func (n *bridge) Validate(config map[string]string) error {
 
 			for _, entry := range strings.Split(value, ",") {
 				entry = strings.TrimSpace(entry)
-				if ValidNetworkName(entry) != nil {
-					return fmt.Errorf("Invalid interface name '%s'", entry)
+				if err := ValidNetworkName(entry); err != nil {
+					return errors.Wrapf(err, "Invalid interface name %q", entry)
 				}
 			}
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -41,6 +41,37 @@ type bridge struct {
 	common
 }
 
+// fillConfig fills requested config with any default values.
+func (n *bridge) fillConfig(req *api.NetworksPost) error {
+	// Set some default values where needed.
+	if req.Config["bridge.mode"] == "fan" {
+		if req.Config["fan.underlay_subnet"] == "" {
+			req.Config["fan.underlay_subnet"] = "auto"
+		}
+	} else {
+		if req.Config["ipv4.address"] == "" {
+			req.Config["ipv4.address"] = "auto"
+		}
+
+		if req.Config["ipv4.address"] == "auto" && req.Config["ipv4.nat"] == "" {
+			req.Config["ipv4.nat"] = "true"
+		}
+
+		if req.Config["ipv6.address"] == "" {
+			content, err := ioutil.ReadFile("/proc/sys/net/ipv6/conf/default/disable_ipv6")
+			if err == nil && string(content) == "0\n" {
+				req.Config["ipv6.address"] = "auto"
+			}
+		}
+
+		if req.Config["ipv6.address"] == "auto" && req.Config["ipv6.nat"] == "" {
+			req.Config["ipv6.nat"] = "true"
+		}
+	}
+
+	return nil
+}
+
 // Validate network config.
 func (n *bridge) Validate(config map[string]string) error {
 	// Build driver specific rules dynamically.

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -310,3 +310,8 @@ func (n *common) delete(clusterNotification bool) error {
 
 	return nil
 }
+
+// HandleHeartbeat is a no-op.
+func (n *common) HandleHeartbeat(heartbeatData *cluster.APIHeartbeat) error {
+	return nil
+}

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -47,6 +47,11 @@ func (n *common) init(state *state.State, id int64, name string, netType string,
 	n.description = description
 }
 
+// fillConfig fills requested config with any default values, by default this is a no-op.
+func (n *common) fillConfig(req *api.NetworksPost) error {
+	return nil
+}
+
 // validationRules returns a map of config rules common to all drivers.
 func (n *common) validationRules() map[string]func(string) error {
 	return map[string]func(string) error{}

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -10,6 +10,7 @@ import (
 type Network interface {
 	// Load.
 	init(state *state.State, id int64, name string, netType string, description string, config map[string]string)
+	fillConfig(*api.NetworksPost) error
 
 	// Config.
 	Validate(config map[string]string) error

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -459,40 +459,6 @@ func ForkdnsServersList(networkName string) ([]string, error) {
 	return servers, nil
 }
 
-// FillConfig populates the supplied api.NetworkPost with automatically populated values.
-func FillConfig(req *api.NetworksPost) error {
-	// Set some default values where needed
-	if req.Config["bridge.mode"] == "fan" {
-		if req.Config["fan.underlay_subnet"] == "" {
-			req.Config["fan.underlay_subnet"] = "auto"
-		}
-	} else {
-		if req.Config["ipv4.address"] == "" {
-			req.Config["ipv4.address"] = "auto"
-		}
-		if req.Config["ipv4.address"] == "auto" && req.Config["ipv4.nat"] == "" {
-			req.Config["ipv4.nat"] = "true"
-		}
-
-		if req.Config["ipv6.address"] == "" {
-			content, err := ioutil.ReadFile("/proc/sys/net/ipv6/conf/default/disable_ipv6")
-			if err == nil && string(content) == "0\n" {
-				req.Config["ipv6.address"] = "auto"
-			}
-		}
-		if req.Config["ipv6.address"] == "auto" && req.Config["ipv6.nat"] == "" {
-			req.Config["ipv6.nat"] = "true"
-		}
-	}
-
-	// Replace "auto" by actual values
-	err := fillAuto(req.Config)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 func fillAuto(config map[string]string) error {
 	if config["ipv4.address"] == "auto" {
 		subnet, err := randomSubnetV4()

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -391,13 +391,12 @@ func doNetworkGet(d *Daemon, name string) (api.Network, error) {
 	// Set the device type as needed
 	if osInfo != nil && shared.IsLoopback(osInfo) {
 		n.Type = "loopback"
-	} else if dbInfo != nil || shared.PathExists(fmt.Sprintf("/sys/class/net/%s/bridge", n.Name)) {
-		if dbInfo != nil {
-			n.Managed = true
-			n.Description = dbInfo.Description
-			n.Config = dbInfo.Config
-		}
-
+	} else if dbInfo != nil {
+		n.Managed = true
+		n.Description = dbInfo.Description
+		n.Config = dbInfo.Config
+		n.Type = dbInfo.Type
+	} else if shared.PathExists(fmt.Sprintf("/sys/class/net/%s/bridge", n.Name)) {
 		n.Type = "bridge"
 	} else if shared.PathExists(fmt.Sprintf("/proc/net/vlan/%s", n.Name)) {
 		n.Type = "vlan"


### PR DESCRIPTION
- Pushes FillConfig logic down into network driver.
- Adds support for different network types to `doNetworkGet`.
- Adds no-op `HandleHeartbeat` to common driver to avoid needing drivers to implement if not needed.
- Exposes actual error message from `ValidNetworkName` when validating driver config.