### PR TITLE
Network: Fixes "Errored" networks from preventing LXD start

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -761,7 +761,7 @@ func clusterInitMember(d, client lxd.InstanceServer, memberConfig []api.ClusterM
 	// configs provided by the user.
 	for _, network := range networks {
 		// Skip not-managed or pending networks
-		if !network.Managed || network.Status == "Pending" {
+		if !network.Managed || network.Status == api.NetworkStatusPending {
 			continue
 		}
 

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -257,8 +257,7 @@ func (c *Cluster) GetNetworks() ([]string, error) {
 	return c.networks("")
 }
 
-// GetNonPendingNetworks returns the names of all networks that are not
-// pending.
+// GetNonPendingNetworks returns the names of all networks that are not pending.
 func (c *Cluster) GetNonPendingNetworks() ([]string, error) {
 	return c.networks("NOT state=?", networkPending)
 }

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -189,9 +189,9 @@ func (c *ClusterTx) CreatePendingNetwork(node, name string, netType NetworkType,
 			return err
 		}
 	} else {
-		// Check that the existing network  is in the pending state.
-		if network.state != networkPending {
-			return fmt.Errorf("network is not in pending state")
+		// Check that the existing network is in the pending state.
+		if network.state != networkPending && network.state != networkErrored {
+			return fmt.Errorf("Network is not in pending or errored state")
 		}
 	}
 

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -305,13 +305,6 @@ const (
 	NetworkTypeBridge NetworkType = iota // Network type bridge.
 )
 
-// GetNetwork returns the network with the given name.
-//
-// The network must be in the created stated, not pending.
-func (c *Cluster) GetNetwork(name string) (int64, *api.Network, error) {
-	return c.getNetwork(name, true)
-}
-
 // GetNetworkInAnyState returns the network with the given name.
 //
 // The network can be in any state.

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -147,11 +147,9 @@ WHERE networks.id = ? AND networks.state = ?
 	return configs, nil
 }
 
-// CreatePendingNetwork creates a new pending network on the node with
-// the given name.
+// CreatePendingNetwork creates a new pending network on the node with the given name.
 func (c *ClusterTx) CreatePendingNetwork(node, name string, netType NetworkType, conf map[string]string) error {
-	// First check if a network with the given name exists, and, if
-	// so, that it's in the pending state.
+	// First check if a network with the given name exists, and, if so, that it's in the pending state.
 	network := struct {
 		id    int64
 		state int
@@ -161,27 +159,29 @@ func (c *ClusterTx) CreatePendingNetwork(node, name string, netType NetworkType,
 	dest := func(i int) []interface{} {
 		// Sanity check that there is at most one pool with the given name.
 		if i != 0 {
-			errConsistency = fmt.Errorf("more than one network exists with the given name")
+			errConsistency = fmt.Errorf("More than one network exists with the given name")
 		}
 		return []interface{}{&network.id, &network.state}
 	}
+
 	stmt, err := c.tx.Prepare("SELECT id, state FROM networks WHERE name=?")
 	if err != nil {
 		return err
 	}
 	defer stmt.Close()
+
 	err = query.SelectObjects(stmt, dest, name)
 	if err != nil {
 		return err
 	}
+
 	if errConsistency != nil {
 		return errConsistency
 	}
 
 	var networkID = network.id
 	if networkID == 0 {
-		// No existing network with the given name was found, let's create
-		// one.
+		// No existing network with the given name was found, let's create one.
 		columns := []string{"name", "type"}
 		values := []interface{}{name, netType}
 		networkID, err = query.UpsertObject(c.tx, "networks", columns, values)
@@ -202,8 +202,7 @@ func (c *ClusterTx) CreatePendingNetwork(node, name string, netType NetworkType,
 	}
 
 	// Check that no network entry for this node and network exists yet.
-	count, err := query.Count(
-		c.tx, "networks_nodes", "network_id=? AND node_id=?", networkID, nodeInfo.ID)
+	count, err := query.Count(c.tx, "networks_nodes", "network_id=? AND node_id=?", networkID, nodeInfo.ID)
 	if err != nil {
 		return err
 	}
@@ -218,6 +217,7 @@ func (c *ClusterTx) CreatePendingNetwork(node, name string, netType NetworkType,
 	if err != nil {
 		return err
 	}
+
 	err = c.CreateNetworkConfig(networkID, nodeInfo.ID, conf)
 	if err != nil {
 		return err

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -357,13 +357,13 @@ func (c *Cluster) getNetwork(name string, onlyCreated bool) (int64, *api.Network
 
 	switch state {
 	case networkPending:
-		network.Status = "Pending"
+		network.Status = api.NetworkStatusPending
 	case networkCreated:
-		network.Status = "Created"
+		network.Status = api.NetworkStatusCreated
 	case networkErrored:
-		network.Status = "Errored"
+		network.Status = api.NetworkStatusErrored
 	default:
-		network.Status = "Unknown"
+		network.Status = api.NetworkStatusUnknown
 	}
 
 	switch netType {

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -28,6 +28,7 @@ import (
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
 )
@@ -81,6 +82,10 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 		n, err := network.LoadByName(d.state, d.config["network"])
 		if err != nil {
 			return errors.Wrapf(err, "Error loading network config for %q", d.config["network"])
+		}
+
+		if n.Status() == api.NetworkStatusPending {
+			return fmt.Errorf("Specified network is not fully created")
 		}
 
 		if n.Type() != "bridge" {

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -456,8 +456,7 @@ func (d *nicBridged) Remove() error {
 	return nil
 }
 
-// rebuildDnsmasqEntry rebuilds the dnsmasq host entry if connected to an LXD managed network
-// and reloads dnsmasq.
+// rebuildDnsmasqEntry rebuilds the dnsmasq host entry if connected to an LXD managed network and reloads dnsmasq.
 func (d *nicBridged) rebuildDnsmasqEntry() error {
 	// Rebuild dnsmasq config if a bridged device has changed and parent is a managed network.
 	if !shared.PathExists(shared.VarPath("networks", d.config["parent"], "dnsmasq.pid")) {
@@ -467,7 +466,7 @@ func (d *nicBridged) rebuildDnsmasqEntry() error {
 	dnsmasq.ConfigMutex.Lock()
 	defer dnsmasq.ConfigMutex.Unlock()
 
-	_, dbInfo, err := d.state.Cluster.GetNetwork(d.config["parent"])
+	_, dbInfo, err := d.state.Cluster.GetNetworkInAnyState(d.config["parent"])
 	if err != nil {
 		return err
 	}

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -82,6 +82,11 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 		if err != nil {
 			return errors.Wrapf(err, "Error loading network config for %q", d.config["network"])
 		}
+
+		if n.Type() != "bridge" {
+			return fmt.Errorf("Specified network must be of type bridge")
+		}
+
 		netConfig := n.Config()
 
 		if d.config["ipv4.address"] != "" {
@@ -128,6 +133,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 			d.config["mtu"] = netConfig["bridge.mtu"]
 		}
 
+		// Copy certain keys verbatim from the network's settings.
 		inheritKeys := []string{"maas.subnet.ipv4", "maas.subnet.ipv6"}
 		for _, inheritKey := range inheritKeys {
 			if _, found := netConfig[inheritKey]; found {

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -347,6 +347,10 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 
 	n.logger.Debug("Setting up network")
 
+	if n.status == api.NetworkStatusPending {
+		return fmt.Errorf("Cannot start pending network")
+	}
+
 	// Create directory
 	if !shared.PathExists(shared.VarPath("networks", n.name)) {
 		err := os.MkdirAll(shared.VarPath("networks", n.name), 0711)

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -34,10 +34,11 @@ type common struct {
 	netType     string
 	description string
 	config      map[string]string
+	status      string
 }
 
 // init initialise internal variables.
-func (n *common) init(state *state.State, id int64, name string, netType string, description string, config map[string]string) {
+func (n *common) init(state *state.State, id int64, name string, netType string, description string, config map[string]string, status string) {
 	n.logger = logging.AddContext(logger.Log, log.Ctx{"driver": netType, "network": name})
 	n.id = id
 	n.name = name
@@ -45,6 +46,7 @@ func (n *common) init(state *state.State, id int64, name string, netType string,
 	n.config = config
 	n.state = state
 	n.description = description
+	n.status = status
 }
 
 // fillConfig fills requested config with any default values, by default this is a no-op.
@@ -99,6 +101,11 @@ func (n *common) validate(config map[string]string, driverRules map[string]func(
 // Name returns the network name.
 func (n *common) Name() string {
 	return n.name
+}
+
+// Status returns the network status.
+func (n *common) Status() string {
+	return n.status
 }
 
 // Type returns the network type.
@@ -292,7 +299,7 @@ func (n *common) rename(newName string) error {
 	}
 
 	// Reinitialise internal name variable and logger context with new name.
-	n.init(n.state, n.id, newName, n.netType, n.description, n.config)
+	n.init(n.state, n.id, newName, n.netType, n.description, n.config, n.status)
 
 	return nil
 }

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -9,13 +9,14 @@ import (
 // Network represents a LXD network.
 type Network interface {
 	// Load.
-	init(state *state.State, id int64, name string, netType string, description string, config map[string]string)
+	init(state *state.State, id int64, name string, netType string, description string, config map[string]string, status string)
 	fillConfig(*api.NetworksPost) error
 
 	// Config.
 	Validate(config map[string]string) error
 	Name() string
 	Type() string
+	Status() string
 	Config() map[string]string
 	IsUsed() bool
 	HasDHCPv4() bool

--- a/lxd/network/network_load.go
+++ b/lxd/network/network_load.go
@@ -11,7 +11,7 @@ var drivers = map[string]func() Network{
 
 // LoadByName loads the network info from the database by name.
 func LoadByName(s *state.State, name string) (Network, error) {
-	id, netInfo, err := s.Cluster.GetNetwork(name)
+	id, netInfo, err := s.Cluster.GetNetworkInAnyState(name)
 	if err != nil {
 		return nil, err
 	}
@@ -22,7 +22,7 @@ func LoadByName(s *state.State, name string) (Network, error) {
 	}
 
 	n := driverFunc()
-	n.init(s, id, name, netInfo.Type, netInfo.Description, netInfo.Config)
+	n.init(s, id, name, netInfo.Type, netInfo.Description, netInfo.Config, netInfo.Status)
 
 	return n, nil
 }
@@ -40,7 +40,7 @@ func Validate(name string, netType string, config map[string]string) error {
 	}
 
 	n := driverFunc()
-	n.init(nil, 0, name, netType, "", config)
+	n.init(nil, 0, name, netType, "", config, "Unknown")
 	return n.Validate(config)
 }
 
@@ -52,7 +52,7 @@ func FillConfig(req *api.NetworksPost) error {
 	}
 
 	n := driverFunc()
-	n.init(nil, 0, req.Name, req.Type, req.Description, req.Config)
+	n.init(nil, 0, req.Name, req.Type, req.Description, req.Config, "Unknown")
 
 	err := n.fillConfig(req)
 	if err != nil {

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -474,7 +474,7 @@ func networkDelete(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.SmartError(err)
 	}
-	if dbNetwork.Status == "Pending" {
+	if dbNetwork.Status == api.NetworkStatusPending {
 		err := d.cluster.DeleteNetwork(name)
 		if err != nil {
 			return response.SmartError(err)

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/logger"
 )
 
 func readUint(path string) (uint64, error) {
@@ -77,7 +78,8 @@ func networkUpdateForkdnsServersTask(s *state.State, heartbeatData *cluster.APIH
 	for _, name := range networks {
 		n, err := network.LoadByName(s, name)
 		if err != nil {
-			return err
+			logger.Errorf("Failed to load network %q for heartbeat", name)
+			continue
 		}
 
 		if n.Type() == "bridge" && n.Config()["bridge.mode"] == "fan" {

--- a/shared/api/network.go
+++ b/shared/api/network.go
@@ -27,6 +27,18 @@ type NetworkPut struct {
 	Description string `json:"description" yaml:"description"`
 }
 
+// NetworkStatusPending network is pending creation on other cluster nodes.
+const NetworkStatusPending = "Pending"
+
+// NetworkStatusCreated network is fully created.
+const NetworkStatusCreated = "Created"
+
+// NetworkStatusErrored network is in error status.
+const NetworkStatusErrored = "Errored"
+
+// NetworkStatusUnknown network is in unknown status.
+const NetworkStatusUnknown = "Unknown"
+
 // Network represents a LXD network
 type Network struct {
 	NetworkPut `yaml:",inline"`


### PR DESCRIPTION
- Removes `GetNetwork` as no longer needed.
- Adds constants for network string statuses.
- Adds check for `bridged` NIC validation that prevents adding a NIC using `network=` for a pending network.
- Adds check preventing starting a pending `bridge` network.
- Fixes issue with `Errored` clustered network not being removable (due to `network.LoadByName()` failing).
- Fixes issue with `Errored` clustered network preventing LXD from starting (due to `network.LoadByName()` failing).