### PR TITLE
Network: Use CanonicalNetworkAddressFromAddressAndPort rather than manual fmt.Sprintf

### DIFF
--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -193,7 +193,7 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 		rHost = host
 		rPort = port
 	} else {
-		rPort = shared.DefaultPort
+		rPort = fmt.Sprintf("%d", shared.DefaultPort)
 	}
 
 	if rScheme == "unix" {

--- a/lxd-agent/main_agent.go
+++ b/lxd-agent/main_agent.go
@@ -118,7 +118,7 @@ func (c *cmdAgent) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Setup the listener.
-	l, err := vsock.Listen(8443)
+	l, err := vsock.Listen(shared.DefaultPort)
 	if err != nil {
 		return errors.Wrap(err, "Failed to listen on vsock")
 	}

--- a/lxd-p2c/utils.go
+++ b/lxd-p2c/utils.go
@@ -203,9 +203,9 @@ func parseURL(URL string) (string, error) {
 		}
 	}
 
-	// If no port was provided, use port 8443
+	// If no port was provided, use default port
 	if u.Port() == "" {
-		u.Host = fmt.Sprintf("%s:8443", u.Hostname())
+		u.Host = fmt.Sprintf("%s:%d", u.Hostname(), shared.DefaultPort)
 	}
 
 	return u.String(), nil

--- a/lxd/device/device_utils_proxy.go
+++ b/lxd/device/device_utils_proxy.go
@@ -3,6 +3,7 @@ package device
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
@@ -53,13 +54,7 @@ func ProxyParseAddr(addr string) (*deviceConfig.ProxyAddress, error) {
 		}
 
 		for i := int64(0); i < portRange; i++ {
-			var newAddr string
-			if strings.Contains(address, ":") {
-				// IPv6 addresses need to be enclosed in square brackets.
-				newAddr = fmt.Sprintf("[%s]:%d", address, portFirst+i)
-			} else {
-				newAddr = fmt.Sprintf("%s:%d", address, portFirst+i)
-			}
+			newAddr := net.JoinHostPort(address, strconv.Itoa(int(portFirst+i)))
 			newProxyAddr.Addr = append(newProxyAddr.Addr, newAddr)
 		}
 	}

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -54,7 +54,7 @@ func (c *cmdInit) Command() *cobra.Command {
 	cmd.Flags().BoolVar(&c.flagDump, "dump", false, "Dump YAML config to stdout")
 
 	cmd.Flags().StringVar(&c.flagNetworkAddress, "network-address", "", "Address to bind LXD to (default: none)"+"``")
-	cmd.Flags().IntVar(&c.flagNetworkPort, "network-port", -1, "Port to bind LXD to (default: 8443)"+"``")
+	cmd.Flags().IntVar(&c.flagNetworkPort, "network-port", -1, fmt.Sprintf("Port to bind LXD to (default: %d)"+"``", shared.DefaultPort))
 	cmd.Flags().StringVar(&c.flagStorageBackend, "storage-backend", "", "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"+"``")
 	cmd.Flags().StringVar(&c.flagStorageDevice, "storage-create-device", "", "Setup device based storage using DEVICE"+"``")
 	cmd.Flags().IntVar(&c.flagStorageLoopSize, "storage-create-loop", -1, "Setup loop based storage with SIZE in GB"+"``")

--- a/lxd/main_init_auto.go
+++ b/lxd/main_init_auto.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lxc/lxd/client"
 	storageDrivers "github.com/lxc/lxd/lxd/storage/drivers"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -57,7 +58,7 @@ func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServe
 	}
 
 	if c.flagNetworkPort == -1 {
-		c.flagNetworkPort = 8443
+		c.flagNetworkPort = shared.DefaultPort
 	}
 
 	// Fill in the node configuration
@@ -66,7 +67,7 @@ func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServe
 
 	// Network listening
 	if c.flagNetworkAddress != "" {
-		config.Config["core.https_address"] = fmt.Sprintf("%s:%d", c.flagNetworkAddress, c.flagNetworkPort)
+		config.Config["core.https_address"] = util.CanonicalNetworkAddressFromAddressAndPort(c.flagNetworkAddress, c.flagNetworkPort)
 
 		if c.flagTrustPassword != "" {
 			config.Config["core.trust_password"] = c.flagTrustPassword

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -135,7 +135,7 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer) error
 
 			listener, err := net.Listen("tcp", address)
 			if err != nil {
-				return fmt.Errorf("Can't bind address %q: %v", address, err)
+				return errors.Wrapf(err, "Can't bind address %q", address)
 			}
 
 			listener.Close()

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -127,7 +127,7 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer) error
 
 			s, _, err := d.GetServer()
 			if err == nil {
-				if s.Config["cluster.https_address"] == value || s.Config["core.https_address"] == value {
+				if s.Config["cluster.https_address"] == address || s.Config["core.https_address"] == address {
 					// We already own the address, just move on.
 					return nil
 				}
@@ -153,7 +153,7 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer) error
 				clusterAddress := cli.AskString("IP address or FQDN of an existing cluster node: ", "", nil)
 				_, _, err := net.SplitHostPort(clusterAddress)
 				if err != nil {
-					clusterAddress = fmt.Sprintf("%s:8443", clusterAddress)
+					clusterAddress = fmt.Sprintf("%s:%d", clusterAddress, shared.DefaultPort)
 				}
 				config.Cluster.ClusterAddress = clusterAddress
 
@@ -674,8 +674,8 @@ they otherwise would.
 			netAddr = fmt.Sprintf("[%s]", netAddr)
 		}
 
-		netPort := cli.AskInt("Port to bind LXD to [default=8443]: ", 1, 65535, "8443", func(netPort int64) error {
-			address := fmt.Sprintf("%s:%d", netAddr, netPort)
+		netPort := cli.AskInt(fmt.Sprintf("Port to bind LXD to [default=%d]: ", shared.DefaultPort), 1, 65535, fmt.Sprintf("%d", shared.DefaultPort), func(netPort int64) error {
+			address := util.CanonicalNetworkAddressFromAddressAndPort(netAddr, int(netPort))
 
 			s, _, err := d.GetServer()
 			if err == nil {
@@ -693,7 +693,7 @@ they otherwise would.
 			listener.Close()
 			return nil
 		})
-		config.Node.Config["core.https_address"] = fmt.Sprintf("%s:%d", netAddr, netPort)
+		config.Node.Config["core.https_address"] = util.CanonicalNetworkAddressFromAddressAndPort(netAddr, int(netPort))
 		config.Node.Config["core.trust_password"] = cli.AskPassword("Trust password for new clients: ")
 		if config.Node.Config["core.trust_password"] == "" {
 			fmt.Printf("No password set, client certificates will have to be manually trusted.")

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -203,7 +203,7 @@ func ListenAddresses(value string) ([]string, error) {
 	localHost, localPort, err := net.SplitHostPort(value)
 	if err != nil {
 		localHost = value
-		localPort = shared.DefaultPort
+		localPort = fmt.Sprintf("%d", shared.DefaultPort)
 	}
 
 	if localHost == "0.0.0.0" || localHost == "::" || localHost == "[::]" {

--- a/lxd/util/net.go
+++ b/lxd/util/net.go
@@ -87,6 +87,14 @@ func CanonicalNetworkAddress(address string) string {
 	return address
 }
 
+// CanonicalNetworkAddressFromAddressAndPort returns a network address from separate address and port values.
+// The address accepts values such as "[::]", "::" and "localhost".
+func CanonicalNetworkAddressFromAddressAndPort(address string, port int) string {
+	// Because we accept just the host part of an IPv6 listen address (e.g. `[::]`) don't use net.JoinHostPort.
+	// If a bare IP address is supplied then CanonicalNetworkAddress will use net.JoinHostPort if needed.
+	return CanonicalNetworkAddress(fmt.Sprintf("%s:%d", address, port))
+}
+
 // ServerTLSConfig returns a new server-side tls.Config generated from the give
 // certificate info.
 func ServerTLSConfig(cert *shared.CertInfo) *tls.Config {

--- a/lxd/util/net.go
+++ b/lxd/util/net.go
@@ -68,19 +68,22 @@ func (a *inMemoryAddr) String() string {
 	return ""
 }
 
-// CanonicalNetworkAddress parses the given network address and returns a
-// string of the form "host:port", possibly filling it with the default port if
-// it's missing.
+// CanonicalNetworkAddress parses the given network address and returns a string of the form "host:port",
+// possibly filling it with the default port if it's missing.
 func CanonicalNetworkAddress(address string) string {
 	_, _, err := net.SplitHostPort(address)
 	if err != nil {
-		ip := net.ParseIP(address)
-		if ip != nil && ip.To4() == nil {
-			address = fmt.Sprintf("[%s]:%s", address, shared.DefaultPort)
+		if net.ParseIP(address) != nil {
+			// If the input address is a bare IP address, then convert it to a proper listen address
+			// using the default port and wrap IPv6 addresses in square brackets.
+			address = net.JoinHostPort(address, fmt.Sprintf("%d", shared.DefaultPort))
 		} else {
-			address = fmt.Sprintf("%s:%s", address, shared.DefaultPort)
+			// Otherwise assume this is either a host name or a partial address (e.g `[::]`) without
+			// a port number, so append the default port.
+			address = fmt.Sprintf("%s:%d", address, shared.DefaultPort)
 		}
 	}
+
 	return address
 }
 

--- a/lxd/vsock/vsock.go
+++ b/lxd/vsock/vsock.go
@@ -34,7 +34,7 @@ func HTTPClient(vsockID int, tlsClientCert string, tlsClientKey string, tlsServe
 		TLSClientConfig: tlsConfig,
 		// Setup a VM socket dialer.
 		Dial: func(network, addr string) (net.Conn, error) {
-			conn, err := Dial(uint32(vsockID), 8443)
+			conn, err := Dial(uint32(vsockID), shared.DefaultPort)
 			if err != nil {
 				return nil, err
 			}

--- a/shared/util.go
+++ b/shared/util.go
@@ -33,7 +33,7 @@ import (
 )
 
 const SnapshotDelimiter = "/"
-const DefaultPort = "8443"
+const DefaultPort = 8443
 
 // URLEncode encodes a path and query parameters to a URL.
 func URLEncode(path string, query map[string]string) (string, error) {


### PR DESCRIPTION
- Further improves upon https://github.com/lxc/lxd/pull/7796/commits/6f3bd86122b84ef64b5cc2c4c6662a8afe942aee by using the canonical address (including port) for comparison rather than just the requested listen IP, as in the default case the existing listen socket was not detected and failed `lxd init`.
- Uses `CanonicalNetworkAddressFromAddressAndPort` rather than manual `fmt.Sprintf`, to make explicit which address types we accept.
- Converts `shared.DefaultPort` to an int, and replaces some internal usage of hardcoded "8443" with it.