### PR TITLE
Network: Bridge defaults on Update

### DIFF
--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -105,7 +105,9 @@ func (c *migrationFields) sendControl(err error) {
 	c.controlLock.Lock()
 	defer c.controlLock.Unlock()
 
-	migration.ProtoSendControl(c.controlConn, err)
+	if c.controlConn != nil {
+		migration.ProtoSendControl(c.controlConn, err)
+	}
 
 	if err != nil {
 		c.disconnect()

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1343,15 +1343,14 @@ func (n *bridge) Stop() error {
 func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clusterNotification bool) error {
 	n.logger.Debug("Update", log.Ctx{"clusterNotification": clusterNotification, "newNetwork": newNetwork})
 
-	// When switching to a fan bridge, auto-detect the underlay if not specified.
-	if newNetwork.Config["bridge.mode"] == "fan" {
-		if newNetwork.Config["fan.underlay_subnet"] == "" {
-			newNetwork.Config["fan.underlay_subnet"] = "auto"
-		}
+	// Populate default values if they are missing.
+	err := n.fillConfig(newNetwork.Config)
+	if err != nil {
+		return err
 	}
 
 	// Populate auto fields.
-	err := fillAuto(newNetwork.Config)
+	err = fillAuto(newNetwork.Config)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -44,30 +44,30 @@ type bridge struct {
 }
 
 // fillConfig fills requested config with any default values.
-func (n *bridge) fillConfig(req *api.NetworksPost) error {
+func (n *bridge) fillConfig(config map[string]string) error {
 	// Set some default values where needed.
-	if req.Config["bridge.mode"] == "fan" {
-		if req.Config["fan.underlay_subnet"] == "" {
-			req.Config["fan.underlay_subnet"] = "auto"
+	if config["bridge.mode"] == "fan" {
+		if config["fan.underlay_subnet"] == "" {
+			config["fan.underlay_subnet"] = "auto"
 		}
 	} else {
-		if req.Config["ipv4.address"] == "" {
-			req.Config["ipv4.address"] = "auto"
+		if config["ipv4.address"] == "" {
+			config["ipv4.address"] = "auto"
 		}
 
-		if req.Config["ipv4.address"] == "auto" && req.Config["ipv4.nat"] == "" {
-			req.Config["ipv4.nat"] = "true"
+		if config["ipv4.address"] == "auto" && config["ipv4.nat"] == "" {
+			config["ipv4.nat"] = "true"
 		}
 
-		if req.Config["ipv6.address"] == "" {
+		if config["ipv6.address"] == "" {
 			content, err := ioutil.ReadFile("/proc/sys/net/ipv6/conf/default/disable_ipv6")
 			if err == nil && string(content) == "0\n" {
-				req.Config["ipv6.address"] = "auto"
+				config["ipv6.address"] = "auto"
 			}
 		}
 
-		if req.Config["ipv6.address"] == "auto" && req.Config["ipv6.nat"] == "" {
-			req.Config["ipv6.nat"] = "true"
+		if config["ipv6.address"] == "auto" && config["ipv6.nat"] == "" {
+			config["ipv6.nat"] = "true"
 		}
 	}
 

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -51,7 +51,7 @@ func (n *common) init(state *state.State, id int64, name string, netType string,
 }
 
 // fillConfig fills requested config with any default values, by default this is a no-op.
-func (n *common) fillConfig(req *api.NetworksPost) error {
+func (n *common) fillConfig(config map[string]string) error {
 	return nil
 }
 

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -10,7 +10,7 @@ import (
 type Network interface {
 	// Load.
 	init(state *state.State, id int64, name string, netType string, description string, config map[string]string, status string)
-	fillConfig(*api.NetworksPost) error
+	fillConfig(config map[string]string) error
 
 	// Config.
 	Validate(config map[string]string) error

--- a/lxd/network/network_load.go
+++ b/lxd/network/network_load.go
@@ -56,7 +56,7 @@ func FillConfig(req *api.NetworksPost) error {
 	n := driverFunc()
 	n.init(nil, 0, req.Name, req.Type, req.Description, req.Config, "Unknown")
 
-	err := n.fillConfig(req)
+	err := n.fillConfig(req.Config)
 	if err != nil {
 		return err
 	}

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -405,8 +405,8 @@ test_container_devices_nic_bridged() {
   lxc config device add "${ctName}" eth0 nic nictype=bridged parent="${brName}" name=eth0
   lxc start "${ctName}"
   lxc exec "${ctName}" -- udhcpc -i eth0 -n -q
-  lxc network unset "${brName}" ipv4.address
-  lxc network unset "${brName}" ipv6.address
+  lxc network set "${brName}" ipv4.address none
+  lxc network set "${brName}" ipv6.address none
 
   if [ -f "${LXD_DIR}/networks/${brName}/dnsmasq.leases" ] ; then
     echo "dnsmasq.leases file still present after disabling DHCP"


### PR DESCRIPTION
Applies defaults to missing config keys on `Update()` not just when creating the initial network.

This fixes a bug where if one of the fields that is automatically populated at create time is removed via an update, the key is re-populated using new (sometimes random) values.

Includes https://github.com/lxc/lxd/pull/7689 (dont merge until after it has been and this has been rebased please).

