### PR TITLE
Network: OVN use DB transactions when allocating external IP on parent network

### DIFF
--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -312,6 +312,26 @@ func (c *ClusterTx) networkState(name string, state int) error {
 	return nil
 }
 
+// UpdateNetwork updates the network with the given ID.
+func (c *ClusterTx) UpdateNetwork(id int64, description string, config map[string]string) error {
+	err := updateNetworkDescription(c.tx, id, description)
+	if err != nil {
+		return err
+	}
+
+	err = clearNetworkConfig(c.tx, id, c.nodeID)
+	if err != nil {
+		return err
+	}
+
+	err = networkConfigAdd(c.tx, id, c.nodeID, config)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // GetNetworks returns the names of existing networks.
 func (c *Cluster) GetNetworks() ([]string, error) {
 	return c.networks("")
@@ -603,17 +623,7 @@ func (c *Cluster) UpdateNetwork(name, description string, config map[string]stri
 	}
 
 	err = c.Transaction(func(tx *ClusterTx) error {
-		err = updateNetworkDescription(tx.tx, id, description)
-		if err != nil {
-			return err
-		}
-
-		err = clearNetworkConfig(tx.tx, id, c.nodeID)
-		if err != nil {
-			return err
-		}
-
-		err = networkConfigAdd(tx.tx, id, c.nodeID, config)
+		err = tx.UpdateNetwork(id, description, config)
 		if err != nil {
 			return err
 		}

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -66,6 +66,60 @@ func (c *ClusterTx) GetNonPendingNetworkIDs() (map[string]int64, error) {
 	return ids, nil
 }
 
+// GetNonPendingNetworks returns a map of api.Network associated to network ID.
+//
+// Pending networks are skipped.
+func (c *ClusterTx) GetNonPendingNetworks() (map[int64]api.Network, error) {
+	stmt, err := c.tx.Prepare("SELECT id, name, description, type, state FROM networks WHERE state != ?")
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+
+	rows, err := stmt.Query(networkPending)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	networks := make(map[int64]api.Network)
+
+	for i := 0; rows.Next(); i++ {
+		var networkID int64
+		var networkType NetworkType
+		var networkState int
+		var network api.Network
+
+		err := rows.Scan(&networkID, &network.Name, &network.Description, &networkType, &networkState)
+		if err != nil {
+			return nil, err
+		}
+
+		// Populate Status and Type fields by converting from DB values.
+		networkFillStatus(&network, networkState)
+		networkFillType(&network, networkType)
+
+		networks[networkID] = network
+	}
+	err = rows.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	// Populate config.
+	for networkID, network := range networks {
+		networkConfig, err := query.SelectConfig(c.tx, "networks_config", "network_id=? AND (node_id=? OR node_id IS NULL)", networkID, c.nodeID)
+		if err != nil {
+			return nil, err
+		}
+
+		network.Config = networkConfig
+		networks[networkID] = network
+	}
+
+	return networks, nil
+}
+
 // GetNetworkID returns the ID of the network with the given name.
 func (c *ClusterTx) GetNetworkID(name string) (int64, error) {
 	stmt := "SELECT id FROM networks WHERE name=?"

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -436,7 +436,7 @@ func (n *ovn) parentAllocateIP(ipRanges []*shared.IPRange, allAllocated []net.IP
 
 		// Iterate through IPs in range, return the first unallocated one found.
 		for {
-			if startBig.Cmp(endBig) >= 0 {
+			if startBig.Cmp(endBig) > 0 {
 				break
 			}
 


### PR DESCRIPTION
- Aims to prevent concurrent OVN network creation from allocating the same IP on the parent network by using transactions. 
- Relies on the sqlite snapshot behaviour in WAL mode to detect if a the IP info of other networks has changed when writing the allocated IP back to the database.
- Adds `GetNonPendingNetworks` and `UpdateNetwork` to `ClusterTx` type so that all network related queries can be done inside a transaction.
- Updates `setupParentPortBridge` to start a transaction and pass it to its associated functions.