### PR TITLE
Operations: Fixes race condition and unsafe Operations() function

### DIFF
--- a/lxd-agent/operations.go
+++ b/lxd-agent/operations.go
@@ -74,9 +74,7 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 
 	localOperationURLs := func() (shared.Jmap, error) {
 		// Get all the operations
-		operations.Lock()
-		ops := operations.Operations()
-		operations.Unlock()
+		ops := operations.Clone()
 
 		// Build a list of URLs
 		body := shared.Jmap{}
@@ -96,9 +94,7 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 
 	localOperations := func() (shared.Jmap, error) {
 		// Get all the operations
-		operations.Lock()
-		ops := operations.Operations()
-		operations.Unlock()
+		ops := operations.Clone()
 
 		// Build a list of operations
 		body := shared.Jmap{}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1635,7 +1635,7 @@ func doImageGet(db *db.Cluster, project, fingerprint string, public bool) (*api.
 }
 
 func imageValidSecret(fingerprint string, secret string) (*operations.Operation, bool) {
-	for _, op := range operations.Operations() {
+	for _, op := range operations.Clone() {
 		if op.Resources() == nil {
 			continue
 		}

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -59,9 +59,7 @@ func waitForOperations(s *state.State, chCancel chan struct{}) {
 		<-tick
 
 		// Get all the operations
-		operations.Lock()
-		ops := operations.Operations()
-		operations.Unlock()
+		ops := operations.Clone()
 
 		runningOps := 0
 
@@ -209,9 +207,7 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 
 	localOperationURLs := func() (shared.Jmap, error) {
 		// Get all the operations
-		operations.Lock()
-		localOps := operations.Operations()
-		operations.Unlock()
+		localOps := operations.Clone()
 
 		// Build a list of URLs
 		body := shared.Jmap{}
@@ -234,9 +230,7 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 
 	localOperations := func() (shared.Jmap, error) {
 		// Get all the operations
-		operations.Lock()
-		localOps := operations.Operations()
-		operations.Unlock()
+		localOps := operations.Clone()
 
 		// Build a list of operations
 		body := shared.Jmap{}

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -59,9 +59,17 @@ func Unlock() {
 	operationsLock.Unlock()
 }
 
-// Operations returns a map of operations.
-func Operations() map[string]*Operation {
-	return operations
+// Clone returns a clone of the internal operations map containing references to the actual operations.
+func Clone() map[string]*Operation {
+	operationsLock.Lock()
+	defer operationsLock.Unlock()
+
+	localOperations := make(map[string]*Operation, len(operations))
+	for k, v := range operations {
+		localOperations[k] = v
+	}
+
+	return localOperations
 }
 
 // OperationGetInternal returns the operation with the given id. It returns an


### PR DESCRIPTION
The PR https://github.com/lxc/lxd/pull/7629 introduced a race condition by using the `operations.Operations()` function that returns a reference to the internal `operations.operations` map in a loop.

Additionally, even with a lock (like the existing usage of the `operations.Operations()` function, it is still not 100% safe, as after getting a reference to the map, the items can still be concurrently changed in an unsafe way. There are other places in the code base that also have this issue.

This PR replaces the unsafe `operations.Operations()` with an `operations.Clone()` function that locks the internal operations map and returns a clone of the map, whilst keeping the elements of the map as references to the original operations themselves.

