### PR TITLE
Apparmor redux

### DIFF
--- a/lxd/apparmor/network_dnsmasq.go
+++ b/lxd/apparmor/network_dnsmasq.go
@@ -57,11 +57,9 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
 {{- if .snap }}
 
   # The binary itself (for nesting)
-  /snap/lxd/current/bin/dnsmasq           mr,
   /snap/lxd/*/bin/dnsmasq                 mr,
 
   # Snap-specific libraries
-  /snap/lxd/current/lib/**.so*            mr,
   /snap/lxd/*/lib/**.so*                  mr,
 {{- end }}
 }

--- a/lxd/apparmor/network_forkdns.go
+++ b/lxd/apparmor/network_forkdns.go
@@ -38,11 +38,9 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
 {{- if .snap }}
   # The binary itself (for nesting)
   /var/snap/lxd/common/lxd.debug      mr,
-  /snap/lxd/current/bin/lxd           mr,
   /snap/lxd/*/bin/lxd                 mr,
 
   # Snap-specific libraries
-  /snap/lxd/current/lib/**.so*            mr,
   /snap/lxd/*/lib/**.so*                  mr,
 {{- end }}
 }


### PR DESCRIPTION
man apparmor.d(5):

>    Globbing
>        File resources may be specified with a globbing syntax similar to that used by popular shells, such as csh(1), bash(1), zsh(1).
> 
>        *   can substitute for any number of characters, excepting '/'

This means `/snap/lxd/*/` covers `/snap/lxd/current/`.