### PR TITLE
Network: Cluster updates

### DIFF
--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -526,7 +526,7 @@ func (c *Cluster) CreateNetwork(name, description string, netType NetworkType, c
 
 // UpdateNetwork updates the network with the given name.
 func (c *Cluster) UpdateNetwork(name, description string, config map[string]string) error {
-	id, _, err := c.GetNetworkInAnyState(name)
+	id, netInfo, err := c.GetNetworkInAnyState(name)
 	if err != nil {
 		return err
 	}
@@ -546,6 +546,15 @@ func (c *Cluster) UpdateNetwork(name, description string, config map[string]stri
 		if err != nil {
 			return err
 		}
+
+		// Update network status if change applied successfully.
+		if netInfo.Status == api.NetworkStatusErrored {
+			err = tx.NetworkCreated(name)
+			if err != nil {
+				return err
+			}
+		}
+
 		return nil
 	})
 

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -151,20 +151,21 @@ WHERE networks.id = ? AND networks.state = ?
 func (c *ClusterTx) CreatePendingNetwork(node, name string, netType NetworkType, conf map[string]string) error {
 	// First check if a network with the given name exists, and, if so, that it's in the pending state.
 	network := struct {
-		id    int64
-		state int
+		id      int64
+		state   int
+		netType NetworkType
 	}{}
 
 	var errConsistency error
 	dest := func(i int) []interface{} {
-		// Sanity check that there is at most one pool with the given name.
+		// Sanity check that there is at most one network with the given name.
 		if i != 0 {
 			errConsistency = fmt.Errorf("More than one network exists with the given name")
 		}
-		return []interface{}{&network.id, &network.state}
+		return []interface{}{&network.id, &network.state, &network.netType}
 	}
 
-	stmt, err := c.tx.Prepare("SELECT id, state FROM networks WHERE name=?")
+	stmt, err := c.tx.Prepare("SELECT id, state, type FROM networks WHERE name=?")
 	if err != nil {
 		return err
 	}
@@ -192,6 +193,11 @@ func (c *ClusterTx) CreatePendingNetwork(node, name string, netType NetworkType,
 		// Check that the existing network is in the pending state.
 		if network.state != networkPending && network.state != networkErrored {
 			return fmt.Errorf("Network is not in pending or errored state")
+		}
+
+		// Check that the existing network type matches the requested type.
+		if network.netType != netType {
+			return fmt.Errorf("Requested network type doesn't match type in existing database record")
 		}
 	}
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1333,8 +1333,8 @@ func (n *bridge) Stop() error {
 
 // Update updates the network. Accepts notification boolean indicating if this update request is coming from a
 // cluster notification, in which case do not update the database, just apply local changes needed.
-func (n *bridge) Update(newNetwork api.NetworkPut, clusterNotification bool) error {
-	n.logger.Debug("Update", log.Ctx{"clusterNotification": clusterNotification})
+func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clusterNotification bool) error {
+	n.logger.Debug("Update", log.Ctx{"clusterNotification": clusterNotification, "newNetwork": newNetwork})
 
 	// When switching to a fan bridge, auto-detect the underlay if not specified.
 	if newNetwork.Config["bridge.mode"] == "fan" {
@@ -1364,7 +1364,7 @@ func (n *bridge) Update(newNetwork api.NetworkPut, clusterNotification bool) err
 	// Define a function which reverts everything.
 	revert.Add(func() {
 		// Reset changes to all nodes and database.
-		n.common.update(oldNetwork, clusterNotification)
+		n.common.update(oldNetwork, targetNode, clusterNotification)
 
 		// Reset any change that was made to local bridge.
 		n.setup(newNetwork.Config)
@@ -1402,7 +1402,7 @@ func (n *bridge) Update(newNetwork api.NetworkPut, clusterNotification bool) err
 	}
 
 	// Apply changes to database.
-	err = n.common.update(newNetwork, clusterNotification)
+	err = n.common.update(newNetwork, targetNode, clusterNotification)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -28,7 +28,7 @@ type Network interface {
 	Start() error
 	Stop() error
 	Rename(name string) error
-	Update(newNetwork api.NetworkPut, clusterNotification bool) error
+	Update(newNetwork api.NetworkPut, targetNode string, clusterNotification bool) error
 	HandleHeartbeat(heartbeatData *cluster.APIHeartbeat) error
 	Delete(clusterNotification bool) error
 }

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -108,17 +108,17 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("No name provided"))
 	}
 
+	err = network.ValidNetworkName(req.Name)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
 	if req.Type == "" {
 		req.Type = "bridge"
 	}
 
 	if req.Config == nil {
 		req.Config = map[string]string{}
-	}
-
-	err = network.Validate(req.Name, req.Type, req.Config)
-	if err != nil {
-		return response.BadRequest(err)
 	}
 
 	// Convert requested network type to DB type code.

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -322,6 +322,12 @@ func doNetworksCreate(d *Daemon, req api.NetworksPost, clusterNotification bool)
 		return err
 	}
 
+	// Validate so that when run on a cluster node the full config (including node specific config) is checked.
+	err = n.Validate(n.Config())
+	if err != nil {
+		return err
+	}
+
 	err = n.Start()
 	if err != nil {
 		n.Delete(clusterNotification)

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -149,7 +149,7 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		// Check that only NodeSpecificNetworkConfig keys are specified.
 		for key := range req.Config {
 			if !shared.StringInSlice(key, db.NodeSpecificNetworkConfig) {
-				return response.SmartError(fmt.Errorf("Config key %q may not be used as node-specific key", key))
+				return response.BadRequest(fmt.Errorf("Config key %q may not be used as node-specific key", key))
 			}
 		}
 
@@ -158,7 +158,7 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		})
 		if err != nil {
 			if err == db.ErrAlreadyDefined {
-				return response.BadRequest(fmt.Errorf("The network already defined on node %q", targetNode))
+				return response.BadRequest(fmt.Errorf("The network is already defined on node %q", targetNode))
 			}
 			return response.SmartError(err)
 		}


### PR DESCRIPTION
@freeekanayaka continues on from yesterday's cluster network improvements.

- Adds network type checks when setting up pending and final networks.
- Rejects node-specific key updates without `--target` flag.
- Rejects non-node-specific key updates when used without `--target` flag.
- Strips node-specific keys when forwarding to other nodes for notification of change.
- Only sends notifications to other nodes when no `--target` specified.
- Forwards node-specific update requests to correct node (fixes etag mismatch issue when used with `--target`).
- Loads node-specific config before applying update keys, to allow proper per-node validation.
- Merges PUT and PATCH network update routes as now functionality equivalent.
- Allows 'repair' of `Errored` clustered network setup by allowing `lxc network set <network> <node key> --target=<node>`