### PR TITLE
Validate: Adds Required() and makes Optional() accept multiple validators

### DIFF
--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -20,14 +20,28 @@ func stringInSlice(key string, list []string) bool {
 	return false
 }
 
-// Optional wraps a validator function to make it an optional field.
-func Optional(f func(value string) error) func(value string) error {
+// Required returns function that runs one or more validators, all must pass without error.
+func Required(validators ...func(value string) error) func(value string) error {
+	return func(value string) error {
+		for _, validator := range validators {
+			err := validator(value)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+// Optional wraps Required() function to make it return nil if value is empty string.
+func Optional(validators ...func(value string) error) func(value string) error {
 	return func(value string) error {
 		if value == "" {
 			return nil
 		}
 
-		return f(value)
+		return Required(validators...)(value)
 	}
 }
 


### PR DESCRIPTION
This is an idea I had whilst working on the network name validation.

Sometimes it would be useful to run multiple validators on a field, and right now the only choice we have is to create an anonymous function that calls multiple validators.

This PR modifies the existing `Optional()` function to make it variadic so it can accept multiple validators.
It also adds a `Required()` function which does the same as `Optional()` without the check that causes it to return nil if the supplied value is an empty string.

This allows validation rules to be defined as follows:

```go
rules := map[string]func(value string) error{
    "parent":           validate.Required(validInterfaceName, validate.IsURLSegmentSafe),
    "mtu":              validate.Optional(validate.IsInt64),
    "vlan":             validate.Optional(validate.IsInt64, validate.IsNetworkVLAN),
}
```

This change is backwards compatible with current usage.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>