### PR TITLE
Network: OVN MTU

### DIFF
--- a/doc/networks.md
+++ b/doc/networks.md
@@ -290,6 +290,7 @@ lxc ls
 Key                             | Type      | Condition             | Default                   | Description
 :--                             | :--       | :--                   | :--                       | :--
 bridge.hwaddr                   | string    | -                     | -                         | MAC address for the bridge
+bridge.mtu                      | integer   | -                     | 1442                      | Bridge MTU (default allows host to host geneve tunnels)
 dns.domain                      | string    | -                     | lxd                       | Domain to advertise to DHCP clients and use for DNS resolution
 dns.search                      | string    | -                     | -                         | Full comma separated domain search list, defaulting to `dns.domain` value
 ipv4.address                    | string    | standard mode         | random unused subnet      | IPv4 address for the bridge (CIDR notation). Use "none" to turn off IPv4 or "auto" to generate a new one

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -11,7 +11,7 @@ func nicValidationRules(requiredFields []string, optionalFields []string) map[st
 		"name":                    validate.IsAny,
 		"parent":                  validate.IsAny,
 		"network":                 validate.IsAny,
-		"mtu":                     validate.IsAny,
+		"mtu":                     validate.Optional(validate.IsNetworkMTU),
 		"vlan":                    validate.IsNetworkVLAN,
 		"hwaddr":                  validate.IsNetworkMAC,
 		"host_name":               validate.IsAny,

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -159,7 +159,7 @@ func (n *bridge) Validate(config map[string]string) error {
 			return nil
 		}),
 		"bridge.hwaddr": validate.Optional(validate.IsNetworkMAC),
-		"bridge.mtu":    validate.Optional(validate.IsInt64),
+		"bridge.mtu":    validate.Optional(validate.IsNetworkMTU),
 		"bridge.mode": func(value string) error {
 			return validate.IsOneOf(value, []string{"standard", "fan"})
 		},

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -18,7 +18,7 @@ type macvlan struct {
 func (n *macvlan) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
 		"parent":           validInterfaceName,
-		"mtu":              validate.Optional(validate.IsInt64),
+		"mtu":              validate.Optional(validate.IsNetworkMTU),
 		"vlan":             validate.Optional(validate.IsNetworkVLAN),
 		"maas.subnet.ipv4": validate.IsAny,
 		"maas.subnet.ipv6": validate.IsAny,

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -18,7 +18,7 @@ type sriov struct {
 func (n *sriov) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
 		"parent":           validInterfaceName,
-		"mtu":              validate.Optional(validate.IsInt64),
+		"mtu":              validate.Optional(validate.IsNetworkMTU),
 		"vlan":             validate.Optional(validate.IsNetworkVLAN),
 		"maas.subnet.ipv4": validate.IsAny,
 		"maas.subnet.ipv6": validate.IsAny,

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -867,29 +867,6 @@ func randomHwaddr(r *rand.Rand) string {
 	return ret.String()
 }
 
-// OVNInstanceDevicePortAdd adds a logical port to the OVN network's internal switch and returns the logical
-// port name for use linking an OVS port on the integration bridge to the logical switch port.
-func OVNInstanceDevicePortAdd(network Network, instanceID int, deviceName string, mac net.HardwareAddr, ips []net.IP) (openvswitch.OVNSwitchPort, error) {
-	// Check network is of type OVN.
-	n, ok := network.(*ovn)
-	if !ok {
-		return "", fmt.Errorf("Network is not OVN type")
-	}
-
-	return n.instanceDevicePortAdd(instanceID, deviceName, mac, ips)
-}
-
-// OVNInstanceDevicePortDelete deletes a logical port from the OVN network's internal switch.
-func OVNInstanceDevicePortDelete(network Network, instanceID int, deviceName string) error {
-	// Check network is of type OVN.
-	n, ok := network.(*ovn)
-	if !ok {
-		return fmt.Errorf("Network is not OVN type")
-	}
-
-	return n.instanceDevicePortDelete(instanceID, deviceName)
-}
-
 // parseIPRange parses an IP range in the format "start-end" and converts it to a shared.IPRange.
 // If allowedNets are supplied, then each IP in the range is checked that it belongs to at least one of them.
 // IPs in the range can be zero prefixed, e.g. "::1" or "0.0.0.1", however they should not overlap with any

--- a/lxd/network/network_utils_ovn.go
+++ b/lxd/network/network_utils_ovn.go
@@ -29,3 +29,14 @@ func OVNInstanceDevicePortDelete(network Network, instanceID int, deviceName str
 
 	return n.instanceDevicePortDelete(instanceID, deviceName)
 }
+
+// OVNInstanceDeviceMTU returns the MTU that should be used for an OVN instance device.
+func OVNInstanceDeviceMTU(network Network) (uint32, error) {
+	// Check network is of type OVN.
+	n, ok := network.(*ovn)
+	if !ok {
+		return 0, fmt.Errorf("Network is not OVN type")
+	}
+
+	return n.getBridgeMTU(), nil
+}

--- a/lxd/network/network_utils_ovn.go
+++ b/lxd/network/network_utils_ovn.go
@@ -1,0 +1,31 @@
+package network
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/lxc/lxd/lxd/network/openvswitch"
+)
+
+// OVNInstanceDevicePortAdd adds a logical port to the OVN network's internal switch and returns the logical
+// port name for use linking an OVS port on the integration bridge to the logical switch port.
+func OVNInstanceDevicePortAdd(network Network, instanceID int, deviceName string, mac net.HardwareAddr, ips []net.IP) (openvswitch.OVNSwitchPort, error) {
+	// Check network is of type OVN.
+	n, ok := network.(*ovn)
+	if !ok {
+		return "", fmt.Errorf("Network is not OVN type")
+	}
+
+	return n.instanceDevicePortAdd(instanceID, deviceName, mac, ips)
+}
+
+// OVNInstanceDevicePortDelete deletes a logical port from the OVN network's internal switch.
+func OVNInstanceDevicePortDelete(network Network, instanceID int, deviceName string) error {
+	// Check network is of type OVN.
+	n, ok := network.(*ovn)
+	if !ok {
+		return fmt.Errorf("Network is not OVN type")
+	}
+
+	return n.instanceDevicePortDelete(instanceID, deviceName)
+}

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -193,7 +193,7 @@ func IsNetworkV4(value string) error {
 func IsNetworkAddressV4(value string) error {
 	ip := net.ParseIP(value)
 	if ip == nil || ip.To4() == nil {
-		return fmt.Errorf("Not an IPv4 address: %s", value)
+		return fmt.Errorf("Not an IPv4 address %q", value)
 	}
 
 	return nil
@@ -207,11 +207,11 @@ func IsNetworkAddressCIDRV4(value string) error {
 	}
 
 	if ip.To4() == nil {
-		return fmt.Errorf("Not an IPv4 address: %s", value)
+		return fmt.Errorf("Not an IPv4 address %q", value)
 	}
 
 	if ip.String() == subnet.IP.String() {
-		return fmt.Errorf("Not a usable IPv4 address: %s", value)
+		return fmt.Errorf("Not a usable IPv4 address %q", value)
 	}
 
 	return nil
@@ -250,11 +250,11 @@ func IsNetworkV6(value string) error {
 	}
 
 	if ip == nil || ip.To4() != nil {
-		return fmt.Errorf("Not an IPv6 network: %s", value)
+		return fmt.Errorf("Not an IPv6 network %q", value)
 	}
 
 	if ip.String() != subnet.IP.String() {
-		return fmt.Errorf("Not an IPv6 network address: %s", value)
+		return fmt.Errorf("Not an IPv6 network address %q", value)
 	}
 
 	return nil
@@ -264,7 +264,7 @@ func IsNetworkV6(value string) error {
 func IsNetworkAddressV6(value string) error {
 	ip := net.ParseIP(value)
 	if ip == nil || ip.To4() != nil {
-		return fmt.Errorf("Not an IPv6 address: %s", value)
+		return fmt.Errorf("Not an IPv6 address %q", value)
 	}
 
 	return nil
@@ -278,11 +278,11 @@ func IsNetworkAddressCIDRV6(value string) error {
 	}
 
 	if ip.To4() != nil {
-		return fmt.Errorf("Not an IPv6 address: %s", value)
+		return fmt.Errorf("Not an IPv6 address %q", value)
 	}
 
 	if ip.String() == subnet.IP.String() {
-		return fmt.Errorf("Not a usable IPv6 address: %s", value)
+		return fmt.Errorf("Not a usable IPv6 address %q", value)
 	}
 
 	return nil
@@ -375,11 +375,11 @@ func IsNetworkRangeV6List(value string) error {
 func IsNetworkVLAN(value string) error {
 	vlanID, err := strconv.Atoi(value)
 	if err != nil {
-		return fmt.Errorf("Invalid VLAN ID: %s", value)
+		return fmt.Errorf("Invalid VLAN ID %q", value)
 	}
 
 	if vlanID < 0 || vlanID > 4094 {
-		return fmt.Errorf("Out of VLAN ID range (0-4094): %s", value)
+		return fmt.Errorf("Out of VLAN ID range (0-4094) %q", value)
 	}
 
 	return nil

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -385,6 +385,22 @@ func IsNetworkVLAN(value string) error {
 	return nil
 }
 
+// IsNetworkMTU validates MTU number >= 1280 and <= 9202.
+// Anything below 68 and the kernel doesn't allow IPv4, anything below 1280 and the kernel doesn't allow IPv6.
+// So require an IPv6-compatible MTU as the low value and cap at the max ethernet jumbo frame size.
+func IsNetworkMTU(value string) error {
+	mtu, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return fmt.Errorf("Invalid MTU %q", value)
+	}
+
+	if mtu < 1280 || mtu > 9202 {
+		return fmt.Errorf("Out of MTU range (1280-9202) %q", value)
+	}
+
+	return nil
+}
+
 // IsURLSegmentSafe validates whether value can be used in a URL segment.
 func IsURLSegmentSafe(value string) error {
 	for _, char := range []string{"/", "?", "&"} {


### PR DESCRIPTION
Adds `bridge.mtu` setting for OVN networks and defaults it to `1442` to allow normal network operation to work when using host<->host geneve tunnels. Propagates this setting into the OVN DHCP and IPv6 RA options and into the per-device NIC devices.

Also fixes OVS uplink bridge and port cleanup in clustered environment when network is deleted.