### PR TITLE
Network: Small miscellaneous networking tweaks

### DIFF
--- a/doc/networks.md
+++ b/doc/networks.md
@@ -68,7 +68,7 @@ bridge.hwaddr                   | string    | -                     | -         
 bridge.mode                     | string    | -                     | standard                  | Bridge operation mode ("standard" or "fan")
 bridge.mtu                      | integer   | -                     | 1500                      | Bridge MTU (default varies if tunnel or fan setup)
 dns.domain                      | string    | -                     | lxd                       | Domain to advertise to DHCP clients and use for DNS resolution
-dns.search                      | string    | -                     | -                         | Full comma eparate domain search list, defaulting to dns.domain
+dns.search                      | string    | -                     | -                         | Full comma separated domain search list, defaulting to dns.domain
 dns.mode                        | string    | -                     | managed                   | DNS registration mode ("none" for no DNS record, "managed" for LXD generated static records or "dynamic" for client generated records)
 fan.overlay\_subnet             | string    | fan mode              | 240.0.0.0/8               | Subnet to use as the overlay for the FAN (CIDR notation)
 fan.type                        | string    | fan mode              | vxlan                     | The tunneling type for the FAN ("vxlan" or "ipip")

--- a/lxd/cluster/config.go
+++ b/lxd/cluster/config.go
@@ -10,11 +10,11 @@ import (
 	"time"
 
 	"github.com/kballard/go-shellquote"
+	"github.com/pkg/errors"
 	"golang.org/x/crypto/scrypt"
 
 	"github.com/lxc/lxd/lxd/config"
 	"github.com/lxc/lxd/lxd/db"
-	"github.com/pkg/errors"
 )
 
 // Config holds cluster-wide configuration values.

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -1045,7 +1045,7 @@ func (d *nicBridged) setupOVSBridgePortVLANs(hostName string) error {
 		// Order is important here, as vlan_mode is set to "access", assuming that vlan.tagged is not used.
 		// If vlan.tagged is specified, then we expect it to also change the vlan_mode as needed.
 		if d.config["vlan"] != "none" {
-			err := ovs.PortSet(hostName, "vlan_mode=access", fmt.Sprintf("tag=%s", d.config["vlan"]))
+			err := ovs.BridgePortSet(hostName, "vlan_mode=access", fmt.Sprintf("tag=%s", d.config["vlan"]))
 			if err != nil {
 				return err
 			}
@@ -1071,7 +1071,7 @@ func (d *nicBridged) setupOVSBridgePortVLANs(hostName string) error {
 		// Also set the vlan_mode as needed from above.
 		// Must come after the PortSet command used for setting "vlan" mode above so that the correct
 		// vlan_mode is retained.
-		err := ovs.PortSet(hostName, fmt.Sprintf("vlan_mode=%s", vlanMode), fmt.Sprintf("trunks=%s", strings.Join(vlanIDs, ",")))
+		err := ovs.BridgePortSet(hostName, fmt.Sprintf("vlan_mode=%s", vlanMode), fmt.Sprintf("trunks=%s", strings.Join(vlanIDs, ",")))
 		if err != nil {
 			return err
 		}

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -436,7 +436,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 				return fmt.Errorf("Open vSwitch isn't installed on this system")
 			}
 
-			err := ovs.BridgeAdd(n.name)
+			err := ovs.BridgeAdd(n.name, false)
 			if err != nil {
 				return err
 			}

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -94,6 +94,11 @@ func (n *common) validate(config map[string]string, driverRules map[string]func(
 	return nil
 }
 
+// ID returns the network ID.
+func (n *common) ID() int64 {
+	return n.id
+}
+
 // Name returns the network name.
 func (n *common) Name() string {
 	return n.name

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -18,6 +18,7 @@ type Network interface {
 	// Config.
 	ValidateName(name string) error
 	Validate(config map[string]string) error
+	ID() int64
 	Name() string
 	Type() string
 	Status() string

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -133,7 +133,7 @@ func AttachInterface(bridgeName string, devName string) error {
 		}
 	} else {
 		ovs := openvswitch.NewOVS()
-		err := ovs.BridgeAddPort(bridgeName, devName)
+		err := ovs.BridgePortAdd(bridgeName, devName, true)
 		if err != nil {
 			return err
 		}
@@ -151,7 +151,7 @@ func DetachInterface(bridgeName string, devName string) error {
 		}
 	} else {
 		ovs := openvswitch.NewOVS()
-		err := ovs.BridgeDeletePort(bridgeName, devName)
+		err := ovs.BridgePortDelete(bridgeName, devName)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- OVS command wrapper function naming consistency and efficiency.
- Import ordering.
- Doc typo.
- Adds `ID()` function to `Network` interface.