### PR TITLE
clarifications about "Error: Missing LXD-Image-Hash header"

### DIFF
--- a/doc/image-handling.md
+++ b/doc/image-handling.md
@@ -79,7 +79,9 @@ Tarball, can be compressed and contains:
  - `metadata.yaml`
  - `templates/` (optional)
 
-In this mode, the image identifier is the SHA-256 of the tarball.
+In this mode, the image identifier is the SHA-256 of the tarball. If the image 
+is hosted on a server, the server hosting the remote image should set the 
+LXD-Image-Hash header else the operation will fail with "Error: Missing LXD-Image-Hash header".
 
 ### Split tarballs
 Two (possibly compressed) tarballs. One for metadata, one for the rootfs.

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -1835,7 +1835,9 @@ In the remote image URL case, the following dict must be used:
 
 After the input is received by LXD, a background operation is started
 which will add the image to the store and possibly do some backend
-filesystem-specific optimizations.
+filesystem-specific optimizations. The server hosting the remote image 
+should set the LXD-Image-Hash header else the operation will fail with 
+"Error: Missing LXD-Image-Hash header".
 
 ### `/1.0/images/<fingerprint>`
 #### GET (optional `?secret=SECRET`)


### PR DESCRIPTION
I put the information about the LXD-Image-Hash header in both doc/rest-api.md and doc/image-handling.md, hopefully in the right places.