### PR TITLE
Reduce privileges and confine forkdns

### DIFF
--- a/lxd/apparmor/network.go
+++ b/lxd/apparmor/network.go
@@ -10,6 +10,7 @@ import (
 
 // Internal copy of the network interface.
 type network interface {
+	Config() map[string]string
 	Name() string
 }
 
@@ -26,6 +27,8 @@ func NetworkLoad(state *state.State, n network) error {
 	 * version out so that the new changes are reflected and we definitely
 	 * force a recompile.
 	 */
+
+	// dnsmasq
 	profile := filepath.Join(aaPath, "profiles", dnsmasqProfileFilename(n))
 	content, err := ioutil.ReadFile(profile)
 	if err != nil && !os.IsNotExist(err) {
@@ -49,15 +52,50 @@ func NetworkLoad(state *state.State, n network) error {
 		return err
 	}
 
+	// forkdns
+	if n.Config()["bridge.mode"] == "fan" {
+		profile := filepath.Join(aaPath, "profiles", forkdnsProfileFilename(n))
+		content, err := ioutil.ReadFile(profile)
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+
+		updated, err := forkdnsProfile(state, n)
+		if err != nil {
+			return err
+		}
+
+		if string(content) != string(updated) {
+			err = ioutil.WriteFile(profile, []byte(updated), 0600)
+			if err != nil {
+				return err
+			}
+		}
+
+		err = loadProfile(state, forkdnsProfileFilename(n))
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
 // NetworkUnload ensures that the network's profiles are unloaded to free kernel memory.
 // This does not delete the policy from disk or cache.
 func NetworkUnload(state *state.State, n network) error {
+	// dnsmasq
 	err := unloadProfile(state, dnsmasqProfileFilename(n))
 	if err != nil {
 		return err
+	}
+
+	// forkdns
+	if n.Config()["bridge.mode"] == "fan" {
+		err := unloadProfile(state, forkdnsProfileFilename(n))
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -65,5 +103,17 @@ func NetworkUnload(state *state.State, n network) error {
 
 // NetworkDelete removes the profiles from cache/disk.
 func NetworkDelete(state *state.State, n network) error {
-	return deleteProfile(state, dnsmasqProfileFilename(n))
+	err := deleteProfile(state, dnsmasqProfileFilename(n))
+	if err != nil {
+		return err
+	}
+
+	if n.Config()["bridge.mode"] == "fan" {
+		err := deleteProfile(state, forkdnsProfileFilename(n))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/lxd/apparmor/network_forkdns.go
+++ b/lxd/apparmor/network_forkdns.go
@@ -1,0 +1,101 @@
+package apparmor
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"strings"
+	"text/template"
+
+	"github.com/lxc/lxd/lxd/state"
+	"github.com/lxc/lxd/shared"
+)
+
+var forkdnsProfileTpl = template.Must(template.New("forkdnsProfile").Parse(`#include <tunables/global>
+profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  # Capabilities
+  capability net_bind_service,
+
+  # Network access
+  network inet dgram,
+  network inet6 dgram,
+
+  # Network-specific paths
+  {{ .varPath }}/networks/{{ .networkName }}/dnsmasq.leases r,
+  {{ .varPath }}/networks/{{ .networkName }}/forkdns.servers/servers.conf r,
+
+  # Needed for lxd fork commands
+  @{PROC}/@{pid}/cmdline r,
+  {{ .rootPath }}/{etc,lib,usr/lib}/os-release r,
+
+  # Things that we definitely don't need
+  deny @{PROC}/@{pid}/cgroup r,
+  deny /sys/module/apparmor/parameters/enabled r,
+  deny /sys/kernel/mm/transparent_hugepage/hpage_pmd_size r,
+
+{{- if .snap }}
+  # The binary itself (for nesting)
+  /var/snap/lxd/common/lxd.debug      mr,
+  /snap/lxd/current/bin/lxd           mr,
+  /snap/lxd/*/bin/lxd                 mr,
+
+  # Snap-specific libraries
+  /snap/lxd/current/lib/**.so*            mr,
+  /snap/lxd/*/lib/**.so*                  mr,
+{{- end }}
+}
+`))
+
+// forkdnsProfile generates the AppArmor profile template from the given network.
+func forkdnsProfile(state *state.State, n network) (string, error) {
+	rootPath := ""
+	if shared.InSnap() {
+		rootPath = "/var/lib/snapd/hostfs"
+	}
+
+	// Render the profile.
+	var sb *strings.Builder = &strings.Builder{}
+	err := forkdnsProfileTpl.Execute(sb, map[string]interface{}{
+		"name":        ForkdnsProfileName(n),
+		"networkName": n.Name(),
+		"varPath":     shared.VarPath(""),
+		"rootPath":    rootPath,
+		"snap":        shared.InSnap(),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return sb.String(), nil
+}
+
+// ForkdnsProfileName returns the AppArmor profile name.
+func ForkdnsProfileName(n network) string {
+	path := shared.VarPath("")
+	name := fmt.Sprintf("%s_<%s>", n.Name(), path)
+
+	// Max length in AppArmor is 253 chars.
+	if len(name)+12 >= 253 {
+		hash := sha256.New()
+		io.WriteString(hash, name)
+		name = fmt.Sprintf("%x", hash.Sum(nil))
+	}
+
+	return fmt.Sprintf("lxd_forkdns-%s", name)
+}
+
+// forkdnsProfileFilename returns the name of the on-disk profile name.
+func forkdnsProfileFilename(n network) string {
+	name := n.Name()
+
+	// Max length in AppArmor is 253 chars.
+	if len(name)+12 >= 253 {
+		hash := sha256.New()
+		io.WriteString(hash, name)
+		name = fmt.Sprintf("%x", hash.Sum(nil))
+	}
+
+	return fmt.Sprintf("lxd_forkdns-%s", name)
+}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -766,7 +766,7 @@ func (vm *qemu) Start(stateful bool) error {
 					return err
 				}
 
-				err = os.Chown(path, vm.state.OS.UnprivUID, -1)
+				err = os.Chown(path, int(vm.state.OS.UnprivUID), -1)
 				if err != nil {
 					op.Done(err)
 					return err

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1544,6 +1544,12 @@ func (n *bridge) spawnForkDNS(listenAddress string) error {
 		return fmt.Errorf("Failed to create subprocess: %s", err)
 	}
 
+	// Drop privileges.
+	p.SetCreds(n.state.OS.UnprivUID, n.state.OS.UnprivGID)
+
+	// Apply AppArmor profile.
+	p.SetApparmor(apparmor.ForkdnsProfileName(n))
+
 	err = p.Start()
 	if err != nil {
 		return fmt.Errorf("Failed to run: %s %s: %v", command, strings.Join(forkdnsargs, " "), err)

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1269,6 +1269,9 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		if n.state.OS.UnprivUser != "" {
 			dnsmasqCmd = append(dnsmasqCmd, []string{"-u", n.state.OS.UnprivUser}...)
 		}
+		if n.state.OS.UnprivGroup != "" {
+			dnsmasqCmd = append(dnsmasqCmd, []string{"-g", n.state.OS.UnprivGroup}...)
+		}
 
 		// Create DHCP hosts directory.
 		if !shared.PathExists(shared.VarPath("networks", n.name, "dnsmasq.hosts")) {

--- a/lxd/resources/usb.go
+++ b/lxd/resources/usb.go
@@ -17,6 +17,9 @@ var sysBusUSB = "/sys/bus/usb/devices"
 
 // GetUSB returns a filled api.ResourcesUSB struct ready for use by LXD
 func GetUSB() (*api.ResourcesUSB, error) {
+	// Load the USB database.
+	usbid.Load()
+
 	usb := api.ResourcesUSB{}
 
 	if !sysfsExists(sysBusUSB) {

--- a/shared/subprocess/proc.go
+++ b/shared/subprocess/proc.go
@@ -25,7 +25,7 @@ type Process struct {
 	Name     string   `yaml:"name"`
 	Args     []string `yaml:"args,flow"`
 	Apparmor string   `yaml:"apparmor"`
-	Pid      int64    `yaml:"pid"`
+	PID      int64    `yaml:"pid"`
 	Stdout   string   `yaml:"stdout"`
 	Stderr   string   `yaml:"stderr"`
 }
@@ -45,10 +45,10 @@ func (p *Process) hasApparmor() bool {
 
 // GetPid returns the pid for the given process object
 func (p *Process) GetPid() (int64, error) {
-	pr, _ := os.FindProcess(int(p.Pid))
+	pr, _ := os.FindProcess(int(p.PID))
 	err := pr.Signal(syscall.Signal(0))
 	if err == nil {
-		return p.Pid, nil
+		return p.PID, nil
 	}
 
 	return 0, ErrNotRunning
@@ -61,7 +61,7 @@ func (p *Process) SetApparmor(profile string) {
 
 // Stop will stop the given process object
 func (p *Process) Stop() error {
-	pr, _ := os.FindProcess(int(p.Pid))
+	pr, _ := os.FindProcess(int(p.PID))
 
 	// Check if process exists.
 	err := pr.Signal(syscall.Signal(0))
@@ -128,7 +128,7 @@ func (p *Process) Start() error {
 		return errors.Wrapf(err, "Unable to start process")
 	}
 
-	p.Pid = int64(cmd.Process.Pid)
+	p.PID = int64(cmd.Process.Pid)
 
 	// Reset exitCode/exitErr
 	p.exitCode = 0
@@ -171,7 +171,7 @@ func (p *Process) Restart() error {
 
 // Reload sends the SIGHUP signal to the given process object
 func (p *Process) Reload() error {
-	pr, _ := os.FindProcess(int(p.Pid))
+	pr, _ := os.FindProcess(int(p.PID))
 	err := pr.Signal(syscall.Signal(0))
 	if err == nil {
 		err = pr.Signal(syscall.SIGHUP)
@@ -203,7 +203,7 @@ func (p *Process) Save(path string) error {
 
 // Signal will send a signal to the given process object given a signal value
 func (p *Process) Signal(signal int64) error {
-	pr, _ := os.FindProcess(int(p.Pid))
+	pr, _ := os.FindProcess(int(p.PID))
 	err := pr.Signal(syscall.Signal(0))
 	if err == nil {
 		err = pr.Signal(syscall.Signal(signal))

--- a/shared/usbid/load.go
+++ b/shared/usbid/load.go
@@ -28,7 +28,8 @@ var (
 	Classes map[ClassCode]*Class
 )
 
-func init() {
+// Load reads the USB database from disk.
+func Load() {
 	usbids, err := os.Open("/usr/share/misc/usb.ids")
 	if err != nil {
 		if !os.IsNotExist(err) {


### PR DESCRIPTION
This branch has the eventual goal of running `forkproxy` under an apparmor profile as well as running it as an unprivileged user.

To achieve this I needed a few extra things:
 - Ability to run a subprocess as another user/group
 - An unprivileged group to use

Additionally because `lxd forkdns` is a sub-command of LXD, a lot of code gets loaded just because it's LXD.
Part of that was loading the whole USB database which we only need for `lxd/resource` so I've changed that code a bit.

We still are accessing a bunch of files on startup that we shouldn't be. The cgroup and apparmor bits come from us loading liblxc. No idea where the hugepage one comes from.