### PR TITLE
Storage: Ensure correct pool name is returned in GetInstancePool

### DIFF
--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -677,6 +677,7 @@ SELECT storage_pools.name FROM storage_pools
    AND storage_volumes_all.node_id=?
    AND storage_volumes_all.name=?
    AND storage_volumes_all.type IN(?,?)
+   AND storage_volumes_all.project_id = instances.project_id
 `
 	inargs := []interface{}{project, c.nodeID, instanceName, StoragePoolVolumeTypeContainer, StoragePoolVolumeTypeVM}
 	outargs := []interface{}{&poolName}


### PR DESCRIPTION
This fixes an issue when:

 - Two storage pools
 - Two projects
 - Instance called `c1` is created in first project and storage pool
 - Instance called `c1` is created in second project and storage pool

This breaks because this function returns the name of the first storage pool for the second container.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>