### PR TITLE
lxd/storage/drivers/ceph: Fix volume deletion

### DIFF
--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -621,6 +621,12 @@ func (d *ceph) deleteVolume(vol Volume) (int, error) {
 			}
 
 			return 1, nil
+		} else if zombies == 0 {
+			// Delete.
+			err = d.rbdDeleteVolume(vol)
+			if err != nil {
+				return -1, err
+			}
 		}
 	} else {
 		if err != db.ErrNoSuchObject {


### PR DESCRIPTION
This fixes a bug in which deleting a volume with snapshots would only
delete the snapshots, not the volume itself.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
