### PR TITLE
Network: Persistent randomly generated MAC address for bridge interface

### DIFF
--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -541,20 +540,6 @@ func networkSetVethLimits(m deviceConfig.Device) error {
 	}
 
 	return nil
-}
-
-// networkValidMAC validates an ethernet MAC address. e.g. "32:47:ae:06:22:f9".
-func networkValidMAC(value string) error {
-	regexHwaddr, err := regexp.Compile("^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$")
-	if err != nil {
-		return err
-	}
-
-	if regexHwaddr.MatchString(value) {
-		return nil
-	}
-
-	return fmt.Errorf("Invalid value, must 6 bytes of lower case hex separated by colons")
 }
 
 // networkValidGateway validates the gateway value.

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -13,7 +13,7 @@ func nicValidationRules(requiredFields []string, optionalFields []string) map[st
 		"network":                 shared.IsAny,
 		"mtu":                     shared.IsAny,
 		"vlan":                    networkValidVLAN,
-		"hwaddr":                  networkValidMAC,
+		"hwaddr":                  shared.IsNetworkMAC,
 		"host_name":               shared.IsAny,
 		"limits.ingress":          shared.IsAny,
 		"limits.egress":           shared.IsAny,

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/daemon"
 	"github.com/lxc/lxd/lxd/dnsmasq"
+	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/network/openvswitch"
 	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/revert"
@@ -41,6 +42,33 @@ var forkdnsServersLock sync.Mutex
 // bridge represents a LXD bridge network.
 type bridge struct {
 	common
+}
+
+// getHwaddr retrieves existing static or volatile MAC address from config.
+func (n *bridge) getHwaddr(config map[string]string) string {
+	hwAddr := config["bridge.hwaddr"]
+	if hwAddr == "" {
+		hwAddr = config["volatile.bridge.hwaddr"]
+	}
+
+	return hwAddr
+}
+
+// fillHwaddr populates the volatile.bridge.hwaddr in config if it, nor bridge.hwaddr, are already set.
+// Returns MAC address generated if needed to, otherwise empty string.
+func (n *bridge) fillHwaddr(config map[string]string) (string, error) {
+	// If no existing MAC address, generate a new one and store in volatile.
+	if n.getHwaddr(config) == "" {
+		hwAddr, err := instance.DeviceNextInterfaceHWAddr()
+		if err != nil {
+			return "", errors.Wrapf(err, "Failed generating MAC address")
+		}
+
+		config["volatile.bridge.hwaddr"] = hwAddr
+		return config["volatile.bridge.hwaddr"], nil
+	}
+
+	return "", nil
 }
 
 // fillConfig fills requested config with any default values.
@@ -71,6 +99,13 @@ func (n *bridge) fillConfig(config map[string]string) error {
 		}
 	}
 
+	// If no static hwaddr specified generate a volatile one to store in DB record so that
+	// there are no races when starting the network at the same time on multiple cluster nodes.
+	_, err := n.fillHwaddr(config)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -95,8 +130,21 @@ func (n *bridge) Validate(config map[string]string) error {
 
 			return nil
 		},
-		"bridge.hwaddr": shared.IsAny,
-		"bridge.mtu":    shared.IsInt64,
+		"bridge.hwaddr": func(value string) error {
+			if value == "" {
+				return nil
+			}
+
+			return shared.IsNetworkMAC(value)
+		},
+		"volatile.bridge.hwaddr": func(value string) error {
+			if value == "" {
+				return nil
+			}
+
+			return shared.IsNetworkMAC(value)
+		},
+		"bridge.mtu": shared.IsInt64,
 		"bridge.mode": func(value string) error {
 			return shared.IsOneOf(value, []string{"standard", "fan"})
 		},
@@ -456,9 +504,14 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		return err
 	}
 
-	// Set the MAC address.
-	if n.config["bridge.hwaddr"] != "" {
-		_, err = shared.RunCommand("ip", "link", "set", "dev", n.name, "address", n.config["bridge.hwaddr"])
+	// If static or persistent volatile MAC address present, use that.
+	// We do not generate missing persistent volatile MAC address at start time so as not to cause DB races
+	// when starting an existing network without volatile key in a cluster. This also allows the previous
+	// behavior for networks (i.e random MAC at start if not specified) until the network is next updated.
+	hwAddr := n.getHwaddr(n.config)
+	if hwAddr != "" {
+		// Set the MAC address on the bridge interface.
+		_, err = shared.RunCommand("ip", "link", "set", "dev", n.name, "address", hwAddr)
 		if err != nil {
 			return err
 		}

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -162,6 +162,20 @@ func IsRootDiskDevice(device map[string]string) bool {
 	return false
 }
 
+// IsNetworkMAC validates an ethernet MAC address. e.g. "32:47:ae:06:22:f9".
+func IsNetworkMAC(value string) error {
+	regexHwaddr, err := regexp.Compile("^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$")
+	if err != nil {
+		return err
+	}
+
+	if regexHwaddr.MatchString(value) {
+		return nil
+	}
+
+	return fmt.Errorf("Invalid value, must 6 bytes of lower case hex separated by colons")
+}
+
 // IsNetworkAddress validates an IP (v4 or v6) address string. If string is empty, returns valid.
 func IsNetworkAddress(value string) error {
 	if value == "" {


### PR DESCRIPTION
With the forthcoming OVN network feature, the first part of this feature will require the use of an existing bridge network to be used as the external "uplink" network to get access to external resources. When running OVN in a clustered environment, OVN chooses one node as the active default gateway, and will use the local bridge on that node as the default gateway next-hop MAC address.

When a node goes down, OVN will switch the default gateway to a different node automatically, however it does not re-run neighbour discovery (ARP/NDP) and continues to use the previously discovered MAC address of the uplink bridge for the default gateway next-hop.

This causes problems at the moment because each bridge defined is given a random MAC address on every start up, which is different on every node.

This PR generates a random, but persistent MAC address, which is stored in volatile, and is applied to every node.

This way when OVN fails over, the previously discovered MAC address will still be valid.

This also has the benefit that the bridge interface's MAC address doesn't change when a new instance is connected with a MAC address 'lower' than its current one.

- Adds generation and persistence of randomly generated MAC address for bridge interface
- Stored in new network config key `volatile.bridge.hwaddr`.
- Automatically generated on create/update of new/existing bridge networks if missing and do not specify static `hwaddr` (but not on start/restart).
- Does not auto generate on network start/restart to avoid races updating database from multiple nodes concurrently when in a cluster environment.

Includes #7690 (dont merge until after it has been and this has been rebased please).

