### PR TITLE
test: Wait for operations to be removed from the database

### DIFF
--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -543,6 +543,7 @@ test_clustering_storage() {
 
     # Copy the container without specifying a target, it will be placed on node2
     # since it's the one with the least number of containers (0 vs 1)
+    sleep 6 # Wait for pending operations to be removed from the database
     LXD_DIR="${LXD_ONE_DIR}" lxc copy foo bar
     LXD_DIR="${LXD_ONE_DIR}" lxc info bar | grep -q "Location: node2"
 


### PR DESCRIPTION
Pending operations take up to 5 seconds to be removed from the database, even
after completion. Since we don't record the status in the database, and that
status appears to be something that only the local node stores, we can't cheaply
know what the status is when we querying the database to decide placement of a
new container.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>