### PR TITLE
lxd/apparmor: Don't fail on missing apparmor

### DIFF
--- a/lxd/apparmor/instance.go
+++ b/lxd/apparmor/instance.go
@@ -150,7 +150,7 @@ func instanceProfile(state *state.State, inst instance) (string, error) {
 	}
 
 	// Check for features.
-	unixSupported, err := parserSupports("unix")
+	unixSupported, err := parserSupports(state, "unix")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This ensures that all the low-level functions properly handle the lack
of AppArmor support.

The higher level functions can therefore ignore this situation entirely.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>