### PR TITLE
Network: Adds network property support to macvlan NIC driver

### DIFF
--- a/doc/clustering.md
+++ b/doc/clustering.md
@@ -401,24 +401,22 @@ lxc storage volume show default web --target node2
 
 ## Networks
 
-As mentioned above, all nodes must have identical networks defined. The only
-difference between networks on different nodes might be their
-`bridge.external_interfaces` optional configuration key (see also documentation
-about [network configuration](networks.md)).
+As mentioned above, all nodes must have identical networks defined.
 
-To create a new network, you first have to define it across all
-nodes, for example:
+The only difference between networks on different nodes might be their optional configuration keys.
+When defining a new network on a specific clustered node the only valid optional configuration keys you can pass
+are `bridge.external_interfaces` and `parent`, as these can be different on each node (see documentation about
+[network configuration](networks.md) for a definition of each).
+
+To create a new network, you first have to define it across all nodes, for example:
 
 ```bash
 lxc network create --target node1 my-network
 lxc network create --target node2 my-network
 ```
 
-Note that when defining a new network on a node the only valid configuration
-key you can pass is `bridge.external_interfaces`, as mentioned above.
-
-At this point the network hasn't been actually created yet, but just
-defined (it's state is marked as Pending if you run `lxc network list`).
+At this point the network hasn't been actually created yet, but just defined
+(it's state is marked as Pending if you run `lxc network list`).
 
 Now run:
 
@@ -426,12 +424,10 @@ Now run:
 lxc network create my-network
 ```
 
-and the network will be instantiated on all nodes. If you didn't
-define it on a particular node, or a node is down, an error will be
-returned.
+The network will be instantiated on all nodes. If you didn't define it on a particular node, or a node is down,
+an error will be returned.
 
-You can pass to this final ``network create`` command any configuration key
-which is not node-specific (see above).
+You can pass to this final ``network create`` command any configuration key which is not node-specific (see above).
 
 ## Separate REST API and clustering networks
 

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -641,4 +641,5 @@ func (c *Cluster) RenameNetwork(oldName string, newName string) error {
 // NodeSpecificNetworkConfig lists all network config keys which are node-specific.
 var NodeSpecificNetworkConfig = []string{
 	"bridge.external_interfaces",
+	"parent",
 }

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -307,7 +307,8 @@ type NetworkType int
 
 // Network types.
 const (
-	NetworkTypeBridge NetworkType = iota // Network type bridge.
+	NetworkTypeBridge  NetworkType = iota // Network type bridge.
+	NetworkTypeMacvlan                    // Network type macvlan.
 )
 
 // GetNetworkInAnyState returns the network with the given name.
@@ -367,6 +368,8 @@ func (c *Cluster) getNetwork(name string, onlyCreated bool) (int64, *api.Network
 	switch netType {
 	case NetworkTypeBridge:
 		network.Type = "bridge"
+	case NetworkTypeMacvlan:
+		network.Type = "macvlan"
 	default:
 		network.Type = "" // Unknown
 	}

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lxc/lxd/lxd/network"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 )
 
 type nicMACVLAN struct {
@@ -51,6 +52,10 @@ func (d *nicMACVLAN) validateConfig(instConf instance.ConfigReader) error {
 		n, err := network.LoadByName(d.state, d.config["network"])
 		if err != nil {
 			return errors.Wrapf(err, "Error loading network config for %q", d.config["network"])
+		}
+
+		if n.Status() == api.NetworkStatusPending {
+			return fmt.Errorf("Specified network is not fully created")
 		}
 
 		if n.Type() != "macvlan" {

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -3,6 +3,8 @@ package device
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
@@ -21,9 +23,11 @@ func (d *nicMACVLAN) validateConfig(instConf instance.ConfigReader) error {
 		return ErrUnsupportedDevType
 	}
 
-	requiredFields := []string{"parent"}
+	var requiredFields []string
 	optionalFields := []string{
 		"name",
+		"network",
+		"parent",
 		"mtu",
 		"hwaddr",
 		"vlan",
@@ -31,6 +35,45 @@ func (d *nicMACVLAN) validateConfig(instConf instance.ConfigReader) error {
 		"maas.subnet.ipv6",
 		"boot.priority",
 	}
+
+	// Check that if network proeperty is set that conflicting keys are not present.
+	if d.config["network"] != "" {
+		requiredFields = append(requiredFields, "network")
+
+		bannedKeys := []string{"nictype", "parent", "mtu", "maas.subnet.ipv4", "maas.subnet.ipv6"}
+		for _, bannedKey := range bannedKeys {
+			if d.config[bannedKey] != "" {
+				return fmt.Errorf("Cannot use %q property in conjunction with %q property", bannedKey, "network")
+			}
+		}
+
+		// If network property is specified, lookup network settings and apply them to the device's config.
+		n, err := network.LoadByName(d.state, d.config["network"])
+		if err != nil {
+			return errors.Wrapf(err, "Error loading network config for %q", d.config["network"])
+		}
+
+		if n.Type() != "macvlan" {
+			return fmt.Errorf("Specified network must be of type macvlan")
+		}
+
+		netConfig := n.Config()
+
+		// Get actual parent device from network's parent setting.
+		d.config["parent"] = netConfig["parent"]
+
+		// Copy certain keys verbatim from the network's settings.
+		inheritKeys := []string{"maas.subnet.ipv4", "maas.subnet.ipv6"}
+		for _, inheritKey := range inheritKeys {
+			if _, found := netConfig[inheritKey]; found {
+				d.config[inheritKey] = netConfig[inheritKey]
+			}
+		}
+	} else {
+		// If no network property supplied, then parent property is required.
+		requiredFields = append(requiredFields, "parent")
+	}
+
 	err := d.config.Validate(nicValidationRules(requiredFields, optionalFields))
 	if err != nil {
 		return err

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -1,0 +1,115 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/lxc/lxd/lxd/revert"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+	log "github.com/lxc/lxd/shared/log15"
+)
+
+// macvlan represents a LXD macvlan network.
+type macvlan struct {
+	common
+}
+
+// Validate network config.
+func (n *macvlan) Validate(config map[string]string) error {
+	rules := map[string]func(value string) error{
+		"parent": func(value string) error {
+			if err := ValidNetworkName(value); err != nil {
+				return errors.Wrapf(err, "Invalid interface name %q", value)
+			}
+
+			return nil
+		},
+		"maas.subnet.ipv4": shared.IsAny,
+		"maas.subnet.ipv6": shared.IsAny,
+	}
+
+	err := n.validate(config, rules)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete deletes a network.
+func (n *macvlan) Delete(clusterNotification bool) error {
+	n.logger.Debug("Delete", log.Ctx{"clusterNotification": clusterNotification})
+	return n.common.delete(clusterNotification)
+}
+
+// Rename renames a network.
+func (n *macvlan) Rename(newName string) error {
+	n.logger.Debug("Rename", log.Ctx{"newName": newName})
+
+	// Sanity checks.
+	inUse, err := n.IsUsed()
+	if err != nil {
+		return err
+	}
+
+	if inUse {
+		return fmt.Errorf("The network is currently in use")
+	}
+
+	// Rename common steps.
+	err = n.common.rename(newName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Start starts is a no-op.
+func (n *macvlan) Start() error {
+	if n.status == api.NetworkStatusPending {
+		return fmt.Errorf("Cannot start pending network")
+	}
+
+	return nil
+}
+
+// Stop stops is a no-op.
+func (n *macvlan) Stop() error {
+	return nil
+}
+
+// Update updates the network. Accepts notification boolean indicating if this update request is coming from a
+// cluster notification, in which case do not update the database, just apply local changes needed.
+func (n *macvlan) Update(newNetwork api.NetworkPut, targetNode string, clusterNotification bool) error {
+	n.logger.Debug("Update", log.Ctx{"clusterNotification": clusterNotification, "newNetwork": newNetwork})
+
+	dbUpdateNeeeded, _, oldNetwork, err := n.common.configChanged(newNetwork)
+	if err != nil {
+		return err
+	}
+
+	if !dbUpdateNeeeded {
+		return nil // Nothing changed.
+	}
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	// Define a function which reverts everything.
+	revert.Add(func() {
+		// Reset changes to all nodes and database.
+		n.common.update(oldNetwork, targetNode, clusterNotification)
+	})
+
+	// Apply changes to database.
+	err = n.common.update(newNetwork, targetNode, clusterNotification)
+	if err != nil {
+		return err
+	}
+
+	revert.Success()
+	return nil
+}

--- a/lxd/network/network_load.go
+++ b/lxd/network/network_load.go
@@ -6,7 +6,8 @@ import (
 )
 
 var drivers = map[string]func() Network{
-	"bridge": func() Network { return &bridge{} },
+	"bridge":  func() Network { return &bridge{} },
+	"macvlan": func() Network { return &macvlan{} },
 }
 
 // LoadByName loads the network info from the database by name.

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -128,6 +128,8 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	switch req.Type {
 	case "bridge":
 		dbNetType = db.NetworkTypeBridge
+	case "macvlan":
+		dbNetType = db.NetworkTypeMacvlan
 	default:
 		return response.BadRequest(fmt.Errorf("Unrecognised network type"))
 	}

--- a/test/suites/container_devices_nic_macvlan.sh
+++ b/test/suites/container_devices_nic_macvlan.sh
@@ -102,6 +102,21 @@ test_container_devices_nic_macvlan() {
     false
   fi
 
+  # Test using macvlan network.
+
+  # Create macvlan network and add NIC device using that network.
+  lxc network create "${ctName}net" --type=macvlan parent="${ctName}"
+  lxc config device add "${ctName}" eth0 nic \
+    network="${ctName}net" \
+    name=eth0
+  lxc exec "${ctName}" -- ip addr add "192.0.2.1${ipRand}/24" dev eth0
+  lxc exec "${ctName}" -- ip addr add "2001:db8::1${ipRand}/64" dev eth0
+  lxc exec "${ctName}" -- ip link set eth0 up
+  lxc exec "${ctName}" -- ping -c2 -W1 "192.0.2.2${ipRand}"
+  lxc exec "${ctName}" -- ping6 -c2 -W1 "2001:db8::2${ipRand}"
+  lxc config device remove "${ctName}" eth0
+  lxc network delete "${ctName}net"
+
   # Check we haven't left any NICS lying around.
   endNicCount=$(find /sys/class/net | wc -l)
   if [ "$startNicCount" != "$endNicCount" ]; then


### PR DESCRIPTION
This PR allows one to use a `macvlan` managed network for adding `macvlan` NICs, e.g.

```
lxc network create test --type=macvlan parent=enp3s0
lxc config device add c1 eth0 nic network=test
```
- Adds support for `network` property to `macvlan` NIC devices.

Please dont merge until after https://github.com/lxc/lxd/pull/7676 has been merged and this has been rebased.