### PR TITLE
Network: Adds features.networks project feature for OVN networks

### DIFF
--- a/doc/projects.md
+++ b/doc/projects.md
@@ -27,6 +27,7 @@ limits.cpu                           | integer   | -                     | -    
 limits.disk                          | string    | -                     | -                         | Maximum value of aggregate disk space used by all instances volumes, custom volumes and images of the project
 limits.memory                        | string    | -                     | -                         | Maximum value for the sum of individual "limits.memory" configs set on the instances of the project
 limits.processes                     | integer   | -                     | -                         | Maximum value for the sum of individual "limits.processes" configs set on the instances of the project
+limits.networks                      | integer   | -                     | -                         | Maximum value for the number of networks this project can have
 restricted                           | boolean   | -                     | true                      | Block access to security-sensitive features
 restricted.containers.nesting        | string    | -                     | block                     | Prevents setting security.nesting=true.
 restricted.containers.privilege      | string    | -                     | unpriviliged              | If "unpriviliged", prevents setting security.privileged=true. If "isolated", prevents setting security.privileged=true and also security.idmap.isolated=true. If "allow", no restriction apply.

--- a/doc/projects.md
+++ b/doc/projects.md
@@ -20,6 +20,7 @@ Key                                  | Type      | Condition             | Defau
 features.images                      | boolean   | -                     | true                      | Separate set of images and image aliases for the project
 features.profiles                    | boolean   | -                     | true                      | Separate set of profiles for the project
 features.storage.volumes             | boolean   | -                     | true                      | Separate set of storage volumes for the project
+features.networks                    | boolean   | -                     | true                      | Separate set of networks for the project
 limits.containers                    | integer   | -                     | -                         | Maximum number of containers that can be created in the project
 limits.virtual-machines              | integer   | -                     | -                         | Maximum number of VMs that can be created in the project
 limits.cpu                           | integer   | -                     | -                         | Maximum value for the sum of individual "limits.cpu" configs set on the instances of the project

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -441,13 +441,18 @@ func (c *cmdProjectList) Run(cmd *cobra.Command, args []string) error {
 			storageVolumes = i18n.G("YES")
 		}
 
+		networks := i18n.G("NO")
+		if shared.IsTrue(project.Config["features.networks"]) {
+			networks = i18n.G("YES")
+		}
+
 		name := project.Name
 		if name == currentProject {
 			name = fmt.Sprintf("%s (%s)", name, i18n.G("current"))
 		}
 
 		strUsedBy := fmt.Sprintf("%d", len(project.UsedBy))
-		data = append(data, []string{name, images, profiles, storageVolumes, strUsedBy})
+		data = append(data, []string{name, images, profiles, storageVolumes, networks, strUsedBy})
 	}
 	sort.Sort(byName(data))
 
@@ -456,6 +461,7 @@ func (c *cmdProjectList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("IMAGES"),
 		i18n.G("PROFILES"),
 		i18n.G("STORAGE VOLUMES"),
+		i18n.G("NETWORKS"),
 		i18n.G("USED BY"),
 	}
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1594,15 +1594,21 @@ func clusterCheckNetworksMatch(cluster *db.Cluster, reqNetworks []internalCluste
 
 		for _, networkName := range networkNames {
 			found := false
+
 			for _, reqNetwork := range reqNetworks {
 				if reqNetwork.Name != networkName || reqNetwork.Project != networkProjectName {
 					continue
 				}
 
 				found = true
+
 				_, network, err := cluster.GetNetworkInAnyState(networkProjectName, networkName)
 				if err != nil {
 					return err
+				}
+
+				if reqNetwork.Type != network.Type {
+					return fmt.Errorf("Mismatching type for network %q in project %q", networkName, networkProjectName)
 				}
 
 				// Exclude the keys which are node-specific.
@@ -1611,6 +1617,7 @@ func clusterCheckNetworksMatch(cluster *db.Cluster, reqNetworks []internalCluste
 				if err != nil {
 					return errors.Wrapf(err, "Mismatching config for network %q in project %q", networkName, networkProjectName)
 				}
+
 				break
 			}
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -744,7 +744,7 @@ func clusterInitMember(d lxd.InstanceServer, client lxd.InstanceServer, memberCo
 			continue
 		}
 
-		logger.Debugf("Populating init data for storage pool %s", pool.Name)
+		logger.Debugf("Populating init data for storage pool %q", pool.Name)
 
 		post := api.StoragePoolsPost{
 			StoragePoolPut: pool.StoragePoolPut,
@@ -767,7 +767,7 @@ func clusterInitMember(d lxd.InstanceServer, client lxd.InstanceServer, memberCo
 			}
 
 			if !shared.StringInSlice(config.Key, db.StoragePoolNodeConfigKeys) {
-				logger.Warnf("Ignoring config key %s for storage pool %s", config.Key, config.Name)
+				logger.Warnf("Ignoring config key %q for storage pool %q", config.Key, config.Name)
 				continue
 			}
 
@@ -808,7 +808,7 @@ func clusterInitMember(d lxd.InstanceServer, client lxd.InstanceServer, memberCo
 			}
 
 			if !shared.StringInSlice(config.Key, db.NodeSpecificNetworkConfig) {
-				logger.Warnf("Ignoring config key %s for network %s", config.Key, config.Name)
+				logger.Warnf("Ignoring config key %q for network %q", config.Key, config.Name)
 				continue
 			}
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/response"
+	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -392,13 +393,16 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) response.Response {
 			return errors.Wrap(err, "Failed to connect to local LXD")
 		}
 
-		err = clusterInitMember(localClient, client, req.MemberConfig)
+		revert := revert.New()
+		defer revert.Fail()
+
+		localRevert, err := clusterInitMember(localClient, client, req.MemberConfig)
 		if err != nil {
 			return errors.Wrap(err, "Failed to initialize member")
 		}
+		revert.Add(localRevert)
 
-		// Get all defined storage pools and networks, so they can be compared
-		// to the ones in the cluster.
+		// Get all defined storage pools and networks, so they can be compared to the ones in the cluster.
 		pools := []api.StoragePool{}
 		poolNames, err := d.cluster.GetStoragePoolNames()
 		if err != nil && err != db.ErrNoSuchObject {
@@ -476,10 +480,10 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) response.Response {
 
 		// Start clustering tasks
 		d.startClusterTasks()
+		revert.Add(func() { d.stopClusterTasks() })
 
 		err = cluster.Join(d.State(), d.gateway, cert, req.ServerName, nodes)
 		if err != nil {
-			d.stopClusterTasks()
 			return err
 		}
 
@@ -642,6 +646,7 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) response.Response {
 			logger.Warnf("Failed to trigger cluster rebalance: %v", err)
 		}
 
+		revert.Success()
 		return nil
 	}
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1221,7 +1221,7 @@ type internalClusterPostAcceptRequest struct {
 }
 
 type internalClusterPostNetwork struct {
-	api.Network
+	api.NetworksPost `yaml:",inline"`
 
 	Project string
 }

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -539,6 +539,7 @@ var projectConfigKeys = map[string]func(value string) error{
 	"limits.processes":               validate.Optional(validate.IsUint32),
 	"limits.cpu":                     validate.Optional(validate.IsUint32),
 	"limits.disk":                    validate.Optional(validate.IsSize),
+	"limits.networks":                validate.Optional(validate.IsUint32),
 	"restricted":                     validate.Optional(validate.IsBool),
 	"restricted.containers.nesting":  isEitherAllowOrBlock,
 	"restricted.containers.lowlevel": isEitherAllowOrBlock,

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -22,7 +22,13 @@ import (
 	"github.com/lxc/lxd/shared/version"
 )
 
-var projectFeatures = []string{"features.images", "features.profiles", "features.storage.volumes"}
+// projectFeatures are the features available to projects.
+var projectFeatures = []string{"features.images", "features.profiles", "features.storage.volumes", "features.networks"}
+
+// projectFeaturesDefaults are the features enabled by default on new projects.
+// The features.networks won't be enabled by default until it becomes clear whether it is practical to run OVN on
+// every system.
+var projectFeaturesDefaults = []string{"features.images", "features.profiles", "features.storage.volumes"}
 
 var projectsCmd = APIEndpoint{
 	Path: "projects",
@@ -100,7 +106,7 @@ func projectsPost(d *Daemon, r *http.Request) response.Response {
 	if project.Config == nil {
 		project.Config = map[string]string{}
 	}
-	for _, feature := range projectFeatures {
+	for _, feature := range projectFeaturesDefaults {
 		_, ok := project.Config[feature]
 		if !ok {
 			project.Config[feature] = "true"
@@ -526,6 +532,7 @@ var projectConfigKeys = map[string]func(value string) error{
 	"features.profiles":              validate.Optional(validate.IsBool),
 	"features.images":                validate.Optional(validate.IsBool),
 	"features.storage.volumes":       validate.Optional(validate.IsBool),
+	"features.networks":              validate.Optional(validate.IsBool),
 	"limits.containers":              validate.Optional(validate.IsUint32),
 	"limits.virtual-machines":        validate.Optional(validate.IsUint32),
 	"limits.memory":                  validate.Optional(validate.IsSize),

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -59,7 +59,7 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 	}
 
 	// The NIC's network may be a non-default project, so lookup project and get network's project name.
-	networkProjectName, err := project.NetworkProject(d.state.Cluster, instConf.Project())
+	networkProjectName, _, err := project.NetworkProject(d.state.Cluster, instConf.Project())
 	if err != nil {
 		return errors.Wrapf(err, "Failed loading network project name")
 	}

--- a/lxd/device/nictype/nictype.go
+++ b/lxd/device/nictype/nictype.go
@@ -21,7 +21,7 @@ func NICType(s *state.State, deviceProjectName string, d deviceConfig.Device) (s
 	if d["type"] == "nic" {
 		if d["network"] != "" {
 			// Translate device's project name into a network project name.
-			networkProjectName, err := project.NetworkProject(s.Cluster, deviceProjectName)
+			networkProjectName, _, err := project.NetworkProject(s.Cluster, deviceProjectName)
 			if err != nil {
 				return "", errors.Wrapf(err, "Failed to translate device project %q into network project", deviceProjectName)
 			}

--- a/lxd/init.go
+++ b/lxd/init.go
@@ -13,9 +13,9 @@ import (
 
 type initDataNode struct {
 	api.ServerPut `yaml:",inline"`
-	Networks      []api.NetworksPost     `json:"networks" yaml:"networks"`
-	StoragePools  []api.StoragePoolsPost `json:"storage_pools" yaml:"storage_pools"`
-	Profiles      []api.ProfilesPost     `json:"profiles" yaml:"profiles"`
+	Networks      []internalClusterPostNetwork `json:"networks" yaml:"networks"`
+	StoragePools  []api.StoragePoolsPost       `json:"storage_pools" yaml:"storage_pools"`
+	Profiles      []api.ProfilesPost           `json:"profiles" yaml:"profiles"`
 }
 
 type initDataCluster struct {

--- a/lxd/main_init_auto.go
+++ b/lxd/main_init_auto.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/lxd/project"
 	storageDrivers "github.com/lxc/lxd/lxd/storage/drivers"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -153,8 +154,9 @@ func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServe
 		}
 
 		// Define the new network
-		network := api.NetworksPost{}
+		network := internalClusterPostNetwork{}
 		network.Name = fmt.Sprintf("lxdbr%d", idx)
+		network.Project = project.Default
 		config.Networks = append(config.Networks, network)
 
 		// Add it to the profile

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -31,7 +31,7 @@ func (c *cmdInit) RunInteractive(cmd *cobra.Command, args []string, d lxd.Instan
 	// Initialize config
 	config := cmdInitData{}
 	config.Node.Config = map[string]interface{}{}
-	config.Node.Networks = []api.NetworksPost{}
+	config.Node.Networks = []internalClusterPostNetwork{}
 	config.Node.StoragePools = []api.StoragePoolsPost{}
 	config.Node.Profiles = []api.ProfilesPost{
 		{

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -365,7 +365,7 @@ func (c *cmdInit) askNetworking(config *cmdInitData, d lxd.InstanceServer) error
 		net.Project = project.Default
 
 		// Network name
-		net.Name = cli.AskString("What should the new bridge be called? [default=lxdbr0]: ", "lxdbr0", func(netName string) error { return network.ValidateName(netName, "bridge") })
+		net.Name = cli.AskString("What should the new bridge be called? [default=lxdbr0]: ", "lxdbr0", func(netName string) error { return network.ValidateNameAndProject(netName, project.Default, "bridge") })
 		_, _, err := d.GetNetwork(net.Name)
 		if err == nil {
 			fmt.Printf("The requested network bridge \"%s\" already exists. Please choose another name.\n", net.Name)

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -18,6 +18,7 @@ import (
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/network"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -310,8 +311,9 @@ func (c *cmdInit) askNetworking(config *cmdInitData, d lxd.InstanceServer) error
 			}
 		} else if config.Cluster != nil && fanKernel && cli.AskBool("Would you like to create a new Fan overlay network? (yes/no) [default=yes]: ", "yes") {
 			// Define the network
-			networkPost := api.NetworksPost{}
+			networkPost := internalClusterPostNetwork{}
 			networkPost.Name = "lxdfan0"
+			networkPost.Project = project.Default
 			networkPost.Config = map[string]string{
 				"bridge.mode": "fan",
 			}
@@ -358,8 +360,9 @@ func (c *cmdInit) askNetworking(config *cmdInitData, d lxd.InstanceServer) error
 
 	for {
 		// Define the network
-		net := api.NetworksPost{}
+		net := internalClusterPostNetwork{}
 		net.Config = map[string]string{}
+		net.Project = project.Default
 
 		// Network name
 		net.Name = cli.AskString("What should the new bridge be called? [default=lxdbr0]: ", "lxdbr0", func(netName string) error { return network.ValidateName(netName, "bridge") })

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -20,6 +20,11 @@ import (
 	"github.com/lxc/lxd/shared/validate"
 )
 
+// Info represents information about a network driver.
+type Info struct {
+	Projects bool // Indicates if driver can be used in network enabled projects.
+}
+
 // common represents a generic LXD network.
 type common struct {
 	logger      logger.Logger
@@ -128,6 +133,13 @@ func (n *common) Type() string {
 // Config returns the network config.
 func (n *common) Config() map[string]string {
 	return n.config
+}
+
+// Config returns the common network driver info.
+func (n *common) Info() Info {
+	return Info{
+		Projects: false,
+	}
 }
 
 // IsUsed returns whether the network is used by any instances or profiles.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -63,6 +63,13 @@ type ovn struct {
 	common
 }
 
+// Config returns the network driver info.
+func (n *ovn) Info() Info {
+	return Info{
+		Projects: true,
+	}
+}
+
 // Validate network config.
 func (n *ovn) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -620,17 +620,21 @@ func (n *ovn) startParentPortBridge(parentNet Network) error {
 // deleteParentPort deletes the parent uplink connection.
 func (n *ovn) deleteParentPort() error {
 	// Parent network must be in default project.
-	parentNet, err := LoadByName(n.state, project.Default, n.config["network"])
-	if err != nil {
-		return errors.Wrapf(err, "Failed loading parent network")
+	if n.config["network"] != "" {
+		parentNet, err := LoadByName(n.state, project.Default, n.config["network"])
+		if err != nil {
+			return errors.Wrapf(err, "Failed loading parent network")
+		}
+
+		switch parentNet.Type() {
+		case "bridge":
+			return n.deleteParentPortBridge(parentNet)
+		}
+
+		return fmt.Errorf("Network type %q unsupported as OVN parent", parentNet.Type())
 	}
 
-	switch parentNet.Type() {
-	case "bridge":
-		return n.deleteParentPortBridge(parentNet)
-	}
-
-	return fmt.Errorf("Network type %q unsupported as OVN parent", parentNet.Type())
+	return nil
 }
 
 // deleteParentPortBridge deletes the dnsmasq static lease and removes parent uplink OVS bridge if not in use.

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -14,6 +14,7 @@ type Network interface {
 	// Load.
 	init(state *state.State, id int64, projectName string, name string, netType string, description string, config map[string]string, status string)
 	fillConfig(config map[string]string) error
+	Info() Info
 
 	// Config.
 	ValidateName(name string) error

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -186,7 +186,7 @@ func UsedBy(s *state.State, networkProjectName string, networkName string, first
 // Checks if the device's parent or network properties match the network name.
 func isInUseByInstance(s *state.State, inst instance.Instance, networkProjectName string, networkName string) (bool, error) {
 	// Get the translated network project name from the instance's project.
-	instNetworkProjectName, err := project.NetworkProject(s.Cluster, inst.Project())
+	instNetworkProjectName, _, err := project.NetworkProject(s.Cluster, inst.Project())
 	if err != nil {
 		return false, err
 	}
@@ -204,7 +204,7 @@ func isInUseByInstance(s *state.State, inst instance.Instance, networkProjectNam
 // Checks if the device's parent or network properties match the network name.
 func isInUseByProfile(s *state.State, profile db.Profile, networkProjectName string, networkName string) (bool, error) {
 	// Get the translated network project name from the profiles's project.
-	profileNetworkProjectName, err := project.NetworkProject(s.Cluster, profile.Project)
+	profileNetworkProjectName, _, err := project.NetworkProject(s.Cluster, profile.Project)
 	if err != nil {
 		return false, err
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -150,7 +150,7 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		req.Config = map[string]string{}
 	}
 
-	err = network.ValidateName(req.Name, req.Type)
+	err = network.ValidateNameAndProject(req.Name, projectName, req.Type)
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -608,7 +608,7 @@ func networkPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("New network name not provided"))
 	}
 
-	err = network.ValidateName(req.Name, n.Type())
+	err = network.ValidateNameAndProject(req.Name, projectName, n.Type())
 	if err != nil {
 		return response.BadRequest(err)
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -67,7 +67,7 @@ var networkStateCmd = APIEndpoint{
 
 // API endpoints
 func networksGet(d *Daemon, r *http.Request) response.Response {
-	projectName, err := project.NetworkProject(d.State().Cluster, projectParam(r))
+	projectName, _, err := project.NetworkProject(d.State().Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -437,7 +437,7 @@ func networkGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, err := project.NetworkProject(d.State().Cluster, projectParam(r))
+	projectName, _, err := project.NetworkProject(d.State().Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -533,7 +533,7 @@ func doNetworkGet(d *Daemon, projectName string, name string) (api.Network, erro
 }
 
 func networkDelete(d *Daemon, r *http.Request) response.Response {
-	projectName, err := project.NetworkProject(d.State().Cluster, projectParam(r))
+	projectName, _, err := project.NetworkProject(d.State().Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -610,7 +610,7 @@ func networkPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	projectName, err := project.NetworkProject(d.State().Cluster, projectParam(r))
+	projectName, _, err := project.NetworkProject(d.State().Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -671,7 +671,7 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	projectName, err := project.NetworkProject(d.State().Cluster, projectParam(r))
+	projectName, _, err := project.NetworkProject(d.State().Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -796,7 +796,7 @@ func networkLeasesGet(d *Daemon, r *http.Request) response.Response {
 	instProjectName := projectParam(r)
 
 	// The project we should use the load the network.
-	networkProjectName, err := project.NetworkProject(d.State().Cluster, instProjectName)
+	networkProjectName, _, err := project.NetworkProject(d.State().Cluster, instProjectName)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/project/project.go
+++ b/lxd/project/project.go
@@ -101,8 +101,9 @@ func StorageVolumeProject(c *db.Cluster, projectName string, volumeType int) (st
 
 // NetworkProject returns the project name to use for the network based on the requested project.
 // If the project specified has the "features.networks" flag enabled then the project name is returned,
-// otherwise the default project name is returned.
-func NetworkProject(c *db.Cluster, projectName string) (string, error) {
+// otherwise the default project name is returned. The second return value is the project's config if non-default
+// project is being returned, nil if not.
+func NetworkProject(c *db.Cluster, projectName string) (string, map[string]string, error) {
 	var project *api.Project
 	var err error
 
@@ -116,14 +117,14 @@ func NetworkProject(c *db.Cluster, projectName string) (string, error) {
 	})
 
 	if err != nil {
-		return "", errors.Wrapf(err, "Failed to load project %q", projectName)
+		return "", nil, errors.Wrapf(err, "Failed to load project %q", projectName)
 	}
 
 	// Networks only use the project specified if the project has the features.networks feature enabled,
 	// otherwise the legacy behaviour of using the default project for networks is used.
 	if shared.IsTrue(project.Config["features.networks"]) {
-		return projectName, nil
+		return projectName, project.Config, nil
 	}
 
-	return Default, nil
+	return Default, nil, nil
 }

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -409,7 +409,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -905,8 +905,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2001,7 +2001,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2073,9 +2073,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2087,7 +2091,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2235,7 +2240,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2474,7 +2479,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2562,7 +2567,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2757,11 +2762,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2868,7 +2873,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3039,7 +3044,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3232,7 +3237,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3277,7 +3282,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3366,7 +3371,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3494,7 +3500,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4151,7 +4157,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4191,7 +4197,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4332,7 +4338,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -409,7 +409,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -905,8 +905,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2001,7 +2001,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2073,9 +2073,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2087,7 +2091,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2235,7 +2240,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2474,7 +2479,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2562,7 +2567,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2757,11 +2762,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2868,7 +2873,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3039,7 +3044,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3232,7 +3237,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3277,7 +3282,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3366,7 +3371,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3494,7 +3500,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4151,7 +4157,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4191,7 +4197,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4332,7 +4338,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
@@ -1087,8 +1087,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1366,7 +1366,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Export instances as backup tarballs."
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2266,7 +2266,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 #, fuzzy
 msgid "Missing project name"
 msgstr "Profilname kann nicht geändert werden"
@@ -2345,9 +2345,13 @@ msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2359,7 +2363,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2512,7 +2517,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2675,7 +2680,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Project %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -2760,7 +2765,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -2854,7 +2859,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 #, fuzzy
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -2966,7 +2971,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -3060,12 +3065,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -3179,7 +3184,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3360,7 +3365,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3560,7 +3565,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3608,7 +3613,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3708,7 +3713,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3865,7 +3871,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4695,7 +4701,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4769,7 +4775,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 #, fuzzy
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -4840,7 +4846,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4907,7 +4913,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 #, fuzzy
 msgid "switch [<remote>:]<project>"
 msgstr ""
@@ -4968,7 +4974,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 #, fuzzy
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -412,7 +412,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -909,8 +909,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1168,7 +1168,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2010,7 +2010,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2082,9 +2082,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2096,7 +2100,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2246,7 +2251,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2404,7 +2409,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2485,7 +2490,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2573,7 +2578,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2678,7 +2683,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2768,11 +2773,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2879,7 +2884,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3050,7 +3055,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3243,7 +3248,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3288,7 +3293,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3377,7 +3382,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3505,7 +3511,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4162,7 +4168,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4202,7 +4208,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4250,7 +4256,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4294,7 +4300,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4343,7 +4349,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -536,7 +536,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1045,8 +1045,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1305,7 +1305,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Export instances as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -1506,7 +1506,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2152,7 +2152,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nombre del contenedor es: %s"
@@ -2226,9 +2226,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2240,7 +2244,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2388,7 +2393,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2549,7 +2554,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2630,7 +2635,7 @@ msgstr "Refrescando la imagen: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2719,7 +2724,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2826,7 +2831,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2916,11 +2921,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -3027,7 +3032,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3198,7 +3203,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3391,7 +3396,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3436,7 +3441,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3525,7 +3530,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3658,7 +3664,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4336,7 +4342,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4380,7 +4386,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4431,7 +4437,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4479,7 +4485,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 #, fuzzy
 msgid "switch [<remote>:]<project>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4531,7 +4537,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -409,7 +409,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -905,8 +905,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2001,7 +2001,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2073,9 +2073,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2087,7 +2091,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2235,7 +2240,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2474,7 +2479,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2562,7 +2567,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2757,11 +2762,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2868,7 +2873,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3039,7 +3044,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3232,7 +3237,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3277,7 +3282,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3366,7 +3371,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3494,7 +3500,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4151,7 +4157,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4191,7 +4197,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4332,7 +4338,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -409,7 +409,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -905,8 +905,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2001,7 +2001,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2073,9 +2073,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2087,7 +2091,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2235,7 +2240,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2474,7 +2479,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2562,7 +2567,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2757,11 +2762,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2868,7 +2873,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3039,7 +3044,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3232,7 +3237,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3277,7 +3282,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3366,7 +3371,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3494,7 +3500,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4151,7 +4157,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4191,7 +4197,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4332,7 +4338,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
@@ -1098,8 +1098,8 @@ msgstr "Copie de l'image : %s"
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1379,7 +1379,7 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Export instances as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -1592,7 +1592,7 @@ msgstr "Pid : %d"
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2326,7 +2326,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nom de l'ensemble de stockage"
@@ -2407,10 +2407,14 @@ msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
 msgstr "NOM"
+
+#: lxc/project.go:464
+msgid "NETWORKS"
+msgstr ""
 
 #: lxc/info.go:380
 msgid "NIC:"
@@ -2421,7 +2425,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr "NON"
 
@@ -2581,7 +2586,7 @@ msgstr "PID"
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr "PROFILS"
 
@@ -2745,7 +2750,7 @@ msgstr "Profil %s créé"
 msgid "Project %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -2831,7 +2836,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -2924,7 +2929,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 #, fuzzy
 msgid "Rename projects"
 msgstr "Créé : %s"
@@ -3038,7 +3043,7 @@ msgstr "ÉTAT"
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 #, fuzzy
 msgid "STORAGE VOLUMES"
 msgstr "ENSEMBLE DE STOCKAGE"
@@ -3135,12 +3140,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -3258,7 +3263,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show profile configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 #, fuzzy
 msgid "Show project options"
 msgstr "Afficher la configuration étendue"
@@ -3441,7 +3446,7 @@ msgstr "Swap (courant)"
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 #, fuzzy
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -3649,7 +3654,7 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
@@ -3699,7 +3704,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3797,7 +3802,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr "OUI"
 
@@ -3958,7 +3964,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -4848,7 +4854,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4928,7 +4934,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 #, fuzzy
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -5008,7 +5014,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -5085,7 +5091,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 #, fuzzy
 msgid "switch [<remote>:]<project>"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -5143,7 +5149,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 #, fuzzy
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -409,7 +409,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -905,8 +905,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2001,7 +2001,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2073,9 +2073,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2087,7 +2091,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2235,7 +2240,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2474,7 +2479,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2562,7 +2567,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2757,11 +2762,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2868,7 +2873,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3039,7 +3044,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3232,7 +3237,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3277,7 +3282,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3366,7 +3371,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3494,7 +3500,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4151,7 +4157,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4191,7 +4197,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4332,7 +4338,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -409,7 +409,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -905,8 +905,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2001,7 +2001,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2073,9 +2073,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2087,7 +2091,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2235,7 +2240,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2474,7 +2479,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2562,7 +2567,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2757,11 +2762,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2868,7 +2873,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3039,7 +3044,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3232,7 +3237,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3277,7 +3282,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3366,7 +3371,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3494,7 +3500,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4151,7 +4157,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4191,7 +4197,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4332,7 +4338,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -527,7 +527,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1034,8 +1034,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1295,7 +1295,7 @@ msgstr "Creazione del container in corso"
 msgid "Export instances as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -1496,7 +1496,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2147,7 +2147,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 #, fuzzy
 msgid "Missing project name"
 msgstr "Il nome del container è: %s"
@@ -2220,9 +2220,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2234,7 +2238,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2382,7 +2387,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2542,7 +2547,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2624,7 +2629,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -2714,7 +2719,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2821,7 +2826,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2911,11 +2916,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -3022,7 +3027,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3195,7 +3200,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3389,7 +3394,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3435,7 +3440,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3524,7 +3529,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3659,7 +3665,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4337,7 +4343,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4381,7 +4387,7 @@ msgstr "Creazione del container in corso"
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4432,7 +4438,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4480,7 +4486,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 #, fuzzy
 msgid "switch [<remote>:]<project>"
 msgstr "Creazione del container in corso"
@@ -4532,7 +4538,7 @@ msgstr "Creazione del container in corso"
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: 2020-07-31 19:11+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -539,7 +539,7 @@ msgstr "BASE IMAGE"
 msgid "Backing up instance: %s"
 msgstr "インスタンスのバックアップ中: %s"
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
@@ -1049,8 +1049,8 @@ msgstr "ストレージボリュームを削除します"
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1334,7 +1334,7 @@ msgstr "インスタンスのバックアップをエクスポートします"
 msgid "Export instances as backup tarballs."
 msgstr "インスタンスを tarball 形式のバックアップとしてエクスポートします。"
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -1550,7 +1550,7 @@ msgstr "ID: %d"
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr "IMAGES"
 
@@ -2310,7 +2310,7 @@ msgid "Missing profile name"
 msgstr "プロファイル名を指定する必要があります"
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr "プロジェクト名を指定する必要があります"
 
@@ -2387,10 +2387,14 @@ msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
 msgstr "NAME"
+
+#: lxc/project.go:464
+msgid "NETWORKS"
+msgstr ""
 
 #: lxc/info.go:380
 msgid "NIC:"
@@ -2401,7 +2405,8 @@ msgid "NICs:"
 msgstr "NICs:"
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr "NO"
 
@@ -2549,7 +2554,7 @@ msgstr "PID"
 msgid "PROCESSES"
 msgstr "PROCESSES"
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr "PROFILES"
 
@@ -2707,7 +2712,7 @@ msgstr "プロジェクト %s を作成しました"
 msgid "Project %s deleted"
 msgstr "プロジェクト %s を削除しました"
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr "プロジェクト名 %s を %s に変更しました"
@@ -2788,7 +2793,7 @@ msgstr "イメージの更新中: %s"
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2876,7 +2881,7 @@ msgstr "ネットワーク名を変更します"
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
@@ -2988,7 +2993,7 @@ msgstr "STATUS"
 msgid "STORAGE POOL"
 msgstr "STORAGE POOL"
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr "STORAGE VOLUMES"
 
@@ -3101,11 +3106,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr "プロジェクトの設定項目を設定します"
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -3225,7 +3230,7 @@ msgstr "ネットワークの設定を表示します"
 msgid "Show profile configurations"
 msgstr "プロファイルの設定を表示します"
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr "プロジェクトの設定を表示します"
 
@@ -3396,7 +3401,7 @@ msgstr "Swap (現在値)"
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
@@ -3614,7 +3619,7 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr "USED BY"
@@ -3660,7 +3665,7 @@ msgstr "ネットワークの設定を削除します"
 msgid "Unset profile configuration keys"
 msgstr "プロファイルの設定を削除します"
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr "プロジェクトの設定を削除します"
 
@@ -3755,7 +3760,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr "インスタンスの稼動状態のスナップショットを取得するかどうか"
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr "YES"
 
@@ -3890,7 +3896,7 @@ msgstr "create [<remote>:]<profile>"
 msgid "create [<remote>:]<project>"
 msgstr "create [<remote>:]<project>"
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr "現在値"
 
@@ -4683,7 +4689,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr "rename [<remote>:]<profile> <new-name>"
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr "rename [<remote>:]<project> <new-name>"
 
@@ -4725,7 +4731,7 @@ msgstr "set [<remote>:]<instance|profile> <device> <key>=<value>..."
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr "set [<remote>:]<profile> <key><value>..."
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr "set [<remote>:]<project> <key>=<value>..."
 
@@ -4773,7 +4779,7 @@ msgstr "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgid "show [<remote>:]<profile>"
 msgstr "show [<remote>:]<profile>"
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr "show [<remote>:]<project>"
 
@@ -4817,7 +4823,7 @@ msgstr "storage"
 msgid "switch <remote>"
 msgstr "switch <remote>"
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr "switch [<remote>:] <project>"
 
@@ -4868,7 +4874,7 @@ msgstr "unset [<remote>:]<instance|profile> <device> <key>"
 msgid "unset [<remote>:]<profile> <key>"
 msgstr "unset [<remote>:]<profile> <key>"
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr "unset [<remote>:]<project> <key>"
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -409,7 +409,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -905,8 +905,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2001,7 +2001,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2073,9 +2073,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2087,7 +2091,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2235,7 +2240,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2474,7 +2479,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2562,7 +2567,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2757,11 +2762,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2868,7 +2873,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3039,7 +3044,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3232,7 +3237,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3277,7 +3282,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3366,7 +3371,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3494,7 +3500,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4151,7 +4157,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4191,7 +4197,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4332,7 +4338,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2020-09-09 14:18-0400\n"
+        "POT-Creation-Date: 2020-09-14 14:06+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -395,7 +395,7 @@ msgstr  ""
 msgid   "Backing up instance: %s"
 msgstr  ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid   "Backup exported successfully!"
 msgstr  ""
 
@@ -839,7 +839,7 @@ msgstr  ""
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154 lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422 lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52 lxc/config_metadata.go:174 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:129 lxc/image.go:277 lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840 lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20 lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109 lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379 lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730 lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024 lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384 lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620 lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539 lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651 lxc/storage.go:735 lxc/storage_volume.go:33 lxc/storage_volume.go:140 lxc/storage_volume.go:223 lxc/storage_volume.go:310 lxc/storage_volume.go:472 lxc/storage_volume.go:551 lxc/storage_volume.go:627 lxc/storage_volume.go:709 lxc/storage_volume.go:790 lxc/storage_volume.go:990 lxc/storage_volume.go:1081 lxc/storage_volume.go:1161 lxc/storage_volume.go:1192 lxc/storage_volume.go:1305 lxc/storage_volume.go:1381 lxc/storage_volume.go:1480 lxc/storage_volume.go:1513 lxc/storage_volume.go:1589 lxc/version.go:22
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154 lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422 lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52 lxc/config_metadata.go:174 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:129 lxc/image.go:277 lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840 lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20 lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109 lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379 lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730 lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024 lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384 lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626 lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539 lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651 lxc/storage.go:735 lxc/storage_volume.go:33 lxc/storage_volume.go:140 lxc/storage_volume.go:223 lxc/storage_volume.go:310 lxc/storage_volume.go:472 lxc/storage_volume.go:551 lxc/storage_volume.go:627 lxc/storage_volume.go:709 lxc/storage_volume.go:790 lxc/storage_volume.go:990 lxc/storage_volume.go:1081 lxc/storage_volume.go:1161 lxc/storage_volume.go:1192 lxc/storage_volume.go:1305 lxc/storage_volume.go:1381 lxc/storage_volume.go:1480 lxc/storage_volume.go:1513 lxc/storage_volume.go:1589 lxc/version.go:22
 msgid   "Description"
 msgstr  ""
 
@@ -1071,7 +1071,7 @@ msgstr  ""
 msgid   "Export instances as backup tarballs."
 msgstr  ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -1261,7 +1261,7 @@ msgstr  ""
 msgid   "ID: %s"
 msgstr  ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid   "IMAGES"
 msgstr  ""
 
@@ -1866,7 +1866,7 @@ msgstr  ""
 msgid   "Missing profile name"
 msgstr  ""
 
-#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358 lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358 lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid   "Missing project name"
 msgstr  ""
 
@@ -1935,8 +1935,12 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620 lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558 lxc/storage_volume.go:1136
+#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558 lxc/storage_volume.go:1136
 msgid   "NAME"
+msgstr  ""
+
+#: lxc/project.go:464
+msgid   "NETWORKS"
 msgstr  ""
 
 #: lxc/info.go:380
@@ -1947,7 +1951,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429 lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429 lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480 lxc/remote.go:485
 msgid   "NO"
 msgstr  ""
 
@@ -2095,7 +2099,7 @@ msgstr  ""
 msgid   "PROCESSES"
 msgstr  ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid   "PROFILES"
 msgstr  ""
 
@@ -2251,7 +2255,7 @@ msgstr  ""
 msgid   "Project %s deleted"
 msgstr  ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid   "Project %s renamed to %s"
 msgstr  ""
@@ -2332,7 +2336,7 @@ msgstr  ""
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671 lxc/remote.go:709
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671 lxc/remote.go:709
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
@@ -2418,7 +2422,7 @@ msgstr  ""
 msgid   "Rename profiles"
 msgstr  ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid   "Rename projects"
 msgstr  ""
 
@@ -2521,7 +2525,7 @@ msgstr  ""
 msgid   "STORAGE POOL"
 msgstr  ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid   "STORAGE VOLUMES"
 msgstr  ""
 
@@ -2601,11 +2605,11 @@ msgid   "Set profile configuration keys\n"
         "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr  ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid   "Set project configuration keys"
 msgstr  ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid   "Set project configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -2706,7 +2710,7 @@ msgstr  ""
 msgid   "Show profile configurations"
 msgstr  ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid   "Show project options"
 msgstr  ""
 
@@ -2877,7 +2881,7 @@ msgstr  ""
 msgid   "Swap (peak)"
 msgstr  ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid   "Switch the current project"
 msgstr  ""
 
@@ -3058,7 +3062,7 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567 lxc/storage_volume.go:1139
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567 lxc/storage_volume.go:1139
 msgid   "USED BY"
 msgstr  ""
 
@@ -3102,7 +3106,7 @@ msgstr  ""
 msgid   "Unset profile configuration keys"
 msgstr  ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid   "Unset project configuration keys"
 msgstr  ""
 
@@ -3186,7 +3190,7 @@ msgstr  ""
 msgid   "Whether or not to snapshot the instance's running state"
 msgstr  ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431 lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431 lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482 lxc/remote.go:487
 msgid   "YES"
 msgstr  ""
 
@@ -3310,7 +3314,7 @@ msgstr  ""
 msgid   "create [<remote>:]<project>"
 msgstr  ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid   "current"
 msgstr  ""
 
@@ -3914,7 +3918,7 @@ msgstr  ""
 msgid   "rename [<remote>:]<profile> <new-name>"
 msgstr  ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid   "rename [<remote>:]<project> <new-name>"
 msgstr  ""
 
@@ -3954,7 +3958,7 @@ msgstr  ""
 msgid   "set [<remote>:]<profile> <key><value>..."
 msgstr  ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid   "set [<remote>:]<project> <key>=<value>..."
 msgstr  ""
 
@@ -4002,7 +4006,7 @@ msgstr  ""
 msgid   "show [<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid   "show [<remote>:]<project>"
 msgstr  ""
 
@@ -4046,7 +4050,7 @@ msgstr  ""
 msgid   "switch <remote>"
 msgstr  ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid   "switch [<remote>:]<project>"
 msgstr  ""
 
@@ -4095,7 +4099,7 @@ msgstr  ""
 msgid   "unset [<remote>:]<profile> <key>"
 msgstr  ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid   "unset [<remote>:]<project> <key>"
 msgstr  ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -409,7 +409,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -905,8 +905,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2001,7 +2001,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2073,9 +2073,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2087,7 +2091,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2235,7 +2240,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2474,7 +2479,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2562,7 +2567,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2757,11 +2762,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2868,7 +2873,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3039,7 +3044,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3232,7 +3237,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3277,7 +3282,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3366,7 +3371,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3494,7 +3500,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4151,7 +4157,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4191,7 +4197,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4332,7 +4338,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -526,7 +526,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1022,8 +1022,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1278,7 +1278,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1478,7 +1478,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2118,7 +2118,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2190,9 +2190,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2204,7 +2208,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2352,7 +2357,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2510,7 +2515,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2591,7 +2596,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2679,7 +2684,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2784,7 +2789,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2874,11 +2879,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2985,7 +2990,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3156,7 +3161,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3349,7 +3354,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3394,7 +3399,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3483,7 +3488,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3611,7 +3617,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4268,7 +4274,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4308,7 +4314,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4356,7 +4362,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4400,7 +4406,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4449,7 +4455,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -409,7 +409,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -905,8 +905,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2001,7 +2001,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2073,9 +2073,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2087,7 +2091,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2235,7 +2240,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2474,7 +2479,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2562,7 +2567,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2757,11 +2762,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2868,7 +2873,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3039,7 +3044,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3232,7 +3237,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3277,7 +3282,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3366,7 +3371,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3494,7 +3500,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4151,7 +4157,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4191,7 +4197,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4332,7 +4338,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -536,7 +536,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1032,8 +1032,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1288,7 +1288,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1488,7 +1488,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2128,7 +2128,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2200,9 +2200,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2214,7 +2218,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2362,7 +2367,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2520,7 +2525,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2601,7 +2606,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2689,7 +2694,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2794,7 +2799,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2884,11 +2889,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2995,7 +3000,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3166,7 +3171,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3359,7 +3364,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3404,7 +3409,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3493,7 +3498,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3621,7 +3627,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4278,7 +4284,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4318,7 +4324,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4366,7 +4372,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4410,7 +4416,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4459,7 +4465,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -550,7 +550,7 @@ msgstr "IMAGEM BASE"
 msgid "Backing up instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
@@ -1069,8 +1069,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2187,7 +2187,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2259,9 +2259,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2273,7 +2277,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2421,7 +2426,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2583,7 +2588,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2665,7 +2670,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2754,7 +2759,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2860,7 +2865,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2952,12 +2957,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -3069,7 +3074,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3241,7 +3246,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3434,7 +3439,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3482,7 +3487,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3572,7 +3577,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3700,7 +3706,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4357,7 +4363,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4397,7 +4403,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4445,7 +4451,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4489,7 +4495,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4538,7 +4544,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: 2020-08-02 01:42+0000\n"
 "Last-Translator: Anthony <aemeltsev@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -541,7 +541,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr "Копирование образа: %s"
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1320,7 +1320,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Export instances as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -1520,7 +1520,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2178,7 +2178,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 #, fuzzy
 msgid "Missing project name"
 msgstr "Имя контейнера: %s"
@@ -2253,9 +2253,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2267,7 +2271,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2418,7 +2423,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2576,7 +2581,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2658,7 +2663,7 @@ msgstr "Копирование образа: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2748,7 +2753,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2858,7 +2863,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2948,11 +2953,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -3061,7 +3066,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3236,7 +3241,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3429,7 +3434,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3474,7 +3479,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3563,7 +3568,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3716,7 +3722,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4525,7 +4531,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4597,7 +4603,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 #, fuzzy
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -4665,7 +4671,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4729,7 +4735,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 #, fuzzy
 msgid "switch [<remote>:]<project>"
 msgstr ""
@@ -4790,7 +4796,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 #, fuzzy
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -409,7 +409,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -905,8 +905,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2001,7 +2001,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2073,9 +2073,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2087,7 +2091,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2235,7 +2240,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2474,7 +2479,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2562,7 +2567,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2757,11 +2762,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2868,7 +2873,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3039,7 +3044,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3232,7 +3237,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3277,7 +3282,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3366,7 +3371,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3494,7 +3500,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4151,7 +4157,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4191,7 +4197,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4332,7 +4338,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -409,7 +409,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -905,8 +905,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2001,7 +2001,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2073,9 +2073,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2087,7 +2091,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2235,7 +2240,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2474,7 +2479,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2562,7 +2567,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2757,11 +2762,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2868,7 +2873,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3039,7 +3044,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3232,7 +3237,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3277,7 +3282,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3366,7 +3371,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3494,7 +3500,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4151,7 +4157,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4191,7 +4197,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4332,7 +4338,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -409,7 +409,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -905,8 +905,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2001,7 +2001,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2073,9 +2073,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2087,7 +2091,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2235,7 +2240,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2474,7 +2479,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2562,7 +2567,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2757,11 +2762,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2868,7 +2873,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3039,7 +3044,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3232,7 +3237,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3277,7 +3282,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3366,7 +3371,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3494,7 +3500,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4151,7 +4157,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4191,7 +4197,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4332,7 +4338,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -409,7 +409,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -905,8 +905,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2001,7 +2001,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2073,9 +2073,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2087,7 +2091,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2235,7 +2240,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2474,7 +2479,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2562,7 +2567,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2757,11 +2762,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2868,7 +2873,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3039,7 +3044,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3232,7 +3237,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3277,7 +3282,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3366,7 +3371,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3494,7 +3500,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4151,7 +4157,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4191,7 +4197,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4332,7 +4338,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -409,7 +409,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -905,8 +905,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2001,7 +2001,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2073,9 +2073,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2087,7 +2091,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2235,7 +2240,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2474,7 +2479,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2562,7 +2567,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2757,11 +2762,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2868,7 +2873,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3039,7 +3044,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3232,7 +3237,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3277,7 +3282,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3366,7 +3371,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3494,7 +3500,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4151,7 +4157,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4191,7 +4197,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4332,7 +4338,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -409,7 +409,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -905,8 +905,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2001,7 +2001,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2073,9 +2073,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2087,7 +2091,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2235,7 +2240,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2474,7 +2479,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2562,7 +2567,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2757,11 +2762,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2868,7 +2873,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3039,7 +3044,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3232,7 +3237,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3277,7 +3282,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3366,7 +3371,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3494,7 +3500,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4151,7 +4157,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4191,7 +4197,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4332,7 +4338,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -409,7 +409,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -905,8 +905,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2001,7 +2001,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2073,9 +2073,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2087,7 +2091,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2235,7 +2240,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2474,7 +2479,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2562,7 +2567,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2757,11 +2762,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2868,7 +2873,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3039,7 +3044,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3232,7 +3237,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3277,7 +3282,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3366,7 +3371,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3494,7 +3500,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4151,7 +4157,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4191,7 +4197,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4332,7 +4338,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-09 14:18-0400\n"
+"POT-Creation-Date: 2020-09-14 14:06+0100\n"
 "PO-Revision-Date: 2018-09-11 19:15+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -412,7 +412,7 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/export.go:152
+#: lxc/export.go:158
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -908,8 +908,8 @@ msgstr ""
 #: lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762
 #: lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86
 #: lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384
-#: lxc/project.go:476 lxc/project.go:531 lxc/project.go:591 lxc/project.go:620
-#: lxc/project.go:673 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626
+#: lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:84 lxc/remote.go:423 lxc/remote.go:459 lxc/remote.go:539
 #: lxc/remote.go:601 lxc/remote.go:651 lxc/remote.go:689 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89
@@ -1164,7 +1164,7 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:136
+#: lxc/export.go:142
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:456
+#: lxc/project.go:461
 msgid "IMAGES"
 msgstr ""
 
@@ -2004,7 +2004,7 @@ msgid "Missing profile name"
 msgstr ""
 
 #: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
-#: lxc/project.go:500 lxc/project.go:558 lxc/project.go:644
+#: lxc/project.go:506 lxc/project.go:564 lxc/project.go:650
 msgid "Missing project name"
 msgstr ""
 
@@ -2076,9 +2076,13 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
-#: lxc/project.go:455 lxc/remote.go:517 lxc/storage.go:558
+#: lxc/project.go:460 lxc/remote.go:517 lxc/storage.go:558
 #: lxc/storage_volume.go:1136
 msgid "NAME"
+msgstr ""
+
+#: lxc/project.go:464
+msgid "NETWORKS"
 msgstr ""
 
 #: lxc/info.go:380
@@ -2090,7 +2094,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
-#: lxc/project.go:434 lxc/project.go:439 lxc/remote.go:480 lxc/remote.go:485
+#: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:480
+#: lxc/remote.go:485
 msgid "NO"
 msgstr ""
 
@@ -2238,7 +2243,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:457
+#: lxc/list.go:438 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:515
+#: lxc/project.go:521
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2477,7 +2482,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:699 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
+#: lxc/project.go:705 lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:671
 #: lxc/remote.go:709
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -2565,7 +2570,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:475 lxc/project.go:476
+#: lxc/project.go:481 lxc/project.go:482
 msgid "Rename projects"
 msgstr ""
 
@@ -2670,7 +2675,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:458
+#: lxc/project.go:463
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -2760,11 +2765,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:530
+#: lxc/project.go:536
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:531
+#: lxc/project.go:537
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2871,7 +2876,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:619 lxc/project.go:620
+#: lxc/project.go:625 lxc/project.go:626
 msgid "Show project options"
 msgstr ""
 
@@ -3042,7 +3047,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:672 lxc/project.go:673
+#: lxc/project.go:678 lxc/project.go:679
 msgid "Switch the current project"
 msgstr ""
 
@@ -3235,7 +3240,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:459 lxc/storage.go:567
+#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:567
 #: lxc/storage_volume.go:1139
 msgid "USED BY"
 msgstr ""
@@ -3280,7 +3285,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:590 lxc/project.go:591
+#: lxc/project.go:596 lxc/project.go:597
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -3369,7 +3374,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
-#: lxc/project.go:436 lxc/project.go:441 lxc/remote.go:482 lxc/remote.go:487
+#: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:482
+#: lxc/remote.go:487
 msgid "YES"
 msgstr ""
 
@@ -3497,7 +3503,7 @@ msgstr ""
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:451
 msgid "current"
 msgstr ""
 
@@ -4154,7 +4160,7 @@ msgstr ""
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:473
+#: lxc/project.go:479
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4194,7 +4200,7 @@ msgstr ""
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:529
+#: lxc/project.go:535
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4242,7 +4248,7 @@ msgstr ""
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:618
+#: lxc/project.go:624
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:671
+#: lxc/project.go:677
 msgid "switch [<remote>:]<project>"
 msgstr ""
 
@@ -4335,7 +4341,7 @@ msgstr ""
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 


### PR DESCRIPTION
- Allows networks to be created under projects.
- Adds helper to translate a project to a network's project based on whether `features.networks` is enabled in the project.
- Adds concept of project to all network related functionality.
- Sends project parameter when notifying cluster nodes of network changes.
- Restricts project networks to OVN type networks only.
- Adds support for project `limits.networks` setting.
- Creates projects on local node as part of cluster pre-join process to allow networks in projects to be created.

Includes https://github.com/lxc/lxd/pull/7821