### PR TITLE
lxd/apparmor/dnsmasq: Add binary for nesting

### DIFF
--- a/lxd/apparmor/network_dnsmasq.go
+++ b/lxd/apparmor/network_dnsmasq.go
@@ -49,6 +49,10 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
 
 {{- if .snap }}
 
+  # The binary itself (for nesting)
+  /snap/lxd/current/bin/dnsmasq           mr,
+  /snap/lxd/*/bin/dnsmasq                 mr,
+
   # Snap-specific libraries
   /snap/lxd/current/lib/**.so*            mr,
   /snap/lxd/*/lib/**.so*                  mr,


### PR DESCRIPTION
Closes #7748

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>