### PR TITLE
Network: Adds support adding nodes to clusters that have OVN networks

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -118,7 +118,7 @@ func setCORSHeaders(rw http.ResponseWriter, req *http.Request, config *cluster.C
 // notifying us of some user-initiated API request that needs some action to be
 // taken on this node as well.
 func isClusterNotification(r *http.Request) bool {
-	return r.Header.Get("User-Agent") == "lxd-cluster-notifier"
+	return r.Header.Get("User-Agent") == cluster.UserAgentNotifier
 }
 
 // projectParam returns the project query parameter from the given request or "default" if parameter is not set.

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -785,9 +785,8 @@ func clusterInitMember(d lxd.InstanceServer, client lxd.InstanceServer, memberCo
 		data.Networks = append(data.Networks, post)
 	}
 
-	revert, err := initDataNodeApply(d, data)
+	err = initDataNodeApply(d, data)
 	if err != nil {
-		revert()
 		return errors.Wrap(err, "Failed to initialize storage pools and networks")
 	}
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -386,7 +386,7 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) response.Response {
 		// As ServerAddress field is required to be set it means that we're using the new join API
 		// introduced with the 'clustering_join' extension.
 		// Connect to ourselves to initialize storage pools and networks using the API.
-		localClient, err := lxd.ConnectLXDUnix(d.UnixSocket(), nil)
+		localClient, err := lxd.ConnectLXDUnix(d.UnixSocket(), &lxd.ConnectionArgs{UserAgent: cluster.UserAgentJoiner})
 		if err != nil {
 			return errors.Wrap(err, "Failed to connect to local LXD")
 		}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -686,11 +686,9 @@ func clusterPutDisable(d *Daemon) response.Response {
 	return response.EmptySyncResponse
 }
 
-// Initialize storage pools and networks on this node.
-//
-// We pass to LXD client instances, one connected to ourselves (the joining
-// node) and one connected to the target cluster node to join.
-func clusterInitMember(d, client lxd.InstanceServer, memberConfig []api.ClusterMemberConfigKey) error {
+// clusterInitMember initialises storage pools and networks on this node. We pass two LXD client instances, one
+// connected to ourselves (the joining node) and one connected to the target cluster node to join.
+func clusterInitMember(d lxd.InstanceServer, client lxd.InstanceServer, memberConfig []api.ClusterMemberConfigKey) error {
 	data := initDataNode{}
 
 	// Fetch all pools currently defined in the cluster.

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -18,11 +18,15 @@ import (
 	"github.com/lxc/lxd/shared/version"
 )
 
+// UserAgentNotifier used to distinguish between a regular client request and an internal cluster request when
+// notifying other nodes of a cluster change.
+const UserAgentNotifier = "lxd-cluster-notifier"
+
 // Connect is a convenience around lxd.ConnectLXD that configures the client
 // with the correct parameters for node-to-node communication.
 //
 // If 'notify' switch is true, then the user agent will be set to the special
-// value 'lxd-cluster-notifier', which can be used in some cases to distinguish
+// to the UserAgentNotifier value, which can be used in some cases to distinguish
 // between a regular client request and an internal cluster request.
 func Connect(address string, cert *shared.CertInfo, notify bool) (lxd.InstanceServer, error) {
 	// Wait for a connection to the events API first for non-notify connections.
@@ -54,7 +58,7 @@ func Connect(address string, cert *shared.CertInfo, notify bool) (lxd.InstanceSe
 		UserAgent:     version.UserAgent,
 	}
 	if notify {
-		args.UserAgent = "lxd-cluster-notifier"
+		args.UserAgent = UserAgentNotifier
 	}
 
 	url := fmt.Sprintf("https://%s", address)

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -22,6 +22,10 @@ import (
 // notifying other nodes of a cluster change.
 const UserAgentNotifier = "lxd-cluster-notifier"
 
+// UserAgentJoiner used to distinguish between a regular client request and an internal cluster request when
+// joining a node to a cluster.
+const UserAgentJoiner = "lxd-cluster-joiner"
+
 // Connect is a convenience around lxd.ConnectLXD that configures the client
 // with the correct parameters for node-to-node communication.
 //

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -26,6 +26,30 @@ const UserAgentNotifier = "lxd-cluster-notifier"
 // joining a node to a cluster.
 const UserAgentJoiner = "lxd-cluster-joiner"
 
+// ClientType indicates which sort of client type is being used.
+type ClientType string
+
+// ClientTypeNotifier cluster notification client.
+const ClientTypeNotifier ClientType = "notifier"
+
+// ClientTypeJoiner cluster joiner client.
+const ClientTypeJoiner ClientType = "joiner"
+
+// ClientTypeNormal normal client.
+const ClientTypeNormal ClientType = "normal"
+
+// UserAgentClientType converts user agent to client type.
+func UserAgentClientType(userAgent string) ClientType {
+	switch userAgent {
+	case UserAgentNotifier:
+		return ClientTypeNotifier
+	case UserAgentJoiner:
+		return ClientTypeJoiner
+	}
+
+	return ClientTypeNormal
+}
+
 // Connect is a convenience around lxd.ConnectLXD that configures the client
 // with the correct parameters for node-to-node communication.
 //

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -149,9 +149,8 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	revert, err := initDataNodeApply(d, config.Node)
+	err = initDataNodeApply(d, config.Node)
 	if err != nil {
-		revert()
 		return err
 	}
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -384,8 +384,8 @@ func (n *bridge) isRunning() bool {
 }
 
 // Delete deletes a network.
-func (n *bridge) Delete(clusterNotification bool) error {
-	n.logger.Debug("Delete", log.Ctx{"clusterNotification": clusterNotification})
+func (n *bridge) Delete(clientType cluster.ClientType) error {
+	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
 
 	// Bring the network down.
 	if n.isRunning() {
@@ -401,7 +401,7 @@ func (n *bridge) Delete(clusterNotification bool) error {
 		return err
 	}
 
-	return n.common.delete(clusterNotification)
+	return n.common.delete(clientType)
 }
 
 // Rename renames a network.
@@ -452,6 +452,8 @@ func (n *bridge) Rename(newName string) error {
 
 // Start starts the network.
 func (n *bridge) Start() error {
+	n.logger.Debug("Start")
+
 	return n.setup(nil)
 }
 
@@ -1420,6 +1422,8 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 
 // Stop stops the network.
 func (n *bridge) Stop() error {
+	n.logger.Debug("Stop")
+
 	if !n.isRunning() {
 		return nil
 	}
@@ -1491,8 +1495,8 @@ func (n *bridge) Stop() error {
 
 // Update updates the network. Accepts notification boolean indicating if this update request is coming from a
 // cluster notification, in which case do not update the database, just apply local changes needed.
-func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clusterNotification bool) error {
-	n.logger.Debug("Update", log.Ctx{"clusterNotification": clusterNotification, "newNetwork": newNetwork})
+func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clientType cluster.ClientType) error {
+	n.logger.Debug("Update", log.Ctx{"clientType": clientType, "newNetwork": newNetwork})
 
 	// Populate default values if they are missing.
 	err := n.fillConfig(newNetwork.Config)
@@ -1515,7 +1519,7 @@ func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clusterNot
 	// Define a function which reverts everything.
 	revert.Add(func() {
 		// Reset changes to all nodes and database.
-		n.common.update(oldNetwork, targetNode, clusterNotification)
+		n.common.update(oldNetwork, targetNode, clientType)
 
 		// Reset any change that was made to local bridge.
 		n.setup(newNetwork.Config)
@@ -1553,7 +1557,7 @@ func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clusterNot
 	}
 
 	// Apply changes to database.
-	err = n.common.update(newNetwork, targetNode, clusterNotification)
+	err = n.common.update(newNetwork, targetNode, clientType)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -3,6 +3,7 @@ package network
 import (
 	"fmt"
 
+	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/shared/api"
 	log "github.com/lxc/lxd/shared/log15"
@@ -33,9 +34,9 @@ func (n *macvlan) Validate(config map[string]string) error {
 }
 
 // Delete deletes a network.
-func (n *macvlan) Delete(clusterNotification bool) error {
-	n.logger.Debug("Delete", log.Ctx{"clusterNotification": clusterNotification})
-	return n.common.delete(clusterNotification)
+func (n *macvlan) Delete(clientType cluster.ClientType) error {
+	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
+	return n.common.delete(clientType)
 }
 
 // Rename renames a network.
@@ -63,6 +64,8 @@ func (n *macvlan) Rename(newName string) error {
 
 // Start starts is a no-op.
 func (n *macvlan) Start() error {
+	n.logger.Debug("Start")
+
 	if n.status == api.NetworkStatusPending {
 		return fmt.Errorf("Cannot start pending network")
 	}
@@ -72,13 +75,15 @@ func (n *macvlan) Start() error {
 
 // Stop stops is a no-op.
 func (n *macvlan) Stop() error {
+	n.logger.Debug("Stop")
+
 	return nil
 }
 
 // Update updates the network. Accepts notification boolean indicating if this update request is coming from a
 // cluster notification, in which case do not update the database, just apply local changes needed.
-func (n *macvlan) Update(newNetwork api.NetworkPut, targetNode string, clusterNotification bool) error {
-	n.logger.Debug("Update", log.Ctx{"clusterNotification": clusterNotification, "newNetwork": newNetwork})
+func (n *macvlan) Update(newNetwork api.NetworkPut, targetNode string, clientType cluster.ClientType) error {
+	n.logger.Debug("Update", log.Ctx{"clientType": clientType, "newNetwork": newNetwork})
 
 	dbUpdateNeeeded, _, oldNetwork, err := n.common.configChanged(newNetwork)
 	if err != nil {
@@ -95,11 +100,11 @@ func (n *macvlan) Update(newNetwork api.NetworkPut, targetNode string, clusterNo
 	// Define a function which reverts everything.
 	revert.Add(func() {
 		// Reset changes to all nodes and database.
-		n.common.update(oldNetwork, targetNode, clusterNotification)
+		n.common.update(oldNetwork, targetNode, clientType)
 	})
 
 	// Apply changes to database.
-	err = n.common.update(newNetwork, targetNode, clusterNotification)
+	err = n.common.update(newNetwork, targetNode, clientType)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -591,7 +591,7 @@ func (n *ovn) startParentPortBridge(parentNet Network) error {
 		// wouldn't work until the next router advertisement was sent (which could be several minutes).
 		// By pinging the OVN router's external IP this will trigger an NDP request from the parent bridge
 		// which will cause the OVN router to learn its MAC address.
-		func() {
+		go func() {
 			// Try several attempts as it can take a few seconds for the network to come up.
 			for i := 0; i < 5; i++ {
 				if pingIP(routerExtPortIPv6) {
@@ -602,7 +602,9 @@ func (n *ovn) startParentPortBridge(parentNet Network) error {
 				time.Sleep(time.Second)
 			}
 
-			n.logger.Warn("OVN router external IPv6 address unreachable", log.Ctx{"ip": routerExtPortIPv6.String()})
+			// We would expect this on a chassis node that isn't the active router gateway, it doesn't
+			// always indicate a problem.
+			n.logger.Debug("OVN router external IPv6 address unreachable", log.Ctx{"ip": routerExtPortIPv6.String()})
 		}()
 	}
 

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -3,6 +3,7 @@ package network
 import (
 	"fmt"
 
+	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/shared/api"
 	log "github.com/lxc/lxd/shared/log15"
@@ -33,9 +34,9 @@ func (n *sriov) Validate(config map[string]string) error {
 }
 
 // Delete deletes a network.
-func (n *sriov) Delete(clusterNotification bool) error {
-	n.logger.Debug("Delete", log.Ctx{"clusterNotification": clusterNotification})
-	return n.common.delete(clusterNotification)
+func (n *sriov) Delete(clientType cluster.ClientType) error {
+	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
+	return n.common.delete(clientType)
 }
 
 // Rename renames a network.
@@ -63,6 +64,8 @@ func (n *sriov) Rename(newName string) error {
 
 // Start starts is a no-op.
 func (n *sriov) Start() error {
+	n.logger.Debug("Start")
+
 	if n.status == api.NetworkStatusPending {
 		return fmt.Errorf("Cannot start pending network")
 	}
@@ -72,13 +75,15 @@ func (n *sriov) Start() error {
 
 // Stop stops is a no-op.
 func (n *sriov) Stop() error {
+	n.logger.Debug("Stop")
+
 	return nil
 }
 
 // Update updates the network. Accepts notification boolean indicating if this update request is coming from a
 // cluster notification, in which case do not update the database, just apply local changes needed.
-func (n *sriov) Update(newNetwork api.NetworkPut, targetNode string, clusterNotification bool) error {
-	n.logger.Debug("Update", log.Ctx{"clusterNotification": clusterNotification, "newNetwork": newNetwork})
+func (n *sriov) Update(newNetwork api.NetworkPut, targetNode string, clientType cluster.ClientType) error {
+	n.logger.Debug("Update", log.Ctx{"clientType": clientType, "newNetwork": newNetwork})
 
 	dbUpdateNeeeded, _, oldNetwork, err := n.common.configChanged(newNetwork)
 	if err != nil {
@@ -95,11 +100,11 @@ func (n *sriov) Update(newNetwork api.NetworkPut, targetNode string, clusterNoti
 	// Define a function which reverts everything.
 	revert.Add(func() {
 		// Reset changes to all nodes and database.
-		n.common.update(oldNetwork, targetNode, clusterNotification)
+		n.common.update(oldNetwork, targetNode, clientType)
 	})
 
 	// Apply changes to database.
-	err = n.common.update(newNetwork, targetNode, clusterNotification)
+	err = n.common.update(newNetwork, targetNode, clientType)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -30,11 +30,11 @@ type Network interface {
 	DHCPv6Ranges() []shared.IPRange
 
 	// Actions.
-	Create(clusterNotification bool) error
+	Create(clientType cluster.ClientType) error
 	Start() error
 	Stop() error
 	Rename(name string) error
-	Update(newNetwork api.NetworkPut, targetNode string, clusterNotification bool) error
+	Update(newNetwork api.NetworkPut, targetNode string, clientType cluster.ClientType) error
 	HandleHeartbeat(heartbeatData *cluster.APIHeartbeat) error
-	Delete(clusterNotification bool) error
+	Delete(clientType cluster.ClientType) error
 }


### PR DESCRIPTION
When a node joins a cluster that has an OVN network, the join process requires that the local storage pools and networks are created on the joining node (both in the local database and any host-side setup, such as creating network interfaces) before joining the cluster.

For networks this is achieved by calling the `n.Create()` followed by the `n.Start()` functions on the network driver.
However for OVN networks this causes a problem because whilst the `n.Start()` function is expected to be called on every node, the `n.Create()` function creates the logical network configuration in the remote OVN cluster's northbound database.

As we are joining an existing cluster it is expected that this logical configuration already exists in the OVN northbound database and as such the creation will fail with resource conflicts.

We need a way to tell LXD in the network create request prior to completing the cluster join process that we want it to populate its local database and perform any host-local system setup, but avoid doing anything that modifies an existing central remote system (in this case the OVN northbound database).

There is already precedent for using the HTTP client's user agent field to indicate cluster specific activities, as the `lxd-cluster-notifier` user agent is used when creating resources (such as networks) via the API when a node is already in a cluster and we just want it to complete any node-local setup without modifying the LXD database.

This PR extends this concept by adding another cluster specific user agent `lxd-cluster-joiner` which is sent by the LXD when it connects back to itself to complete pre-join local node setup.

This is then used by the OVN network driver to detect a pre-join is in process and avoids modifying the OVN northbound database during the creation process.

By using an additional HTTP user agent this allows us to reuse the network create API routes (as they are today by the current join process) and indicate to the network driver a join is in process without needing to modify the published API structures.

It turns out that ceph storage pools also have need for this same concept (which is currently handled outside of the driver as an exception). This PR lays the groundwork for the ceph storage pool driver to use the same concept to alter its storage pool create behaviour to not try and create the pool on the remote ceph cluster (which will follow in a separate PR).