### PR TITLE
Network: Adds shared IPRange struct

### DIFF
--- a/lxd/dnsmasq/dhcpalloc/dhcpalloc.go
+++ b/lxd/dnsmasq/dhcpalloc/dhcpalloc.go
@@ -22,14 +22,8 @@ import (
 // ErrDHCPNotSupported indicates network doesn't support DHCP for this IP protocol.
 var ErrDHCPNotSupported error = errors.New("Network doesn't support DHCP")
 
-// DHCPRange represents a range of IPs from start to end.
-type DHCPRange struct {
-	Start net.IP
-	End   net.IP
-}
-
 // DHCPValidIP returns whether an IP fits inside one of the supplied DHCP ranges and subnet.
-func DHCPValidIP(subnet *net.IPNet, ranges []DHCPRange, IP net.IP) bool {
+func DHCPValidIP(subnet *net.IPNet, ranges []shared.IPRange, IP net.IP) bool {
 	inSubnet := subnet.Contains(IP)
 	if !inSubnet {
 		return false
@@ -90,8 +84,8 @@ type Network interface {
 	Config() map[string]string
 	DHCPv4Subnet() *net.IPNet
 	DHCPv6Subnet() *net.IPNet
-	DHCPv4Ranges() []DHCPRange
-	DHCPv6Ranges() []DHCPRange
+	DHCPv4Ranges() []shared.IPRange
+	DHCPv6Ranges() []shared.IPRange
 }
 
 // Options to initialise the allocator with.
@@ -203,7 +197,7 @@ func (t *Transaction) getDHCPFreeIPv4(usedIPs map[[4]byte]dnsmasq.DHCPAllocation
 
 	// If no custom ranges defined, convert subnet pool to a range.
 	if len(dhcpRanges) <= 0 {
-		dhcpRanges = append(dhcpRanges, DHCPRange{
+		dhcpRanges = append(dhcpRanges, shared.IPRange{
 			Start: GetIP(subnet, 1).To4(),
 			End:   GetIP(subnet, -2).To4()},
 		)
@@ -292,7 +286,7 @@ func (t *Transaction) getDHCPFreeIPv6(usedIPs map[[16]byte]dnsmasq.DHCPAllocatio
 
 	// If no custom ranges defined, convert subnet pool to a range.
 	if len(dhcpRanges) <= 0 {
-		dhcpRanges = append(dhcpRanges, DHCPRange{
+		dhcpRanges = append(dhcpRanges, shared.IPRange{
 			Start: GetIP(subnet, 1).To16(),
 			End:   GetIP(subnet, -1).To16()},
 		)

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -11,7 +11,6 @@ import (
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
-	"github.com/lxc/lxd/lxd/dnsmasq/dhcpalloc"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
@@ -183,15 +182,15 @@ func (n *common) DHCPv6Subnet() *net.IPNet {
 }
 
 // DHCPv4Ranges returns a parsed set of DHCPv4 ranges for this network.
-func (n *common) DHCPv4Ranges() []dhcpalloc.DHCPRange {
-	dhcpRanges := make([]dhcpalloc.DHCPRange, 0)
+func (n *common) DHCPv4Ranges() []shared.IPRange {
+	dhcpRanges := make([]shared.IPRange, 0)
 	if n.config["ipv4.dhcp.ranges"] != "" {
 		for _, r := range strings.Split(n.config["ipv4.dhcp.ranges"], ",") {
 			parts := strings.SplitN(strings.TrimSpace(r), "-", 2)
 			if len(parts) == 2 {
 				startIP := net.ParseIP(parts[0])
 				endIP := net.ParseIP(parts[1])
-				dhcpRanges = append(dhcpRanges, dhcpalloc.DHCPRange{
+				dhcpRanges = append(dhcpRanges, shared.IPRange{
 					Start: startIP.To4(),
 					End:   endIP.To4(),
 				})
@@ -203,15 +202,15 @@ func (n *common) DHCPv4Ranges() []dhcpalloc.DHCPRange {
 }
 
 // DHCPv6Ranges returns a parsed set of DHCPv6 ranges for this network.
-func (n *common) DHCPv6Ranges() []dhcpalloc.DHCPRange {
-	dhcpRanges := make([]dhcpalloc.DHCPRange, 0)
+func (n *common) DHCPv6Ranges() []shared.IPRange {
+	dhcpRanges := make([]shared.IPRange, 0)
 	if n.config["ipv6.dhcp.ranges"] != "" {
 		for _, r := range strings.Split(n.config["ipv6.dhcp.ranges"], ",") {
 			parts := strings.SplitN(strings.TrimSpace(r), "-", 2)
 			if len(parts) == 2 {
 				startIP := net.ParseIP(parts[0])
 				endIP := net.ParseIP(parts[1])
-				dhcpRanges = append(dhcpRanges, dhcpalloc.DHCPRange{
+				dhcpRanges = append(dhcpRanges, shared.IPRange{
 					Start: startIP.To16(),
 					End:   endIP.To16(),
 				})

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -4,8 +4,8 @@ import (
 	"net"
 
 	"github.com/lxc/lxd/lxd/cluster"
-	"github.com/lxc/lxd/lxd/dnsmasq/dhcpalloc"
 	"github.com/lxc/lxd/lxd/state"
+	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
 
@@ -26,8 +26,8 @@ type Network interface {
 	IsUsed() (bool, error)
 	DHCPv4Subnet() *net.IPNet
 	DHCPv6Subnet() *net.IPNet
-	DHCPv4Ranges() []dhcpalloc.DHCPRange
-	DHCPv6Ranges() []dhcpalloc.DHCPRange
+	DHCPv4Ranges() []shared.IPRange
+	DHCPv6Ranges() []shared.IPRange
 
 	// Actions.
 	Create(clusterNotification bool) error

--- a/shared/network_ip.go
+++ b/shared/network_ip.go
@@ -1,0 +1,12 @@
+package shared
+
+import (
+	"net"
+)
+
+// IPRange defines a range of IP addresses.
+// Optionally just set Start to indicate a single IP.
+type IPRange struct {
+	Start net.IP
+	End   net.IP
+}


### PR DESCRIPTION
Replaces `dhcpalloc.DHCPRange` and will be used in upcoming OVN networks.

Removes dependency on dnsmasq specific `dnsmasq/dhcpalloc` package in network common and interface.