### PR TITLE
api: Adds network types API extension for macvlan and sriov

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1130,3 +1130,10 @@ specify which parent interface should be used for creating NIC device interfaces
 
 Also adds `network` configuration key support for `macvlan` NICs to allow them to specify the associated network of
 the same type that they should use as the basis for the NIC device.
+
+## network\_type\_sriov
+Adds support for additional network type `sriov` and adds `parent` configuration key for this network type to
+specify which parent interface should be used for creating NIC device interfaces on top of.
+
+Also adds `network` configuration key support for `sriov` NICs to allow them to specify the associated network of
+the same type that they should use as the basis for the NIC device.

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1123,3 +1123,10 @@ attached to a SPICE unix socket of the target virtual machine.
 Add `limits.disk` to the available project configuration keys. If set, it limits
 the total amount of disk space that instances volumes, custom volumes and images
 volumes can use in the project.
+
+## network\_type\_macvlan
+Adds support for additional network type `macvlan` and adds `parent` configuration key for this network type to
+specify which parent interface should be used for creating NIC device interfaces on top of.
+
+Also adds `network` configuration key support for `macvlan` NICs to allow them to specify the associated network of
+the same type that they should use as the basis for the NIC device.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -221,6 +221,7 @@ var APIExtensions = []string{
 	"console_vga_type",
 	"projects_limits_disk",
 	"network_type_macvlan",
+	"network_type_sriov",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -220,6 +220,7 @@ var APIExtensions = []string{
 	"resources_gpu_mdev",
 	"console_vga_type",
 	"projects_limits_disk",
+	"network_type_macvlan",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>