### PR TITLE
exec: switch to close_range()

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -639,6 +639,13 @@ func (d *Daemon) init() error {
 
 	// Look for kernel features
 	logger.Infof("Kernel features:")
+	d.os.CloseRange = canUseCloseRange()
+	if d.os.CloseRange {
+		logger.Infof(" - closing multiple file descriptros efficiently: yes")
+	} else {
+		logger.Infof(" - closing multiple file descriptros efficiently: no")
+	}
+
 	d.os.NetnsGetifaddrs = canUseNetnsGetifaddrs()
 	if d.os.NetnsGetifaddrs {
 		logger.Infof(" - netnsid-based network retrieval: yes")

--- a/lxd/include/process_utils.h
+++ b/lxd/include/process_utils.h
@@ -1,5 +1,3 @@
-/* SPDX-License-Identifier: LGPL-2.1+ */
-
 #ifndef __LXD_PROCESS_UTILS_H
 #define __LXD_PROCESS_UTILS_H
 

--- a/lxd/include/syscall_numbers.h
+++ b/lxd/include/syscall_numbers.h
@@ -129,4 +129,24 @@
 	#endif
 #endif
 
+#ifndef __NR_close_range
+	#if defined __alpha__
+		#define __NR_close_range 546
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_close_range 4436
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_close_range 6436
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_close_range 5436
+		#endif
+	#elif defined __ia64__
+		#define __NR_close_range (436 + 1024)
+	#else
+		#define __NR_close_range 436
+	#endif
+#endif
+
 #endif /* __LXD_SYSCALL_NUMBERS_H */

--- a/lxd/include/syscall_numbers.h
+++ b/lxd/include/syscall_numbers.h
@@ -1,4 +1,3 @@
-/* SPDX-License-Identifier: LGPL-2.1+ */
 #ifndef __LXD_SYSCALL_NUMBERS_H
 #define __LXD_SYSCALL_NUMBERS_H
 

--- a/lxd/include/syscall_wrappers.h
+++ b/lxd/include/syscall_wrappers.h
@@ -1,0 +1,24 @@
+#ifndef __LXD_SYSCALL_WRAPPER_H
+#define __LXD_SYSCALL_WRAPPER_H
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+#include <asm/unistd.h>
+#include <errno.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "syscall_numbers.h"
+
+#ifndef CLOSE_RANGE_UNSHARE
+#define CLOSE_RANGE_UNSHARE (1U << 1)
+#endif
+
+static inline int close_range(unsigned int fd, unsigned int max_fd, unsigned int flags)
+{
+	return syscall(__NR_close_range, fd, max_fd, flags);
+}
+
+#endif /* __LXD_SYSCALL_WRAPPER_H */

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -63,6 +63,7 @@ type OS struct {
 	CGInfo cgroup.Info
 
 	// Kernel features
+	CloseRange              bool
 	NativeTerminals         bool
 	NetnsGetifaddrs         bool
 	PidFds                  bool


### PR DESCRIPTION
Starting with v5.9 we don't need the crazy proc-based loop anymore since we've
implemented the close_range() syscall: detact and use it!

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>