### PR TITLE
Network: Adds network property support to sriov NIC driver 

### DIFF
--- a/doc/instances.md
+++ b/doc/instances.md
@@ -326,6 +326,7 @@ Device configuration properties:
 Key                     | Type      | Default           | Required  | Description
 :--                     | :--       | :--               | :--       | :--
 parent                  | string    | -                 | yes       | The name of the host device
+network                 | string    | -                 | yes       | The LXD network to link device to (instead of parent)
 name                    | string    | kernel assigned   | no        | The name of the interface inside the instance
 mtu                     | integer   | parent MTU        | no        | The MTU of the new interface
 hwaddr                  | string    | randomly assigned | no        | The MAC address of the new interface
@@ -410,6 +411,7 @@ Device configuration properties:
 Key                     | Type      | Default           | Required  | Description
 :--                     | :--       | :--               | :--       | :--
 parent                  | string    | -                 | yes       | The name of the host device
+network                 | string    | -                 | yes       | The LXD network to link device to (instead of parent)
 name                    | string    | kernel assigned   | no        | The name of the interface inside the instance
 mtu                     | integer   | kernel assigned   | no        | The MTU of the new interface
 hwaddr                  | string    | randomly assigned | no        | The MAC address of the new interface

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -180,7 +180,7 @@ This will then allow LXD's own firewall rules to take effect.
 ### How to let Firewalld control the LXD's iptables rules
 
 When using firewalld and LXD together, iptables rules can overlaps. For example, firewalld could erase LXD iptables rules if it is started after LXD daemon, then LXD container will not be able to do any oubound internet access.
-On way to fix it is to delegate to firewalld the LXD's iptables rules and to disable the LXD ones.
+One way to fix it is to delegate to firewalld the LXD's iptables rules and to disable the LXD ones.
 
 First step is to [allow DNS and DHCP](#allow-dhcp-dns-with-firewalld).
 

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -1,36 +1,27 @@
 # Network configuration
 
-The key/value configuration is namespaced with the following namespaces
-currently supported:
+LXD supports the following network types:
 
- - `bridge` (L2 interface configuration)
- - `fan` (configuration specific to the Ubuntu FAN overlay)
- - `tunnel` (cross-host tunneling configuration)
- - `ipv4` (L3 IPv4 configuration)
- - `ipv6` (L3 IPv6 configuration)
- - `dns` (DNS server and resolution configuration)
- - `raw` (raw configuration file content)
+ - [bridge](#network-bridge): Creates an L2 bridge for connecting instances to (can provide local DHCP and DNS).
+
+The configuration keys are namespaced with the following namespaces currently supported for all network types:
+
+ - `maas` (MAAS network identification)
  - `user` (free form key/value for user metadata)
 
-## Bridges
+## network: bridge
 
-As one of the possible network configuration types under LXD,
-LXD supports creating and managing network bridges. LXD bridges
-can leverage underlying native Linux bridges and Open vSwitch.
+As one of the possible network configuration types under LXD, LXD supports creating and managing network bridges.
+LXD bridges can leverage underlying native Linux bridges and Open vSwitch.
 
-Creation and management of LXD bridges is performed via the `lxc network`
-command. A bridge created by LXD is by default "managed" which
-means that LXD also will additionally set up a local `dnsmasq`
-DHCP server and if desired also perform NAT for the bridge (this
-is the default.)
+Creation and management of LXD bridges is performed via the `lxc network` command.
+A bridge created by LXD is by default "managed" which means that LXD also will additionally set up a local `dnsmasq`
+DHCP server and if desired also perform NAT for the bridge (this is the default.)
 
-When a bridge is managed by LXD, configuration values
-under the `bridge` namespace can be used to configure it.
+When a bridge is managed by LXD, configuration values under the `bridge` namespace can be used to configure it.
 
-Additionally, LXD can utilize a pre-existing Linux
-bridge. In this case, the bridge does not need to be created via
-`lxc network` and can simply be referenced in an instance or
-profile device configuration as follows:
+Additionally, LXD can utilize a pre-existing Linux bridge. In this case, the bridge does not need to be created via
+`lxc network` and can simply be referenced in an instance or profile device configuration as follows:
 
 ```
 devices:
@@ -41,15 +32,23 @@ devices:
      type: nic
 ```
 
-## Configuration Settings
+Network configuration properties:
 
-A complete list of configuration settings for LXD networks can
-be found below.
+A complete list of configuration settings for LXD networks can be found below.
 
-It is expected that IP addresses and subnets are given using CIDR
-notation (`1.1.1.1/24` or `fd80:1234::1/64`). The exception being
-tunnel local and remote addresses which are just plain addresses
-(`1.1.1.1` or `fd80:1234::1`).
+The following configuration key namespaces are currently supported for bridge networks:
+
+ - `bridge` (L2 interface configuration)
+ - `fan` (configuration specific to the Ubuntu FAN overlay)
+ - `tunnel` (cross-host tunneling configuration)
+ - `ipv4` (L3 IPv4 configuration)
+ - `ipv6` (L3 IPv6 configuration)
+ - `dns` (DNS server and resolution configuration)
+ - `raw` (raw configuration file content)
+
+It is expected that IP addresses and subnets are given using CIDR notation (`1.1.1.1/24` or `fd80:1234::1/64`).
+
+The exception being tunnel local and remote addresses which are just plain addresses (`1.1.1.1` or `fd80:1234::1`).
 
 Key                             | Type      | Condition             | Default                   | Description
 :--                             | :--       | :--                   | :--                       | :--
@@ -98,14 +97,13 @@ tunnel.NAME.protocol            | string    | standard mode         | -         
 tunnel.NAME.remote              | string    | gre or vxlan          | -                         | Remote address for the tunnel (not necessary for multicast vxlan)
 tunnel.NAME.ttl                 | integer   | vxlan                 | 1                         | Specific TTL to use for multicast routing topologies
 
-
 Those keys can be set using the lxc tool with:
 
 ```bash
 lxc network set <network> <key> <value>
 ```
 
-## Integration with systemd-resolved
+### Integration with systemd-resolved
 
 If the system running LXD uses systemd-resolved to perform DNS
 lookups, it's possible to notify resolved of the domain(s) that
@@ -147,7 +145,7 @@ exists, so you must repeat this command each reboot and after
 LXD is restarted.  Also note this only works if the bridge
 `dns.mode` is not `none`.
 
-## IPv6 prefix size
+### IPv6 prefix size
 For optimal operation, a prefix size of 64 is preferred.
 Larger subnets (prefix smaller than 64) should work properly too but
 aren't typically that useful for SLAAC.
@@ -157,7 +155,7 @@ IPv6 allocation aren't properly supported by dnsmasq and may be the
 source of issue. If you must use one of those, static allocation or
 another standalone RA daemon be used.
 
-## Allow DHCP, DNS with Firewalld
+### Allow DHCP, DNS with Firewalld
 
 In order to allow instances to access the DHCP and DNS server that LXD runs on the host when using firewalld
 you need to add the host's bridge interface to the `trusted` zone in firewalld.
@@ -177,7 +175,7 @@ firewall-cmd --zone=trusted --change-interface=lxdbr0 --permanent
 This will then allow LXD's own firewall rules to take effect.
 
 
-## How to let Firewalld control the LXD's iptables rules
+### How to let Firewalld control the LXD's iptables rules
 
 When using firewalld and LXD together, iptables rules can overlaps. For example, firewalld could erase LXD iptables rules if it is started after LXD daemon, then LXD container will not be able to do any oubound internet access.
 On way to fix it is to delegate to firewalld the LXD's iptables rules and to disable the LXD ones.
@@ -202,7 +200,7 @@ firewall-cmd --reload
 ```
 To check the rules are taken into account by firewalld:
 ```
-firewall-cmd --direct --get-all-rules 
+firewall-cmd --direct --get-all-rules
 ```
 
 Warning: what is exposed above is not a fool-proof approach and may end up inadvertently introducing a security risk.

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -3,6 +3,8 @@
 LXD supports the following network types:
 
  - [bridge](#network-bridge): Creates an L2 bridge for connecting instances to (can provide local DHCP and DNS).
+ - [macvlan](#network-macvlan): Provides preset configuration to use when connecting instances to a parent macvlan interface.
+ - [sriov](#network-sriov): Provides preset configuration to use when connecting instances to a parent SR-IOV interface.
 
 The configuration keys are namespaced with the following namespaces currently supported for all network types:
 
@@ -204,3 +206,31 @@ firewall-cmd --direct --get-all-rules
 ```
 
 Warning: what is exposed above is not a fool-proof approach and may end up inadvertently introducing a security risk.
+
+## network: macvlan
+
+The macvlan network type allows one to specify presets to use when connecting instances to a parent interface
+using macvlan NICs. This allows the instance NIC itself to simply specify the `network` it is connecting to without
+knowing any of the underlying configuration details.
+
+Network configuration properties:
+
+Key                             | Type      | Condition             | Default                   | Description
+:--                             | :--       | :--                   | :--                       | :--
+parent                          | string    | -                     | -                         | Parent interface to create macvlan NICs on
+maas.subnet.ipv4                | string    | ipv4 address          | -                         | MAAS IPv4 subnet to register instances in (when using `network` property on nic)
+maas.subnet.ipv6                | string    | ipv6 address          | -                         | MAAS IPv6 subnet to register instances in (when using `network` property on nic)
+
+## network: sriov
+
+The sriov network type allows one to specify presets to use when connecting instances to a parent interface
+using sriov NICs. This allows the instance NIC itself to simply specify the `network` it is connecting to without
+knowing any of the underlying configuration details.
+
+Network configuration properties:
+
+Key                             | Type      | Condition             | Default                   | Description
+:--                             | :--       | :--                   | :--                       | :--
+parent                          | string    | -                     | -                         | Parent interface to create sriov NICs on
+maas.subnet.ipv4                | string    | ipv4 address          | -                         | MAAS IPv4 subnet to register instances in (when using `network` property on nic)
+maas.subnet.ipv6                | string    | ipv6 address          | -                         | MAAS IPv6 subnet to register instances in (when using `network` property on nic)

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -309,6 +309,7 @@ type NetworkType int
 const (
 	NetworkTypeBridge  NetworkType = iota // Network type bridge.
 	NetworkTypeMacvlan                    // Network type macvlan.
+	NetworkTypeSriov                      // Network type sriov.
 )
 
 // GetNetworkInAnyState returns the network with the given name.
@@ -370,6 +371,8 @@ func (c *Cluster) getNetwork(name string, onlyCreated bool) (int64, *api.Network
 		network.Type = "bridge"
 	case NetworkTypeMacvlan:
 		network.Type = "macvlan"
+	case NetworkTypeSriov:
+		network.Type = "sriov"
 	default:
 		network.Type = "" // Unknown
 	}

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -17,9 +17,11 @@ import (
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/lxd/network"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 )
 
 type nicSRIOV struct {
@@ -32,15 +34,59 @@ func (d *nicSRIOV) validateConfig(instConf instance.ConfigReader) error {
 		return ErrUnsupportedDevType
 	}
 
-	requiredFields := []string{"parent"}
+	var requiredFields []string
 	optionalFields := []string{
 		"name",
+		"network",
+		"parent",
 		"hwaddr",
 		"vlan",
 		"security.mac_filtering",
 		"maas.subnet.ipv4",
 		"maas.subnet.ipv6",
 		"boot.priority",
+	}
+
+	// Check that if network proeperty is set that conflicting keys are not present.
+	if d.config["network"] != "" {
+		requiredFields = append(requiredFields, "network")
+
+		bannedKeys := []string{"nictype", "parent", "mtu", "maas.subnet.ipv4", "maas.subnet.ipv6"}
+		for _, bannedKey := range bannedKeys {
+			if d.config[bannedKey] != "" {
+				return fmt.Errorf("Cannot use %q property in conjunction with %q property", bannedKey, "network")
+			}
+		}
+
+		// If network property is specified, lookup network settings and apply them to the device's config.
+		n, err := network.LoadByName(d.state, d.config["network"])
+		if err != nil {
+			return errors.Wrapf(err, "Error loading network config for %q", d.config["network"])
+		}
+
+		if n.Status() == api.NetworkStatusPending {
+			return fmt.Errorf("Specified network is not fully created")
+		}
+
+		if n.Type() != "sriov" {
+			return fmt.Errorf("Specified network must be of type macvlan")
+		}
+
+		netConfig := n.Config()
+
+		// Get actual parent device from network's parent setting.
+		d.config["parent"] = netConfig["parent"]
+
+		// Copy certain keys verbatim from the network's settings.
+		inheritKeys := []string{"maas.subnet.ipv4", "maas.subnet.ipv6"}
+		for _, inheritKey := range inheritKeys {
+			if _, found := netConfig[inheritKey]; found {
+				d.config[inheritKey] = netConfig[inheritKey]
+			}
+		}
+	} else {
+		// If no network property supplied, then parent property is required.
+		requiredFields = append(requiredFields, "parent")
 	}
 
 	// For VMs only NIC properties that can be specified on the parent's VF settings are controllable.

--- a/lxd/device/nictype/nictype.go
+++ b/lxd/device/nictype/nictype.go
@@ -30,6 +30,8 @@ func NICType(s *state.State, d deviceConfig.Device) (string, error) {
 				nicType = "bridged"
 			case "macvlan":
 				nicType = "macvlan"
+			case "sriov":
+				nicType = "sriov"
 			default:
 				return "", fmt.Errorf("Unrecognised NIC network type for network %q", d["network"])
 			}

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -1,0 +1,115 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/lxc/lxd/lxd/revert"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+	log "github.com/lxc/lxd/shared/log15"
+)
+
+// sriov represents a LXD sriov network.
+type sriov struct {
+	common
+}
+
+// Validate network config.
+func (n *sriov) Validate(config map[string]string) error {
+	rules := map[string]func(value string) error{
+		"parent": func(value string) error {
+			if err := ValidNetworkName(value); err != nil {
+				return errors.Wrapf(err, "Invalid interface name %q", value)
+			}
+
+			return nil
+		},
+		"maas.subnet.ipv4": shared.IsAny,
+		"maas.subnet.ipv6": shared.IsAny,
+	}
+
+	err := n.validate(config, rules)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete deletes a network.
+func (n *sriov) Delete(clusterNotification bool) error {
+	n.logger.Debug("Delete", log.Ctx{"clusterNotification": clusterNotification})
+	return n.common.delete(clusterNotification)
+}
+
+// Rename renames a network.
+func (n *sriov) Rename(newName string) error {
+	n.logger.Debug("Rename", log.Ctx{"newName": newName})
+
+	// Sanity checks.
+	inUse, err := n.IsUsed()
+	if err != nil {
+		return err
+	}
+
+	if inUse {
+		return fmt.Errorf("The network is currently in use")
+	}
+
+	// Rename common steps.
+	err = n.common.rename(newName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Start starts is a no-op.
+func (n *sriov) Start() error {
+	if n.status == api.NetworkStatusPending {
+		return fmt.Errorf("Cannot start pending network")
+	}
+
+	return nil
+}
+
+// Stop stops is a no-op.
+func (n *sriov) Stop() error {
+	return nil
+}
+
+// Update updates the network. Accepts notification boolean indicating if this update request is coming from a
+// cluster notification, in which case do not update the database, just apply local changes needed.
+func (n *sriov) Update(newNetwork api.NetworkPut, targetNode string, clusterNotification bool) error {
+	n.logger.Debug("Update", log.Ctx{"clusterNotification": clusterNotification, "newNetwork": newNetwork})
+
+	dbUpdateNeeeded, _, oldNetwork, err := n.common.configChanged(newNetwork)
+	if err != nil {
+		return err
+	}
+
+	if !dbUpdateNeeeded {
+		return nil // Nothing changed.
+	}
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	// Define a function which reverts everything.
+	revert.Add(func() {
+		// Reset changes to all nodes and database.
+		n.common.update(oldNetwork, targetNode, clusterNotification)
+	})
+
+	// Apply changes to database.
+	err = n.common.update(newNetwork, targetNode, clusterNotification)
+	if err != nil {
+		return err
+	}
+
+	revert.Success()
+	return nil
+}

--- a/lxd/network/network_load.go
+++ b/lxd/network/network_load.go
@@ -8,6 +8,7 @@ import (
 var drivers = map[string]func() Network{
 	"bridge":  func() Network { return &bridge{} },
 	"macvlan": func() Network { return &macvlan{} },
+	"sriov":   func() Network { return &sriov{} },
 }
 
 // LoadByName loads the network info from the database by name.

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -130,6 +130,8 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		dbNetType = db.NetworkTypeBridge
 	case "macvlan":
 		dbNetType = db.NetworkTypeMacvlan
+	case "sriov":
+		dbNetType = db.NetworkTypeSriov
 	default:
 		return response.BadRequest(fmt.Errorf("Unrecognised network type"))
 	}

--- a/test/suites/container_devices_nic_sriov.sh
+++ b/test/suites/container_devices_nic_sriov.sh
@@ -38,7 +38,7 @@ test_container_devices_nic_sriov() {
     parent="${parent}"
   lxc start "${ctName}"
 
-  # Check spoof checking has been disabled (the default)
+  # Check spoof checking has been disabled (the default).
   vfID=$(lxc config get "${ctName}" volatile.eth0.last_state.vf.id)
   if ip link show "${parent}" | grep "vf ${vfID}" | grep "spoof checking on"; then
     echo "spoof checking is still enabled"
@@ -47,7 +47,7 @@ test_container_devices_nic_sriov() {
 
   lxc config device set "${ctName}" eth0 vlan 1234
 
-  # Check custom vlan has been enabled
+  # Check custom vlan has been enabled.
   vfID=$(lxc config get "${ctName}" volatile.eth0.last_state.vf.id)
   if ! ip link show "${parent}" | grep "vf ${vfID}" | grep "vlan 1234"; then
     echo "vlan not set"
@@ -65,7 +65,7 @@ test_container_devices_nic_sriov() {
 
   lxc config device set "${ctName}" eth0 vlan 0
 
-  # Check custom vlan has been disabled
+  # Check custom vlan has been disabled.
   vfID=$(lxc config get "${ctName}" volatile.eth0.last_state.vf.id)
   if ip link show "${parent}" | grep "vf ${vfID}" | grep "vlan"; then
     # Mellanox cards display vlan 0 as vlan 4095!
@@ -89,7 +89,7 @@ test_container_devices_nic_sriov() {
   lxc config device set "${ctName}" eth0 hwaddr "${ctMAC1}"
   lxc start "${ctName}"
 
-  # Check custom MAC is applied
+  # Check custom MAC is applied.
   vfID=$(lxc config get "${ctName}" volatile.eth0.last_state.vf.id)
   if ! ip link show "${parent}" | grep "vf ${vfID}" | grep "${ctMAC1}"; then
     echo "eth0 MAC not set"
@@ -98,24 +98,24 @@ test_container_devices_nic_sriov() {
 
   lxc stop -f "${ctName}"
 
-  # Disable mac filtering and try fresh boot
+  # Disable mac filtering and try fresh boot.
   lxc config device set "${ctName}" eth0 security.mac_filtering false
   lxc start "${ctName}"
 
-  # Check spoof checking has been disabled (the default)
+  # Check spoof checking has been disabled (the default).
   vfID=$(lxc config get "${ctName}" volatile.eth0.last_state.vf.id)
   if ! ip link show "${parent}" | grep "vf ${vfID}" | grep "spoof checking off"; then
     echo "spoof checking is still enabled"
     false
   fi
 
-  # Hot plug fresh device
+  # Hot plug fresh device.
   lxc config device add "${ctName}" eth1 nic \
     nictype=sriov \
     parent="${parent}" \
     security.mac_filtering=true
 
-  # Check spoof checking has been enabled
+  # Check spoof checking has been enabled.
   vfID=$(lxc config get "${ctName}" volatile.eth1.last_state.vf.id)
   if ! ip link show "${parent}" | grep "vf ${vfID}" | grep "spoof checking on"; then
     echo "spoof checking is still disabled"
@@ -124,11 +124,11 @@ test_container_devices_nic_sriov() {
 
   lxc stop -f "${ctName}"
 
-  # Test setting MAC offline
+  # Test setting MAC offline.
   lxc config device set "${ctName}" eth1 hwaddr "${ctMAC2}"
   lxc start "${ctName}"
 
-  # Check custom MAC is applied
+  # Check custom MAC is applied.
   vfID=$(lxc config get "${ctName}" volatile.eth1.last_state.vf.id)
   if ! ip link show "${parent}" | grep "vf ${vfID}" | grep "${ctMAC2}"; then
     echo "eth1 MAC not set"


### PR DESCRIPTION
This PR allows one to use a sriov managed network for adding sriov NICs, e.g.

```
lxc network create test --type=sriov parent=enp4s0f0
lxc config device add c1 eth0 nic network=test
```