### PR TITLE
lxd/storage: Refuse BLOCK_AND_RSYNC with running instance

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1475,6 +1475,11 @@ func (b *lxdBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCl
 	logger.Debug("MigrateInstance started")
 	defer logger.Debug("MigrateInstance finished")
 
+	// rsync+dd can't handle running source instances
+	if inst.IsRunning() && args.MigrationType.FSType == migration.MigrationFSType_BLOCK_AND_RSYNC {
+		return fmt.Errorf("Rsync based migration doesn't support running virtual machines")
+	}
+
 	volType, err := InstanceTypeToVolumeType(inst.Type())
 	if err != nil {
 		return err


### PR DESCRIPTION
This is needed as QEMU will normally acquire a lock on the block device
backing the instance, preventing any further reader/writer to it.

Closes #7745

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>