### PR TITLE
Network: Validate network name differently based on network type

### DIFF
--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -351,7 +351,7 @@ func (c *cmdInit) askNetworking(config *cmdInitData, d lxd.InstanceServer) error
 		net.Config = map[string]string{}
 
 		// Network name
-		net.Name = cli.AskString("What should the new bridge be called? [default=lxdbr0]: ", "lxdbr0", network.ValidNetworkName)
+		net.Name = cli.AskString("What should the new bridge be called? [default=lxdbr0]: ", "lxdbr0", func(netName string) error { return network.ValidateName(netName, "bridge") })
 		_, _, err := d.GetNetwork(net.Name)
 		if err == nil {
 			fmt.Printf("The requested network bridge \"%s\" already exists. Please choose another name.\n", net.Name)

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -118,6 +118,11 @@ func (n *bridge) fillConfig(config map[string]string) error {
 	return nil
 }
 
+// ValidateName validates network name.
+func (n *bridge) ValidateName(name string) error {
+	return validInterfaceName(name)
+}
+
 // Validate network config.
 func (n *bridge) Validate(config map[string]string) error {
 	// Build driver specific rules dynamically.
@@ -132,7 +137,7 @@ func (n *bridge) Validate(config map[string]string) error {
 
 			for _, entry := range strings.Split(value, ",") {
 				entry = strings.TrimSpace(entry)
-				if err := ValidNetworkName(entry); err != nil {
+				if err := validInterfaceName(entry); err != nil {
 					return errors.Wrapf(err, "Invalid interface name %q", entry)
 				}
 			}
@@ -255,7 +260,7 @@ func (n *bridge) Validate(config map[string]string) error {
 			case "id":
 				rules[k] = validate.Optional(validate.IsInt64)
 			case "inteface":
-				rules[k] = ValidNetworkName
+				rules[k] = validInterfaceName
 			case "ttl":
 				rules[k] = validate.Optional(validate.IsUint8)
 			}

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -3,8 +3,6 @@ package network
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/shared/api"
 	log "github.com/lxc/lxd/shared/log15"
@@ -16,16 +14,15 @@ type macvlan struct {
 	common
 }
 
+// ValidateName validates network name.
+func (n *macvlan) ValidateName(name string) error {
+	return validVirtualNetworkName(name)
+}
+
 // Validate network config.
 func (n *macvlan) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
-		"parent": func(value string) error {
-			if err := ValidNetworkName(value); err != nil {
-				return errors.Wrapf(err, "Invalid interface name %q", value)
-			}
-
-			return nil
-		},
+		"parent":           validInterfaceName,
 		"mtu":              validate.Optional(validate.IsInt64),
 		"vlan":             validate.Optional(validate.IsNetworkVLAN),
 		"maas.subnet.ipv4": validate.IsAny,

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -3,8 +3,6 @@ package network
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/shared/api"
 	log "github.com/lxc/lxd/shared/log15"
@@ -16,16 +14,15 @@ type sriov struct {
 	common
 }
 
+// ValidateName validates network name.
+func (n *sriov) ValidateName(name string) error {
+	return validVirtualNetworkName(name)
+}
+
 // Validate network config.
 func (n *sriov) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
-		"parent": func(value string) error {
-			if err := ValidNetworkName(value); err != nil {
-				return errors.Wrapf(err, "Invalid interface name %q", value)
-			}
-
-			return nil
-		},
+		"parent":           validInterfaceName,
 		"mtu":              validate.Optional(validate.IsInt64),
 		"vlan":             validate.Optional(validate.IsNetworkVLAN),
 		"maas.subnet.ipv4": validate.IsAny,

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -16,6 +16,7 @@ type Network interface {
 	fillConfig(config map[string]string) error
 
 	// Config.
+	ValidateName(name string) error
 	Validate(config map[string]string) error
 	Name() string
 	Type() string

--- a/lxd/network/network_load.go
+++ b/lxd/network/network_load.go
@@ -29,20 +29,34 @@ func LoadByName(s *state.State, name string) (Network, error) {
 	return n, nil
 }
 
-// Validate validates the supplied network configuration for the specified network type.
+// ValidateName validates the supplied network name for the specified network type.
+func ValidateName(name string, netType string) error {
+	driverFunc, ok := drivers[netType]
+	if !ok {
+		return ErrUnknownDriver
+	}
+
+	n := driverFunc()
+	n.init(nil, 0, name, netType, "", nil, "Unknown")
+
+	return n.ValidateName(name)
+}
+
+// Validate validates the supplied network name and configuration for the specified network type.
 func Validate(name string, netType string, config map[string]string) error {
 	driverFunc, ok := drivers[netType]
 	if !ok {
 		return ErrUnknownDriver
 	}
 
-	err := ValidNetworkName(name)
+	n := driverFunc()
+	n.init(nil, 0, name, netType, "", config, "Unknown")
+
+	err := n.ValidateName(name)
 	if err != nil {
 		return err
 	}
 
-	n := driverFunc()
-	n.init(nil, 0, name, netType, "", config, "Unknown")
 	return n.Validate(config)
 }
 

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -50,6 +50,15 @@ func validInterfaceName(value string) error {
 	return nil
 }
 
+// validVirtualNetworkName validates a virtual network name (one that doesn't have an actual network interface).
+func validVirtualNetworkName(value string) error {
+	if strings.Contains(value, "/") {
+		return fmt.Errorf(`Network name cannot contain "/"`)
+	}
+
+	return nil
+}
+
 func networkValidPort(value string) error {
 	if value == "" {
 		return nil

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -30,26 +30,21 @@ import (
 	"github.com/lxc/lxd/shared/logger"
 )
 
-// ValidNetworkName validates network name.
-func ValidNetworkName(value string) error {
-	// Not a veth-liked name
-	if strings.HasPrefix(value, "veth") {
-		return fmt.Errorf("Interface name cannot be prefix with veth")
-	}
-
-	// Validate the length
+// validInterfaceName validates a real network interface name.
+func validInterfaceName(value string) error {
+	// Validate the length.
 	if len(value) < 2 {
-		return fmt.Errorf("Interface name is too short (minimum 2 characters)")
+		return fmt.Errorf("Network interface is too short (minimum 2 characters)")
 	}
 
 	if len(value) > 15 {
-		return fmt.Errorf("Interface name is too long (maximum 15 characters)")
+		return fmt.Errorf("Network interface is too long (maximum 15 characters)")
 	}
 
-	// Validate the character set
+	// Validate the character set.
 	match, _ := regexp.MatchString("^[-_a-zA-Z0-9.]*$", value)
 	if !match {
-		return fmt.Errorf("Interface name contains invalid characters")
+		return fmt.Errorf("Network interface contains invalid characters")
 	}
 
 	return nil

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -111,17 +111,17 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("No name provided"))
 	}
 
-	err = network.ValidNetworkName(req.Name)
-	if err != nil {
-		return response.BadRequest(err)
-	}
-
 	if req.Type == "" {
 		req.Type = "bridge"
 	}
 
 	if req.Config == nil {
 		req.Config = map[string]string{}
+	}
+
+	err = network.ValidateName(req.Name, req.Type)
+	if err != nil {
+		return response.BadRequest(err)
 	}
 
 	// Convert requested network type to DB type code.
@@ -611,7 +611,7 @@ func networkPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("No name provided"))
 	}
 
-	err = network.ValidNetworkName(req.Name)
+	err = network.ValidateName(req.Name, n.Type())
 	if err != nil {
 		return response.BadRequest(err)
 	}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -34,7 +34,7 @@ import (
 // ValidName validates the provided name, and returns an error if it's not a valid storage name.
 func ValidName(value string) error {
 	if strings.Contains(value, "/") {
-		return fmt.Errorf("Invalid storage volume name \"%s\". Storage volumes cannot contain \"/\" in their name", value)
+		return fmt.Errorf(`Storage name cannot contain "/"`)
 	}
 
 	return nil


### PR DESCRIPTION
Introduces concept of "real" networks vs "virtual" networks, where the former is tied to one or more actual Linux network interfaces, and the latter is not. These "virtual" networks have much relaxed naming rules compared with their "real" counterparts.

