### PR TITLE
Network: Splits host veth helper functions

### DIFF
--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -1,10 +1,12 @@
 package device
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"strconv"
 	"strings"
 	"sync"
@@ -602,4 +604,24 @@ func networkInterfaceBindWait(ifName string) error {
 	}
 
 	return fmt.Errorf("Bind of interface %q took too long", ifName)
+}
+
+// networkDHCPValidIP returns whether an IP fits inside one of the supplied DHCP ranges and subnet.
+func networkDHCPValidIP(subnet *net.IPNet, ranges []network.DHCPRange, IP net.IP) bool {
+	inSubnet := subnet.Contains(IP)
+	if !inSubnet {
+		return false
+	}
+
+	if len(ranges) > 0 {
+		for _, IPRange := range ranges {
+			if bytes.Compare(IP, IPRange.Start) >= 0 && bytes.Compare(IP, IPRange.End) <= 0 {
+				return true
+			}
+		}
+	} else if inSubnet {
+		return true
+	}
+
+	return false
 }

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -337,51 +337,41 @@ func networkCreateTap(hostName string, m deviceConfig.Device) error {
 	return nil
 }
 
-// networkSetupHostVethDevice configures a nic device's host side veth settings.
-func networkSetupHostVethDevice(s *state.State, device deviceConfig.Device, oldDevice deviceConfig.Device, v map[string]string) error {
-	// If not configured, check if volatile data contains the most recently added host_name.
-	if device["host_name"] == "" {
-		device["host_name"] = v["host_name"]
-	}
-
-	// If not configured, check if volatile data contains the most recently added hwaddr.
-	if device["hwaddr"] == "" {
-		device["hwaddr"] = v["hwaddr"]
-	}
-
+// networkSetupHostVethRoutes configures a nic device's host side veth routes.
+// Accepts an optional oldDevice that will have its old host routes removed before adding the new device routes.
+// This allows live update of a veth device.
+func networkSetupHostVethRoutes(s *state.State, device deviceConfig.Device, oldDevice deviceConfig.Device, v map[string]string) error {
 	// Check whether host device resolution succeeded.
 	if device["host_name"] == "" {
-		return fmt.Errorf("Failed to find host side veth name for device \"%s\"", device["name"])
-	}
-
-	// Refresh tc limits.
-	err := networkSetVethLimits(device)
-	if err != nil {
-		return err
+		return fmt.Errorf("Failed to find host side veth name for device %q", device["name"])
 	}
 
 	// If oldDevice provided, remove old routes if any remain.
 	if oldDevice != nil {
-		// If not configured, copy the volatile host_name into old device to support live updates.
-		if oldDevice["host_name"] == "" {
-			oldDevice["host_name"] = v["host_name"]
-		}
-
-		// If not configured, copy the volatile hwaddr into old device to support live updates.
-		if oldDevice["hwaddr"] == "" {
-			oldDevice["hwaddr"] = v["hwaddr"]
-		}
-
+		networkVethFillFromVolatile(oldDevice, v)
 		networkRemoveVethRoutes(s, oldDevice)
 	}
 
 	// Setup static routes to container.
-	err = networkSetVethRoutes(s, device)
+	err := networkSetVethRoutes(s, device)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// networkVethFillFromVolatile fills veth host_name and hwaddr fields from volatile if not set in device config.
+func networkVethFillFromVolatile(device deviceConfig.Device, volatile map[string]string) {
+	// If not configured, check if volatile data contains the most recently added host_name.
+	if device["host_name"] == "" {
+		device["host_name"] = volatile["host_name"]
+	}
+
+	// If not configured, check if volatile data contains the most recently added hwaddr.
+	if device["hwaddr"] == "" {
+		device["hwaddr"] = volatile["hwaddr"]
+	}
 }
 
 // networkSetVethRoutes applies any static routes configured from the host to the container nic.
@@ -476,13 +466,14 @@ func networkRemoveVethRoutes(s *state.State, m deviceConfig.Device) {
 	}
 }
 
-// networkSetVethLimits applies any network rate limits to the veth device specified in the config.
-func networkSetVethLimits(m deviceConfig.Device) error {
+// networkSetupHostVethLimits applies any network rate limits to the veth device specified in the config.
+func networkSetupHostVethLimits(m deviceConfig.Device) error {
 	var err error
 
 	veth := m["host_name"]
-	if !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", veth)) {
-		return fmt.Errorf("Unknown or missing host side veth: %s", veth)
+
+	if veth == "" || !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", veth)) {
+		return fmt.Errorf("Unknown or missing host side veth device %q", veth)
 	}
 
 	// Apply max limit

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -266,8 +266,17 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 
 	revert.Add(func() { NetworkRemoveInterface(saveData["host_name"]) })
 
-	// Apply and host-side limits and routes.
-	err = networkSetupHostVethDevice(d.state, d.config, nil, saveData)
+	// Populate device config with volatile fields if needed.
+	networkVethFillFromVolatile(d.config, saveData)
+
+	// Apply host-side routes.
+	err = networkSetupHostVethRoutes(d.state, d.config, nil, saveData)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply host-side limits.
+	err = networkSetupHostVethLimits(d.config)
 	if err != nil {
 		return nil, err
 	}
@@ -351,6 +360,9 @@ func (d *nicBridged) Update(oldDevices deviceConfig.Devices, isRunning bool) err
 
 	v := d.volatileGet()
 
+	// Populate device config with volatile fields if needed.
+	networkVethFillFromVolatile(d.config, v)
+
 	// If instance is running, apply host side limits and filters first before rebuilding
 	// dnsmasq config below so that existing config can be used as part of the filter removal.
 	if isRunning {
@@ -359,8 +371,14 @@ func (d *nicBridged) Update(oldDevices deviceConfig.Devices, isRunning bool) err
 			return err
 		}
 
-		// Apply and host-side limits and routes.
-		err = networkSetupHostVethDevice(d.state, d.config, oldConfig, v)
+		// Apply host-side routes.
+		err = networkSetupHostVethRoutes(d.state, d.config, oldConfig, v)
+		if err != nil {
+			return err
+		}
+
+		// Apply host-side limits.
+		err = networkSetupHostVethLimits(d.config)
 		if err != nil {
 			return err
 		}
@@ -381,12 +399,12 @@ func (d *nicBridged) Update(oldDevices deviceConfig.Devices, isRunning bool) err
 	// If an IPv6 address has changed, if the instance is running we should bounce the host-side
 	// veth interface to give the instance a chance to detect the change and re-apply for an
 	// updated lease with new IP address.
-	if d.config["ipv6.address"] != oldConfig["ipv6.address"] && v["host_name"] != "" && shared.PathExists(fmt.Sprintf("/sys/class/net/%s", v["host_name"])) {
-		_, err := shared.RunCommand("ip", "link", "set", v["host_name"], "down")
+	if d.config["ipv6.address"] != oldConfig["ipv6.address"] && d.config["host_name"] != "" && shared.PathExists(fmt.Sprintf("/sys/class/net/%s", d.config["host_name"])) {
+		_, err := shared.RunCommand("ip", "link", "set", d.config["host_name"], "down")
 		if err != nil {
 			return err
 		}
-		_, err = shared.RunCommand("ip", "link", "set", v["host_name"], "up")
+		_, err = shared.RunCommand("ip", "link", "set", d.config["host_name"], "up")
 		if err != nil {
 			return err
 		}
@@ -412,13 +430,7 @@ func (d *nicBridged) postStop() error {
 
 	v := d.volatileGet()
 
-	if d.config["host_name"] == "" {
-		d.config["host_name"] = v["host_name"]
-	}
-
-	if d.config["hwaddr"] == "" {
-		d.config["hwaddr"] = v["hwaddr"]
-	}
+	networkVethFillFromVolatile(d.config, v)
 
 	if d.config["host_name"] != "" && shared.PathExists(fmt.Sprintf("/sys/class/net/%s", d.config["host_name"])) {
 		// Detach host-side end of veth pair from bridge (required for openvswitch particularly).

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -109,7 +109,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 
 			// Check the static IP supplied is valid for the linked network. It should be part of the
 			// network's subnet, but not necessarily part of the dynamic allocation ranges.
-			if !d.networkDHCPValidIP(subnet, nil, net.ParseIP(d.config["ipv4.address"])) {
+			if !networkDHCPValidIP(subnet, nil, net.ParseIP(d.config["ipv4.address"])) {
 				return fmt.Errorf("Device IP address %q not within network %q subnet", d.config["ipv4.address"], d.config["network"])
 			}
 		}
@@ -127,7 +127,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 
 			// Check the static IP supplied is valid for the linked network. It should be part of the
 			// network's subnet, but not necessarily part of the dynamic allocation ranges.
-			if !d.networkDHCPValidIP(subnet, nil, net.ParseIP(d.config["ipv6.address"])) {
+			if !networkDHCPValidIP(subnet, nil, net.ParseIP(d.config["ipv6.address"])) {
 				return fmt.Errorf("Device IP address %q not within network %q subnet", d.config["ipv6.address"], d.config["network"])
 			}
 		}
@@ -208,7 +208,7 @@ func (d *nicBridged) validateEnvironment() error {
 	}
 
 	if !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", d.config["parent"])) {
-		return fmt.Errorf("Parent device '%s' doesn't exist", d.config["parent"])
+		return fmt.Errorf("Parent device %q doesn't exist", d.config["parent"])
 	}
 
 	return nil
@@ -715,7 +715,7 @@ func (d *nicBridged) allocateFilterIPs(n network.Network) (net.IP, net.IP, error
 		// Check the existing static DHCP IP is still valid in the subnet & ranges, if not
 		// then we'll need to generate a new one.
 		ranges := n.DHCPv4Ranges()
-		if d.networkDHCPValidIP(subnet, ranges, curIPv4.IP.To4()) {
+		if networkDHCPValidIP(subnet, ranges, curIPv4.IP.To4()) {
 			IPv4 = curIPv4.IP.To4()
 		}
 	}
@@ -730,7 +730,7 @@ func (d *nicBridged) allocateFilterIPs(n network.Network) (net.IP, net.IP, error
 		// Check the existing static DHCP IP is still valid in the subnet & ranges, if not
 		// then we'll need to generate a new one.
 		ranges := n.DHCPv6Ranges()
-		if d.networkDHCPValidIP(subnet, ranges, curIPv6.IP.To16()) {
+		if networkDHCPValidIP(subnet, ranges, curIPv6.IP.To16()) {
 			IPv6 = curIPv6.IP.To16()
 		}
 	}
@@ -787,26 +787,6 @@ func (d *nicBridged) allocateFilterIPs(n network.Network) (net.IP, net.IP, error
 	return IPv4, IPv6, nil
 }
 
-// networkDHCPValidIP returns whether an IP fits inside one of the supplied DHCP ranges and subnet.
-func (d *nicBridged) networkDHCPValidIP(subnet *net.IPNet, ranges []network.DHCPRange, IP net.IP) bool {
-	inSubnet := subnet.Contains(IP)
-	if !inSubnet {
-		return false
-	}
-
-	if len(ranges) > 0 {
-		for _, IPRange := range ranges {
-			if bytes.Compare(IP, IPRange.Start) >= 0 && bytes.Compare(IP, IPRange.End) <= 0 {
-				return true
-			}
-		}
-	} else if inSubnet {
-		return true
-	}
-
-	return false
-}
-
 // getDHCPFreeIPv4 attempts to find a free IPv4 address for the device.
 // It first checks whether there is an existing allocation for the instance.
 // If no previous allocation, then a free IP is picked from the ranges configured.
@@ -826,7 +806,7 @@ func (d *nicBridged) getDHCPFreeIPv4(usedIPs map[[4]byte]dnsmasq.DHCPAllocation,
 	// Lets see if there is already an allocation for our device and that it sits within subnet.
 	// If there are custom DHCP ranges defined, check also that the IP falls within one of the ranges.
 	for _, DHCP := range usedIPs {
-		if (ctName == DHCP.Name || bytes.Compare(MAC, DHCP.MAC) == 0) && d.networkDHCPValidIP(subnet, dhcpRanges, DHCP.IP) {
+		if (ctName == DHCP.Name || bytes.Compare(MAC, DHCP.MAC) == 0) && networkDHCPValidIP(subnet, dhcpRanges, DHCP.IP) {
 			return DHCP.IP, nil
 		}
 	}
@@ -898,7 +878,7 @@ func (d *nicBridged) getDHCPFreeIPv6(usedIPs map[[16]byte]dnsmasq.DHCPAllocation
 	// allocations using instance name. If there are custom DHCP ranges defined, check also
 	// that the IP falls within one of the ranges.
 	for _, DHCP := range usedIPs {
-		if ctName == DHCP.Name && d.networkDHCPValidIP(subnet, dhcpRanges, DHCP.IP) {
+		if ctName == DHCP.Name && networkDHCPValidIP(subnet, dhcpRanges, DHCP.IP) {
 			return DHCP.IP, nil
 		}
 	}

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -362,6 +362,11 @@ func (n *common) delete(clusterNotification bool) error {
 	return nil
 }
 
+// Create is a no-op.
+func (n *common) Create(clusterNotification bool) error {
+	return nil
+}
+
 // HandleHeartbeat is a no-op.
 func (n *common) HandleHeartbeat(heartbeatData *cluster.APIHeartbeat) error {
 	return nil

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -25,6 +25,7 @@ type Network interface {
 	DHCPv6Ranges() []DHCPRange
 
 	// Actions.
+	Create(clusterNotification bool) error
 	Start() error
 	Stop() error
 	Rename(name string) error

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -101,9 +101,8 @@ func isInUseByDevices(s *state.State, devices deviceConfig.Devices, networkName 
 			continue
 		}
 
-		// Temporarily populate parent from network setting if used.
-		if d["network"] != "" {
-			d["parent"] = d["network"]
+		if d["network"] != "" && d["network"] == networkName {
+			return true, nil
 		}
 
 		if d["parent"] == "" {

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -355,6 +355,12 @@ func doNetworksCreate(d *Daemon, req api.NetworksPost, clusterNotification bool)
 		return err
 	}
 
+	// Run initial creation setup for the network driver.
+	err = n.Create(clusterNotification)
+	if err != nil {
+		return err
+	}
+
 	err = n.Start()
 	if err != nil {
 		n.Delete(clusterNotification)


### PR DESCRIPTION
- Splits host veth helper functions, so that OVN NICs can make selective use of them.
- Standardises enrichment of `hwaddr` and `host_name` fields from volatile map.
- Adds `Create` function for networks, and defaults to it being a no-op.
- Updates network in-use detection to directly match managed network names referenced by `network` property in NIC.