### PR TITLE
daemon: check whether shiftfs is useable

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -694,7 +694,7 @@ func (d *Daemon) init() error {
 	if shared.IsTrue(os.Getenv("LXD_SHIFTFS_DISABLE")) {
 		logger.Infof(" - shiftfs support: disabled")
 	} else {
-		if util.HasFilesystem("shiftfs") || util.LoadModule("shiftfs") == nil {
+		if canUseShiftfs() && (util.HasFilesystem("shiftfs") || util.LoadModule("shiftfs") == nil) {
 			d.os.Shiftfs = true
 			logger.Infof(" - shiftfs support: yes")
 		} else {

--- a/lxd/main_checkfeature.go
+++ b/lxd/main_checkfeature.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"golang.org/x/sys/unix"
+	"os"
+	"runtime"
 	// Used by cgo
 	_ "github.com/lxc/lxd/lxd/include"
 
+	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -46,6 +50,7 @@ __ro_after_init char errbuf[4096];
 
 extern int can_inject_uevent(const char *uevent, size_t len);
 extern int wait_for_pid(pid_t pid);
+extern int preserve_ns(pid_t pid, int ns_fd, const char *ns);
 
 static int netns_set_nsid(int fd)
 {
@@ -326,6 +331,7 @@ static void is_pidfd_aware(void)
 	pidfd_aware = true;
 }
 
+
 void checkfeature(void)
 {
 	__do_close int hostnetns_fd = -EBADF, newnetns_fd = -EBADF;
@@ -369,4 +375,42 @@ func canUseSeccompListenerContinue() bool {
 
 func canUsePidFds() bool {
 	return bool(C.pidfd_aware)
+}
+
+func canUseShiftfs() bool {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	hostMntNs, err := os.Open("/proc/self/ns/mnt")
+	if err != nil {
+		logger.Debugf("%s - Failed to open host mount namespace", err)
+		return false
+	}
+	defer hostMntNs.Close()
+
+	err = unix.Unshare(unix.CLONE_NEWNS)
+	if err != nil {
+		logger.Debugf("%s - Failed to unshare mount namespace", err)
+		return false
+	}
+	defer func() {
+		err = unix.Setns(int(hostMntNs.Fd()), unix.CLONE_NEWNS)
+		if err != nil {
+			logger.Debugf("%s - Failed to reattach to host mount namespace", err)
+		}
+	}()
+
+	err = unix.Mount("/", "/", "", unix.MS_REC|unix.MS_PRIVATE, "")
+	if err != nil {
+		logger.Debugf("%s - Failed to turn \"/\" into private mount", err)
+		return false
+	}
+
+	err = unix.Mount(shared.VarPath(), shared.VarPath(), "shiftfs", 0, "mark")
+	if err != nil {
+		logger.Debugf("%s - Failed to mount shiftfs", err)
+		return false
+	}
+
+	return true
 }

--- a/lxd/main_forksyscall.go
+++ b/lxd/main_forksyscall.go
@@ -36,6 +36,7 @@ extern char* advance_arg(bool required);
 extern void attach_userns_fd(int ns_fd);
 extern int pidfd_nsfd(int pidfd, pid_t pid);
 extern bool setnsat(int ns_fd, const char *ns);
+extern int preserve_ns(const int pid, const char *ns);
 
 static bool chdirchroot_in_mntns(int cwd_fd, int root_fd)
 {
@@ -335,27 +336,6 @@ static int make_tmpfile(char *template, bool dir)
 		return -1;
 
 	return 0;
-}
-
-static int preserve_ns(const int pid, const char *ns)
-{
-	int ret;
-// 5 /proc + 21 /int_as_str + 3 /ns + 20 /NS_NAME + 1 \0
-#define __NS_PATH_LEN 50
-	char path[__NS_PATH_LEN];
-
-	// This way we can use this function to also check whether namespaces
-	// are supported by the kernel by passing in the NULL or the empty
-	// string.
-	ret = snprintf(path, __NS_PATH_LEN, "/proc/%d/ns%s%s", pid,
-		       !ns || strcmp(ns, "") == 0 ? "" : "/",
-		       !ns || strcmp(ns, "") == 0 ? "" : ns);
-	if (ret < 0 || (size_t)ret >= __NS_PATH_LEN) {
-		errno = EFBIG;
-		return -1;
-	}
-
-	return open(path, O_RDONLY | O_CLOEXEC);
 }
 
 static void mount_emulate(void)

--- a/lxd/main_nsexec.go
+++ b/lxd/main_nsexec.go
@@ -144,7 +144,7 @@ int dosetns_file(char *file, char *nstype) {
 	return 0;
 }
 
-static int preserve_ns(pid_t pid, int ns_fd, const char *ns)
+int preserve_ns(pid_t pid, int ns_fd, const char *ns)
 {
 	int ret;
 	if (ns_fd >= 0)


### PR DESCRIPTION
In nested workloads where the outer LXD hasn't used shiftfs the container's
rootfs won't be marked for shifting and since the inner container hasn't
mounted the rootfs itself it's user namespace doesn't own the superblock of the
rootfs filesystem. Since we require CAP_SYS_ADMIN in the owning user namespace
of the superblock shiftfs isn't useable for the inner LXD. Handle that case.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>