### PR TITLE
Network: OVN

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1140,3 +1140,14 @@ the same type that they should use as the basis for the NIC device.
 
 ## container\_syscall\_intercept\_bpf\_devices
 This adds support to intercept the bpf syscall in containers. Specifically, it allows to manage device cgroup bpf programs.
+
+## network\_type\_ovn
+Adds support for additional network type `ovn` with the ability to specify a `bridge` type network as the `parent`.
+
+Introduces a new NIC device type of `ovn` which allows the `network` configuration key to specify which `ovn`
+type network they should connect to.
+
+Also introduces two new global config keys that apply to all `ovn` networks and NIC devices:
+
+ - network.ovn.integration\_bridge - the OVS integration bridge to use.
+ - network.ovn.northbound\_connection - the OVN northbound database connection string.

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -68,8 +68,8 @@ bridge.hwaddr                   | string    | -                     | -         
 bridge.mode                     | string    | -                     | standard                  | Bridge operation mode ("standard" or "fan")
 bridge.mtu                      | integer   | -                     | 1500                      | Bridge MTU (default varies if tunnel or fan setup)
 dns.domain                      | string    | -                     | lxd                       | Domain to advertise to DHCP clients and use for DNS resolution
-dns.search                      | string    | -                     | -                         | Full comma separated domain search list, defaulting to `dns.domain` value
 dns.mode                        | string    | -                     | managed                   | DNS registration mode ("none" for no DNS record, "managed" for LXD generated static records or "dynamic" for client generated records)
+dns.search                      | string    | -                     | -                         | Full comma separated domain search list, defaulting to `dns.domain` value
 fan.overlay\_subnet             | string    | fan mode              | 240.0.0.0/8               | Subnet to use as the overlay for the FAN (CIDR notation)
 fan.type                        | string    | fan mode              | vxlan                     | The tunneling type for the FAN ("vxlan" or "ipip")
 fan.underlay\_subnet            | string    | fan mode              | default gateway subnet    | Subnet to use as the underlay for the FAN (CIDR notation)
@@ -79,9 +79,9 @@ ipv4.dhcp.expiry                | string    | ipv4 dhcp             | 1h        
 ipv4.dhcp.gateway               | string    | ipv4 dhcp             | ipv4.address              | Address of the gateway for the subnet
 ipv4.dhcp.ranges                | string    | ipv4 dhcp             | all addresses             | Comma separated list of IP ranges to use for DHCP (FIRST-LAST format)
 ipv4.firewall                   | boolean   | ipv4 address          | true                      | Whether to generate filtering firewall rules for this network
+ipv4.nat.address                | string    | ipv4 address          | -                         | The source address used for outbound traffic from the bridge
 ipv4.nat                        | boolean   | ipv4 address          | false                     | Whether to NAT (will default to true if unset and a random ipv4.address is generated)
 ipv4.nat.order                  | string    | ipv4 address          | before                    | Whether to add the required NAT rules before or after any pre-existing rules
-ipv4.nat.address                | string    | ipv4 address          | -                         | The source address used for outbound traffic from the bridge
 ipv4.ovn.ranges                 | string    | -                     | none                      | Comma separate list of IPv4 ranges to use for child OVN networks (FIRST-LAST format)
 ipv4.routes                     | string    | ipv4 address          | -                         | Comma separated list of additional IPv4 CIDR subnets to route to the bridge
 ipv4.routing                    | boolean   | ipv4 address          | true                      | Whether to route traffic in and out of the bridge
@@ -91,9 +91,9 @@ ipv6.dhcp.expiry                | string    | ipv6 dhcp             | 1h        
 ipv6.dhcp.ranges                | string    | ipv6 stateful dhcp    | all addresses             | Comma separated list of IPv6 ranges to use for DHCP (FIRST-LAST format)
 ipv6.dhcp.stateful              | boolean   | ipv6 dhcp             | false                     | Whether to allocate addresses using DHCP
 ipv6.firewall                   | boolean   | ipv6 address          | true                      | Whether to generate filtering firewall rules for this network
+ipv6.nat.address                | string    | ipv6 address          | -                         | The source address used for outbound traffic from the bridge
 ipv6.nat                        | boolean   | ipv6 address          | false                     | Whether to NAT (will default to true if unset and a random ipv6.address is generated)
 ipv6.nat.order                  | string    | ipv6 address          | before                    | Whether to add the required NAT rules before or after any pre-existing rules
-ipv6.nat.address                | string    | ipv6 address          | -                         | The source address used for outbound traffic from the bridge
 ipv6.ovn.ranges                 | string    | -                     | none                      | Comma separate list of IPv6 ranges to use for child OVN networks (FIRST-LAST format)
 ipv6.routes                     | string    | ipv6 address          | -                         | Comma separated list of additional IPv6 CIDR subnets to route to the bridge
 ipv6.routing                    | boolean   | ipv6 address          | true                      | Whether to route traffic in and out of the bridge
@@ -227,11 +227,11 @@ Network configuration properties:
 
 Key                             | Type      | Condition             | Default                   | Description
 :--                             | :--       | :--                   | :--                       | :--
-parent                          | string    | -                     | -                         | Parent interface to create macvlan NICs on
-mtu                             | integer   | -                     | -                         | The MTU of the new interface
-vlan                            | integer   | -                     | -                         | The VLAN ID to attach to
 maas.subnet.ipv4                | string    | ipv4 address          | -                         | MAAS IPv4 subnet to register instances in (when using `network` property on nic)
 maas.subnet.ipv6                | string    | ipv6 address          | -                         | MAAS IPv6 subnet to register instances in (when using `network` property on nic)
+mtu                             | integer   | -                     | -                         | The MTU of the new interface
+parent                          | string    | -                     | -                         | Parent interface to create macvlan NICs on
+vlan                            | integer   | -                     | -                         | The VLAN ID to attach to
 
 ## network: sriov
 
@@ -243,11 +243,11 @@ Network configuration properties:
 
 Key                             | Type      | Condition             | Default                   | Description
 :--                             | :--       | :--                   | :--                       | :--
-parent                          | string    | -                     | -                         | Parent interface to create sriov NICs on
-mtu                             | integer   | -                     | -                         | The MTU of the new interface
-vlan                            | integer   | -                     | -                         | The VLAN ID to attach to
 maas.subnet.ipv4                | string    | ipv4 address          | -                         | MAAS IPv4 subnet to register instances in (when using `network` property on nic)
 maas.subnet.ipv6                | string    | ipv6 address          | -                         | MAAS IPv6 subnet to register instances in (when using `network` property on nic)
+mtu                             | integer   | -                     | -                         | The MTU of the new interface
+parent                          | string    | -                     | -                         | Parent interface to create sriov NICs on
+vlan                            | integer   | -                     | -                         | The VLAN ID to attach to
 
 ## network: ovn
 
@@ -289,9 +289,9 @@ lxc ls
 
 Key                             | Type      | Condition             | Default                   | Description
 :--                             | :--       | :--                   | :--                       | :--
-parent                          | string    | -                     | -                         | Parent network to use for outbound external network access
 bridge.hwaddr                   | string    | -                     | -                         | MAC address for the bridge
 dns.domain                      | string    | -                     | lxd                       | Domain to advertise to DHCP clients and use for DNS resolution
 dns.search                      | string    | -                     | -                         | Full comma separated domain search list, defaulting to `dns.domain` value
 ipv4.address                    | string    | standard mode         | random unused subnet      | IPv4 address for the bridge (CIDR notation). Use "none" to turn off IPv4 or "auto" to generate a new one
 ipv6.address                    | string    | standard mode         | random unused subnet      | IPv6 address for the bridge (CIDR notation). Use "none" to turn off IPv6 or "auto" to generate a new one
+parent                          | string    | -                     | -                         | Parent network to use for outbound external network access

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -82,6 +82,7 @@ ipv4.firewall                   | boolean   | ipv4 address          | true      
 ipv4.nat                        | boolean   | ipv4 address          | false                     | Whether to NAT (will default to true if unset and a random ipv4.address is generated)
 ipv4.nat.order                  | string    | ipv4 address          | before                    | Whether to add the required NAT rules before or after any pre-existing rules
 ipv4.nat.address                | string    | ipv4 address          | -                         | The source address used for outbound traffic from the bridge
+ipv4.ovn.ranges                 | string    | -                     | none                      | Comma separate list of IPv4 ranges to use for child OVN networks (FIRST-LAST format)
 ipv4.routes                     | string    | ipv4 address          | -                         | Comma separated list of additional IPv4 CIDR subnets to route to the bridge
 ipv4.routing                    | boolean   | ipv4 address          | true                      | Whether to route traffic in and out of the bridge
 ipv6.address                    | string    | standard mode         | random unused subnet      | IPv6 address for the bridge (CIDR notation). Use "none" to turn off IPv6 or "auto" to generate a new one
@@ -93,6 +94,7 @@ ipv6.firewall                   | boolean   | ipv6 address          | true      
 ipv6.nat                        | boolean   | ipv6 address          | false                     | Whether to NAT (will default to true if unset and a random ipv6.address is generated)
 ipv6.nat.order                  | string    | ipv6 address          | before                    | Whether to add the required NAT rules before or after any pre-existing rules
 ipv6.nat.address                | string    | ipv6 address          | -                         | The source address used for outbound traffic from the bridge
+ipv6.ovn.ranges                 | string    | -                     | none                      | Comma separate list of IPv6 ranges to use for child OVN networks (FIRST-LAST format)
 ipv6.routes                     | string    | ipv6 address          | -                         | Comma separated list of additional IPv6 CIDR subnets to route to the bridge
 ipv6.routing                    | boolean   | ipv6 address          | true                      | Whether to route traffic in and out of the bridge
 maas.subnet.ipv4                | string    | ipv4 address          | -                         | MAAS IPv4 subnet to register instances in (when using `network` property on nic)

--- a/doc/server.md
+++ b/doc/server.md
@@ -12,45 +12,47 @@ currently supported:
  - `maas` (MAAS integration)
  - `rbac` (Role Based Access Control through external Candid + Canonical RBAC)
 
-Key                                 | Type      | Scope     | Default   | API extension                     | Description
-:--                                 | :---      | :----     | :------   | :------------                     | :----------
-backups.compression\_algorithm      | string    | global    | gzip      | backup\_compression               | Compression algorithm to use for new images (bzip2, gzip, lzma, xz or none)
-candid.api.key                      | string    | global    | -         | candid\_config\_key               | Public key of the candid server (required for HTTP-only servers)
-candid.api.url                      | string    | global    | -         | candid\_authentication            | URL of the the external authentication endpoint using Candid
-candid.expiry                       | integer   | global    | 3600      | candid\_config                    | Candid macaroon expiry in seconds
-candid.domains                      | string    | global    | -         | candid\_config                    | Comma-separated list of allowed Candid domains (empty string means all domains are valid)
-cluster.https\_address              | string    | local     | -         | clustering\_server\_address       | Address the server should using for clustering traffic
-cluster.offline\_threshold          | integer   | global    | 20        | clustering                        | Number of seconds after which an unresponsive node is considered offline
-cluster.images\_minimal\_replica    | integer   | global    | 3         | clustering\_image\_replication    | Minimal numbers of cluster members with a copy of a particular image (set 1 for no replication, -1 for all members)
-cluster.max\_voters                 | integer   | global    | 3         | clustering\_sizing                | Maximum number of cluster members that will be assigned the database voter role
-cluster.max\_standby                | integer   | global    | 2         | clustering\_sizing                | Maximum number of cluster members that will be assigned the database stand-by role
-core.debug\_address                 | string    | local     | -         | pprof\_http                       | Address to bind the pprof debug server to (HTTP)
-core.https\_address                 | string    | local     | -         | -                                 | Address to bind for the remote API (HTTPS)
-core.https\_allowed\_credentials    | boolean   | global    | -         | -                                 | Whether to set Access-Control-Allow-Credentials http header value to "true"
-core.https\_allowed\_headers        | string    | global    | -         | -                                 | Access-Control-Allow-Headers http header value
-core.https\_allowed\_methods        | string    | global    | -         | -                                 | Access-Control-Allow-Methods http header value
-core.https\_allowed\_origin         | string    | global    | -         | -                                 | Access-Control-Allow-Origin http header value
-core.proxy\_https                   | string    | global    | -         | -                                 | https proxy to use, if any (falls back to HTTPS\_PROXY environment variable)
-core.proxy\_http                    | string    | global    | -         | -                                 | http proxy to use, if any (falls back to HTTP\_PROXY environment variable)
-core.proxy\_ignore\_hosts           | string    | global    | -         | -                                 | hosts which don't need the proxy for use (similar format to NO\_PROXY, e.g. 1.2.3.4,1.2.3.5, falls back to NO\_PROXY environment variable)
-core.trust\_ca\_certificates        | boolean   | global    | -         | -                                 | Whether to automatically trust clients signed by the CA
-core.trust\_password                | string    | global    | -         | -                                 | Password to be provided by clients to setup a trust
-images.auto\_update\_cached         | boolean   | global    | true      | -                                 | Whether to automatically update any image that LXD caches
-images.auto\_update\_interval       | integer   | global    | 6         | -                                 | Interval in hours at which to look for update to cached images (0 disables it)
-images.compression\_algorithm       | string    | global    | gzip      | -                                 | Compression algorithm to use for new images (bzip2, gzip, lzma, xz or none)
-images.remote\_cache\_expiry        | integer   | global    | 10        | -                                 | Number of days after which an unused cached remote image will be flushed
-maas.api.key                        | string    | global    | -         | maas\_network                     | API key to manage MAAS
-maas.api.url                        | string    | global    | -         | maas\_network                     | URL of the MAAS server
-maas.machine                        | string    | local     | hostname  | maas\_network                     | Name of this LXD host in MAAS
-rbac.agent.url                      | string    | global    | -         | rbac                              | The Candid agent url as provided during RBAC registration
-rbac.agent.username                 | string    | global    | -         | rbac                              | The Candid agent username as provided during RBAC registration
-rbac.agent.public\_key              | string    | global    | -         | rbac                              | The Candid agent public key as provided during RBAC registration
-rbac.agent.private\_key             | string    | global    | -         | rbac                              | The Candid agent private key as provided during RBAC registration
-rbac.api.expiry                     | integer   | global    | -         | rbac                              | RBAC macaroon expiry in seconds
-rbac.api.key                        | string    | global    | -         | rbac                              | Public key of the RBAC server (required for HTTP-only servers)
-rbac.api.url                        | string    | global    | -         | rbac                              | URL of the external RBAC server
-storage.backups\_volume             | string    | local     | -         | daemon\_storage                   | Volume to use to store the backup tarballs (syntax is POOL/VOLUME)
-storage.images\_volume              | string    | local     | -         | daemon\_storage                   | Volume to use to store the image tarballs (syntax is POOL/VOLUME)
+Key                                 | Type      | Scope     | Default                         | API extension                     | Description
+:--                                 | :---      | :----     | :------                         | :------------                     | :----------
+backups.compression\_algorithm      | string    | global    | gzip                            | backup\_compression               | Compression algorithm to use for new images (bzip2, gzip, lzma, xz or none)
+candid.api.key                      | string    | global    | -                               | candid\_config\_key               | Public key of the candid server (required for HTTP-only servers)
+candid.api.url                      | string    | global    | -                               | candid\_authentication            | URL of the the external authentication endpoint using Candid
+candid.expiry                       | integer   | global    | 3600                            | candid\_config                    | Candid macaroon expiry in seconds
+candid.domains                      | string    | global    | -                               | candid\_config                    | Comma-separated list of allowed Candid domains (empty string means all domains are valid)
+cluster.https\_address              | string    | local     | -                               | clustering\_server\_address       | Address the server should using for clustering traffic
+cluster.offline\_threshold          | integer   | global    | 20                              | clustering                        | Number of seconds after which an unresponsive node is considered offline
+cluster.images\_minimal\_replica    | integer   | global    | 3                               | clustering\_image\_replication    | Minimal numbers of cluster members with a copy of a particular image (set 1 for no replication, -1 for all members)
+cluster.max\_voters                 | integer   | global    | 3                               | clustering\_sizing                | Maximum number of cluster members that will be assigned the database voter role
+cluster.max\_standby                | integer   | global    | 2                               | clustering\_sizing                | Maximum number of cluster members that will be assigned the database stand-by role
+core.debug\_address                 | string    | local     | -                               | pprof\_http                       | Address to bind the pprof debug server to (HTTP)
+core.https\_address                 | string    | local     | -                               | -                                 | Address to bind for the remote API (HTTPS)
+core.https\_allowed\_credentials    | boolean   | global    | -                               | -                                 | Whether to set Access-Control-Allow-Credentials http header value to "true"
+core.https\_allowed\_headers        | string    | global    | -                               | -                                 | Access-Control-Allow-Headers http header value
+core.https\_allowed\_methods        | string    | global    | -                               | -                                 | Access-Control-Allow-Methods http header value
+core.https\_allowed\_origin         | string    | global    | -                               | -                                 | Access-Control-Allow-Origin http header value
+core.proxy\_https                   | string    | global    | -                               | -                                 | https proxy to use, if any (falls back to HTTPS\_PROXY environment variable)
+core.proxy\_http                    | string    | global    | -                               | -                                 | http proxy to use, if any (falls back to HTTP\_PROXY environment variable)
+core.proxy\_ignore\_hosts           | string    | global    | -                               | -                                 | hosts which don't need the proxy for use (similar format to NO\_PROXY, e.g. 1.2.3.4,1.2.3.5, falls back to NO\_PROXY environment variable)
+core.trust\_ca\_certificates        | boolean   | global    | -                               | -                                 | Whether to automatically trust clients signed by the CA
+core.trust\_password                | string    | global    | -                               | -                                 | Password to be provided by clients to setup a trust
+images.auto\_update\_cached         | boolean   | global    | true                            | -                                 | Whether to automatically update any image that LXD caches
+images.auto\_update\_interval       | integer   | global    | 6                               | -                                 | Interval in hours at which to look for update to cached images (0 disables it)
+images.compression\_algorithm       | string    | global    | gzip                            | -                                 | Compression algorithm to use for new images (bzip2, gzip, lzma, xz or none)
+images.remote\_cache\_expiry        | integer   | global    | 10                              | -                                 | Number of days after which an unused cached remote image will be flushed
+maas.api.key                        | string    | global    | -                               | maas\_network                     | API key to manage MAAS
+maas.api.url                        | string    | global    | -                               | maas\_network                     | URL of the MAAS server
+maas.machine                        | string    | local     | hostname                        | maas\_network                     | Name of this LXD host in MAAS
+rbac.agent.url                      | string    | global    | -                               | rbac                              | The Candid agent url as provided during RBAC registration
+rbac.agent.username                 | string    | global    | -                               | rbac                              | The Candid agent username as provided during RBAC registration
+rbac.agent.public\_key              | string    | global    | -                               | rbac                              | The Candid agent public key as provided during RBAC registration
+rbac.agent.private\_key             | string    | global    | -                               | rbac                              | The Candid agent private key as provided during RBAC registration
+rbac.api.expiry                     | integer   | global    | -                               | rbac                              | RBAC macaroon expiry in seconds
+rbac.api.key                        | string    | global    | -                               | rbac                              | Public key of the RBAC server (required for HTTP-only servers)
+rbac.api.url                        | string    | global    | -                               | rbac                              | URL of the external RBAC server
+storage.backups\_volume             | string    | local     | -                               | daemon\_storage                   | Volume to use to store the backup tarballs (syntax is POOL/VOLUME)
+storage.images\_volume              | string    | local     | -                               | daemon\_storage                   | Volume to use to store the image tarballs (syntax is POOL/VOLUME)
+network.ovn.integration\_bridge     | string    | global    | br-int                          | network\_type\_ovn                | OVS integration bridge to use for OVN networks
+network.ovn.northbound\_connection  | string    | global    | unix:/var/run/ovn/ovnnb_db.sock | network\_type\_ovn                | OVN northbound database connection string
 
 Those keys can be set using the lxc tool with:
 

--- a/lxd/cluster/config.go
+++ b/lxd/cluster/config.go
@@ -280,6 +280,10 @@ var ConfigSchema = config.Schema{
 	"storage.zfs_pool_name":        {Setter: deprecatedStorage},
 	"storage.zfs_remove_snapshots": {Setter: deprecatedStorage, Type: config.Bool},
 	"storage.zfs_use_refquota":     {Setter: deprecatedStorage, Type: config.Bool},
+
+	// OVN networking global keys.
+	"network.ovn.integration_bridge":    {Default: "br-int"},
+	"network.ovn.northbound_connection": {Default: "unix:/var/run/ovn/ovnnb_db.sock"},
 }
 
 func offlineThresholdDefault() string {

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -310,6 +310,7 @@ const (
 	NetworkTypeBridge  NetworkType = iota // Network type bridge.
 	NetworkTypeMacvlan                    // Network type macvlan.
 	NetworkTypeSriov                      // Network type sriov.
+	NetworkTypeOVN                        // Network type ovn.
 )
 
 // GetNetworkInAnyState returns the network with the given name.
@@ -373,6 +374,8 @@ func (c *Cluster) getNetwork(name string, onlyCreated bool) (int64, *api.Network
 		network.Type = "macvlan"
 	case NetworkTypeSriov:
 		network.Type = "sriov"
+	case NetworkTypeOVN:
+		network.Type = "ovn"
 	default:
 		network.Type = "" // Unknown
 	}

--- a/lxd/device/device_load.go
+++ b/lxd/device/device_load.go
@@ -40,6 +40,8 @@ func load(inst instance.Instance, state *state.State, name string, conf deviceCo
 			dev = &nicMACVLAN{}
 		case "sriov":
 			dev = &nicSRIOV{}
+		case "ovn":
+			dev = &nicOVN{}
 		}
 	case "infiniband":
 		switch nicType {

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -1,0 +1,377 @@
+package device
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/pkg/errors"
+
+	"github.com/lxc/lxd/lxd/cluster"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
+	"github.com/lxc/lxd/lxd/dnsmasq/dhcpalloc"
+	"github.com/lxc/lxd/lxd/instance"
+	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/lxd/network"
+	"github.com/lxc/lxd/lxd/network/openvswitch"
+	"github.com/lxc/lxd/lxd/revert"
+	"github.com/lxc/lxd/lxd/util"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+	log "github.com/lxc/lxd/shared/log15"
+)
+
+type nicOVN struct {
+	deviceCommon
+
+	network network.Network
+}
+
+// getIntegrationBridgeName returns the OVS integration bridge to use.
+func (d *nicOVN) getIntegrationBridgeName() (string, error) {
+	integrationBridge, err := cluster.ConfigGetString(d.state.Cluster, "network.ovn.integration_bridge")
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to get OVN integration bridge name")
+	}
+
+	return integrationBridge, nil
+}
+
+// validateConfig checks the supplied config for correctness.
+func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
+	if !instanceSupported(instConf.Type(), instancetype.Container, instancetype.VM) {
+		return ErrUnsupportedDevType
+	}
+
+	requiredFields := []string{
+		"network",
+	}
+
+	optionalFields := []string{
+		"name",
+		"hwaddr",
+		"host_name",
+		"ipv4.address",
+		"ipv6.address",
+		"boot.priority",
+	}
+
+	// Lookup network settings and apply them to the device's config.
+	n, err := network.LoadByName(d.state, d.config["network"])
+	if err != nil {
+		return errors.Wrapf(err, "Error loading network config for %q", d.config["network"])
+	}
+
+	if n.Status() == api.NetworkStatusPending {
+		return fmt.Errorf("Specified network is not fully created")
+	}
+
+	if n.Type() != "ovn" {
+		return fmt.Errorf("Specified network must be of type ovn")
+	}
+
+	d.network = n // Stored loaded instance for use by other functions.
+	netConfig := d.network.Config()
+
+	if d.config["ipv4.address"] != "" {
+		// Check that DHCPv4 is enabled on parent network (needed to use static assigned IPs).
+		if n.DHCPv4Subnet() == nil {
+			return fmt.Errorf("Cannot specify %q when DHCP is disabled on network %q", "ipv4.address", d.config["network"])
+		}
+
+		_, subnet, err := net.ParseCIDR(netConfig["ipv4.address"])
+		if err != nil {
+			return errors.Wrapf(err, "Invalid network ipv4.address")
+		}
+
+		// Check the static IP supplied is valid for the linked network. It should be part of the
+		// network's subnet, but not necessarily part of the dynamic allocation ranges.
+		if !dhcpalloc.DHCPValidIP(subnet, nil, net.ParseIP(d.config["ipv4.address"])) {
+			return fmt.Errorf("Device IP address %q not within network %q subnet", d.config["ipv4.address"], d.config["network"])
+		}
+	}
+
+	if d.config["ipv6.address"] != "" {
+		// Check that DHCPv6 is enabled on parent network (needed to use static assigned IPs).
+		if n.DHCPv6Subnet() == nil || !shared.IsTrue(netConfig["ipv6.dhcp.stateful"]) {
+			return fmt.Errorf("Cannot specify %q when DHCP or %q are disabled on network %q", "ipv6.address", "ipv6.dhcp.stateful", d.config["network"])
+		}
+
+		_, subnet, err := net.ParseCIDR(netConfig["ipv6.address"])
+		if err != nil {
+			return errors.Wrapf(err, "Invalid network ipv6.address")
+		}
+
+		// Check the static IP supplied is valid for the linked network. It should be part of the
+		// network's subnet, but not necessarily part of the dynamic allocation ranges.
+		if !dhcpalloc.DHCPValidIP(subnet, nil, net.ParseIP(d.config["ipv6.address"])) {
+			return fmt.Errorf("Device IP address %q not within network %q subnet", d.config["ipv6.address"], d.config["network"])
+		}
+	}
+
+	rules := nicValidationRules(requiredFields, optionalFields)
+
+	// Now run normal validation.
+	err = d.config.Validate(rules)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateEnvironment checks the runtime environment for correctness.
+func (d *nicOVN) validateEnvironment() error {
+	if d.inst.Type() == instancetype.Container && d.config["name"] == "" {
+		return fmt.Errorf("Requires name property to start")
+	}
+
+	integrationBridge, err := d.getIntegrationBridgeName()
+	if err != nil {
+		return err
+	}
+
+	if !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", integrationBridge)) {
+		return fmt.Errorf("OVS integration bridge device %q doesn't exist", integrationBridge)
+	}
+
+	return nil
+}
+
+// CanHotPlug returns whether the device can be managed whilst the instance is running, it also
+// returns a list of fields that can be updated without triggering a device remove & add.
+func (d *nicOVN) CanHotPlug() (bool, []string) {
+	return true, []string{}
+}
+
+// Add is run when a device is added to an instance whether or not the instance is running.
+func (d *nicOVN) Add() error {
+	return nil
+}
+
+// Start is run when the device is added to a running instance or instance is starting up.
+func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
+	err := d.validateEnvironment()
+	if err != nil {
+		return nil, err
+	}
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	saveData := make(map[string]string)
+	saveData["host_name"] = d.config["host_name"]
+
+	var peerName string
+
+	// Create veth pair and configure the peer end with custom hwaddr and mtu if supplied.
+	if d.inst.Type() == instancetype.Container {
+		if saveData["host_name"] == "" {
+			saveData["host_name"] = networkRandomDevName("veth")
+		}
+		peerName, err = networkCreateVethPair(saveData["host_name"], d.config)
+	} else if d.inst.Type() == instancetype.VM {
+		if saveData["host_name"] == "" {
+			saveData["host_name"] = networkRandomDevName("tap")
+		}
+		peerName = saveData["host_name"] // VMs use the host_name to link to the TAP FD.
+		err = networkCreateTap(saveData["host_name"], d.config)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	revert.Add(func() { NetworkRemoveInterface(saveData["host_name"]) })
+
+	// Populate device config with volatile fields if needed.
+	networkVethFillFromVolatile(d.config, saveData)
+
+	// Apply host-side limits.
+	err = networkSetupHostVethLimits(d.config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Disable IPv6 on host-side veth interface (prevents host-side interface getting link-local address)
+	// which isn't needed because the host-side interface is connected to a bridge.
+	err = util.SysctlSet(fmt.Sprintf("net/ipv6/conf/%s/disable_ipv6", saveData["host_name"]), "1")
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	mac, err := net.ParseMAC(d.config["hwaddr"])
+	if err != nil {
+		return nil, err
+	}
+
+	ips := []net.IP{}
+	for _, key := range []string{"ipv4.address", "ipv6.address"} {
+		if d.config[key] != "" {
+			ip := net.ParseIP(d.config[key])
+			if ip == nil {
+				return nil, fmt.Errorf("Invalid %s value %q", key, d.config[key])
+			}
+			ips = append(ips, ip)
+		}
+	}
+
+	// Add new OVN logical switch port for instance.
+	logicalPortName, err := network.OVNInstanceDevicePortAdd(d.network, d.inst.ID(), d.name, mac, ips)
+	if err != nil {
+		return nil, err
+	}
+
+	revert.Add(func() { network.OVNInstanceDevicePortDelete(d.network, d.inst.ID(), d.name) })
+
+	// Attach host side veth interface to bridge.
+	integrationBridge, err := d.getIntegrationBridgeName()
+	if err != nil {
+		return nil, err
+	}
+
+	ovs := openvswitch.NewOVS()
+	err = ovs.BridgePortAdd(integrationBridge, saveData["host_name"], true)
+	if err != nil {
+		return nil, err
+	}
+
+	revert.Add(func() { ovs.BridgePortDelete(integrationBridge, saveData["host_name"]) })
+
+	// Link OVS port to OVN logical port.
+	err = ovs.InterfaceAssociateOVNSwitchPort(saveData["host_name"], logicalPortName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Attempt to disable router advertisement acceptance.
+	err = util.SysctlSet(fmt.Sprintf("net/ipv6/conf/%s/accept_ra", saveData["host_name"]), "0")
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	// Attempt to disable IPv4 forwarding.
+	err = util.SysctlSet(fmt.Sprintf("net/ipv4/conf/%s/forwarding", saveData["host_name"]), "0")
+	if err != nil {
+		return nil, err
+	}
+
+	err = d.volatileSet(saveData)
+	if err != nil {
+		return nil, err
+	}
+
+	runConf := deviceConfig.RunConfig{}
+	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
+		{Key: "name", Value: d.config["name"]},
+		{Key: "type", Value: "phys"},
+		{Key: "flags", Value: "up"},
+		{Key: "link", Value: peerName},
+	}
+
+	if d.inst.Type() == instancetype.VM {
+		runConf.NetworkInterface = append(runConf.NetworkInterface,
+			[]deviceConfig.RunConfigItem{
+				{Key: "devName", Value: d.name},
+				{Key: "hwaddr", Value: d.config["hwaddr"]},
+			}...)
+	}
+
+	revert.Success()
+	return &runConf, nil
+}
+
+// Update applies configuration changes to a started device.
+func (d *nicOVN) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
+	oldConfig := oldDevices[d.name]
+
+	v := d.volatileGet()
+
+	// Populate device config with volatile fields if needed.
+	networkVethFillFromVolatile(d.config, v)
+
+	// If instance is running, apply host side limits and filters first before rebuilding
+	// dnsmasq config below so that existing config can be used as part of the filter removal.
+	if isRunning {
+		err := d.validateEnvironment()
+		if err != nil {
+			return err
+		}
+
+		// Apply host-side limits.
+		err = networkSetupHostVethLimits(d.config)
+		if err != nil {
+			return err
+		}
+	}
+
+	// If an IPv6 address has changed, if the instance is running we should bounce the host-side
+	// veth interface to give the instance a chance to detect the change and re-apply for an
+	// updated lease with new IP address.
+	if d.config["ipv6.address"] != oldConfig["ipv6.address"] && d.config["host_name"] != "" && shared.PathExists(fmt.Sprintf("/sys/class/net/%s", d.config["host_name"])) {
+		_, err := shared.RunCommand("ip", "link", "set", d.config["host_name"], "down")
+		if err != nil {
+			return err
+		}
+		_, err = shared.RunCommand("ip", "link", "set", d.config["host_name"], "up")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Stop is run when the device is removed from the instance.
+func (d *nicOVN) Stop() (*deviceConfig.RunConfig, error) {
+	runConf := deviceConfig.RunConfig{
+		PostHooks: []func() error{d.postStop},
+	}
+
+	err := network.OVNInstanceDevicePortDelete(d.network, d.inst.ID(), d.name)
+	if err != nil {
+		// Don't fail here as we still want the postStop hook to run to clean up the local veth pair.
+		d.logger.Error("Failed to remove OVN device port", log.Ctx{"err": err})
+	}
+
+	return &runConf, nil
+}
+
+// postStop is run after the device is removed from the instance.
+func (d *nicOVN) postStop() error {
+	defer d.volatileSet(map[string]string{
+		"host_name": "",
+	})
+
+	v := d.volatileGet()
+
+	networkVethFillFromVolatile(d.config, v)
+
+	if d.config["host_name"] != "" && shared.PathExists(fmt.Sprintf("/sys/class/net/%s", d.config["host_name"])) {
+		integrationBridge, err := d.getIntegrationBridgeName()
+		if err != nil {
+			return err
+		}
+
+		ovs := openvswitch.NewOVS()
+
+		// Detach host-side end of veth pair from bridge (required for openvswitch particularly).
+		err = ovs.BridgePortDelete(integrationBridge, d.config["host_name"])
+		if err != nil {
+			return errors.Wrapf(err, "Failed to detach interface %q from %q", d.config["host_name"], integrationBridge)
+		}
+
+		// Removing host-side end of veth pair will delete the peer end too.
+		err = NetworkRemoveInterface(d.config["host_name"])
+		if err != nil {
+			return errors.Wrapf(err, "Failed to remove interface %q", d.config["host_name"])
+		}
+	}
+
+	return nil
+}
+
+// Remove is run when the device is removed from the instance or the instance is deleted.
+func (d *nicOVN) Remove() error {
+	return nil
+}

--- a/lxd/device/nictype/nictype.go
+++ b/lxd/device/nictype/nictype.go
@@ -32,6 +32,8 @@ func NICType(s *state.State, d deviceConfig.Device) (string, error) {
 				nicType = "macvlan"
 			case "sriov":
 				nicType = "sriov"
+			case "ovn":
+				nicType = "ovn"
 			default:
 				return "", fmt.Errorf("Unrecognised NIC network type for network %q", d["network"])
 			}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1,0 +1,1239 @@
+package network
+
+import (
+	"fmt"
+	"hash/fnv"
+	"io"
+	"io/ioutil"
+	"math/big"
+	"math/rand"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/mdlayher/netx/eui64"
+	"github.com/pkg/errors"
+
+	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/dnsmasq"
+	"github.com/lxc/lxd/lxd/locking"
+	"github.com/lxc/lxd/lxd/network/openvswitch"
+	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/revert"
+	"github.com/lxc/lxd/lxd/util"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+	log "github.com/lxc/lxd/shared/log15"
+	"github.com/lxc/lxd/shared/validate"
+)
+
+const ovnChassisPriorityMax = 32767
+const ovnVolatileParentIPv4 = "volatile.parent.ipv4.address"
+const ovnVolatileParentIPv6 = "volatile.parent.ipv6.address"
+
+// ovnParentVars OVN object variables derived from parent network.
+type ovnParentVars struct {
+	// Router.
+	routerExtPortIPv4Net string
+	routerExtPortIPv6Net string
+	routerExtGwIPv4      net.IP
+	routerExtGwIPv6      net.IP
+
+	// External Switch.
+	extSwitchProviderName string
+
+	// DNS.
+	dnsIPv6 net.IP
+	dnsIPv4 net.IP
+}
+
+// ovnParentPortBridgeVars parent bridge port variables used for start/stop.
+type ovnParentPortBridgeVars struct {
+	ovsBridge string
+	parentEnd string
+	ovsEnd    string
+}
+
+// ovn represents a LXD OVN network.
+type ovn struct {
+	common
+}
+
+// Validate network config.
+func (n *ovn) Validate(config map[string]string) error {
+	rules := map[string]func(value string) error{
+		"parent": func(value string) error {
+			if err := validInterfaceName(value); err != nil {
+				return errors.Wrapf(err, "Invalid network name %q", value)
+			}
+
+			return nil
+		},
+		"bridge.hwaddr": validate.Optional(validate.IsNetworkMAC),
+		"ipv4.address": func(value string) error {
+			if validate.IsOneOf(value, []string{"auto"}) == nil {
+				return nil
+			}
+
+			return validate.Optional(validate.IsNetworkAddressCIDRV4)(value)
+		},
+		"ipv6.address": func(value string) error {
+			if validate.IsOneOf(value, []string{"auto"}) == nil {
+				return nil
+			}
+
+			return validate.Optional(validate.IsNetworkAddressCIDRV6)(value)
+		},
+		"dns.domain": validate.IsAny,
+		"dns.search": validate.IsAny,
+
+		// Volatile keys populated automatically as needed.
+		ovnVolatileParentIPv4: validate.Optional(validate.IsNetworkAddressV4),
+		ovnVolatileParentIPv6: validate.Optional(validate.IsNetworkAddressV6),
+	}
+
+	err := n.validate(config, rules)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// getClient initialises OVN client and returns it.
+func (n *ovn) getClient() (*openvswitch.OVN, error) {
+	nbConnection, err := cluster.ConfigGetString(n.state.Cluster, "network.ovn.northbound_connection")
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to get OVN northbound connection string")
+	}
+
+	client := openvswitch.NewOVN()
+	client.SetDatabaseAddress(nbConnection)
+
+	return client, nil
+}
+
+// getNetworkPrefix returns OVN network prefix to use for object names.
+func (n *ovn) getNetworkPrefix() string {
+	return fmt.Sprintf("lxd-net%d", n.id)
+}
+
+// getChassisGroup returns OVN chassis group name to use.
+func (n *ovn) getChassisGroupName() openvswitch.OVNChassisGroup {
+	return openvswitch.OVNChassisGroup(n.getNetworkPrefix())
+}
+
+// getRouterName returns OVN logical router name to use.
+func (n *ovn) getRouterName() openvswitch.OVNRouter {
+	return openvswitch.OVNRouter(fmt.Sprintf("%s-lr", n.getNetworkPrefix()))
+}
+
+// getRouterExtPortName returns OVN logical router external port name to use.
+func (n *ovn) getRouterExtPortName() openvswitch.OVNRouterPort {
+	return openvswitch.OVNRouterPort(fmt.Sprintf("%s-lrp-ext", n.getRouterName()))
+}
+
+// getRouterIntPortName returns OVN logical router internal port name to use.
+func (n *ovn) getRouterIntPortName() openvswitch.OVNRouterPort {
+	return openvswitch.OVNRouterPort(fmt.Sprintf("%s-lrp-int", n.getRouterName()))
+}
+
+// getRouterMAC returns OVN router MAC address to use for ports. Uses a stable seed to return stable random MAC.
+func (n *ovn) getRouterMAC() (net.HardwareAddr, error) {
+	hwAddr := n.config["bridge.hwaddr"]
+	if hwAddr == "" {
+		// Load server certificate. This is needs to be the same certificate for all nodes in a cluster.
+		cert, err := util.LoadCert(n.state.OS.VarDir)
+		if err != nil {
+			return nil, err
+		}
+
+		// Generate the random seed, this uses the server certificate fingerprint (to ensure that multiple
+		// standalone nodes on the same external network don't generate the same MAC for their networks).
+		// It relies on the certificate being the same for all nodes in a cluster to allow the same MAC to
+		// be generated on each bridge interface in the network.
+		seed := fmt.Sprintf("%s.%d.%d", cert.Fingerprint(), 0, n.ID())
+
+		// Generate a hash from the randSourceNodeID and network ID to use as seed for random MAC.
+		// Use the FNV-1a hash algorithm to convert our seed string into an int64 for use as seed.
+		hash := fnv.New64a()
+		_, err = io.WriteString(hash, seed)
+		if err != nil {
+			return nil, err
+		}
+
+		// Initialise a non-cryptographic random number generator using the stable seed.
+		r := rand.New(rand.NewSource(int64(hash.Sum64())))
+		hwAddr = randomHwaddr(r)
+		n.logger.Debug("Stable MAC generated", log.Ctx{"seed": seed, "hwAddr": hwAddr})
+	}
+
+	mac, err := net.ParseMAC(hwAddr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed parsing router MAC address %q", mac)
+	}
+
+	return mac, nil
+}
+
+// getRouterIntPortIPv4Net returns OVN logical router internal port IPv4 address and subnet.
+func (n *ovn) getRouterIntPortIPv4Net() string {
+	return n.config["ipv4.address"]
+}
+
+// getRouterIntPortIPv4Net returns OVN logical router internal port IPv6 address and subnet.
+func (n *ovn) getRouterIntPortIPv6Net() string {
+	return n.config["ipv6.address"]
+}
+
+// getDomainName returns OVN DHCP domain name.
+func (n *ovn) getDomainName() string {
+	if n.config["dns.domain"] != "" {
+		return n.config["dns.domain"]
+	}
+
+	return "lxd"
+}
+
+// getDNSSearchList returns OVN DHCP DNS search list. If no search list set returns getDomainName() as list.
+func (n *ovn) getDNSSearchList() []string {
+	if n.config["dns.search"] != "" {
+		dnsSearchList := []string{}
+		for _, domain := range strings.SplitN(n.config["dns.search"], ",", -1) {
+			dnsSearchList = append(dnsSearchList, strings.TrimSpace(domain))
+		}
+
+		return dnsSearchList
+	}
+
+	return []string{n.getDomainName()}
+}
+
+// getExtSwitchName returns OVN  logical external switch name.
+func (n *ovn) getExtSwitchName() openvswitch.OVNSwitch {
+	return openvswitch.OVNSwitch(fmt.Sprintf("%s-ls-ext", n.getNetworkPrefix()))
+}
+
+// getExtSwitchRouterPortName returns OVN logical external switch router port name.
+func (n *ovn) getExtSwitchRouterPortName() openvswitch.OVNSwitchPort {
+	return openvswitch.OVNSwitchPort(fmt.Sprintf("%s-lsp-router", n.getExtSwitchName()))
+}
+
+// getExtSwitchProviderPortName returns OVN logical external switch provider port name.
+func (n *ovn) getExtSwitchProviderPortName() openvswitch.OVNSwitchPort {
+	return openvswitch.OVNSwitchPort(fmt.Sprintf("%s-lsp-provider", n.getExtSwitchName()))
+}
+
+// getIntSwitchName returns OVN logical internal switch name.
+func (n *ovn) getIntSwitchName() openvswitch.OVNSwitch {
+	return openvswitch.OVNSwitch(fmt.Sprintf("%s-ls-int", n.getNetworkPrefix()))
+}
+
+// getIntSwitchRouterPortName returns OVN logical internal switch router port name.
+func (n *ovn) getIntSwitchRouterPortName() openvswitch.OVNSwitchPort {
+	return openvswitch.OVNSwitchPort(fmt.Sprintf("%s-lsp-router", n.getIntSwitchName()))
+}
+
+// getIntSwitchInstancePortPrefix returns OVN logical internal switch instance port name prefix.
+func (n *ovn) getIntSwitchInstancePortPrefix() string {
+	return fmt.Sprintf("%s-instance", n.getNetworkPrefix())
+}
+
+// setupParentPort initialises the parent uplink connection. Returns the derived ovnParentVars settings used
+// during the initial creation of the logical network.
+func (n *ovn) setupParentPort(routerMAC net.HardwareAddr) (*ovnParentVars, error) {
+	parentNet, err := LoadByName(n.state, n.config["parent"])
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed loading parent network")
+	}
+
+	switch parentNet.Type() {
+	case "bridge":
+		return n.setupParentPortBridge(parentNet, routerMAC)
+	}
+
+	return nil, fmt.Errorf("Network type %q unsupported as OVN parent", parentNet.Type())
+}
+
+// setupParentPortBridge allocates external IPs on the parent bridge.
+// Returns the derived ovnParentVars settings.
+func (n *ovn) setupParentPortBridge(parentNet Network, routerMAC net.HardwareAddr) (*ovnParentVars, error) {
+	v := &ovnParentVars{}
+
+	bridgeNet, ok := parentNet.(*bridge)
+	if !ok {
+		return nil, fmt.Errorf("Network is not bridge type")
+	}
+
+	err := bridgeNet.checkClusterWideMACSafe(bridgeNet.config)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Network %q is not suitable for use as OVN parent", bridgeNet.name)
+	}
+
+	parentNetConf := parentNet.Config()
+
+	// Parent derived settings.
+	v.extSwitchProviderName = parentNet.Name()
+
+	// Optional parent values.
+	parentIPv4, parentIPv4Net, err := net.ParseCIDR(parentNetConf["ipv4.address"])
+	if err == nil {
+		v.dnsIPv4 = parentIPv4
+		v.routerExtGwIPv4 = parentIPv4
+	}
+
+	parentIPv6, parentIPv6Net, err := net.ParseCIDR(parentNetConf["ipv6.address"])
+	if err == nil {
+		v.dnsIPv6 = parentIPv6
+		v.routerExtGwIPv6 = parentIPv6
+	}
+
+	// Retrieve and parse existing allocated IPs for this network on the parent network.
+	routerExtPortIPv4 := net.ParseIP(n.config[ovnVolatileParentIPv4])
+	routerExtPortIPv6 := net.ParseIP(n.config[ovnVolatileParentIPv6])
+
+	// Decide whether we need to allocate new IP(s) and go to the expense of retrieving all allocated IPs.
+	if (parentIPv4Net != nil && routerExtPortIPv4 == nil) || (parentIPv6Net != nil && routerExtPortIPv6 == nil) {
+		allAllocatedIPv4, allAllocatedIPv6, err := n.parentAllAllocatedIPs(parentNet.Name())
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to get all allocated IPs for parent")
+		}
+
+		if parentIPv4Net != nil && routerExtPortIPv4 == nil {
+			ipRanges, err := parseIPRanges(parentNetConf["ipv4.ovn.ranges"], parentNet.DHCPv4Subnet())
+			if err != nil {
+				return nil, errors.Wrapf(err, "Failed to parse parent IPv4 OVN ranges")
+			}
+
+			routerExtPortIPv4, err = n.parentAllocateIP(ipRanges, allAllocatedIPv4)
+			if err != nil {
+				return nil, errors.Wrapf(err, "Failed to allocate parent IPv4 address")
+			}
+
+			n.config[ovnVolatileParentIPv4] = routerExtPortIPv4.String()
+		}
+
+		if parentIPv6Net != nil && routerExtPortIPv6 == nil {
+			// If IPv6 OVN ranges are specified by the parent, allocate from them.
+			if parentNetConf["ipv6.ovn.ranges"] != "" {
+				ipRanges, err := parseIPRanges(parentNetConf["ipv6.ovn.ranges"], parentNet.DHCPv6Subnet())
+				if err != nil {
+					return nil, errors.Wrapf(err, "Failed to parse parent IPv6 OVN ranges")
+				}
+
+				routerExtPortIPv6, err = n.parentAllocateIP(ipRanges, allAllocatedIPv6)
+				if err != nil {
+					return nil, errors.Wrapf(err, "Failed to allocate parent IPv6 address")
+				}
+
+			} else {
+				// Otherwise use EUI64 derived from MAC address.
+				routerExtPortIPv6, err = eui64.ParseMAC(parentIPv6Net.IP, routerMAC)
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			n.config[ovnVolatileParentIPv6] = routerExtPortIPv6.String()
+		}
+
+		err = n.state.Cluster.UpdateNetwork(n.name, n.description, n.config)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed saving allocated parent network IPs")
+		}
+	}
+
+	// Configure variables needed to configure OVN router.
+	if parentIPv4Net != nil && routerExtPortIPv4 != nil {
+		routerExtPortIPv4Net := &net.IPNet{
+			Mask: parentIPv4Net.Mask,
+			IP:   routerExtPortIPv4,
+		}
+		v.routerExtPortIPv4Net = routerExtPortIPv4Net.String()
+	}
+
+	if parentIPv6Net != nil {
+		routerExtPortIPv6Net := &net.IPNet{
+			Mask: parentIPv6Net.Mask,
+			IP:   routerExtPortIPv6,
+		}
+		v.routerExtPortIPv6Net = routerExtPortIPv6Net.String()
+	}
+
+	return v, nil
+}
+
+// parentAllAllocatedIPs gets a list of all IPv4 and IPv6 addresses allocated to OVN networks connected to parent.
+func (n *ovn) parentAllAllocatedIPs(parentNetName string) ([]net.IP, []net.IP, error) {
+	// Get a list of managed networks.
+	networks, err := n.state.Cluster.GetNonPendingNetworks()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v4IPs := make([]net.IP, 0)
+	v6IPs := make([]net.IP, 0)
+
+	for _, name := range networks {
+		_, netInfo, err := n.state.Cluster.GetNetworkInAnyState(name)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if netInfo.Type != "ovn" || netInfo.Config["parent"] != parentNetName {
+			continue
+		}
+
+		for _, k := range []string{ovnVolatileParentIPv4, ovnVolatileParentIPv6} {
+			if netInfo.Config[k] != "" {
+				ip := net.ParseIP(netInfo.Config[k])
+				if ip != nil {
+					if ip.To4() != nil {
+						v4IPs = append(v4IPs, ip)
+					} else {
+						v6IPs = append(v6IPs, ip)
+					}
+				}
+			}
+		}
+	}
+
+	return v4IPs, v6IPs, nil
+}
+
+// parentAllocateIP allocates a free IP from one of the IP ranges.
+func (n *ovn) parentAllocateIP(ipRanges []*shared.IPRange, allAllocated []net.IP) (net.IP, error) {
+	for _, ipRange := range ipRanges {
+		inc := big.NewInt(1)
+
+		// Convert IPs in range to native representations to allow incrementing and comparison.
+		startIP := ipRange.Start.To4()
+		if startIP == nil {
+			startIP = ipRange.Start.To16()
+		}
+
+		endIP := ipRange.End.To4()
+		if endIP == nil {
+			endIP = ipRange.End.To16()
+		}
+
+		startBig := big.NewInt(0)
+		startBig.SetBytes(startIP)
+		endBig := big.NewInt(0)
+		endBig.SetBytes(endIP)
+
+		// Iterate through IPs in range, return the first unallocated one found.
+		for {
+			if startBig.Cmp(endBig) >= 0 {
+				break
+			}
+
+			ip := net.IP(startBig.Bytes())
+
+			// Check IP is not already allocated.
+			freeIP := true
+			for _, allocatedIP := range allAllocated {
+				if ip.Equal(allocatedIP) {
+					freeIP = false
+					break
+				}
+
+			}
+
+			if !freeIP {
+				startBig.Add(startBig, inc)
+				continue
+			}
+
+			return ip, nil
+		}
+	}
+
+	return nil, fmt.Errorf("No free IPs available")
+}
+
+// startParentPort performs any network start up logic needed to connect the parent uplink connection to OVN.
+func (n *ovn) startParentPort() error {
+	parentNet, err := LoadByName(n.state, n.config["parent"])
+	if err != nil {
+		return errors.Wrapf(err, "Failed loading parent network")
+	}
+
+	switch parentNet.Type() {
+	case "bridge":
+		return n.startParentPortBridge(parentNet)
+	}
+
+	return fmt.Errorf("Network type %q unsupported as OVN parent", parentNet.Type())
+}
+
+// parentOperationLockName returns the lock name to use for operations on the parent network.
+func (n *ovn) parentOperationLockName(parentNet Network) string {
+	return fmt.Sprintf("network.ovn.%s", parentNet.Name())
+}
+
+// parentPortBridgeVars returns the parent port bridge variables needed for port start/stop.
+func (n *ovn) parentPortBridgeVars(parentNet Network) *ovnParentPortBridgeVars {
+	ovsBridge := fmt.Sprintf("lxdovn%d", parentNet.ID())
+
+	return &ovnParentPortBridgeVars{
+		ovsBridge: ovsBridge,
+		parentEnd: fmt.Sprintf("%sa", ovsBridge),
+		ovsEnd:    fmt.Sprintf("%sb", ovsBridge),
+	}
+}
+
+// startParentPortBridge creates veth pair (if doesn't exist), creates OVS bridge (if doesn't exist) and
+// connects veth pair to parent bridge and OVS bridge.
+func (n *ovn) startParentPortBridge(parentNet Network) error {
+	vars := n.parentPortBridgeVars(parentNet)
+
+	// Lock parent network so that if multiple OVN networks are trying to connect to the same parent we don't
+	// race each other setting up the connection.
+	unlock := locking.Lock(n.parentOperationLockName(parentNet))
+	defer unlock()
+
+	// Do this after gaining lock so that on failure we revert before release locking.
+	revert := revert.New()
+	defer revert.Fail()
+
+	// Create veth pair if needed.
+	if !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", vars.parentEnd)) && !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", vars.ovsEnd)) {
+		_, err := shared.RunCommand("ip", "link", "add", "dev", vars.parentEnd, "type", "veth", "peer", "name", vars.ovsEnd)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to create the uplink veth interfaces %q and %q", vars.parentEnd, vars.ovsEnd)
+		}
+
+		revert.Add(func() { shared.RunCommand("ip", "link", "delete", vars.parentEnd) })
+	}
+
+	// Ensure correct sysctls are set on uplink veth interfaces to avoid getting IPv6 link-local addresses.
+	_, err := shared.RunCommand("sysctl",
+		fmt.Sprintf("net.ipv6.conf.%s.disable_ipv6=1", vars.parentEnd),
+		fmt.Sprintf("net.ipv6.conf.%s.disable_ipv6=1", vars.ovsEnd),
+		fmt.Sprintf("net.ipv6.conf.%s.forwarding=0", vars.parentEnd),
+		fmt.Sprintf("net.ipv6.conf.%s.forwarding=0", vars.ovsEnd),
+	)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to set configure uplink veth interfaces %q and %q", vars.parentEnd, vars.ovsEnd)
+	}
+
+	// Connect parent end of veth pair to parent bridge and bring up.
+	_, err = shared.RunCommand("ip", "link", "set", "master", parentNet.Name(), "dev", vars.parentEnd, "up")
+	if err != nil {
+		return errors.Wrapf(err, "Failed to connect uplink veth interface %q to parent bridge %q", vars.parentEnd, parentNet.Name())
+	}
+
+	// Ensure uplink OVS end veth interface is up.
+	_, err = shared.RunCommand("ip", "link", "set", "dev", vars.ovsEnd, "up")
+	if err != nil {
+		return errors.Wrapf(err, "Failed to bring up parent veth interface %q", vars.ovsEnd)
+	}
+
+	// Create parent OVS bridge if needed.
+	ovs := openvswitch.NewOVS()
+	err = ovs.BridgeAdd(vars.ovsBridge, true)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to create parent uplink OVS bridge %q", vars.ovsBridge)
+	}
+
+	// Connect OVS end veth interface to OVS bridge.
+	err = ovs.BridgePortAdd(vars.ovsBridge, vars.ovsEnd, true)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to connect uplink veth interface %q to parent OVS bridge %q", vars.ovsEnd, vars.ovsBridge)
+	}
+
+	// Associate OVS bridge to logical OVN provider.
+	err = ovs.OVNBridgeMappingAdd(vars.ovsBridge, parentNet.Name())
+	if err != nil {
+		return errors.Wrapf(err, "Failed to associate parent OVS bridge %q to OVN provider %q", vars.ovsBridge, parentNet.Name())
+	}
+
+	revert.Success()
+	return nil
+}
+
+// deleteParentPort deletes the parent uplink connection.
+func (n *ovn) deleteParentPort() error {
+	parentNet, err := LoadByName(n.state, n.config["parent"])
+	if err != nil {
+		return errors.Wrapf(err, "Failed loading parent network")
+	}
+
+	switch parentNet.Type() {
+	case "bridge":
+		return n.deleteParentPortBridge(parentNet)
+	}
+
+	return fmt.Errorf("Network type %q unsupported as OVN parent", parentNet.Type())
+}
+
+// deleteParentPortBridge deletes the dnsmasq static lease and removes parent uplink OVS bridge if not in use.
+func (n *ovn) deleteParentPortBridge(parentNet Network) error {
+	err := dnsmasq.RemoveStaticEntry(parentNet.Name(), project.Default, n.getNetworkPrefix())
+	if err != nil {
+		return err
+	}
+
+	// Reload dnsmasq.
+	err = dnsmasq.Kill(parentNet.Name(), true)
+	if err != nil {
+		return err
+	}
+
+	// Lock parent network so we don;t race each other networks using the OVS uplink bridge.
+	unlock := locking.Lock(n.parentOperationLockName(parentNet))
+	defer unlock()
+
+	// Check OVS uplink bridge exists, if it does, check how many ports it has.
+	removeVeths := false
+	vars := n.parentPortBridgeVars(parentNet)
+	if shared.PathExists(fmt.Sprintf("/sys/class/net/%s", vars.ovsBridge)) {
+		ovs := openvswitch.NewOVS()
+		ports, err := ovs.BridgePortList(vars.ovsBridge)
+		if err != nil {
+			return err
+		}
+
+		// If the OVS bridge has only 1 port (the OVS veth end) or fewer connected then we can delete it.
+		if len(ports) <= 1 {
+			removeVeths = true
+
+			err = ovs.OVNBridgeMappingDelete(vars.ovsBridge, parentNet.Name())
+			if err != nil {
+				return err
+			}
+
+			err = ovs.BridgeDelete(vars.ovsBridge)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		removeVeths = true // Remove the veths if OVS bridge already gone.
+	}
+
+	// Remove the veth interfaces if they exist.
+	if removeVeths {
+		if shared.PathExists(fmt.Sprintf("/sys/class/net/%s", vars.parentEnd)) {
+			_, err := shared.RunCommand("ip", "link", "delete", "dev", vars.parentEnd)
+			if err != nil {
+				return errors.Wrapf(err, "Failed to delete the uplink veth interface %q", vars.parentEnd)
+			}
+		}
+
+		if shared.PathExists(fmt.Sprintf("/sys/class/net/%s", vars.ovsEnd)) {
+			_, err := shared.RunCommand("ip", "link", "delete", "dev", vars.ovsEnd)
+			if err != nil {
+				return errors.Wrapf(err, "Failed to delete the uplink veth interface %q", vars.ovsEnd)
+			}
+		}
+	}
+
+	return nil
+}
+
+// fillConfig fills requested config with any default values.
+func (n *ovn) fillConfig(config map[string]string) error {
+	if config["ipv4.address"] == "" {
+		config["ipv4.address"] = "auto"
+	}
+
+	if config["ipv6.address"] == "" {
+		content, err := ioutil.ReadFile("/proc/sys/net/ipv6/conf/default/disable_ipv6")
+		if err == nil && string(content) == "0\n" {
+			config["ipv6.address"] = "auto"
+		}
+	}
+
+	// Now populate "auto" values where needed.
+	if config["ipv4.address"] == "auto" {
+		subnet, err := randomSubnetV4()
+		if err != nil {
+			return err
+		}
+
+		config["ipv4.address"] = subnet
+	}
+
+	if config["ipv6.address"] == "auto" {
+		subnet, err := randomSubnetV6()
+		if err != nil {
+			return err
+		}
+
+		config["ipv6.address"] = subnet
+	}
+
+	return nil
+}
+
+// Create sets up network in OVN Northbound database.
+func (n *ovn) Create(clusterNotification bool) error {
+	n.logger.Debug("Create", log.Ctx{"clusterNotification": clusterNotification, "config": n.config})
+
+	// We only need to setup the OVN Northbound database once, not on every clustered node.
+	if !clusterNotification {
+		err := n.setup(false)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (n *ovn) setup(update bool) error {
+	// If we are in mock mode, just no-op.
+	if n.state.OS.MockMode {
+		return nil
+	}
+
+	n.logger.Debug("Setting up network")
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	client, err := n.getClient()
+	if err != nil {
+		return err
+	}
+
+	var routerExtPortIPv4, routerIntPortIPv4, routerExtPortIPv6, routerIntPortIPv6 net.IP
+	var routerExtPortIPv4Net, routerIntPortIPv4Net, routerExtPortIPv6Net, routerIntPortIPv6Net *net.IPNet
+
+	// Get router MAC address.
+	routerMAC, err := n.getRouterMAC()
+	if err != nil {
+		return err
+	}
+
+	// Setup parent port (do this first to check parent is suitable).
+	parent, err := n.setupParentPort(routerMAC)
+	if err != nil {
+		return err
+	}
+
+	// Parse router IP config.
+	if parent.routerExtPortIPv4Net != "" {
+		routerExtPortIPv4, routerExtPortIPv4Net, err = net.ParseCIDR(parent.routerExtPortIPv4Net)
+		if err != nil {
+			return errors.Wrapf(err, "Failed parsing router's external parent port IPv4 Net")
+		}
+	}
+
+	if parent.routerExtPortIPv6Net != "" {
+		routerExtPortIPv6, routerExtPortIPv6Net, err = net.ParseCIDR(parent.routerExtPortIPv6Net)
+		if err != nil {
+			return errors.Wrapf(err, "Failed parsing router's external parent port IPv6 Net")
+		}
+	}
+
+	if n.getRouterIntPortIPv4Net() != "" {
+		routerIntPortIPv4, routerIntPortIPv4Net, err = net.ParseCIDR(n.getRouterIntPortIPv4Net())
+		if err != nil {
+			return errors.Wrapf(err, "Failed parsing router's internal port IPv4 Net")
+		}
+	}
+
+	if n.getRouterIntPortIPv6Net() != "" {
+		routerIntPortIPv6, routerIntPortIPv6Net, err = net.ParseCIDR(n.getRouterIntPortIPv6Net())
+		if err != nil {
+			return errors.Wrapf(err, "Failed parsing router's internal port IPv6 Net")
+		}
+	}
+
+	// Create chassis group.
+	err = client.ChassisGroupAdd(n.getChassisGroupName(), update)
+	if err != nil {
+		return err
+	}
+
+	revert.Add(func() { client.ChassisGroupDelete(n.getChassisGroupName()) })
+
+	// Add local chassis to chassis group.
+	ovs := openvswitch.NewOVS()
+	chassisID, err := ovs.ChassisID()
+	if err != nil {
+		return errors.Wrapf(err, "Failed getting OVS Chassis ID")
+	}
+
+	var priority uint = ovnChassisPriorityMax
+	err = client.ChassisGroupChassisAdd(n.getChassisGroupName(), chassisID, priority)
+	if err != nil {
+		return errors.Wrapf(err, "Failed adding OVS chassis %q with priority %d to chassis group %q", chassisID, priority, n.getChassisGroupName())
+	}
+
+	// Create logical router.
+	if update {
+		client.LogicalRouterDelete(n.getRouterName())
+	}
+
+	err = client.LogicalRouterAdd(n.getRouterName())
+	if err != nil {
+		return errors.Wrapf(err, "Failed adding router")
+	}
+	revert.Add(func() { client.LogicalRouterDelete(n.getRouterName()) })
+
+	// Configure logical router.
+
+	// Add default routes.
+	if parent.routerExtGwIPv4 != nil {
+		err = client.LogicalRouterRouteAdd(n.getRouterName(), &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)}, parent.routerExtGwIPv4)
+		if err != nil {
+			return errors.Wrapf(err, "Failed adding IPv4 default route")
+		}
+	}
+
+	if parent.routerExtGwIPv6 != nil {
+		err = client.LogicalRouterRouteAdd(n.getRouterName(), &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)}, parent.routerExtGwIPv6)
+		if err != nil {
+			return errors.Wrapf(err, "Failed adding IPv6 default route")
+		}
+	}
+
+	// Add SNAT rules.
+	if routerIntPortIPv4Net != nil {
+		err = client.LogicalRouterSNATAdd(n.getRouterName(), routerIntPortIPv4Net, routerExtPortIPv4)
+		if err != nil {
+			return err
+		}
+	}
+
+	if routerIntPortIPv6Net != nil {
+		err = client.LogicalRouterSNATAdd(n.getRouterName(), routerIntPortIPv6Net, routerExtPortIPv6)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Create external logical switch.
+	if update {
+		client.LogicalSwitchDelete(n.getExtSwitchName())
+	}
+
+	err = client.LogicalSwitchAdd(n.getExtSwitchName(), false)
+	if err != nil {
+		return errors.Wrapf(err, "Failed adding external switch")
+	}
+	revert.Add(func() { client.LogicalSwitchDelete(n.getExtSwitchName()) })
+
+	// Generate external router port IPs (in CIDR format).
+	extRouterIPs := []*net.IPNet{}
+	if routerExtPortIPv4Net != nil {
+		extRouterIPs = append(extRouterIPs, &net.IPNet{
+			IP:   routerExtPortIPv4,
+			Mask: routerExtPortIPv4Net.Mask,
+		})
+	}
+
+	if routerExtPortIPv6Net != nil {
+		extRouterIPs = append(extRouterIPs, &net.IPNet{
+			IP:   routerExtPortIPv6,
+			Mask: routerExtPortIPv6Net.Mask,
+		})
+	}
+
+	// Create external router port.
+	err = client.LogicalRouterPortAdd(n.getRouterName(), n.getRouterExtPortName(), routerMAC, extRouterIPs...)
+	if err != nil {
+		return errors.Wrapf(err, "Failed adding external router port")
+	}
+	revert.Add(func() { client.LogicalRouterPortDelete(n.getRouterExtPortName()) })
+
+	// Associate external router port to chassis group.
+	err = client.LogicalRouterPortLinkChassisGroup(n.getRouterExtPortName(), n.getChassisGroupName())
+	if err != nil {
+		return errors.Wrapf(err, "Failed linking external router port to chassis group")
+	}
+
+	// Create external switch port and link to router port.
+	err = client.LogicalSwitchPortAdd(n.getExtSwitchName(), n.getExtSwitchRouterPortName(), false)
+	if err != nil {
+		return errors.Wrapf(err, "Failed adding external switch router port")
+	}
+	revert.Add(func() { client.LogicalSwitchPortDelete(n.getExtSwitchRouterPortName()) })
+
+	err = client.LogicalSwitchPortLinkRouter(n.getExtSwitchRouterPortName(), n.getRouterExtPortName())
+	if err != nil {
+		return errors.Wrapf(err, "Failed linking external router port to external switch port")
+	}
+
+	// Create external switch port and link to external provider network.
+	err = client.LogicalSwitchPortAdd(n.getExtSwitchName(), n.getExtSwitchProviderPortName(), false)
+	if err != nil {
+		return errors.Wrapf(err, "Failed adding external switch provider port")
+	}
+	revert.Add(func() { client.LogicalSwitchPortDelete(n.getExtSwitchProviderPortName()) })
+
+	err = client.LogicalSwitchPortLinkProviderNetwork(n.getExtSwitchProviderPortName(), parent.extSwitchProviderName)
+	if err != nil {
+		return errors.Wrapf(err, "Failed linking external switch provider port to external provider network")
+	}
+
+	// Create internal logical switch if not updating.
+	err = client.LogicalSwitchAdd(n.getIntSwitchName(), update)
+	if err != nil {
+		return errors.Wrapf(err, "Failed adding internal switch")
+	}
+	revert.Add(func() { client.LogicalSwitchDelete(n.getIntSwitchName()) })
+
+	// Setup IP allocation config on logical switch.
+	err = client.LogicalSwitchSetIPAllocation(n.getIntSwitchName(), &openvswitch.OVNIPAllocationOpts{
+		PrefixIPv4:  routerIntPortIPv4Net,
+		PrefixIPv6:  routerIntPortIPv6Net,
+		ExcludeIPv4: []shared.IPRange{{Start: routerIntPortIPv4}},
+	})
+	if err != nil {
+		return errors.Wrapf(err, "Failed setting IP allocation settings on internal switch")
+	}
+
+	// Find MAC address for internal router port.
+
+	var dhcpv4UUID, dhcpv6UUID string
+
+	if update {
+		// Find first existing DHCP options set for IPv4 and IPv6 and update them instead of adding sets.
+		existingOpts, err := client.LogicalSwitchDHCPOptionsGet(n.getIntSwitchName())
+		if err != nil {
+			return errors.Wrapf(err, "Failed getting existing DHCP settings for internal switch")
+		}
+
+		for _, existingOpt := range existingOpts {
+			if existingOpt.CIDR.IP.To4() == nil {
+				if dhcpv6UUID == "" {
+					dhcpv6UUID = existingOpt.UUID
+				}
+			} else {
+				if dhcpv4UUID == "" {
+					dhcpv4UUID = existingOpt.UUID
+				}
+			}
+		}
+	}
+
+	// Create DHCPv4 options for internal switch.
+	err = client.LogicalSwitchDHCPv4OptionsSet(n.getIntSwitchName(), dhcpv4UUID, routerIntPortIPv4Net, &openvswitch.OVNDHCPv4Opts{
+		ServerID:           routerIntPortIPv4,
+		ServerMAC:          routerMAC,
+		Router:             routerIntPortIPv4,
+		RecursiveDNSServer: parent.dnsIPv4,
+		DomainName:         n.getDomainName(),
+		LeaseTime:          time.Duration(time.Hour * 1),
+	})
+	if err != nil {
+		return errors.Wrapf(err, "Failed adding DHCPv4 settings for internal switch")
+	}
+
+	// Create DHCPv6 options for internal switch.
+	err = client.LogicalSwitchDHCPv6OptionsSet(n.getIntSwitchName(), dhcpv6UUID, routerIntPortIPv6Net, &openvswitch.OVNDHCPv6Opts{
+		ServerID:           routerMAC,
+		RecursiveDNSServer: parent.dnsIPv6,
+		DNSSearchList:      n.getDNSSearchList(),
+	})
+	if err != nil {
+		return errors.Wrapf(err, "Failed adding DHCPv6 settings for internal switch")
+	}
+
+	// Generate internal router port IPs (in CIDR format).
+	intRouterIPs := []*net.IPNet{}
+	if routerIntPortIPv4Net != nil {
+		intRouterIPs = append(intRouterIPs, &net.IPNet{
+			IP:   routerIntPortIPv4,
+			Mask: routerIntPortIPv4Net.Mask,
+		})
+	}
+
+	if routerIntPortIPv6Net != nil {
+		intRouterIPs = append(intRouterIPs, &net.IPNet{
+			IP:   routerIntPortIPv6,
+			Mask: routerIntPortIPv6Net.Mask,
+		})
+	}
+
+	// Create internal router port.
+	err = client.LogicalRouterPortAdd(n.getRouterName(), n.getRouterIntPortName(), routerMAC, intRouterIPs...)
+	if err != nil {
+		return errors.Wrapf(err, "Failed adding internal router port")
+	}
+	revert.Add(func() { client.LogicalRouterPortDelete(n.getRouterIntPortName()) })
+
+	// Set IPv6 router advertisement settings.
+	if routerIntPortIPv6Net != nil {
+		err = client.LogicalRouterPortSetIPv6Advertisements(n.getRouterIntPortName(), &openvswitch.OVNIPv6RAOpts{
+			AddressMode:        openvswitch.OVNIPv6AddressModeSLAAC,
+			SendPeriodic:       true,
+			DNSSearchList:      n.getDNSSearchList(),
+			RecursiveDNSServer: parent.dnsIPv6,
+
+			// Keep these low until we support DNS search domains via DHCPv4, as otherwise RA DNSSL
+			// won't take effect until advert after DHCPv4 has run on instance.
+			MinInterval: time.Duration(time.Second * 30),
+			MaxInterval: time.Duration(time.Minute * 1),
+		})
+		if err != nil {
+			return errors.Wrapf(err, "Failed setting internal router port IPv6 advertisement settings")
+		}
+	}
+
+	// Create internal switch port and link to router port.
+	err = client.LogicalSwitchPortAdd(n.getIntSwitchName(), n.getIntSwitchRouterPortName(), update)
+	if err != nil {
+		return errors.Wrapf(err, "Failed adding internal switch router port")
+	}
+	revert.Add(func() { client.LogicalSwitchPortDelete(n.getIntSwitchRouterPortName()) })
+
+	err = client.LogicalSwitchPortLinkRouter(n.getIntSwitchRouterPortName(), n.getRouterIntPortName())
+	if err != nil {
+		return errors.Wrapf(err, "Failed linking internal router port to internal switch port")
+	}
+
+	revert.Success()
+	return nil
+}
+
+// Delete deletes a network.
+func (n *ovn) Delete(clusterNotification bool) error {
+	n.logger.Debug("Delete", log.Ctx{"clusterNotification": clusterNotification})
+
+	if !clusterNotification {
+		client, err := n.getClient()
+		if err != nil {
+			return err
+		}
+
+		err = client.LogicalRouterDelete(n.getRouterName())
+		if err != nil {
+			return err
+		}
+
+		err = client.LogicalSwitchDelete(n.getExtSwitchName())
+		if err != nil {
+			return err
+		}
+
+		err = client.LogicalSwitchDelete(n.getIntSwitchName())
+		if err != nil {
+			return err
+		}
+
+		err = client.LogicalRouterPortDelete(n.getRouterExtPortName())
+		if err != nil {
+			return err
+		}
+
+		err = client.LogicalRouterPortDelete(n.getRouterIntPortName())
+		if err != nil {
+			return err
+		}
+
+		err = client.LogicalSwitchPortDelete(n.getExtSwitchRouterPortName())
+		if err != nil {
+			return err
+		}
+
+		err = client.LogicalSwitchPortDelete(n.getExtSwitchProviderPortName())
+		if err != nil {
+			return err
+		}
+
+		err = client.LogicalSwitchPortDelete(n.getIntSwitchRouterPortName())
+		if err != nil {
+			return err
+		}
+
+		// Must be done after logical router removal.
+		err = client.ChassisGroupDelete(n.getChassisGroupName())
+		if err != nil {
+			return err
+		}
+	}
+
+	// Delete local parent uplink port.
+	err := n.deleteParentPort()
+	if err != nil {
+		return err
+	}
+
+	return n.common.delete(clusterNotification)
+}
+
+// Rename renames a network.
+func (n *ovn) Rename(newName string) error {
+	n.logger.Debug("Rename", log.Ctx{"newName": newName})
+
+	// Sanity checks.
+	inUse, err := n.IsUsed()
+	if err != nil {
+		return err
+	}
+
+	if inUse {
+		return fmt.Errorf("The network is currently in use")
+	}
+
+	// Rename common steps.
+	err = n.common.rename(newName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Start starts configures the local OVS parent uplink port.
+func (n *ovn) Start() error {
+	if n.status == api.NetworkStatusPending {
+		return fmt.Errorf("Cannot start pending network")
+	}
+
+	err := n.startParentPort()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Stop stops is a no-op.
+func (n *ovn) Stop() error {
+	return nil
+}
+
+// Update updates the network. Accepts notification boolean indicating if this update request is coming from a
+// cluster notification, in which case do not update the database, just apply local changes needed.
+func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clusterNotification bool) error {
+	n.logger.Debug("Update", log.Ctx{"clusterNotification": clusterNotification, "newNetwork": newNetwork})
+
+	// Populate default values if they are missing.
+	err := n.fillConfig(newNetwork.Config)
+	if err != nil {
+		return err
+	}
+
+	dbUpdateNeeeded, changedKeys, oldNetwork, err := n.common.configChanged(newNetwork)
+	if err != nil {
+		return err
+	}
+
+	if !dbUpdateNeeeded {
+		return nil // Nothing changed.
+	}
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	// Define a function which reverts everything.
+	revert.Add(func() {
+		// Reset changes to all nodes and database.
+		n.common.update(oldNetwork, targetNode, clusterNotification)
+
+		// Reset any change that was made to logical network.
+		if !clusterNotification {
+			n.setup(true)
+		}
+	})
+
+	// Apply changes to database.
+	err = n.common.update(newNetwork, targetNode, clusterNotification)
+	if err != nil {
+		return err
+	}
+
+	// Restart the logical network if needed.
+	if len(changedKeys) > 0 && !clusterNotification {
+		err = n.setup(true)
+		if err != nil {
+			return err
+		}
+	}
+
+	revert.Success()
+	return nil
+}
+
+// getInstanceDevicePortName returns the switch port name to use for an instance device.
+func (n *ovn) getInstanceDevicePortName(instanceID int, deviceName string) openvswitch.OVNSwitchPort {
+	return openvswitch.OVNSwitchPort(fmt.Sprintf("%s-%d-%s", n.getIntSwitchInstancePortPrefix(), instanceID, deviceName))
+}
+
+// instanceDevicePortAdd adds an instance device port to the internal logical switch and returns the port name.
+func (n *ovn) instanceDevicePortAdd(instanceID int, deviceName string, mac net.HardwareAddr, ips []net.IP) (openvswitch.OVNSwitchPort, error) {
+	var dhcpV4ID, dhcpv6ID string
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	client, err := n.getClient()
+	if err != nil {
+		return "", err
+	}
+
+	// Get DHCP options IDs.
+	if n.getRouterIntPortIPv4Net() != "" {
+		_, routerIntPortIPv4Net, err := net.ParseCIDR(n.getRouterIntPortIPv4Net())
+		if err != nil {
+			return "", err
+		}
+
+		dhcpV4ID, err = client.LogicalSwitchDHCPOptionsGetID(n.getIntSwitchName(), routerIntPortIPv4Net)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if n.getRouterIntPortIPv6Net() != "" {
+		_, routerIntPortIPv6Net, err := net.ParseCIDR(n.getRouterIntPortIPv6Net())
+		if err != nil {
+			return "", err
+		}
+
+		dhcpv6ID, err = client.LogicalSwitchDHCPOptionsGetID(n.getIntSwitchName(), routerIntPortIPv6Net)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	instancePortName := n.getInstanceDevicePortName(instanceID, deviceName)
+
+	// Add port with mayExist set to true, so that if instance port exists, we don't fail and continue below
+	// to configure the port as needed. This is required in case the OVN northbound database was unavailable
+	// when the instance NIC was stopped and was unable to remove the port on last stop, which would otherwise
+	// prevent future NIC starts.
+	err = client.LogicalSwitchPortAdd(n.getIntSwitchName(), instancePortName, true)
+	if err != nil {
+		return "", err
+	}
+
+	revert.Add(func() { client.LogicalSwitchPortDelete(instancePortName) })
+
+	err = client.LogicalSwitchPortSet(instancePortName, &openvswitch.OVNSwitchPortOpts{
+		DHCPv4OptsID: dhcpV4ID,
+		DHCPv6OptsID: dhcpv6ID,
+		MAC:          mac,
+		IPs:          ips,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	revert.Success()
+	return instancePortName, nil
+}
+
+// instanceDevicePortDelete deletes an instance device port from the internal logical switch.
+func (n *ovn) instanceDevicePortDelete(instanceID int, deviceName string) error {
+	instancePortName := n.getInstanceDevicePortName(instanceID, deviceName)
+
+	client, err := n.getClient()
+	if err != nil {
+		return err
+	}
+
+	err = client.LogicalSwitchPortDelete(instancePortName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lxd/network/network_load.go
+++ b/lxd/network/network_load.go
@@ -11,6 +11,7 @@ var drivers = map[string]func() Network{
 	"bridge":  func() Network { return &bridge{} },
 	"macvlan": func() Network { return &macvlan{} },
 	"sriov":   func() Network { return &sriov{} },
+	"ovn":     func() Network { return &ovn{} },
 }
 
 // LoadByName loads the network info from the database by name.

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -866,3 +866,26 @@ func randomHwaddr(r *rand.Rand) string {
 
 	return ret.String()
 }
+
+// OVNInstanceDevicePortAdd adds a logical port to the OVN network's internal switch and returns the logical
+// port name for use linking an OVS port on the integration bridge to the logical switch port.
+func OVNInstanceDevicePortAdd(network Network, instanceID int, deviceName string, mac net.HardwareAddr, ips []net.IP) (openvswitch.OVNSwitchPort, error) {
+	// Check network is of type OVN.
+	n, ok := network.(*ovn)
+	if !ok {
+		return "", fmt.Errorf("Network is not OVN type")
+	}
+
+	return n.instanceDevicePortAdd(instanceID, deviceName, mac, ips)
+}
+
+// OVNInstanceDevicePortDelete deletes a logical port from the OVN network's internal switch.
+func OVNInstanceDevicePortDelete(network Network, instanceID int, deviceName string) error {
+	// Check network is of type OVN.
+	n, ok := network.(*ovn)
+	if !ok {
+		return fmt.Errorf("Network is not OVN type")
+	}
+
+	return n.instanceDevicePortDelete(instanceID, deviceName)
+}

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -889,3 +889,113 @@ func OVNInstanceDevicePortDelete(network Network, instanceID int, deviceName str
 
 	return n.instanceDevicePortDelete(instanceID, deviceName)
 }
+
+// parseIPRange parses an IP range in the format "start-end" and converts it to a shared.IPRange.
+// If allowedNets are supplied, then each IP in the range is checked that it belongs to at least one of them.
+// IPs in the range can be zero prefixed, e.g. "::1" or "0.0.0.1", however they should not overlap with any
+// supplied allowedNets prefixes. If they are within an allowed network, any zero prefixed addresses are
+// returned combined with the first allowed network they are within.
+// If no allowedNets supplied they are returned as-is.
+func parseIPRange(ipRange string, allowedNets ...*net.IPNet) (*shared.IPRange, error) {
+	inAllowedNet := func(ip net.IP, allowedNet *net.IPNet) net.IP {
+		if ip == nil {
+			return nil
+		}
+
+		ipv4 := ip.To4()
+
+		// Only match IPv6 addresses against IPv6 networks.
+		if ipv4 == nil && allowedNet.IP.To4() != nil {
+			return nil
+		}
+
+		// Combine IP with network prefix if IP starts with a zero.
+		// If IP is v4, then compare against 4-byte representation, otherwise use 16 byte representation.
+		if (ipv4 != nil && ipv4[0] == 0) || (ipv4 == nil && ip[0] == 0) {
+			allowedNet16 := allowedNet.IP.To16()
+			ipCombined := make(net.IP, net.IPv6len)
+			for i, b := range ip {
+				ipCombined[i] = allowedNet16[i] | b
+			}
+
+			ip = ipCombined
+		}
+
+		// Check start IP is within one of the allowed networks.
+		if !allowedNet.Contains(ip) {
+			return nil
+		}
+
+		return ip
+	}
+
+	rangeParts := strings.SplitN(ipRange, "-", 2)
+	if len(rangeParts) != 2 {
+		return nil, fmt.Errorf("IP range %q must contain start and end IP addresses", ipRange)
+	}
+
+	startIP := net.ParseIP(rangeParts[0])
+	endIP := net.ParseIP(rangeParts[1])
+
+	if startIP == nil {
+		return nil, fmt.Errorf("Start IP %q is invalid", rangeParts[0])
+	}
+
+	if endIP == nil {
+		return nil, fmt.Errorf("End IP %q is invalid", rangeParts[0])
+	}
+
+	if bytes.Compare(startIP, endIP) > 0 {
+		return nil, fmt.Errorf("Start IP %q must be less than End IP %q", startIP, endIP)
+	}
+
+	if len(allowedNets) > 0 {
+		matchFound := false
+		for _, allowedNet := range allowedNets {
+			if allowedNet == nil {
+				return nil, fmt.Errorf("Invalid allowed network")
+			}
+
+			combinedStartIP := inAllowedNet(startIP, allowedNet)
+			if combinedStartIP == nil {
+				continue
+			}
+
+			combinedEndIP := inAllowedNet(endIP, allowedNet)
+			if combinedEndIP == nil {
+				continue
+			}
+
+			// If both match then replace parsed IPs with combined IPs and stop searching.
+			matchFound = true
+			startIP = combinedStartIP
+			endIP = combinedEndIP
+			break
+		}
+
+		if !matchFound {
+			return nil, fmt.Errorf("IP range %q does not fall within any of the allowed networks %v", ipRange, allowedNets)
+		}
+	}
+
+	return &shared.IPRange{
+		Start: startIP,
+		End:   endIP,
+	}, nil
+}
+
+// parseIPRanges parses a comma separated list of IP ranges using parseIPRange.
+func parseIPRanges(ipRangesList string, allowedNets ...*net.IPNet) ([]*shared.IPRange, error) {
+	ipRanges := strings.Split(ipRangesList, ",")
+	netIPRanges := make([]*shared.IPRange, 0, len(ipRanges))
+	for _, ipRange := range ipRanges {
+		netIPRange, err := parseIPRange(strings.TrimSpace(ipRange), allowedNets...)
+		if err != nil {
+			return nil, err
+		}
+
+		netIPRanges = append(netIPRanges, netIPRange)
+	}
+
+	return netIPRanges, nil
+}

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -91,7 +91,7 @@ func isInUseByDevices(s *state.State, devices deviceConfig.Devices, networkName 
 			return false, err
 		}
 
-		if !shared.StringInSlice(nicType, []string{"bridged", "macvlan", "ipvlan", "physical", "sriov"}) {
+		if !shared.StringInSlice(nicType, []string{"bridged", "macvlan", "ipvlan", "physical", "sriov", "ovn"}) {
 			continue
 		}
 

--- a/lxd/network/network_utils_test.go
+++ b/lxd/network/network_utils_test.go
@@ -1,0 +1,88 @@
+package network
+
+import (
+	"fmt"
+	"net"
+)
+
+func Example_parseIPRange() {
+	_, allowedv4NetworkA, _ := net.ParseCIDR("192.168.1.0/24")
+	_, allowedv4NetworkB, _ := net.ParseCIDR("192.168.0.0/16")
+	_, allowedv6NetworkA, _ := net.ParseCIDR("fd22:c952:653e:3df6::/64")
+	_, allowedv6NetworkB, _ := net.ParseCIDR("fd22:c952:653e::/48")
+
+	ipRanges := []string{
+		// Ranges within allowedv4NetworkA.
+		"192.168.1.1-192.168.1.255",
+		"0.0.0.1-192.168.1.255",
+		"0.0.0.1-0.0.0.255",
+		// Ranges outsde of allowedv4NetworkA but within allowedv4NetworkB.
+		"192.168.0.1-192.168.0.255",
+		"192.168.0.0-192.168.0.0",
+		"0.0.2.0-0.0.2.255",
+		// Invalid IP ranges.
+		"0.0.0.0.1-192.168.1.255",
+		"192.0.0.1-192.0.0.255",
+		"0.0.0.1-01.0.0.255",
+		"0.0.2.1-0.0.0.255",
+		// Ranges within allowedv6NetworkA.
+		"fd22:c952:653e:3df6::1-fd22:c952:653e:3df6::FFFF",
+		"::1-::FFFF",
+		// Ranges outsde of allowedv6NetworkA but within allowedv6NetworkB.
+		"fd22:c952:653e:FFFF::1-fd22:c952:653e:FFFF::FFFF",
+		"::AAAA:FFFF:FFFF:FFFF:1-::AAAA:FFFF:FFFF:FFFF:FFFF",
+	}
+
+	fmt.Println("With allowed networks")
+	for _, ipRange := range ipRanges {
+		parsedRange, err := parseIPRange(ipRange, allowedv4NetworkA, allowedv4NetworkB, allowedv6NetworkA, allowedv6NetworkB)
+		if err != nil {
+			fmt.Printf("Err: %v\n", err)
+			continue
+		}
+
+		fmt.Printf("Start: %s, End: %s\n", parsedRange.Start.String(), parsedRange.End.String())
+	}
+
+	fmt.Println("Without allowed networks")
+	for _, ipRange := range ipRanges {
+		parsedRange, err := parseIPRange(ipRange)
+		if err != nil {
+			fmt.Printf("Err: %v\n", err)
+			continue
+		}
+
+		fmt.Printf("Start: %s, End: %s\n", parsedRange.Start.String(), parsedRange.End.String())
+	}
+
+	// Output: With allowed networks
+	// Start: 192.168.1.1, End: 192.168.1.255
+	// Start: 192.168.1.1, End: 192.168.1.255
+	// Start: 192.168.1.1, End: 192.168.1.255
+	// Start: 192.168.0.1, End: 192.168.0.255
+	// Start: 192.168.0.0, End: 192.168.0.0
+	// Start: 192.168.2.0, End: 192.168.2.255
+	// Err: Start IP "0.0.0.0.1" is invalid
+	// Err: IP range "192.0.0.1-192.0.0.255" does not fall within any of the allowed networks [192.168.1.0/24 192.168.0.0/16 fd22:c952:653e:3df6::/64 fd22:c952:653e::/48]
+	// Err: IP range "0.0.0.1-01.0.0.255" does not fall within any of the allowed networks [192.168.1.0/24 192.168.0.0/16 fd22:c952:653e:3df6::/64 fd22:c952:653e::/48]
+	// Err: Start IP "0.0.2.1" must be less than End IP "0.0.0.255"
+	// Start: fd22:c952:653e:3df6::1, End: fd22:c952:653e:3df6::ffff
+	// Start: fd22:c952:653e:3df6::1, End: fd22:c952:653e:3df6::ffff
+	// Start: fd22:c952:653e:ffff::1, End: fd22:c952:653e:ffff::ffff
+	// Start: fd22:c952:653e:aaaa:ffff:ffff:ffff:1, End: fd22:c952:653e:aaaa:ffff:ffff:ffff:ffff
+	// Without allowed networks
+	// Start: 192.168.1.1, End: 192.168.1.255
+	// Start: 0.0.0.1, End: 192.168.1.255
+	// Start: 0.0.0.1, End: 0.0.0.255
+	// Start: 192.168.0.1, End: 192.168.0.255
+	// Start: 192.168.0.0, End: 192.168.0.0
+	// Start: 0.0.2.0, End: 0.0.2.255
+	// Err: Start IP "0.0.0.0.1" is invalid
+	// Start: 192.0.0.1, End: 192.0.0.255
+	// Start: 0.0.0.1, End: 1.0.0.255
+	// Err: Start IP "0.0.2.1" must be less than End IP "0.0.0.255"
+	// Start: fd22:c952:653e:3df6::1, End: fd22:c952:653e:3df6::ffff
+	// Start: ::1, End: ::ffff
+	// Start: fd22:c952:653e:ffff::1, End: fd22:c952:653e:ffff::ffff
+	// Start: ::aaaa:ffff:ffff:ffff:1, End: ::aaaa:ffff:ffff:ffff:ffff
+}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1,0 +1,632 @@
+package openvswitch
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/lxc/lxd/shared"
+)
+
+// OVNRouter OVN router name.
+type OVNRouter string
+
+// OVNRouterPort OVN router port name.
+type OVNRouterPort string
+
+// OVNSwitch OVN switch name.
+type OVNSwitch string
+
+// OVNSwitchPort OVN switch port name.
+type OVNSwitchPort string
+
+// OVNChassisGroup OVN HA chassis group name.
+type OVNChassisGroup string
+
+// OVNIPAllocationOpts defines IP allocation settings that can be applied to a logical switch.
+type OVNIPAllocationOpts struct {
+	PrefixIPv4  *net.IPNet
+	PrefixIPv6  *net.IPNet
+	ExcludeIPv4 []shared.IPRange
+}
+
+// OVNIPv6AddressMode IPv6 router advertisement address mode.
+type OVNIPv6AddressMode string
+
+// OVNIPv6AddressModeSLAAC IPv6 SLAAC mode.
+const OVNIPv6AddressModeSLAAC OVNIPv6AddressMode = "slaac"
+
+// OVNIPv6AddressModeDHCPStateful IPv6 DHCPv6 stateful mode.
+const OVNIPv6AddressModeDHCPStateful OVNIPv6AddressMode = "dhcp_stateful"
+
+// OVNIPv6AddressModeDHCPStateless IPv6 DHCPv6 stateless mode.
+const OVNIPv6AddressModeDHCPStateless OVNIPv6AddressMode = "dhcp_stateless"
+
+// OVNIPv6RAOpts IPv6 router advertisements options that can be applied to a router.
+type OVNIPv6RAOpts struct {
+	SendPeriodic       bool
+	AddressMode        OVNIPv6AddressMode
+	MinInterval        time.Duration
+	MaxInterval        time.Duration
+	RecursiveDNSServer net.IP
+	DNSSearchList      []string
+}
+
+// OVNDHCPOptsSet is an existing DHCP options set in the northbound database.
+type OVNDHCPOptsSet struct {
+	UUID string
+	CIDR *net.IPNet
+}
+
+// OVNDHCPv4Opts IPv4 DHCP options that can be applied to a switch port.
+type OVNDHCPv4Opts struct {
+	ServerID           net.IP
+	ServerMAC          net.HardwareAddr
+	Router             net.IP
+	RecursiveDNSServer net.IP
+	DomainName         string
+	LeaseTime          time.Duration
+}
+
+// OVNDHCPv6Opts IPv6 DHCP option set that can be created (and then applied to a switch port by resulting ID).
+type OVNDHCPv6Opts struct {
+	ServerID           net.HardwareAddr
+	RecursiveDNSServer net.IP
+	DNSSearchList      []string
+}
+
+// OVNSwitchPortOpts options that can be applied to a swich port.
+type OVNSwitchPortOpts struct {
+	MAC          net.HardwareAddr // Optional, if nil will be set to dynamic.
+	IPs          []net.IP         // Optional, if empty IPs will be set to dynamic.
+	DHCPv4OptsID string           // Optional, if empty, no DHCPv4 enabled on port.
+	DHCPv6OptsID string           // Optional, if empty, no DHCPv6 enabled on port.
+}
+
+// NewOVN initialises new OVN wrapper.
+func NewOVN() *OVN {
+	return &OVN{}
+}
+
+// OVN command wrapper.
+type OVN struct {
+	dbAddr string
+}
+
+// SetDatabaseAddress sets the address that runs the OVN northbound and southbound databases.
+func (o *OVN) SetDatabaseAddress(addr string) {
+	o.dbAddr = addr
+}
+
+// getNorthboundDB returns connection string to use for northbound database.
+func (o *OVN) getNorthboundDB() string {
+	if o.dbAddr == "" {
+		return "unix:/var/run/ovn/ovnnb_db.sock"
+	}
+
+	return o.dbAddr
+}
+
+// nbctl executes ovn-nbctl with arguments to connect to wrapper's northbound database.
+func (o *OVN) nbctl(args ...string) (string, error) {
+	return shared.RunCommand("ovn-nbctl", append([]string{"--db", o.getNorthboundDB()}, args...)...)
+}
+
+// LogicalRouterAdd adds a named logical router.
+func (o *OVN) LogicalRouterAdd(routerName OVNRouter) error {
+	_, err := o.nbctl("lr-add", string(routerName))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LogicalRouterDelete deletes a named logical router.
+func (o OVN) LogicalRouterDelete(routerName OVNRouter) error {
+	_, err := o.nbctl("--if-exists", "lr-del", string(routerName))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LogicalRouterSNATAdd adds an SNAT rule to a logical router to translate packets from intNet to extIP.
+func (o *OVN) LogicalRouterSNATAdd(routerName OVNRouter, intNet *net.IPNet, extIP net.IP) error {
+	_, err := o.nbctl("lr-nat-add", string(routerName), "snat", extIP.String(), intNet.String())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LogicalRouterRouteAdd adds a static route to the logical router.
+func (o *OVN) LogicalRouterRouteAdd(routerName OVNRouter, destination *net.IPNet, nextHop net.IP) error {
+	_, err := o.nbctl("lr-route-add", string(routerName), destination.String(), nextHop.String())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LogicalRouterPortAdd adds a named logical router port to a logical router.
+func (o *OVN) LogicalRouterPortAdd(routerName OVNRouter, portName OVNRouterPort, mac net.HardwareAddr, ipAddr ...*net.IPNet) error {
+	args := []string{"lrp-add", string(routerName), string(portName), mac.String()}
+	for _, ipNet := range ipAddr {
+		args = append(args, ipNet.String())
+	}
+
+	_, err := o.nbctl(args...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LogicalRouterPortDelete deletes a named logical router port from a logical router.
+func (o *OVN) LogicalRouterPortDelete(portName OVNRouterPort) error {
+	_, err := o.nbctl("--if-exists", "lrp-del", string(portName))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LogicalRouterPortSetIPv6Advertisements sets the IPv6 router advertisement options on a router port.
+func (o *OVN) LogicalRouterPortSetIPv6Advertisements(portName OVNRouterPort, opts *OVNIPv6RAOpts) error {
+	args := []string{"set", "logical_router_port", string(portName),
+		fmt.Sprintf("ipv6_ra_configs:send_periodic=%t", opts.SendPeriodic),
+		fmt.Sprintf("ipv6_ra_configs:address_mode=%s", string(opts.AddressMode)),
+	}
+
+	if opts.MaxInterval > 0 {
+		args = append(args, fmt.Sprintf("ipv6_ra_configs:max_interval=%d", opts.MaxInterval/time.Second))
+	}
+
+	if opts.MinInterval > 0 {
+		args = append(args, fmt.Sprintf("ipv6_ra_configs:min_interval=%d", opts.MinInterval/time.Second))
+	}
+
+	if len(opts.DNSSearchList) > 0 {
+		args = append(args, fmt.Sprintf("ipv6_ra_configs:dnssl=%s", strings.Join(opts.DNSSearchList, ",")))
+	}
+
+	if opts.RecursiveDNSServer != nil {
+		args = append(args, fmt.Sprintf("ipv6_ra_configs:rdnss=%s", opts.RecursiveDNSServer.String()))
+
+	}
+
+	// Configure IPv6 Router Advertisements.
+	_, err := o.nbctl(args...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LogicalRouterPortLinkChassisGroup links a logical router port to a HA chassis group.
+func (o *OVN) LogicalRouterPortLinkChassisGroup(portName OVNRouterPort, haChassisGroupName OVNChassisGroup) error {
+	chassisGroupID, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--colum=_uuid", "find", "ha_chassis_group", fmt.Sprintf("name=%s", haChassisGroupName))
+	if err != nil {
+		return err
+	}
+
+	chassisGroupID = strings.TrimSpace(chassisGroupID)
+
+	if chassisGroupID == "" {
+		return fmt.Errorf("Chassis group not found")
+	}
+
+	_, err = o.nbctl("set", "logical_router_port", string(portName), fmt.Sprintf("ha_chassis_group=%s", chassisGroupID))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LogicalSwitchAdd adds a named logical switch.
+// If mayExist is true, then an existing resource of the same name is not treated as an error.
+func (o *OVN) LogicalSwitchAdd(switchName OVNSwitch, mayExist bool) error {
+	args := []string{}
+
+	if mayExist {
+		args = append(args, "--may-exist")
+	}
+
+	args = append(args, "ls-add", string(switchName))
+	_, err := o.nbctl(args...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LogicalSwitchDelete deletes a named logical switch.
+func (o *OVN) LogicalSwitchDelete(switchName OVNSwitch) error {
+	_, err := o.nbctl("--if-exists", "ls-del", string(switchName))
+	if err != nil {
+		return err
+	}
+
+	return o.logicalSwitchDHCPOptionsDelete(switchName)
+}
+
+// LogicalSwitchSetIPAllocation sets the IP allocation config on the logical switch.
+func (o *OVN) LogicalSwitchSetIPAllocation(switchName OVNSwitch, opts *OVNIPAllocationOpts) error {
+	args := []string{"set", "logical_switch", string(switchName)}
+
+	if opts.PrefixIPv4 != nil {
+		args = append(args, fmt.Sprintf("other_config:subnet=%s", opts.PrefixIPv4.String()))
+	}
+
+	if opts.PrefixIPv6 != nil {
+		args = append(args, fmt.Sprintf("other_config:ipv6_prefix=%s", opts.PrefixIPv6.String()))
+	}
+
+	if len(opts.ExcludeIPv4) > 0 {
+		excludeIPs := make([]string, 0, len(opts.ExcludeIPv4))
+		for _, v := range opts.ExcludeIPv4 {
+			if v.Start == nil {
+				return fmt.Errorf("Invalid exclude IPv4 range start address")
+			} else if v.End == nil {
+				excludeIPs = append(excludeIPs, v.Start.String())
+			} else {
+				excludeIPs = append(excludeIPs, fmt.Sprintf("%s..%s", v.Start.String(), v.End.String()))
+			}
+		}
+
+		args = append(args, fmt.Sprintf("other_config:exclude_ips=%s", strings.Join(excludeIPs, " ")))
+	}
+
+	// Only run command if at least one setting is specified.
+	if len(args) > 3 {
+		_, err := o.nbctl(args...)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// LogicalSwitchDHCPv4OptionsSet creates or updates a DHCPv4 option set associated with the specified switchName
+// and subnet. If uuid is non-empty then the record that exists with that ID is updated, otherwise a new record
+// is created.
+func (o *OVN) LogicalSwitchDHCPv4OptionsSet(switchName OVNSwitch, uuid string, subnet *net.IPNet, opts *OVNDHCPv4Opts) error {
+	var err error
+
+	if uuid != "" {
+		_, err = o.nbctl("set", "dhcp_option", uuid,
+			fmt.Sprintf("external_ids:lxd_switch=%s", string(switchName)),
+			fmt.Sprintf("cidr=%s", subnet.String()),
+		)
+		if err != nil {
+			return err
+		}
+	} else {
+		uuid, err = o.nbctl("create", "dhcp_option",
+			fmt.Sprintf("external_ids:lxd_switch=%s", string(switchName)),
+			fmt.Sprintf("cidr=%s", subnet.String()),
+		)
+		if err != nil {
+			return err
+		}
+
+		uuid = strings.TrimSpace(uuid)
+	}
+
+	// We have to use dhcp-options-set-options rather than the command above as its the only way to allow the
+	// domain_name option to be properly escaped.
+	args := []string{"dhcp-options-set-options", uuid,
+		fmt.Sprintf("server_id=%s", opts.ServerID.String()),
+		fmt.Sprintf("server_mac=%s", opts.ServerMAC.String()),
+		fmt.Sprintf("lease_time=%d", opts.LeaseTime/time.Second),
+	}
+
+	if opts.Router != nil {
+		args = append(args, fmt.Sprintf("router=%s", opts.Router.String()))
+	}
+
+	if opts.RecursiveDNSServer != nil {
+		args = append(args, fmt.Sprintf("dns_server=%s", opts.RecursiveDNSServer.String()))
+	}
+
+	if opts.DomainName != "" {
+		// Special quoting to allow domain names.
+		args = append(args, fmt.Sprintf(`domain_name="%s"`, opts.DomainName))
+	}
+
+	_, err = o.nbctl(args...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LogicalSwitchDHCPv6OptionsSet creates or updates a DHCPv6 option set associated with the specified switchName
+// and subnet. If uuid is non-empty then the record that exists with that ID is updated, otherwise a new record
+// is created.
+func (o *OVN) LogicalSwitchDHCPv6OptionsSet(switchName OVNSwitch, uuid string, subnet *net.IPNet, opts *OVNDHCPv6Opts) error {
+	var err error
+
+	if uuid != "" {
+		_, err = o.nbctl("set", "dhcp_option", uuid,
+			fmt.Sprintf("external_ids:lxd_switch=%s", string(switchName)),
+			fmt.Sprintf(`cidr="%s"`, subnet.String()), // Special quoting to allow IPv6 address.
+		)
+		if err != nil {
+			return err
+		}
+	} else {
+		uuid, err = o.nbctl("create", "dhcp_option",
+			fmt.Sprintf("external_ids:lxd_switch=%s", string(switchName)),
+			fmt.Sprintf(`cidr="%s"`, subnet.String()), // Special quoting to allow IPv6 address.
+		)
+		if err != nil {
+			return err
+		}
+
+		uuid = strings.TrimSpace(uuid)
+	}
+
+	// We have to use dhcp-options-set-options rather than the command above as its the only way to allow the
+	// domain_name option to be properly escaped.
+	args := []string{"dhcp-options-set-options", uuid,
+		fmt.Sprintf("server_id=%s", opts.ServerID.String()),
+	}
+
+	if len(opts.DNSSearchList) > 0 {
+		// Special quoting to allow domain names.
+		args = append(args, fmt.Sprintf(`domain_search="%s"`, strings.Join(opts.DNSSearchList, ",")))
+	}
+
+	if opts.RecursiveDNSServer != nil {
+		args = append(args, fmt.Sprintf("dns_server=%s", opts.RecursiveDNSServer.String()))
+	}
+
+	_, err = o.nbctl(args...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LogicalSwitchDHCPOptionsGetID returns the UUID for DHCP options set associated to the logical switch and subnet.
+func (o *OVN) LogicalSwitchDHCPOptionsGetID(switchName OVNSwitch, subnet *net.IPNet) (string, error) {
+	uuid, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--colum=_uuid", "find", "dhcp_options",
+		fmt.Sprintf("external_ids:lxd_switch=%s", string(switchName)),
+		fmt.Sprintf(`cidr="%s"`, subnet.String()), // Special quoting to support IPv6 subnets.
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(uuid), nil
+}
+
+// LogicalSwitchDHCPOptionsGet retrieves the existing DHCP options defined for a logical switch.
+func (o *OVN) LogicalSwitchDHCPOptionsGet(switchName OVNSwitch) ([]OVNDHCPOptsSet, error) {
+	output, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--colum=_uuid,cidr", "find", "dhcp_options",
+		fmt.Sprintf("external_ids:lxd_switch=%s", string(switchName)),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	colCount := 2
+	dhcpOpts := []OVNDHCPOptsSet{}
+	output = strings.TrimSpace(output)
+	if output != "" {
+		for _, row := range strings.Split(output, "\n") {
+			rowParts := strings.SplitN(row, ",", colCount)
+			if len(rowParts) < colCount {
+				return nil, fmt.Errorf("Too few columns in output")
+			}
+
+			_, cidr, err := net.ParseCIDR(rowParts[1])
+			if err != nil {
+				return nil, err
+			}
+
+			dhcpOpts = append(dhcpOpts, OVNDHCPOptsSet{
+				UUID: rowParts[0],
+				CIDR: cidr,
+			})
+		}
+	}
+
+	return dhcpOpts, nil
+}
+
+// logicalSwitchDHCPOptionsDelete deletes any DHCP options defined for a switch.
+func (o *OVN) logicalSwitchDHCPOptionsDelete(switchName OVNSwitch) error {
+	existingOpts, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--colum=_uuid", "find", "dhcp_options",
+		fmt.Sprintf("external_ids:lxd_switch=%s", string(switchName)),
+	)
+	if err != nil {
+		return err
+	}
+
+	existingOpts = strings.TrimSpace(existingOpts)
+	if existingOpts != "" {
+		for _, uuid := range strings.Split(existingOpts, "\n") {
+			_, err = o.nbctl("destroy", "dhcp_options", uuid)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// LogicalSwitchPortAdd adds a named logical switch port to a logical switch.
+// If mayExist is true, then an existing resource of the same name is not treated as an error.
+func (o *OVN) LogicalSwitchPortAdd(switchName OVNSwitch, portName OVNSwitchPort, mayExist bool) error {
+	args := []string{}
+
+	if mayExist {
+		args = append(args, "--may-exist")
+	}
+
+	args = append(args, "lsp-add", string(switchName), string(portName))
+
+	_, err := o.nbctl(args...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LogicalSwitchPortSet sets options on logical switch port.
+func (o *OVN) LogicalSwitchPortSet(portName OVNSwitchPort, opts *OVNSwitchPortOpts) error {
+	ipStr := make([]string, 0, len(opts.IPs))
+	for _, ip := range opts.IPs {
+		ipStr = append(ipStr, ip.String())
+	}
+
+	var addresses string
+	if opts.MAC != nil && len(ipStr) > 0 {
+		addresses = fmt.Sprintf("%s %s", opts.MAC.String(), strings.Join(ipStr, " "))
+	} else if opts.MAC != nil && len(ipStr) <= 0 {
+		addresses = fmt.Sprintf("%s %s", opts.MAC.String(), "dynamic")
+	} else {
+		addresses = "dynamic"
+	}
+
+	_, err := o.nbctl("lsp-set-addresses", string(portName), addresses)
+	if err != nil {
+		return err
+	}
+
+	if opts.DHCPv4OptsID != "" {
+		_, err = o.nbctl("lsp-set-dhcpv4-options", string(portName), opts.DHCPv4OptsID)
+		if err != nil {
+			return err
+		}
+	}
+
+	if opts.DHCPv6OptsID != "" {
+		_, err = o.nbctl("lsp-set-dhcpv6-options", string(portName), opts.DHCPv6OptsID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// LogicalSwitchPortDelete deletes a named logical switch port.
+func (o *OVN) LogicalSwitchPortDelete(portName OVNSwitchPort) error {
+	_, err := o.nbctl("--if-exists", "lsp-del", string(portName))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LogicalSwitchPortLinkRouter links a logical switch port to a logical router port.
+func (o *OVN) LogicalSwitchPortLinkRouter(switchPortName OVNSwitchPort, routerPortName OVNRouterPort) error {
+	// Connect logical router port to switch.
+	_, err := o.nbctl("lsp-set-type", string(switchPortName), "router")
+	if err != nil {
+		return err
+	}
+
+	_, err = o.nbctl("lsp-set-addresses", string(switchPortName), "router")
+	if err != nil {
+		return err
+	}
+
+	_, err = o.nbctl("lsp-set-options", string(switchPortName),
+		fmt.Sprintf("nat-addresses=%s", "router"),
+		fmt.Sprintf("router-port=%s", string(routerPortName)),
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LogicalSwitchPortLinkProviderNetwork links a logical switch port to a provider network.
+func (o *OVN) LogicalSwitchPortLinkProviderNetwork(switchPortName OVNSwitchPort, extNetworkName string) error {
+	// Forward any unknown MAC frames down this port.
+	_, err := o.nbctl("lsp-set-addresses", string(switchPortName), "unknown")
+	if err != nil {
+		return err
+	}
+
+	_, err = o.nbctl("lsp-set-type", string(switchPortName), "localnet")
+	if err != nil {
+		return err
+	}
+
+	_, err = o.nbctl("lsp-set-options", string(switchPortName), fmt.Sprintf("network_name=%s", extNetworkName))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ChassisGroupAdd adds a new HA chassis group.
+// If mayExist is true, then an existing resource of the same name is not treated as an error.
+func (o *OVN) ChassisGroupAdd(haChassisGroupName OVNChassisGroup, mayExist bool) error {
+	if mayExist {
+		// Check if it exists (sadly ha-chassis-group-add doesn't provide --may-exist option).
+		_, err := o.nbctl("list", "HA_Chassis_Group", string(haChassisGroupName))
+		if err == nil {
+			return nil // Chassis group exists.
+		}
+	}
+
+	_, err := o.nbctl("ha-chassis-group-add", string(haChassisGroupName))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ChassisGroupDelete deletes an HA chassis group.
+func (o *OVN) ChassisGroupDelete(haChassisGroupName OVNChassisGroup) error {
+	// ovn-nbctl doesn't provide an "--if-exists" option for removing chassis groups.
+	existing, err := o.nbctl("--no-headings", "--data=bare", "--colum=name", "find", "ha_chassis_group", fmt.Sprintf("name=%s", string(haChassisGroupName)))
+	if err != nil {
+		return err
+	}
+
+	// Remove chassis group if exists.
+	if strings.TrimSpace(existing) != "" {
+		_, err := o.nbctl("ha-chassis-group-del", string(haChassisGroupName))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ChassisGroupChassisAdd adds a chassis ID to an HA chassis group with the specified priority.
+func (o *OVN) ChassisGroupChassisAdd(haChassisGroupName OVNChassisGroup, chassisID string, priority uint) error {
+	_, err := o.nbctl("ha-chassis-group-add-chassis", string(haChassisGroupName), chassisID, fmt.Sprintf("%d", priority))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lxd/network/openvswitch/ovs.go
+++ b/lxd/network/openvswitch/ovs.go
@@ -143,3 +143,23 @@ func (o *OVS) InterfaceAssociateOVNSwitchPort(interfaceName string, ovnSwitchPor
 
 	return nil
 }
+
+// ChassisID returns the local chassis ID.
+func (o *OVS) ChassisID() (string, error) {
+	// ovs-vsctl's get command doesn't support its --format flag, so we always get the output quoted.
+	// However ovs-vsctl's find and list commands don't support retrieving a single column's map field.
+	// And ovs-vsctl's JSON output is unfriendly towards statically typed languages as it mixes data types
+	// in a slice. So stick with "get" command and use Go's strconv.Unquote to return the actual values.
+	chassisID, err := shared.RunCommand("ovs-vsctl", "get", "open_vswitch", ".", "external_ids:system-id")
+	if err != nil {
+		return "", err
+	}
+
+	chassisID = strings.TrimSpace(chassisID)
+	chassisID, err = strconv.Unquote(chassisID)
+	if err != nil {
+		return "", err
+	}
+
+	return chassisID, nil
+}

--- a/lxd/network/openvswitch/ovs.go
+++ b/lxd/network/openvswitch/ovs.go
@@ -220,3 +220,23 @@ func (o *OVS) OVNBridgeMappingAdd(bridgeName string, providerName string) error 
 
 	return nil
 }
+
+// BridgePortList returns a list of ports that are connected to the bridge.
+func (o *OVS) BridgePortList(bridgeName string) ([]string, error) {
+	// Clear existing ports that were formerly associated to ovnSwitchPortName.
+	portString, err := shared.RunCommand("ovs-vsctl", "list-ports", bridgeName)
+	if err != nil {
+		return nil, err
+	}
+
+	ports := []string{}
+
+	portString = strings.TrimSpace(portString)
+	if portString != "" {
+		for _, port := range strings.Split(portString, "\n") {
+			ports = append(ports, strings.TrimSpace(port))
+		}
+	}
+
+	return ports, nil
+}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -133,6 +133,8 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		dbNetType = db.NetworkTypeMacvlan
 	case "sriov":
 		dbNetType = db.NetworkTypeSriov
+	case "ovn":
+		dbNetType = db.NetworkTypeOVN
 	default:
 		return response.BadRequest(fmt.Errorf("Unrecognised network type"))
 	}

--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -80,6 +80,7 @@ _have lxc && {
       images.auto_update_cached images.auto_update_interval \
       images.compression_algorithm images.remote_cache_expiry \
       maas.api.url maas.api.key maas.machine cluster.images_minimal_replica \
+      network.ovn.integration_bridge network.ovn.northbound_connection \
       rbac.agent.url rbac.agent.username rbac.agent.public_key \
       rbac.agent.private_key rbac.api.expiry rbac.api.key rbac.api.url \
       storage.backups_volume storage.images_volume"
@@ -128,10 +129,10 @@ _have lxc && {
     networks_keys="bridge.driver bridge.external_interfaces bridge.mode \
       bridge.mtu bridge.hwaddr dns.domain dns.mode dns.search fan.overlay_subnet fan.type \
       fan.underlay_subnet ipv4.address ipv4.dhcp ipv4.dhcp.expiry ipv4.dhcp.gateway \
-      ipv4.dhcp.ranges ipv4.firewall ipv4.nat ipv4.nat.address ipv4.nat.order \
+      ipv4.dhcp.ranges ipv4.firewall ipv4.nat ipv4.nat.address ipv4.nat.order ipv4.ovn.ranges \
       ipv4.routes ipv4.routing ipv6.address ipv6.dhcp ipv6.dhcp.expiry ipv6.dhcp.ranges \
-      ipv6.dhcp.stateful ipv6.firewall ipv6.nat ipv6.nat.address ipv6.nat.order \
-      ipv6.routes ipv6.routing maas.subnet.ipv4 maas.subnet.ipv6 raw.dnsmasq"
+      ipv6.dhcp.stateful ipv6.firewall ipv6.nat ipv6.nat.address ipv6.nat.order ipv6.ovn.ranges \
+      ipv6.routes ipv6.routing maas.subnet.ipv4 maas.subnet.ipv6 mtu parent raw.dnsmasq vlan"
 
     project_keys="features.images features.profiles features.storage.volumes \
       limits.containers limits.virtual-machines limits.memory limits.processes limits.cpu \

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -223,6 +223,7 @@ var APIExtensions = []string{
 	"network_type_macvlan",
 	"network_type_sriov",
 	"container_syscall_intercept_bpf_devices",
+	"network_type_ovn",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR adds the `ovn` network type and the associated `ovn` NIC device type.

It provides the ability to setup an OVN logical network and connect it (via SNAT) to a parent LXD managed bridge.


# Standalone Node Setup

Install the OVN tools and configure the OVN integration bridge on the local node:

```
apt install ovn-host ovn-central
ovs-vsctl set open_vswitch . \
  external_ids:ovn-remote=unix:/var/run/ovn/ovnsb_db.sock \
  external_ids:ovn-encap-type=geneve \
  external_ids:ovn-encap-ip=n.n.n.n \ # The IP of your LXD host on the LAN
```

Create an OVN network and an instance using it:

```
lxc network create ovntest --type=ovn parent=lxdbr0
lxc init images:ubuntu/focal c1
lxc config device override c1 eth0 network=ovntest
lxc start c1
lxc ls
+------+---------+---------------------+----------------------------------------------+-----------+-----------+
| NAME |  STATE  |        IPV4         |                     IPV6                     |   TYPE    | SNAPSHOTS |
+------+---------+---------------------+----------------------------------------------+-----------+-----------+
| c1   | RUNNING | 10.254.118.2 (eth0) | fd42:887:cff3:5089:216:3eff:fef0:549f (eth0) | CONTAINER | 0         |
+------+---------+---------------------+----------------------------------------------+-----------+-----------+
```