### PR TITLE
cluster: Don't upgrade nodes without raft role concurrently

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1250,6 +1250,26 @@ again:
 	goto again
 }
 
+// Check if there are nodes not part of the raft configuration and add them in
+// case.
+func upgradeNodesWithoutRaftRole(d *Daemon) error {
+	var allNodes []db.NodeInfo
+	err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
+		var err error
+		allNodes, err = tx.GetNodes()
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "Failed to get current cluster nodes")
+
+	}
+	return cluster.UpgradeMembersWithoutRole(d.gateway, allNodes)
+}
+
 // Post a change role request to the member with the given address. The nodes
 // slice contains details about all members, including the one being changed.
 func changeMemberRole(d *Daemon, address string, nodes []db.RaftNode) error {

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -245,15 +245,6 @@ func (g *Gateway) heartbeat(ctx context.Context, initialHeartbeat bool) {
 		return
 	}
 
-	if len(allNodes) != len(raftNodes) {
-		logger.Infof("Upgrading %d nodes not part of raft configuration", len(allNodes)-len(raftNodes))
-		err = upgradeMembersWithoutRole(g, allNodes, raftNodes)
-		if err != nil {
-			logger.Warnf("Failed upgrade raft roles: %v", err)
-			return
-		}
-	}
-
 	// Cumulative set of node states (will be written back to database once done).
 	hbState := &APIHeartbeat{}
 

--- a/lxd/cluster/upgrade_export_test.go
+++ b/lxd/cluster/upgrade_export_test.go
@@ -1,7 +1,0 @@
-package cluster
-
-import "github.com/lxc/lxd/lxd/db"
-
-func UpgradeMembersWithoutRole(gateway *Gateway, members []db.NodeInfo, nodes []db.RaftNode) error {
-	return upgradeMembersWithoutRole(gateway, members, nodes)
-}

--- a/lxd/cluster/upgrade_test.go
+++ b/lxd/cluster/upgrade_test.go
@@ -157,14 +157,11 @@ func TestUpgradeMembersWithoutRole(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	nodes, err := gateway.RaftNodes()
-	require.NoError(t, err)
-
-	err = cluster.UpgradeMembersWithoutRole(gateway, members, nodes)
+	err = cluster.UpgradeMembersWithoutRole(gateway, members)
 	require.NoError(t, err)
 
 	// The members have been added to the raft configuration.
-	nodes, err = gateway.RaftNodes()
+	nodes, err := gateway.RaftNodes()
 	require.NoError(t, err)
 
 	assert.Len(t, nodes, 3)


### PR DESCRIPTION
If there are other raft-related changes in progress, trying to upgrade a node without raft configuration (typically when upgrading a pre-3.20 cluster to >=3.20) might race with other cluster changes (e.g. node removal).

This change makes sure that we perform such upgrades serially, by acquiring the same Daemon.clusterMembershipMutex lock used for other membership operations.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>