### PR TITLE
Networks: Adds mtu and vlan options for macvlan and sriov networks

### DIFF
--- a/doc/networks.md
+++ b/doc/networks.md
@@ -226,6 +226,8 @@ Network configuration properties:
 Key                             | Type      | Condition             | Default                   | Description
 :--                             | :--       | :--                   | :--                       | :--
 parent                          | string    | -                     | -                         | Parent interface to create macvlan NICs on
+mtu                             | integer   | -                     | -                         | The MTU of the new interface
+vlan                            | integer   | -                     | -                         | The VLAN ID to attach to
 maas.subnet.ipv4                | string    | ipv4 address          | -                         | MAAS IPv4 subnet to register instances in (when using `network` property on nic)
 maas.subnet.ipv6                | string    | ipv6 address          | -                         | MAAS IPv6 subnet to register instances in (when using `network` property on nic)
 
@@ -240,5 +242,7 @@ Network configuration properties:
 Key                             | Type      | Condition             | Default                   | Description
 :--                             | :--       | :--                   | :--                       | :--
 parent                          | string    | -                     | -                         | Parent interface to create sriov NICs on
+mtu                             | integer   | -                     | -                         | The MTU of the new interface
+vlan                            | integer   | -                     | -                         | The VLAN ID to attach to
 maas.subnet.ipv4                | string    | ipv4 address          | -                         | MAAS IPv4 subnet to register instances in (when using `network` property on nic)
 maas.subnet.ipv6                | string    | ipv6 address          | -                         | MAAS IPv6 subnet to register instances in (when using `network` property on nic)

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -551,20 +551,6 @@ func networkValidGateway(value string) error {
 	return fmt.Errorf("Invalid gateway: %s", value)
 }
 
-// networkValidVLAN validates a VLAN ID.
-func networkValidVLAN(value string) error {
-	vlanID, err := strconv.Atoi(value)
-	if err != nil {
-		return fmt.Errorf("Invalid VLAN ID: %s", value)
-	}
-
-	if vlanID < 0 || vlanID > 4094 {
-		return fmt.Errorf("Out of range (0-4094) VLAN ID: %s", value)
-	}
-
-	return nil
-}
-
 // networkValidVLANList validates a comma delimited list of VLAN IDs.
 func networkValidVLANList(value string) error {
 	for _, vlanID := range strings.Split(value, ",") {

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/units"
+	"github.com/lxc/lxd/shared/validate"
 )
 
 // Instances can be started in parallel, so lock the creation of VLANs.
@@ -555,7 +556,7 @@ func networkValidGateway(value string) error {
 func networkValidVLANList(value string) error {
 	for _, vlanID := range strings.Split(value, ",") {
 		vlanID = strings.TrimSpace(vlanID)
-		err := networkValidVLAN(vlanID)
+		err := validate.IsNetworkVLAN(vlanID)
 		if err != nil {
 			return err
 		}

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -12,7 +12,7 @@ func nicValidationRules(requiredFields []string, optionalFields []string) map[st
 		"parent":                  validate.IsAny,
 		"network":                 validate.IsAny,
 		"mtu":                     validate.IsAny,
-		"vlan":                    networkValidVLAN,
+		"vlan":                    validate.IsNetworkVLAN,
 		"hwaddr":                  validate.IsNetworkMAC,
 		"host_name":               validate.IsAny,
 		"limits.ingress":          validate.IsAny,

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -32,6 +32,7 @@ import (
 	"github.com/lxc/lxd/shared/api"
 	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/validate"
 )
 
 type nicBridged struct {
@@ -166,7 +167,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 			return nil
 		}
 
-		return networkValidVLAN(value)
+		return validate.IsNetworkVLAN(value)
 	}
 
 	// Add bridge specific vlan.tagged validation.

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -41,7 +41,7 @@ func (d *nicMACVLAN) validateConfig(instConf instance.ConfigReader) error {
 	if d.config["network"] != "" {
 		requiredFields = append(requiredFields, "network")
 
-		bannedKeys := []string{"nictype", "parent", "mtu", "maas.subnet.ipv4", "maas.subnet.ipv6"}
+		bannedKeys := []string{"nictype", "parent", "mtu", "vlan", "maas.subnet.ipv4", "maas.subnet.ipv6"}
 		for _, bannedKey := range bannedKeys {
 			if d.config[bannedKey] != "" {
 				return fmt.Errorf("Cannot use %q property in conjunction with %q property", bannedKey, "network")
@@ -68,7 +68,7 @@ func (d *nicMACVLAN) validateConfig(instConf instance.ConfigReader) error {
 		d.config["parent"] = netConfig["parent"]
 
 		// Copy certain keys verbatim from the network's settings.
-		inheritKeys := []string{"maas.subnet.ipv4", "maas.subnet.ipv6"}
+		inheritKeys := []string{"mtu", "vlan", "maas.subnet.ipv4", "maas.subnet.ipv6"}
 		for _, inheritKey := range inheritKeys {
 			if _, found := netConfig[inheritKey]; found {
 				d.config[inheritKey] = netConfig[inheritKey]

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -51,7 +51,7 @@ func (d *nicSRIOV) validateConfig(instConf instance.ConfigReader) error {
 	if d.config["network"] != "" {
 		requiredFields = append(requiredFields, "network")
 
-		bannedKeys := []string{"nictype", "parent", "mtu", "maas.subnet.ipv4", "maas.subnet.ipv6"}
+		bannedKeys := []string{"nictype", "parent", "mtu", "vlan", "maas.subnet.ipv4", "maas.subnet.ipv6"}
 		for _, bannedKey := range bannedKeys {
 			if d.config[bannedKey] != "" {
 				return fmt.Errorf("Cannot use %q property in conjunction with %q property", bannedKey, "network")
@@ -78,7 +78,7 @@ func (d *nicSRIOV) validateConfig(instConf instance.ConfigReader) error {
 		d.config["parent"] = netConfig["parent"]
 
 		// Copy certain keys verbatim from the network's settings.
-		inheritKeys := []string{"maas.subnet.ipv4", "maas.subnet.ipv6"}
+		inheritKeys := []string{"mtu", "vlan", "maas.subnet.ipv4", "maas.subnet.ipv6"}
 		for _, inheritKey := range inheritKeys {
 			if _, found := netConfig[inheritKey]; found {
 				d.config[inheritKey] = netConfig[inheritKey]

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -152,7 +152,7 @@ func (n *bridge) Validate(config map[string]string) error {
 
 			return validate.IsNetworkMAC(value)
 		},
-		"bridge.mtu": validate.IsInt64,
+		"bridge.mtu": validate.Optional(validate.IsInt64),
 		"bridge.mode": func(value string) error {
 			return validate.IsOneOf(value, []string{"standard", "fan"})
 		},
@@ -252,7 +252,7 @@ func (n *bridge) Validate(config map[string]string) error {
 			case "group":
 				rules[k] = validate.IsNetworkAddress
 			case "id":
-				rules[k] = validate.IsInt64
+				rules[k] = validate.Optional(validate.IsInt64)
 			case "inteface":
 				rules[k] = ValidNetworkName
 			case "ttl":

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -26,6 +26,8 @@ func (n *macvlan) Validate(config map[string]string) error {
 
 			return nil
 		},
+		"mtu":              validate.Optional(validate.IsInt64),
+		"vlan":             validate.Optional(validate.IsNetworkVLAN),
 		"maas.subnet.ipv4": validate.IsAny,
 		"maas.subnet.ipv6": validate.IsAny,
 	}

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -26,6 +26,8 @@ func (n *sriov) Validate(config map[string]string) error {
 
 			return nil
 		},
+		"mtu":              validate.Optional(validate.IsInt64),
+		"vlan":             validate.Optional(validate.IsNetworkVLAN),
 		"maas.subnet.ipv4": validate.IsAny,
 		"maas.subnet.ipv6": validate.IsAny,
 	}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -479,7 +479,7 @@ func validateVolumeCommonRules(vol drivers.Volume) map[string]func(string) error
 
 	// volatile.rootfs.size is only used for image volumes.
 	if vol.Type() == drivers.VolumeTypeImage {
-		rules["volatile.rootfs.size"] = validate.IsInt64
+		rules["volatile.rootfs.size"] = validate.Optional(validate.IsInt64)
 	}
 
 	return rules

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -72,10 +72,10 @@ var HugePageSizeSuffix = [...]string{"64KB", "1MB", "2MB", "1GB"}
 // given value is syntactically legal.
 var KnownInstanceConfigKeys = map[string]func(value string) error{
 	"boot.autostart":             validate.IsBool,
-	"boot.autostart.delay":       validate.IsInt64,
-	"boot.autostart.priority":    validate.IsInt64,
-	"boot.stop.priority":         validate.IsInt64,
-	"boot.host_shutdown_timeout": validate.IsInt64,
+	"boot.autostart.delay":       validate.Optional(validate.IsInt64),
+	"boot.autostart.priority":    validate.Optional(validate.IsInt64),
+	"boot.stop.priority":         validate.Optional(validate.IsInt64),
+	"boot.host_shutdown_timeout": validate.Optional(validate.IsInt64),
 
 	"limits.cpu": func(value string) error {
 		if value == "" {
@@ -172,7 +172,7 @@ var KnownInstanceConfigKeys = map[string]func(value string) error{
 
 	"limits.network.priority": validate.IsPriority,
 
-	"limits.processes": validate.IsInt64,
+	"limits.processes": validate.Optional(validate.IsInt64),
 
 	"linux.kernel_modules": validate.IsAny,
 

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -20,6 +20,17 @@ func stringInSlice(key string, list []string) bool {
 	return false
 }
 
+// Optional wraps a validator function to make it an optional field.
+func Optional(f func(value string) error) func(value string) error {
+	return func(value string) error {
+		if value == "" {
+			return nil
+		}
+
+		return f(value)
+	}
+}
+
 // IsInt64 validates whether the string can be converted to an int64.
 func IsInt64(value string) error {
 	if value == "" {

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -350,3 +350,17 @@ func IsNetworkV6List(value string) error {
 
 	return nil
 }
+
+// IsNetworkVLAN validates a VLAN ID.
+func IsNetworkVLAN(value string) error {
+	vlanID, err := strconv.Atoi(value)
+	if err != nil {
+		return fmt.Errorf("Invalid VLAN ID: %s", value)
+	}
+
+	if vlanID < 0 || vlanID > 4094 {
+		return fmt.Errorf("Out of range (0-4094) VLAN ID: %s", value)
+	}
+
+	return nil
+}

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -33,10 +33,6 @@ func Optional(f func(value string) error) func(value string) error {
 
 // IsInt64 validates whether the string can be converted to an int64.
 func IsInt64(value string) error {
-	if value == "" {
-		return nil
-	}
-
 	_, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
 		return fmt.Errorf("Invalid value for an integer %q", value)


### PR DESCRIPTION
- Adds mtu and vlan options for macvlan and sriov networks.
- Introduces `validate.Optional()` wrapper which can be used with existing validate helper functions to make them optional, rather than building support into every helper.
- Updated `validate.IsInt64` to not be optional and updated usage of it to wrap with `validate.Optional()`.