### PR TITLE
Network: DHCP static allocation package

### DIFF
--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -1,12 +1,10 @@
 package device
 
 import (
-	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"strconv"
 	"strings"
 	"sync"
@@ -595,24 +593,4 @@ func networkInterfaceBindWait(ifName string) error {
 	}
 
 	return fmt.Errorf("Bind of interface %q took too long", ifName)
-}
-
-// networkDHCPValidIP returns whether an IP fits inside one of the supplied DHCP ranges and subnet.
-func networkDHCPValidIP(subnet *net.IPNet, ranges []network.DHCPRange, IP net.IP) bool {
-	inSubnet := subnet.Contains(IP)
-	if !inSubnet {
-		return false
-	}
-
-	if len(ranges) > 0 {
-		for _, IPRange := range ranges {
-			if bytes.Compare(IP, IPRange.Start) >= 0 && bytes.Compare(IP, IPRange.End) <= 0 {
-				return true
-			}
-		}
-	} else if inSubnet {
-		return true
-	}
-
-	return false
 }

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -288,7 +288,7 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 		return nil, err
 	}
 
-	// Apply and host-side network filters (uses enriched host_name from networkSetupHostVethDevice).
+	// Apply and host-side network filters (uses enriched host_name from networkVethFillFromVolatile).
 	err = d.setupHostFilters(nil)
 	if err != nil {
 		return nil, err
@@ -383,7 +383,7 @@ func (d *nicBridged) Update(oldDevices deviceConfig.Devices, isRunning bool) err
 			return err
 		}
 
-		// Apply and host-side network filters (uses enriched host_name from networkSetupHostVethDevice).
+		// Apply and host-side network filters (uses enriched host_name from networkVethFillFromVolatile).
 		err = d.setupHostFilters(oldConfig)
 		if err != nil {
 			return err

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -98,8 +98,8 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 
 		if d.config["ipv4.address"] != "" {
 			// Check that DHCPv4 is enabled on parent network (needed to use static assigned IPs).
-			if !n.HasDHCPv4() {
-				return fmt.Errorf("Cannot specify %q when %q is disabled on network %q", "ipv4.address", "ipv4.dhcp", d.config["network"])
+			if n.DHCPv4Subnet() == nil {
+				return fmt.Errorf("Cannot specify %q when DHCP is disabled on network %q", "ipv4.address", d.config["network"])
 			}
 
 			_, subnet, err := net.ParseCIDR(netConfig["ipv4.address"])
@@ -109,15 +109,15 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 
 			// Check the static IP supplied is valid for the linked network. It should be part of the
 			// network's subnet, but not necessarily part of the dynamic allocation ranges.
-			if !networkDHCPValidIP(subnet, nil, net.ParseIP(d.config["ipv4.address"])) {
+			if !dhcpalloc.DHCPValidIP(subnet, nil, net.ParseIP(d.config["ipv4.address"])) {
 				return fmt.Errorf("Device IP address %q not within network %q subnet", d.config["ipv4.address"], d.config["network"])
 			}
 		}
 
 		if d.config["ipv6.address"] != "" {
 			// Check that DHCPv6 is enabled on parent network (needed to use static assigned IPs).
-			if !n.HasDHCPv6() || !shared.IsTrue(netConfig["ipv6.dhcp.stateful"]) {
-				return fmt.Errorf("Cannot specify %q when %q or %q are disabled on network %q", "ipv6.address", "ipv6.dhcp", "ipv6.dhcp.stateful", d.config["network"])
+			if n.DHCPv6Subnet() == nil || !shared.IsTrue(netConfig["ipv6.dhcp.stateful"]) {
+				return fmt.Errorf("Cannot specify %q when DHCP or %q are disabled on network %q", "ipv6.address", "ipv6.dhcp.stateful", d.config["network"])
 			}
 
 			_, subnet, err := net.ParseCIDR(netConfig["ipv6.address"])

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -2,11 +2,9 @@ package device
 
 import (
 	"bufio"
-	"bytes"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"math/big"
 	"math/rand"
 	"net"
 	"os"
@@ -15,7 +13,6 @@ import (
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	"github.com/mdlayher/netx/eui64"
 	"github.com/pkg/errors"
 
 	"github.com/lxc/lxd/lxd/db"
@@ -638,8 +635,17 @@ func (d *nicBridged) setFilters() (err error) {
 		}
 	}
 
+	// Parse device config.
+	mac, err := net.ParseMAC(d.config["hwaddr"])
+	if err != nil {
+		return errors.Wrapf(err, "Invalid hwaddr")
+	}
+
+	// Parse static IPs, relies on invalid IPs being set to nil.
+	IPv4 := net.ParseIP(d.config["ipv4.address"])
+	IPv6 := net.ParseIP(d.config["ipv6.address"])
+
 	// Check if the parent is managed and load config. If parent is unmanaged continue anyway.
-	var IPv4, IPv6 net.IP
 	n, err := network.LoadByName(d.state, d.config["parent"])
 	if err != nil && err != db.ErrNoSuchObject {
 		return err
@@ -652,21 +658,45 @@ func (d *nicBridged) setFilters() (err error) {
 		}
 	}
 
-	// If parent bridge is unmanaged we cannot allocate static IPs.
-	if n != nil {
-		// Retrieve existing IPs, or allocate new ones if needed.
-		IPv4, IPv6, err = d.allocateFilterIPs(n)
-		if err != nil {
+	// If parent bridge is managed, allocate the static IPs (if needed).
+	if n != nil && (IPv4 == nil || IPv6 == nil) {
+		opts := &dhcpalloc.Options{
+			ProjectName: d.inst.Project(),
+			HostName:    d.inst.Name(),
+			HostMAC:     mac,
+			Network:     n,
+		}
+
+		err = dhcpalloc.AllocateTask(opts, func(t *dhcpalloc.Transaction) error {
+			if shared.IsTrue(d.config["security.ipv4_filtering"]) && IPv4 == nil {
+				IPv4, err = t.AllocateIPv4()
+
+				// If DHCP not supported, skip error, and will result in total protocol filter.
+				if err != nil && err != dhcpalloc.ErrDHCPNotSupported {
+					return err
+				}
+			}
+
+			if shared.IsTrue(d.config["security.ipv6_filtering"]) && IPv6 == nil {
+				IPv6, err = t.AllocateIPv6()
+
+				// If DHCP not supported, skip error, and will result in total protocol filter.
+				if err != nil && err != dhcpalloc.ErrDHCPNotSupported {
+					return err
+				}
+			}
+
+			return nil
+		})
+		if err != nil && err != dhcpalloc.ErrDHCPNotSupported {
 			return err
 		}
 	}
 
 	// If anything goes wrong, clean up so we don't leave orphaned rules.
-	defer func() {
-		if err != nil {
-			d.removeFilters(d.config)
-		}
-	}()
+	revert := revert.New()
+	defer revert.Fail()
+	revert.Add(func() { d.removeFilters(d.config) })
 
 	// If no allocated IPv4 address for filtering and filtering enabled, then block all IPv4 traffic.
 	if shared.IsTrue(d.config["security.ipv4_filtering"]) && IPv4 == nil {
@@ -678,290 +708,13 @@ func (d *nicBridged) setFilters() (err error) {
 		IPv6 = net.ParseIP(firewallDrivers.FilterIPv6All)
 	}
 
-	return d.state.Firewall.InstanceSetupBridgeFilter(d.inst.Project(), d.inst.Name(), d.name, d.config["parent"], d.config["host_name"], d.config["hwaddr"], IPv4, IPv6)
-}
-
-// networkAllocateVethFilterIPs retrieves previously allocated IPs, or allocate new ones if needed.
-// This function only works with LXD managed networks, and as such, requires the managed network's
-// config to be supplied.
-func (d *nicBridged) allocateFilterIPs(n network.Network) (net.IP, net.IP, error) {
-	var IPv4, IPv6 net.IP
-
-	// Check if there is a valid static IPv4 address defined.
-	if d.config["ipv4.address"] != "" {
-		IPv4 = net.ParseIP(d.config["ipv4.address"])
-		if IPv4 == nil {
-			return nil, nil, fmt.Errorf("Invalid static IPv4 address %s", d.config["ipv4.address"])
-		}
-	}
-
-	// Check if there is a valid static IPv6 address defined.
-	if d.config["ipv6.address"] != "" {
-		IPv6 = net.ParseIP(d.config["ipv6.address"])
-		if IPv6 == nil {
-			return nil, nil, fmt.Errorf("Invalid static IPv6 address %s", d.config["ipv6.address"])
-		}
-	}
-
-	netConfig := n.Config()
-
-	// Check the conditions required to dynamically allocated IPs.
-	canIPv4Allocate := netConfig["ipv4.address"] != "" && netConfig["ipv4.address"] != "none" && n.HasDHCPv4()
-	canIPv6Allocate := netConfig["ipv6.address"] != "" && netConfig["ipv6.address"] != "none" && n.HasDHCPv6()
-
-	dnsmasq.ConfigMutex.Lock()
-	defer dnsmasq.ConfigMutex.Unlock()
-
-	// Read current static IP allocation configured from dnsmasq host config (if exists).
-	curIPv4, curIPv6, err := dnsmasq.DHCPStaticIPs(d.config["parent"], d.inst.Project(), d.inst.Name())
-	if err != nil && !os.IsNotExist(err) {
-		return nil, nil, err
-	}
-
-	// If no static IPv4, then check if there is a valid static DHCP IPv4 address defined.
-	if IPv4 == nil && curIPv4.IP != nil && canIPv4Allocate {
-		_, subnet, err := net.ParseCIDR(netConfig["ipv4.address"])
-		if err != nil {
-			return nil, nil, err
-		}
-
-		// Check the existing static DHCP IP is still valid in the subnet & ranges, if not
-		// then we'll need to generate a new one.
-		ranges := n.DHCPv4Ranges()
-		if networkDHCPValidIP(subnet, ranges, curIPv4.IP.To4()) {
-			IPv4 = curIPv4.IP.To4()
-		}
-	}
-
-	// If no static IPv6, then check if there is a valid static DHCP IPv6 address defined.
-	if IPv6 == nil && curIPv6.IP != nil && canIPv6Allocate {
-		_, subnet, err := net.ParseCIDR(netConfig["ipv6.address"])
-		if err != nil {
-			return IPv4, IPv6, err
-		}
-
-		// Check the existing static DHCP IP is still valid in the subnet & ranges, if not
-		// then we'll need to generate a new one.
-		ranges := n.DHCPv6Ranges()
-		if networkDHCPValidIP(subnet, ranges, curIPv6.IP.To16()) {
-			IPv6 = curIPv6.IP.To16()
-		}
-	}
-
-	// If we need to generate either a new IPv4 or IPv6, load existing IPs used in network.
-	if (IPv4 == nil && canIPv4Allocate) || (IPv6 == nil && canIPv6Allocate) {
-		// Get existing allocations in network.
-		IPv4Allocs, IPv6Allocs, err := dnsmasq.DHCPAllocatedIPs(d.config["parent"])
-		if err != nil {
-			return nil, nil, err
-		}
-
-		// Allocate a new IPv4 address if IPv4 filtering enabled.
-		if IPv4 == nil && canIPv4Allocate && shared.IsTrue(d.config["security.ipv4_filtering"]) {
-			IPv4, err = d.getDHCPFreeIPv4(IPv4Allocs, n, d.inst.Name(), d.config["hwaddr"])
-			if err != nil {
-				return nil, nil, err
-			}
-		}
-
-		// Allocate a new IPv6 address if IPv6 filtering enabled.
-		if IPv6 == nil && canIPv6Allocate && shared.IsTrue(d.config["security.ipv6_filtering"]) {
-			IPv6, err = d.getDHCPFreeIPv6(IPv6Allocs, n, d.inst.Name(), d.config["hwaddr"])
-			if err != nil {
-				return nil, nil, err
-			}
-		}
-	}
-
-	// If parent is a DHCP enabled managed network and either IPv4 or IPv6 assigned is different than what is in dnsmasq config, rebuild config.
-	if shared.PathExists(shared.VarPath("networks", d.config["parent"], "dnsmasq.pid")) &&
-		((IPv4 != nil && bytes.Compare(curIPv4.IP, IPv4.To4()) != 0) || (IPv6 != nil && bytes.Compare(curIPv6.IP, IPv6.To16()) != 0)) {
-		var IPv4Str, IPv6Str string
-
-		if IPv4 != nil {
-			IPv4Str = IPv4.String()
-		}
-
-		if IPv6 != nil {
-			IPv6Str = IPv6.String()
-		}
-
-		err = dnsmasq.UpdateStaticEntry(d.config["parent"], d.inst.Project(), d.inst.Name(), netConfig, d.config["hwaddr"], IPv4Str, IPv6Str)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		err = dnsmasq.Kill(d.config["parent"], true)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-
-	return IPv4, IPv6, nil
-}
-
-// getDHCPFreeIPv4 attempts to find a free IPv4 address for the device.
-// It first checks whether there is an existing allocation for the instance.
-// If no previous allocation, then a free IP is picked from the ranges configured.
-func (d *nicBridged) getDHCPFreeIPv4(usedIPs map[[4]byte]dnsmasq.DHCPAllocation, n network.Network, ctName string, deviceMAC string) (net.IP, error) {
-	MAC, err := net.ParseMAC(deviceMAC)
+	err = d.state.Firewall.InstanceSetupBridgeFilter(d.inst.Project(), d.inst.Name(), d.name, d.config["parent"], d.config["host_name"], d.config["hwaddr"], IPv4, IPv6)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	lxdIP, subnet, err := net.ParseCIDR(n.Config()["ipv4.address"])
-	if err != nil {
-		return nil, err
-	}
-
-	dhcpRanges := n.DHCPv4Ranges()
-
-	// Lets see if there is already an allocation for our device and that it sits within subnet.
-	// If there are custom DHCP ranges defined, check also that the IP falls within one of the ranges.
-	for _, DHCP := range usedIPs {
-		if (ctName == DHCP.Name || bytes.Compare(MAC, DHCP.MAC) == 0) && networkDHCPValidIP(subnet, dhcpRanges, DHCP.IP) {
-			return DHCP.IP, nil
-		}
-	}
-
-	// If no custom ranges defined, convert subnet pool to a range.
-	if len(dhcpRanges) <= 0 {
-		dhcpRanges = append(dhcpRanges, network.DHCPRange{
-			Start: network.GetIP(subnet, 1).To4(),
-			End:   network.GetIP(subnet, -2).To4()},
-		)
-	}
-
-	// If no valid existing allocation found, try and find a free one in the subnet pool/ranges.
-	for _, IPRange := range dhcpRanges {
-		inc := big.NewInt(1)
-		startBig := big.NewInt(0)
-		startBig.SetBytes(IPRange.Start)
-		endBig := big.NewInt(0)
-		endBig.SetBytes(IPRange.End)
-
-		for {
-			if startBig.Cmp(endBig) >= 0 {
-				break
-			}
-
-			IP := net.IP(startBig.Bytes())
-
-			// Check IP generated is not LXD's IP.
-			if IP.Equal(lxdIP) {
-				startBig.Add(startBig, inc)
-				continue
-			}
-
-			// Check IP is not already allocated.
-			var IPKey [4]byte
-			copy(IPKey[:], IP.To4())
-
-			_, inUse := usedIPs[IPKey]
-			if inUse {
-				startBig.Add(startBig, inc)
-				continue
-			}
-
-			return IP, nil
-		}
-	}
-
-	return nil, fmt.Errorf("No available IP could not be found")
-}
-
-// getDHCPFreeIPv6 attempts to find a free IPv6 address for the device.
-// It first checks whether there is an existing allocation for the instance. Due to the limitations
-// of dnsmasq lease file format, we can only search for previous static allocations.
-// If no previous allocation, then if SLAAC (stateless) mode is enabled on the network, or if
-// DHCPv6 stateful mode is enabled without custom ranges, then an EUI64 IP is generated from the
-// device's MAC address. Finally if stateful custom ranges are enabled, then a free IP is picked
-// from the ranges configured.
-func (d *nicBridged) getDHCPFreeIPv6(usedIPs map[[16]byte]dnsmasq.DHCPAllocation, n network.Network, ctName string, deviceMAC string) (net.IP, error) {
-	netConfig := n.Config()
-	lxdIP, subnet, err := net.ParseCIDR(netConfig["ipv6.address"])
-	if err != nil {
-		return nil, err
-	}
-
-	dhcpRanges := n.DHCPv6Ranges()
-
-	// Lets see if there is already an allocation for our device and that it sits within subnet.
-	// Because of dnsmasq's lease file format we can only match safely against static
-	// allocations using instance name. If there are custom DHCP ranges defined, check also
-	// that the IP falls within one of the ranges.
-	for _, DHCP := range usedIPs {
-		if ctName == DHCP.Name && networkDHCPValidIP(subnet, dhcpRanges, DHCP.IP) {
-			return DHCP.IP, nil
-		}
-	}
-
-	// Try using an EUI64 IP when in either SLAAC or DHCPv6 stateful mode without custom ranges.
-	if !shared.IsTrue(netConfig["ipv6.dhcp.stateful"]) || netConfig["ipv6.dhcp.ranges"] == "" {
-		MAC, err := net.ParseMAC(deviceMAC)
-		if err != nil {
-			return nil, err
-		}
-
-		IP, err := eui64.ParseMAC(subnet.IP, MAC)
-		if err != nil {
-			return nil, err
-		}
-
-		// Check IP is not already allocated and not the LXD IP.
-		var IPKey [16]byte
-		copy(IPKey[:], IP.To16())
-		_, inUse := usedIPs[IPKey]
-		if !inUse && !IP.Equal(lxdIP) {
-			return IP, nil
-		}
-	}
-
-	// If no custom ranges defined, convert subnet pool to a range.
-	if len(dhcpRanges) <= 0 {
-		dhcpRanges = append(dhcpRanges, network.DHCPRange{
-			Start: network.GetIP(subnet, 1).To16(),
-			End:   network.GetIP(subnet, -1).To16()},
-		)
-	}
-
-	// If we get here, then someone already has our SLAAC IP, or we are using custom ranges.
-	// Try and find a free one in the subnet pool/ranges.
-	for _, IPRange := range dhcpRanges {
-		inc := big.NewInt(1)
-		startBig := big.NewInt(0)
-		startBig.SetBytes(IPRange.Start)
-		endBig := big.NewInt(0)
-		endBig.SetBytes(IPRange.End)
-
-		for {
-			if startBig.Cmp(endBig) >= 0 {
-				break
-			}
-
-			IP := net.IP(startBig.Bytes())
-
-			// Check IP generated is not LXD's IP.
-			if IP.Equal(lxdIP) {
-				startBig.Add(startBig, inc)
-				continue
-			}
-
-			// Check IP is not already allocated.
-			var IPKey [16]byte
-			copy(IPKey[:], IP.To16())
-
-			_, inUse := usedIPs[IPKey]
-			if inUse {
-				startBig.Add(startBig, inc)
-				continue
-			}
-
-			return IP, nil
-		}
-	}
-
-	return nil, fmt.Errorf("No available IP could not be found")
+	revert.Success()
+	return nil
 }
 
 const (

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/dnsmasq"
+	"github.com/lxc/lxd/lxd/dnsmasq/dhcpalloc"
 	firewallDrivers "github.com/lxc/lxd/lxd/firewall/drivers"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
@@ -127,7 +128,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 
 			// Check the static IP supplied is valid for the linked network. It should be part of the
 			// network's subnet, but not necessarily part of the dynamic allocation ranges.
-			if !networkDHCPValidIP(subnet, nil, net.ParseIP(d.config["ipv6.address"])) {
+			if !dhcpalloc.DHCPValidIP(subnet, nil, net.ParseIP(d.config["ipv6.address"])) {
 				return fmt.Errorf("Device IP address %q not within network %q subnet", d.config["ipv6.address"], d.config["network"])
 			}
 		}

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -503,7 +503,7 @@ func (d *nicBridged) rebuildDnsmasqEntry() error {
 	// If IP filtering is enabled, and no static IP in config, check if there is already a
 	// dynamically assigned static IP in dnsmasq config and write that back out in new config.
 	if (shared.IsTrue(d.config["security.ipv4_filtering"]) && ipv4Address == "") || (shared.IsTrue(d.config["security.ipv6_filtering"]) && ipv6Address == "") {
-		curIPv4, curIPv6, err := dnsmasq.DHCPStaticIPs(d.config["parent"], d.inst.Project(), d.inst.Name())
+		_, curIPv4, curIPv6, err := dnsmasq.DHCPStaticAllocation(d.config["parent"], d.inst.Project(), d.inst.Name())
 		if err != nil && !os.IsNotExist(err) {
 			return err
 		}
@@ -591,7 +591,7 @@ func (d *nicBridged) removeFilters(m deviceConfig.Device) {
 
 	// Read current static DHCP IP allocation configured from dnsmasq host config (if exists).
 	// This covers the case when IPs are not defined in config, but have been assigned in managed DHCP.
-	IPv4Alloc, IPv6Alloc, err := dnsmasq.DHCPStaticIPs(m["parent"], d.inst.Project(), d.inst.Name())
+	_, IPv4Alloc, IPv6Alloc, err := dnsmasq.DHCPStaticAllocation(m["parent"], d.inst.Project(), d.inst.Name())
 	if err != nil {
 		if os.IsNotExist(err) {
 			return

--- a/lxd/dnsmasq/dhcpalloc/dhcpalloc.go
+++ b/lxd/dnsmasq/dhcpalloc/dhcpalloc.go
@@ -1,0 +1,415 @@
+package dhcpalloc
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"net"
+	"os"
+
+	"github.com/mdlayher/netx/eui64"
+
+	"github.com/lxc/lxd/lxd/dnsmasq"
+	"github.com/lxc/lxd/shared"
+	log "github.com/lxc/lxd/shared/log15"
+	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/logging"
+)
+
+// ErrDHCPNotSupported indicates network doesn't support DHCP for this IP protocol.
+var ErrDHCPNotSupported error = errors.New("Network doesn't support DHCP")
+
+// DHCPRange represents a range of IPs from start to end.
+type DHCPRange struct {
+	Start net.IP
+	End   net.IP
+}
+
+// DHCPValidIP returns whether an IP fits inside one of the supplied DHCP ranges and subnet.
+func DHCPValidIP(subnet *net.IPNet, ranges []DHCPRange, IP net.IP) bool {
+	inSubnet := subnet.Contains(IP)
+	if !inSubnet {
+		return false
+	}
+
+	if len(ranges) > 0 {
+		for _, IPRange := range ranges {
+			if bytes.Compare(IP, IPRange.Start) >= 0 && bytes.Compare(IP, IPRange.End) <= 0 {
+				return true
+			}
+		}
+	} else if inSubnet {
+		return true
+	}
+
+	return false
+}
+
+// GetIP returns a net.IP representing the IP belonging to the subnet for the host number supplied.
+func GetIP(subnet *net.IPNet, host int64) net.IP {
+	// Convert IP to a big int.
+	bigIP := big.NewInt(0)
+	bigIP.SetBytes(subnet.IP.To16())
+
+	// Deal with negative offsets.
+	bigHost := big.NewInt(host)
+	bigCount := big.NewInt(host)
+	if host < 0 {
+		mask, size := subnet.Mask.Size()
+
+		bigHosts := big.NewFloat(0)
+		bigHosts.SetFloat64((math.Pow(2, float64(size-mask))))
+		bigHostsInt, _ := bigHosts.Int(nil)
+
+		bigCount.Set(bigHostsInt)
+		bigCount.Add(bigCount, bigHost)
+	}
+
+	// Get the new IP int.
+	bigIP.Add(bigIP, bigCount)
+
+	// Generate an IPv6.
+	if subnet.IP.To4() == nil {
+		newIP := bigIP.Bytes()
+		return newIP
+	}
+
+	// Generate an IPv4.
+	newIP := make(net.IP, 4)
+	binary.BigEndian.PutUint32(newIP, uint32(bigIP.Int64()))
+	return newIP
+}
+
+// Network represents a LXD network responsible for running dnsmasq.
+type Network interface {
+	Name() string
+	Type() string
+	Config() map[string]string
+	DHCPv4Subnet() *net.IPNet
+	DHCPv6Subnet() *net.IPNet
+	DHCPv4Ranges() []DHCPRange
+	DHCPv6Ranges() []DHCPRange
+}
+
+// Options to initialise the allocator with.
+type Options struct {
+	ProjectName string
+	HostName    string
+	HostMAC     net.HardwareAddr
+	Network     Network
+}
+
+// Transaction is a locked transaction of the dnsmasq config files that allows IP allocations for a host.
+type Transaction struct {
+	opts              *Options
+	currentDHCPMAC    net.HardwareAddr
+	currentDHCPv4     dnsmasq.DHCPAllocation
+	currentDHCPv6     dnsmasq.DHCPAllocation
+	allocationsDHCPv4 map[[4]byte]dnsmasq.DHCPAllocation
+	allocationsDHCPv6 map[[16]byte]dnsmasq.DHCPAllocation
+	allocatedIPv4     net.IP
+	allocatedIPv6     net.IP
+}
+
+// AllocateIPv4 allocate an IPv4 static DHCP allocation.
+func (t *Transaction) AllocateIPv4() (net.IP, error) {
+	var err error
+
+	// Should have a (at least empty) map if DHCP is supported.
+	if t.allocationsDHCPv4 == nil {
+		return nil, ErrDHCPNotSupported
+	}
+
+	dhcpSubnet := t.opts.Network.DHCPv4Subnet()
+	if dhcpSubnet == nil {
+		return nil, ErrDHCPNotSupported
+	}
+
+	// Check the existing allocated IP is still valid in the network's subnet & ranges, if not then
+	// we'll need to generate a new one.
+	if t.allocatedIPv4 != nil {
+		ranges := t.opts.Network.DHCPv4Ranges()
+		if !DHCPValidIP(dhcpSubnet, ranges, t.allocatedIPv4.To4()) {
+			t.allocatedIPv4 = nil // We need a new IP allocated.
+		}
+	}
+
+	// Allocate a new IPv4 address if needed.
+	if t.allocatedIPv4 == nil {
+		t.allocatedIPv4, err = t.getDHCPFreeIPv4(t.allocationsDHCPv4, t.opts.HostName, t.opts.HostMAC)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return t.allocatedIPv4, nil
+}
+
+// AllocateIPv6 allocate an IPv6 static DHCP allocation.
+func (t *Transaction) AllocateIPv6() (net.IP, error) {
+	var err error
+
+	// Should have a (at least empty) map if DHCP is supported.
+	if t.allocationsDHCPv6 == nil {
+		return nil, ErrDHCPNotSupported
+	}
+
+	dhcpSubnet := t.opts.Network.DHCPv6Subnet()
+	if dhcpSubnet == nil {
+		return nil, ErrDHCPNotSupported
+	}
+
+	// Check the existing allocated IP is still valid in the network's subnet & ranges, if not then
+	// we'll need to generate a new one.
+	if t.allocatedIPv6 != nil {
+		ranges := t.opts.Network.DHCPv6Ranges()
+		if !DHCPValidIP(dhcpSubnet, ranges, t.allocatedIPv6.To16()) {
+			t.allocatedIPv6 = nil // We need a new IP allocated.
+		}
+	}
+
+	// Allocate a new IPv6 address if needed.
+	if t.allocatedIPv6 == nil {
+		t.allocatedIPv6, err = t.getDHCPFreeIPv6(t.allocationsDHCPv6, t.opts.HostName, t.opts.HostMAC)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return t.allocatedIPv6, nil
+}
+
+// getDHCPFreeIPv4 attempts to find a free IPv4 address for the device.
+// It first checks whether there is an existing allocation for the instance.
+// If no previous allocation, then a free IP is picked from the ranges configured.
+func (t *Transaction) getDHCPFreeIPv4(usedIPs map[[4]byte]dnsmasq.DHCPAllocation, instName string, mac net.HardwareAddr) (net.IP, error) {
+	lxdIP, subnet, err := net.ParseCIDR(t.opts.Network.Config()["ipv4.address"])
+	if err != nil {
+		return nil, err
+	}
+
+	dhcpRanges := t.opts.Network.DHCPv4Ranges()
+
+	// Lets see if there is already an allocation for our device and that it sits within subnet.
+	// If there are custom DHCP ranges defined, check also that the IP falls within one of the ranges.
+	for _, DHCP := range usedIPs {
+		if (instName == DHCP.Name || bytes.Compare(mac, DHCP.MAC) == 0) && DHCPValidIP(subnet, dhcpRanges, DHCP.IP) {
+			return DHCP.IP, nil
+		}
+	}
+
+	// If no custom ranges defined, convert subnet pool to a range.
+	if len(dhcpRanges) <= 0 {
+		dhcpRanges = append(dhcpRanges, DHCPRange{
+			Start: GetIP(subnet, 1).To4(),
+			End:   GetIP(subnet, -2).To4()},
+		)
+	}
+
+	// If no valid existing allocation found, try and find a free one in the subnet pool/ranges.
+	for _, IPRange := range dhcpRanges {
+		inc := big.NewInt(1)
+		startBig := big.NewInt(0)
+		startBig.SetBytes(IPRange.Start)
+		endBig := big.NewInt(0)
+		endBig.SetBytes(IPRange.End)
+
+		for {
+			if startBig.Cmp(endBig) >= 0 {
+				break
+			}
+
+			IP := net.IP(startBig.Bytes())
+
+			// Check IP generated is not LXD's IP.
+			if IP.Equal(lxdIP) {
+				startBig.Add(startBig, inc)
+				continue
+			}
+
+			// Check IP is not already allocated.
+			var IPKey [4]byte
+			copy(IPKey[:], IP.To4())
+
+			_, inUse := usedIPs[IPKey]
+			if inUse {
+				startBig.Add(startBig, inc)
+				continue
+			}
+
+			return IP, nil
+		}
+	}
+
+	return nil, fmt.Errorf("No available IP could not be found")
+}
+
+// getDHCPFreeIPv6 attempts to find a free IPv6 address for the device.
+// It first checks whether there is an existing allocation for the instance. Due to the limitations
+// of dnsmasq lease file format, we can only search for previous static allocations.
+// If no previous allocation, then if SLAAC (stateless) mode is enabled on the network, or if
+// DHCPv6 stateful mode is enabled without custom ranges, then an EUI64 IP is generated from the
+// device's MAC address. Finally if stateful custom ranges are enabled, then a free IP is picked
+// from the ranges configured.
+func (t *Transaction) getDHCPFreeIPv6(usedIPs map[[16]byte]dnsmasq.DHCPAllocation, instName string, mac net.HardwareAddr) (net.IP, error) {
+	lxdIP, subnet, err := net.ParseCIDR(t.opts.Network.Config()["ipv6.address"])
+	if err != nil {
+		return nil, err
+	}
+
+	dhcpRanges := t.opts.Network.DHCPv6Ranges()
+
+	// Lets see if there is already an allocation for our device and that it sits within subnet.
+	// Because of dnsmasq's lease file format we can only match safely against static
+	// allocations using instance name. If there are custom DHCP ranges defined, check also
+	// that the IP falls within one of the ranges.
+	for _, DHCP := range usedIPs {
+		if instName == DHCP.Name && DHCPValidIP(subnet, dhcpRanges, DHCP.IP) {
+			return DHCP.IP, nil
+		}
+	}
+
+	netConfig := t.opts.Network.Config()
+
+	// Try using an EUI64 IP when in either SLAAC or DHCPv6 stateful mode without custom ranges.
+	if !shared.IsTrue(netConfig["ipv6.dhcp.stateful"]) || netConfig["ipv6.dhcp.ranges"] == "" {
+		IP, err := eui64.ParseMAC(subnet.IP, mac)
+		if err != nil {
+			return nil, err
+		}
+
+		// Check IP is not already allocated and not the LXD IP.
+		var IPKey [16]byte
+		copy(IPKey[:], IP.To16())
+		_, inUse := usedIPs[IPKey]
+		if !inUse && !IP.Equal(lxdIP) {
+			return IP, nil
+		}
+	}
+
+	// If no custom ranges defined, convert subnet pool to a range.
+	if len(dhcpRanges) <= 0 {
+		dhcpRanges = append(dhcpRanges, DHCPRange{
+			Start: GetIP(subnet, 1).To16(),
+			End:   GetIP(subnet, -1).To16()},
+		)
+	}
+
+	// If we get here, then someone already has our SLAAC IP, or we are using custom ranges.
+	// Try and find a free one in the subnet pool/ranges.
+	for _, IPRange := range dhcpRanges {
+		inc := big.NewInt(1)
+		startBig := big.NewInt(0)
+		startBig.SetBytes(IPRange.Start)
+		endBig := big.NewInt(0)
+		endBig.SetBytes(IPRange.End)
+
+		for {
+			if startBig.Cmp(endBig) >= 0 {
+				break
+			}
+
+			IP := net.IP(startBig.Bytes())
+
+			// Check IP generated is not LXD's IP.
+			if IP.Equal(lxdIP) {
+				startBig.Add(startBig, inc)
+				continue
+			}
+
+			// Check IP is not already allocated.
+			var IPKey [16]byte
+			copy(IPKey[:], IP.To16())
+
+			_, inUse := usedIPs[IPKey]
+			if inUse {
+				startBig.Add(startBig, inc)
+				continue
+			}
+
+			return IP, nil
+		}
+	}
+
+	return nil, fmt.Errorf("No available IP could not be found")
+}
+
+// AllocateTask initialises a new locked Transaction for a specific host and executes the supplied function on it.
+// The lock on the dnsmasq config is released when the function returns.
+func AllocateTask(opts *Options, f func(*Transaction) error) error {
+	logger := logging.AddContext(logger.Log, log.Ctx{"driver": opts.Network.Type(), "network": opts.Network.Name(), "project": opts.ProjectName, "host": opts.HostName})
+
+	dnsmasq.ConfigMutex.Lock()
+	defer dnsmasq.ConfigMutex.Unlock()
+
+	var err error
+	t := &Transaction{opts: opts}
+
+	// Read current static IP allocation configured from dnsmasq host config (if exists).
+	t.currentDHCPMAC, t.currentDHCPv4, t.currentDHCPv6, err = dnsmasq.DHCPStaticAllocation(opts.Network.Name(), opts.ProjectName, opts.HostName)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	// Set the current allocated IPs internally (these may be changed later), and if they are it will trigger
+	// a dnsmasq static host config file rebuild.
+	t.allocatedIPv4 = t.currentDHCPv4.IP
+	t.allocatedIPv6 = t.currentDHCPv6.IP
+
+	// Get all existing allocations in network if leases file exists. If not then we will detect this later
+	// due to the existing allocations maps being nil.
+	if shared.PathExists(shared.VarPath("networks", opts.Network.Name(), "dnsmasq.leases")) {
+		t.allocationsDHCPv4, t.allocationsDHCPv6, err = dnsmasq.DHCPAllAllocations(opts.Network.Name())
+		if err != nil {
+			return err
+		}
+	}
+
+	// Run the supplied allocation function.
+	err = f(t)
+	if err != nil {
+		return err
+	}
+
+	// If the user's function didn't fail despite DHCP allocation not being available for either protocol,
+	// then presumably they ignored allocation errors. So fail here, rather than try to write the new config
+	// out, which will fail with a less helpful error about missing paths.
+	if t.allocationsDHCPv4 == nil && t.allocationsDHCPv6 == nil {
+		return ErrDHCPNotSupported
+	}
+
+	// If MAC or either IPv4 or IPv6 assigned is different than what is in dnsmasq config, rebuild config.
+	macChanged := bytes.Compare(opts.HostMAC, t.currentDHCPMAC) != 0
+	ipv4Changed := (t.allocatedIPv4 != nil && bytes.Compare(t.currentDHCPv4.IP, t.allocatedIPv4.To4()) != 0)
+	ipv6Changed := (t.allocatedIPv6 != nil && bytes.Compare(t.currentDHCPv6.IP, t.allocatedIPv6.To16()) != 0)
+
+	if macChanged || ipv4Changed || ipv6Changed {
+		var IPv4Str, IPv6Str string
+
+		if t.allocatedIPv4 != nil {
+			IPv4Str = t.allocatedIPv4.String()
+		}
+
+		if t.allocatedIPv6 != nil {
+			IPv6Str = t.allocatedIPv6.String()
+		}
+
+		// Write out new dnsmasq static host allocation config file.
+		err = dnsmasq.UpdateStaticEntry(opts.Network.Name(), opts.ProjectName, opts.HostName, opts.Network.Config(), opts.HostMAC.String(), IPv4Str, IPv6Str)
+		if err != nil {
+			return err
+		}
+		logger.Debug("Updated static DHCP entry", log.Ctx{"mac": opts.HostMAC.String(), "IPv4": IPv4Str, "IPv6": IPv6Str})
+
+		// Reload dnsmasq.
+		err = dnsmasq.Kill(opts.Network.Name(), true)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/lxd/dnsmasq/dnsmasq.go
+++ b/lxd/dnsmasq/dnsmasq.go
@@ -157,32 +157,32 @@ func DHCPStaticAllocation(network, projectName, instanceName string) (net.Hardwa
 	return mac, IPv4, IPv6, nil
 }
 
-// DHCPAllocatedIPs returns a map of IPs currently allocated (statically and dynamically)
+// DHCPAllAllocations returns a map of IPs currently allocated (statically and dynamically)
 // in dnsmasq for a specific network. The returned map is keyed by a 16 byte array representing
 // the net.IP format. The value of each map item is a DHCPAllocation struct containing at least
-// whether the allocation was static or dynamic and optionally container name or MAC address.
+// whether the allocation was static or dynamic and optionally instance name or MAC address.
 // MAC addresses are only included for dynamic IPv4 allocations (where name is not reliable).
-// Static allocations are not overridden by dynamic allocations, allowing for container name to be
+// Static allocations are not overridden by dynamic allocations, allowing for instance name to be
 // included for static IPv6 allocations. IPv6 addresses that are dynamically assigned cannot be
-// reliably linked to containers using either name or MAC because dnsmasq does not record the MAC
-// address for these records, and the recorded host name can be set by the container if the dns.mode
+// reliably linked to instances using either name or MAC because dnsmasq does not record the MAC
+// address for these records, and the recorded host name can be set by the instance if the dns.mode
 // for the network is set to "dynamic" and so cannot be trusted, so in this case we do not return
 // any identifying info.
-func DHCPAllocatedIPs(network string) (map[[4]byte]DHCPAllocation, map[[16]byte]DHCPAllocation, error) {
+func DHCPAllAllocations(network string) (map[[4]byte]DHCPAllocation, map[[16]byte]DHCPAllocation, error) {
 	IPv4s := make(map[[4]byte]DHCPAllocation)
 	IPv6s := make(map[[16]byte]DHCPAllocation)
 
 	// First read all statically allocated IPs.
 	files, err := ioutil.ReadDir(shared.VarPath("networks", network, "dnsmasq.hosts"))
-	if err != nil {
-		return IPv4s, IPv6s, err
+	if err != nil && os.IsNotExist(err) {
+		return nil, nil, err
 	}
 
 	for _, entry := range files {
 		projectName, instanceName := project.InstanceParts(entry.Name())
-		IPv4, IPv6, err := DHCPStaticIPs(network, projectName, instanceName)
+		_, IPv4, IPv6, err := DHCPStaticAllocation(network, projectName, instanceName)
 		if err != nil {
-			return IPv4s, IPv6s, err
+			return nil, nil, err
 		}
 
 		if IPv4.IP != nil {
@@ -201,7 +201,7 @@ func DHCPAllocatedIPs(network string) (map[[4]byte]DHCPAllocation, map[[16]byte]
 	// Next read all dynamic allocated IPs.
 	file, err := os.Open(shared.VarPath("networks", network, "dnsmasq.leases"))
 	if err != nil {
-		return IPv4s, IPv6s, err
+		return nil, nil, err
 	}
 	defer file.Close()
 
@@ -211,7 +211,7 @@ func DHCPAllocatedIPs(network string) (map[[4]byte]DHCPAllocation, map[[16]byte]
 		if len(fields) == 5 {
 			IP := net.ParseIP(fields[2])
 			if IP == nil {
-				return IPv4s, IPv6s, fmt.Errorf("Error parsing IP address: %v", fields[2])
+				return nil, nil, fmt.Errorf("Error parsing IP address: %v", fields[2])
 			}
 
 			// Handle IPv6 addresses.
@@ -232,7 +232,7 @@ func DHCPAllocatedIPs(network string) (map[[4]byte]DHCPAllocation, map[[16]byte]
 				// MAC only available in IPv4 leases.
 				MAC, err := net.ParseMAC(fields[1])
 				if err != nil {
-					return IPv4s, IPv6s, err
+					return nil, nil, err
 				}
 
 				var IPKey [4]byte
@@ -252,7 +252,7 @@ func DHCPAllocatedIPs(network string) (map[[4]byte]DHCPAllocation, map[[16]byte]
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return IPv4s, IPv6s, err
+		return nil, nil, err
 	}
 
 	return IPv4s, IPv6s, nil

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1828,3 +1828,33 @@ func (n *bridge) hasIPv6Firewall() bool {
 
 	return false
 }
+
+// DHCPv4Subnet returns the DHCPv4 subnet (if DHCP is enabled on network).
+func (n *bridge) DHCPv4Subnet() *net.IPNet {
+	// DHCP is disabled on this network (an empty ipv4.dhcp setting indicates enabled by default).
+	if n.config["ipv4.dhcp"] != "" && !shared.IsTrue(n.config["ipv4.dhcp"]) {
+		return nil
+	}
+
+	_, subnet, err := net.ParseCIDR(n.config["ipv4.address"])
+	if err != nil {
+		return nil
+	}
+
+	return subnet
+}
+
+// DHCPv6Subnet returns the DHCPv6 subnet (if DHCP or SLAAC is enabled on network).
+func (n *bridge) DHCPv6Subnet() *net.IPNet {
+	// DHCP is disabled on this network (an empty ipv6.dhcp setting indicates enabled by default).
+	if n.config["ipv6.dhcp"] != "" && !shared.IsTrue(n.config["ipv6.dhcp"]) {
+		return nil
+	}
+
+	_, subnet, err := net.ParseCIDR(n.config["ipv6.address"])
+	if err != nil {
+		return nil
+	}
+
+	return subnet
+}

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -11,6 +11,7 @@ import (
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/dnsmasq/dhcpalloc"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
@@ -19,12 +20,6 @@ import (
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/logging"
 )
-
-// DHCPRange represents a range of IPs from start to end.
-type DHCPRange struct {
-	Start net.IP
-	End   net.IP
-}
 
 // common represents a generic LXD network.
 type common struct {
@@ -177,15 +172,15 @@ func (n *common) DHCPv6Subnet() *net.IPNet {
 }
 
 // DHCPv4Ranges returns a parsed set of DHCPv4 ranges for this network.
-func (n *common) DHCPv4Ranges() []DHCPRange {
-	dhcpRanges := make([]DHCPRange, 0)
+func (n *common) DHCPv4Ranges() []dhcpalloc.DHCPRange {
+	dhcpRanges := make([]dhcpalloc.DHCPRange, 0)
 	if n.config["ipv4.dhcp.ranges"] != "" {
 		for _, r := range strings.Split(n.config["ipv4.dhcp.ranges"], ",") {
 			parts := strings.SplitN(strings.TrimSpace(r), "-", 2)
 			if len(parts) == 2 {
 				startIP := net.ParseIP(parts[0])
 				endIP := net.ParseIP(parts[1])
-				dhcpRanges = append(dhcpRanges, DHCPRange{
+				dhcpRanges = append(dhcpRanges, dhcpalloc.DHCPRange{
 					Start: startIP.To4(),
 					End:   endIP.To4(),
 				})
@@ -197,15 +192,15 @@ func (n *common) DHCPv4Ranges() []DHCPRange {
 }
 
 // DHCPv6Ranges returns a parsed set of DHCPv6 ranges for this network.
-func (n *common) DHCPv6Ranges() []DHCPRange {
-	dhcpRanges := make([]DHCPRange, 0)
+func (n *common) DHCPv6Ranges() []dhcpalloc.DHCPRange {
+	dhcpRanges := make([]dhcpalloc.DHCPRange, 0)
 	if n.config["ipv6.dhcp.ranges"] != "" {
 		for _, r := range strings.Split(n.config["ipv6.dhcp.ranges"], ",") {
 			parts := strings.SplitN(strings.TrimSpace(r), "-", 2)
 			if len(parts) == 2 {
 				startIP := net.ParseIP(parts[0])
 				endIP := net.ParseIP(parts[1])
-				dhcpRanges = append(dhcpRanges, DHCPRange{
+				dhcpRanges = append(dhcpRanges, dhcpalloc.DHCPRange{
 					Start: startIP.To16(),
 					End:   endIP.To16(),
 				})

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -231,8 +231,7 @@ func (n *common) DHCPv6Ranges() []DHCPRange {
 func (n *common) update(applyNetwork api.NetworkPut, targetNode string, clusterNotification bool) error {
 	// Update internal config before database has been updated (so that if update is a notification we apply
 	// the config being supplied and not that in the database).
-	n.description = applyNetwork.Description
-	n.config = applyNetwork.Config
+	n.init(n.state, n.id, n.name, n.netType, applyNetwork.Description, applyNetwork.Config, n.status)
 
 	// If this update isn't coming via a cluster notification itself, then notify all nodes of change and then
 	// update the database.

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -166,25 +166,14 @@ func (n *common) IsUsed() (bool, error) {
 	return false, nil
 }
 
-// HasDHCPv4 indicates whether the network has DHCPv4 enabled.
-func (n *common) HasDHCPv4() bool {
-	if n.config["ipv4.dhcp"] == "" || shared.IsTrue(n.config["ipv4.dhcp"]) {
-		return true
-	}
-
-	return false
+// DHCPv4Subnet returns nil always.
+func (n *common) DHCPv4Subnet() *net.IPNet {
+	return nil
 }
 
-// HasDHCPv6 indicates whether the network has DHCPv6 enabled (includes stateless SLAAC router advertisement mode).
-// Technically speaking stateless SLAAC RA mode isn't DHCPv6, but for consistency with LXD's config paradigm, DHCP
-// here means "an ability to automatically allocate IPs and routes", rather than stateful DHCP with leases.
-// To check if true stateful DHCPv6 is enabled check the "ipv6.dhcp.stateful" config key.
-func (n *common) HasDHCPv6() bool {
-	if n.config["ipv6.dhcp"] == "" || shared.IsTrue(n.config["ipv6.dhcp"]) {
-		return true
-	}
-
-	return false
+// DHCPv6Subnet returns nil always.
+func (n *common) DHCPv6Subnet() *net.IPNet {
+	return nil
 }
 
 // DHCPv4Ranges returns a parsed set of DHCPv4 ranges for this network.

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -1,7 +1,10 @@
 package network
 
 import (
+	"net"
+
 	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/dnsmasq/dhcpalloc"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -19,10 +22,10 @@ type Network interface {
 	Status() string
 	Config() map[string]string
 	IsUsed() (bool, error)
-	HasDHCPv4() bool
-	HasDHCPv6() bool
-	DHCPv4Ranges() []DHCPRange
-	DHCPv6Ranges() []DHCPRange
+	DHCPv4Subnet() *net.IPNet
+	DHCPv6Subnet() *net.IPNet
+	DHCPv4Ranges() []dhcpalloc.DHCPRange
+	DHCPv6Ranges() []dhcpalloc.DHCPRange
 
 	// Actions.
 	Create(clusterNotification bool) error

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -19,6 +19,7 @@ import (
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/device/nictype"
 	"github.com/lxc/lxd/lxd/dnsmasq"
+	"github.com/lxc/lxd/lxd/dnsmasq/dhcpalloc"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/network/openvswitch"
@@ -622,21 +623,21 @@ func pingSubnet(subnet *net.IPNet) bool {
 
 	// Ping first IP
 	wgChecks.Add(1)
-	go ping(GetIP(subnet, 1))
+	go ping(dhcpalloc.GetIP(subnet, 1))
 
 	// Poke port on first IP
 	wgChecks.Add(1)
-	go poke(GetIP(subnet, 1))
+	go poke(dhcpalloc.GetIP(subnet, 1))
 
 	// Ping check
 	if subnet.IP.To4() != nil {
 		// Ping last IP
 		wgChecks.Add(1)
-		go ping(GetIP(subnet, -2))
+		go ping(dhcpalloc.GetIP(subnet, -2))
 
 		// Poke port on last IP
 		wgChecks.Add(1)
-		go poke(GetIP(subnet, -2))
+		go poke(dhcpalloc.GetIP(subnet, -2))
 	}
 
 	wgChecks.Wait()

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -2,12 +2,9 @@ package network
 
 import (
 	"bufio"
-	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
-	"math"
-	"math/big"
 	"math/rand"
 	"net"
 	"os"
@@ -115,41 +112,6 @@ func isInUseByDevices(s *state.State, devices deviceConfig.Devices, networkName 
 	}
 
 	return false, nil
-}
-
-// GetIP returns a net.IP representing the IP belonging to the subnet for the host number supplied.
-func GetIP(subnet *net.IPNet, host int64) net.IP {
-	// Convert IP to a big int.
-	bigIP := big.NewInt(0)
-	bigIP.SetBytes(subnet.IP.To16())
-
-	// Deal with negative offsets.
-	bigHost := big.NewInt(host)
-	bigCount := big.NewInt(host)
-	if host < 0 {
-		mask, size := subnet.Mask.Size()
-
-		bigHosts := big.NewFloat(0)
-		bigHosts.SetFloat64((math.Pow(2, float64(size-mask))))
-		bigHostsInt, _ := bigHosts.Int(nil)
-
-		bigCount.Set(bigHostsInt)
-		bigCount.Add(bigCount, bigHost)
-	}
-
-	// Get the new IP int.
-	bigIP.Add(bigIP, bigCount)
-
-	// Generate an IPv6.
-	if subnet.IP.To4() == nil {
-		newIP := bigIP.Bytes()
-		return newIP
-	}
-
-	// Generate an IPv4.
-	newIP := make(net.IP, 4)
-	binary.BigEndian.PutUint32(newIP, uint32(bigIP.Int64()))
-	return newIP
 }
 
 // IsNativeBridge returns whether the bridge name specified is a Linux native bridge.

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -299,7 +299,7 @@ func UpdateDNSMasqStatic(s *state.State, networkName string) error {
 			}
 
 			if (shared.IsTrue(d["security.ipv4_filtering"]) && d["ipv4.address"] == "") || (shared.IsTrue(d["security.ipv6_filtering"]) && d["ipv6.address"] == "") {
-				curIPv4, curIPv6, err := dnsmasq.DHCPStaticIPs(d["parent"], inst.Project(), inst.Name())
+				_, curIPv4, curIPv6, err := dnsmasq.DHCPStaticAllocation(d["parent"], inst.Project(), inst.Name())
 				if err != nil && !os.IsNotExist(err) {
 					return err
 				}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -943,10 +943,18 @@ func networkStartup(s *state.State) error {
 			return err
 		}
 
+		err = n.Validate(n.Config())
+		if err != nil {
+			// Don't cause LXD to fail to start entirely on network start up failure.
+			logger.Error("Failed to validate network", log.Ctx{"err": err, "name": name})
+			continue
+		}
+
 		err = n.Start()
 		if err != nil {
 			// Don't cause LXD to fail to start entirely on network start up failure.
 			logger.Error("Failed to bring up network", log.Ctx{"err": err, "name": name})
+			continue
 		}
 	}
 


### PR DESCRIPTION
We need to perform static DHCP allocation against the dnsmasq config on a managed LXD bridge in order to allocate an IP for the OVN uplink ports.

This is very similar to what we already do in the bridged NIC when automatically allocating  static IP for use with the `security.ipN_filtering` features.

The existing implementation was tightly coupled to said IP filtering features and the bridged NIC type. Also I was not happy with the clarity of the existing code (I wrote it) as the way it dealt with the ability to selectively generate IP allocations for each protocol dependent on which IP filtering feature was enabled, whilst still only parsing the dnsmasq leases file once, was not particularly clear and had to handle many edge cases in multiple places.

In hind site what would have made it clearer was to introduce the concept of a dnsmasq allocation 'transaction', whereby the dnsmasq config could be locked, the leases file read in one go, and then allow the caller to provide a function to perform the desired allocations against that config, then finally write the generated host config file back to disk at the end.

This allows the caller to choose to only allocate certain protocol IPs based on their specific config/situation.

This PR introduces a new package called `dnsmasq/dhcpalloc` which provides just that, and then updates the bridged NIC to use it.