### PR TITLE
Network: Moves calls to ovs-vsctl to own package

### DIFF
--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lxc/lxd/lxd/dnsmasq"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/lxd/network/openvswitch"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
@@ -165,13 +166,10 @@ func AttachInterface(bridgeName string, devName string) error {
 			return err
 		}
 	} else {
-		// Check if interface is already connected to a bridge, if not connect it to the specified bridge.
-		_, err := shared.RunCommand("ovs-vsctl", "port-to-br", devName)
+		ovs := openvswitch.NewOVS()
+		err := ovs.BridgeAddPort(bridgeName, devName)
 		if err != nil {
-			_, err := shared.RunCommand("ovs-vsctl", "add-port", bridgeName, devName)
-			if err != nil {
-				return err
-			}
+			return err
 		}
 	}
 
@@ -186,13 +184,10 @@ func DetachInterface(bridgeName string, devName string) error {
 			return err
 		}
 	} else {
-		// Check if interface is connected to a bridge, if so, then remove it from the bridge.
-		_, err := shared.RunCommand("ovs-vsctl", "port-to-br", devName)
-		if err == nil {
-			_, err := shared.RunCommand("ovs-vsctl", "del-port", bridgeName, devName)
-			if err != nil {
-				return err
-			}
+		ovs := openvswitch.NewOVS()
+		err := ovs.BridgeDeletePort(bridgeName, devName)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/lxd/network/openvswitch/ovs.go
+++ b/lxd/network/openvswitch/ovs.go
@@ -1,0 +1,103 @@
+package openvswitch
+
+import (
+	"os/exec"
+
+	"github.com/lxc/lxd/shared"
+)
+
+// NewOVS initialises new OVS wrapper.
+func NewOVS() *OVS {
+	return &OVS{}
+}
+
+// OVS command wrapper.
+type OVS struct{}
+
+// Installed returns true if OVS tools are installed.
+func (o *OVS) Installed() bool {
+	_, err := exec.LookPath("ovs-vsctl")
+	if err != nil {
+		return false
+	}
+
+	return true
+}
+
+// BridgeExists returns true if OVS bridge exists.
+func (o *OVS) BridgeExists(bridgeName string) (bool, error) {
+	_, err := shared.RunCommand("ovs-vsctl", "br-exists", bridgeName)
+	if err != nil {
+		runErr, ok := err.(shared.RunError)
+		if ok {
+			exitError, ok := runErr.Err.(*exec.ExitError)
+
+			// ovs-vsctl manpage says that br-exists exits with code 2 if bridge doesn't exist.
+			if ok && exitError.ExitCode() == 2 {
+				return false, nil
+			}
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}
+
+// BridgeAdd adds an OVS bridge.
+func (o *OVS) BridgeAdd(bridgeName string) error {
+	_, err := shared.RunCommand("ovs-vsctl", "add-br", bridgeName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// BridgeDelete deletes an OVS bridge.
+func (o *OVS) BridgeDelete(bridgeName string) error {
+	_, err := shared.RunCommand("ovs-vsctl", "del-br", bridgeName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// BridgeAddPort adds a port to the bridge (if already attached does nothing).
+func (o *OVS) BridgeAddPort(bridgeName string, portName string) error {
+	// Check if interface is already connected to a bridge, if not, connect it to the specified bridge.
+	_, err := shared.RunCommand("ovs-vsctl", "port-to-br", portName)
+	if err != nil {
+		_, err := shared.RunCommand("ovs-vsctl", "add-port", bridgeName, portName)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// BridgeDeletePort deletes a port from the bridge (if already deteached does nothing).
+func (o *OVS) BridgeDeletePort(bridgeName string, portName string) error {
+	// Check if interface is connected to a bridge, if so, then remove it from the bridge.
+	_, err := shared.RunCommand("ovs-vsctl", "port-to-br", portName)
+	if err == nil {
+		_, err := shared.RunCommand("ovs-vsctl", "del-port", bridgeName, portName)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// PortSet sets port options.
+func (o *OVS) PortSet(portName string, options ...string) error {
+	_, err := shared.RunCommand("ovs-vsctl", append([]string{"set", "port", portName}, options...)...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lxc/lxd/lxd/device/nictype"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/network"
+	"github.com/lxc/lxd/lxd/network/openvswitch"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/revert"
@@ -434,8 +435,8 @@ func doNetworkGet(d *Daemon, name string) (api.Network, error) {
 	} else if shared.PathExists(fmt.Sprintf("/sys/class/net/%s/bonding", n.Name)) {
 		n.Type = "bond"
 	} else {
-		_, err := shared.RunCommand("ovs-vsctl", "br-exists", n.Name)
-		if err == nil {
+		ovs := openvswitch.NewOVS()
+		if exists, _ := ovs.BridgeExists(n.Name); exists {
 			n.Type = "bridge"
 		} else {
 			n.Type = "unknown"


### PR DESCRIPTION
As part of the planned OVN work I am intending to create a wrapper struct to encapsulate calls to the `ovn-*` commands.

The OVN project will also require running some `ovs-*` commands too, so for the first part of this I have created `openvswitch` package that will house both OVS and OVN wrapper functions, and initially moved just the OVS related functions over to it.