### PR TITLE
seccomp: enable bpf in unprivileged containers

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1137,3 +1137,6 @@ specify which parent interface should be used for creating NIC device interfaces
 
 Also adds `network` configuration key support for `sriov` NICs to allow them to specify the associated network of
 the same type that they should use as the basis for the NIC device.
+
+## container\_syscall\_intercept\_bpf\_devices
+This adds support to intercept the bpf syscall in containers. Specifically, it allows to manage device cgroup bpf programs.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -85,6 +85,8 @@ security.syscalls.allow                     | string    | -                 | no
 security.syscalls.deny                      | string    | -                 | no            | container                 | A '\n' separated list of syscalls to deny
 security.syscalls.deny\_compat              | boolean   | false             | no            | container                 | On x86\_64 this enables blocking of compat\_\* syscalls, it is a no-op on other arches
 security.syscalls.deny\_default             | boolean   | true              | no            | container                 | Enables the default syscall deny
+security.syscalls.intercept.bpf             | boolean   | false             | no            | container                 | Handles the `bpf` system call
+security.syscalls.intercept.bpf.devices     | boolean   | false             | no            | container                 | Allows `bpf` programs for the devices cgroup in the unified hierarchy to be loaded.
 security.syscalls.intercept.mknod           | boolean   | false             | no            | container                 | Handles the `mknod` and `mknodat` system calls (allows creation of a limited subset of char/block devices)
 security.syscalls.intercept.mount           | boolean   | false             | no            | container                 | Handles the `mount` system call
 security.syscalls.intercept.mount.allowed   | string    | -                 | yes           | container                 | Specify a comma-separated list of filesystems that are safe to mount for processes inside the instance

--- a/doc/production-setup.md
+++ b/doc/production-setup.md
@@ -30,6 +30,8 @@ root    | soft  | nofile  | 1048576   | unset     | maximum number of open files
 root    | hard  | nofile  | 1048576   | unset     | maximum number of open files
 \*      | soft  | memlock | unlimited | unset     | maximum locked-in-memory address space (KB)
 \*      | hard  | memlock | unlimited | unset     | maximum locked-in-memory address space (KB)
+root    | soft  | memlock | unlimited | unset     | maximum locked-in-memory address space (KB) (Only need with `bpf` syscall supervision)
+root    | hard  | memlock | unlimited | unset     | maximum locked-in-memory address space (KB) (Only need with `bpf` syscall supervision)
 
 
 ### /etc/sysctl.conf

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -631,6 +631,7 @@ func (d *Daemon) init() error {
 		"pidfd",
 		"seccomp_allow_deny_syntax",
 		"devpts_fd",
+		"seccomp_proxy_send_notify_fd",
 	}
 	for _, extension := range lxcExtensions {
 		d.os.LXCFeatures[extension] = liblxc.HasApiExtension(extension)
@@ -673,6 +674,13 @@ func (d *Daemon) init() error {
 		logger.Infof(" - seccomp listener continue syscalls: yes")
 	} else {
 		logger.Infof(" - seccomp listener continue syscalls: no")
+	}
+
+	if canUseSeccompListenerAddfd() && d.os.LXCFeatures["seccomp_proxy_send_notify_fd"] {
+		d.os.SeccompListenerAddfd = true
+		logger.Infof(" - seccomp listener add file descriptors: yes")
+	} else {
+		logger.Infof(" - seccomp listener add file descriptors: no")
 	}
 
 	if d.os.LXCFeatures["devpts_fd"] && canUseNativeTerminals() {

--- a/lxd/include/lxd_seccomp.h
+++ b/lxd/include/lxd_seccomp.h
@@ -65,4 +65,27 @@ struct seccomp_notif_sizes {
 						struct seccomp_notif_resp)
 #define SECCOMP_IOCTL_NOTIF_ID_VALID	SECCOMP_IOR(2, __u64)
 #endif
+
+#ifndef SECCOMP_IOCTL_NOTIF_ADDFD
+#define SECCOMP_IOCTL_NOTIF_ADDFD	SECCOMP_IOW(3, struct seccomp_notif_addfd)
+
+/* valid flags for seccomp_notif_addfd */
+#define SECCOMP_ADDFD_FLAG_SETFD	(1UL << 0) /* Specify remote fd */
+
+/**
+ * struct seccomp_notif_addfd
+ * @id: The ID of the seccomp notification
+ * @flags: SECCOMP_ADDFD_FLAG_*
+ * @srcfd: The local fd number
+ * @newfd: Optional remote FD number if SETFD option is set, otherwise 0.
+ * @newfd_flags: The O_* flags the remote FD should have applied
+ */
+struct seccomp_notif_addfd {
+	__u64 id;
+	__u32 flags;
+	__u32 srcfd;
+	__u32 newfd;
+	__u32 newfd_flags;
+};
+#endif
 #endif /* LXD_SECCOMP_H */

--- a/lxd/include/syscall_numbers.h
+++ b/lxd/include/syscall_numbers.h
@@ -94,4 +94,39 @@
 	#endif
 #endif
 
+#ifndef __NR_bpf
+	#if defined __i386__
+		#define __NR_bpf 357
+	#elif defined __x86_64__
+		#define __NR_bpf 321
+	#elif defined __arm__
+		#define __NR_bpf 386
+	#elif defined __aarch64__
+		#define __NR_bpf 386
+	#elif defined __s390__
+		#define __NR_bpf 351
+	#elif defined __powerpc__
+		#define __NR_bpf 361
+	#elif defined __riscv
+		#define __NR_bpf 280
+	#elif defined __sparc__
+		#define __NR_bpf 349
+	#elif defined __ia64__
+		#define __NR_bpf (317 + 1024)
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_bpf 4355
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_bpf 6319
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_bpf 5315
+		#endif
+	#else
+		#define -1
+		#warning "__NR_bpf not defined for your architecture"
+	#endif
+#endif
+
 #endif /* __LXD_SYSCALL_NUMBERS_H */

--- a/lxd/include/syscall_numbers.h
+++ b/lxd/include/syscall_numbers.h
@@ -34,6 +34,26 @@
 	#endif
 #endif
 
+#ifndef __NR_pidfd_getfd
+	#if defined __alpha__
+		#define __NR_pidfd_getfd 548
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_pidfd_getfd 4438
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_pidfd_getfd 6438
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_pidfd_getfd 5438
+		#endif
+	#elif defined __ia64__
+		#define __NR_pidfd_getfd (438 + 1024)
+	#else
+		#define __NR_pidfd_getfd 438
+	#endif
+#endif
+
 #ifndef __NR_pidfd_send_signal
 	#if defined __alpha__
 		#define __NR_pidfd_send_signal 534

--- a/lxd/include/syscall_numbers.h
+++ b/lxd/include/syscall_numbers.h
@@ -28,9 +28,9 @@
 			#define __NR_pidfd_open 5434
 		#endif
 	#elif defined __ia64__
-		#define __NR_clone3 (424 + 1024)
+		#define __NR_pidfd_open (434 + 1024)
 	#else
-		#define __NR_pidfd_open 424
+		#define __NR_pidfd_open 434
 	#endif
 #endif
 

--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -541,9 +541,10 @@ func seccompGetPolicyContent(s *state.State, c Instance) (string, error) {
 
 		if shared.IsTrue(config["security.syscalls.intercept.mount"]) {
 			policy += seccompNotifyMount
-			// We can't handle the new mount API since it keeps
-			// in-kernel state across an arbitrary number of
-			// multiple syscalls.
+			// We block the new mount api for now to simplify mount
+			// syscall interception. Since it keeps state over
+			// multiple syscalls we'd need more invasive changes to
+			// make this work.
 			policy += seccompBlockNewMountAPI
 		}
 	}

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -67,6 +67,7 @@ type OS struct {
 	NetnsGetifaddrs         bool
 	PidFds                  bool
 	SeccompListener         bool
+	SeccompListenerAddfd    bool
 	SeccompListenerContinue bool
 	Shiftfs                 bool
 	UeventInjection         bool

--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -102,6 +102,7 @@ _have lxc && {
       security.syscalls.allow \
       security.syscalls.deny \
       security.syscalls.deny_compat security.syscalls.deny_default \
+      security.syscalls.intercept.bpf security.syscalls.intercept.bpf.devices \
       security.syscalls.intercept.mknod security.syscalls.intercept.mount \
       security.syscalls.intercept.mount.allowed \
       security.syscalls.intercept.mount.fuse \

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -206,6 +206,8 @@ var KnownInstanceConfigKeys = map[string]func(value string) error{
 	"security.syscalls.deny_default":            validate.Optional(validate.IsBool),
 	"security.syscalls.deny_compat":             validate.Optional(validate.IsBool),
 	"security.syscalls.deny":                    validate.IsAny,
+	"security.syscalls.intercept.bpf":           validate.Optional(validate.IsBool),
+	"security.syscalls.intercept.bpf.devices":   validate.Optional(validate.IsBool),
 	"security.syscalls.intercept.mknod":         validate.Optional(validate.IsBool),
 	"security.syscalls.intercept.mount":         validate.Optional(validate.IsBool),
 	"security.syscalls.intercept.mount.allowed": validate.IsAny,

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -222,6 +222,7 @@ var APIExtensions = []string{
 	"projects_limits_disk",
 	"network_type_macvlan",
 	"network_type_sriov",
+	"container_syscall_intercept_bpf_devices",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Thing's aren't normal on Linux anymore and we have users that want to run bpf
in unprivileged containers. This is of course completely opt-in and not to be
used lightly.

This patch makes it possible for LXD to manage the bpf() syscalls of an
unprivileged task in a container.

For a start, this enables support for BPF_PROG_TYPE_CGROUP_DEVICE program types
and BPF_CGROUP_DEVICE attach and detach types. This serves as a POC that it is
possible to manage bpf programs for a task running in an unprivileged
container.

I expect this to be extended in the future should users have a need for it.
There are a several ways we could extend this:
- supporting more program types
- supporting maps of pre-compiled or pre-written bpf programs instead of
  loading the container's own

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>