### PR TITLE
Network: Adds initial project support to networks

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/operations"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -413,13 +414,13 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) response.Response {
 		}
 
 		networks := []api.Network{}
-		networkNames, err := d.cluster.GetNetworks()
+		networkNames, err := d.cluster.GetNetworks(project.Default)
 		if err != nil && err != db.ErrNoSuchObject {
 			return err
 		}
 
 		for _, name := range networkNames {
-			_, network, err := d.cluster.GetNetworkInAnyState(name)
+			_, network, err := d.cluster.GetNetworkInAnyState(project.Default, name)
 			if err != nil {
 				return err
 			}
@@ -1030,7 +1031,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 			return response.SmartError(err)
 		}
 
-		networks, err := d.cluster.GetNetworks()
+		networks, err := d.cluster.GetNetworks(project.Default)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -1508,7 +1509,7 @@ func clusterCheckStoragePoolsMatch(cluster *db.Cluster, reqPools []api.StoragePo
 }
 
 func clusterCheckNetworksMatch(cluster *db.Cluster, reqNetworks []api.Network) error {
-	networkNames, err := cluster.GetNonPendingNetworks()
+	networkNames, err := cluster.GetNonPendingNetworks(project.Default)
 	if err != nil && err != db.ErrNoSuchObject {
 		return err
 	}
@@ -1519,7 +1520,7 @@ func clusterCheckNetworksMatch(cluster *db.Cluster, reqNetworks []api.Network) e
 				continue
 			}
 			found = true
-			_, network, err := cluster.GetNetworkInAnyState(name)
+			_, network, err := cluster.GetNetworkInAnyState(project.Default, name)
 			if err != nil {
 				return err
 			}

--- a/lxd/cluster/membership_test.go
+++ b/lxd/cluster/membership_test.go
@@ -9,15 +9,17 @@ import (
 	"time"
 
 	"github.com/canonical/go-dqlite/driver"
+	"github.com/mpvl/subtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/osarch"
 	"github.com/lxc/lxd/shared/version"
-	"github.com/mpvl/subtest"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBootstrap_UnmetPreconditions(t *testing.T) {
@@ -270,7 +272,7 @@ func TestJoin(t *testing.T) {
 
 	err = cluster.Bootstrap(targetState, targetGateway, "buzz")
 	require.NoError(t, err)
-	_, err = targetState.Cluster.GetNetworks()
+	_, err = targetState.Cluster.GetNetworks(project.Default)
 	require.NoError(t, err)
 
 	// Setup a joining node

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -578,5 +578,5 @@ CREATE TABLE storage_volumes_snapshots_config (
     UNIQUE (storage_volume_snapshot_id, key)
 );
 
-INSERT INTO schema (version, updated_at) VALUES (37, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (38, strftime("%s"))
 `

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -74,6 +74,21 @@ var updates = map[int]schema.Update{
 	35: updateFromV34,
 	36: updateFromV35,
 	37: updateFromV36,
+	38: updateFromV37,
+}
+
+// Attempt to add missing project features.networks feature to default project.
+func updateFromV37(tx *sql.Tx) error {
+	ids, err := query.SelectIntegers(tx, `SELECT id FROM projects WHERE name = "default" LIMIT 1`)
+	if err != nil {
+		return err
+	}
+
+	if len(ids) == 1 {
+		tx.Exec("INSERT INTO projects_config (project_id, key, value) VALUES (?, 'features.networks', 'true');", ids[0])
+	}
+
+	return nil
 }
 
 // Add networks to projects references.

--- a/lxd/db/migration_test.go
+++ b/lxd/db/migration_test.go
@@ -10,10 +10,12 @@ import (
 	"time"
 
 	"github.com/canonical/go-dqlite/driver"
-	"github.com/lxc/lxd/lxd/db"
-	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/db/query"
+	"github.com/lxc/lxd/lxd/project"
 )
 
 func TestLoadPreClusteringData(t *testing.T) {
@@ -85,10 +87,10 @@ func TestImportPreClusteringData(t *testing.T) {
 	require.NoError(t, err)
 
 	// networks
-	networks, err := cluster.GetNetworks()
+	networks, err := cluster.GetNetworks(project.Default)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"lxcbr0"}, networks)
-	id, network, err := cluster.GetNetworkInAnyState("lxcbr0")
+	id, network, err := cluster.GetNetworkInAnyState(project.Default, "lxcbr0")
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), id)
 	assert.Equal(t, "true", network.Config["ipv4.nat"])

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -144,9 +144,9 @@ func (c *ClusterTx) GetNonPendingNetworks() (map[string]map[int64]api.Network, e
 }
 
 // GetNetworkID returns the ID of the network with the given name.
-func (c *ClusterTx) GetNetworkID(name string) (int64, error) {
-	stmt := "SELECT id FROM networks WHERE name=?"
-	ids, err := query.SelectIntegers(c.tx, stmt, name)
+func (c *ClusterTx) GetNetworkID(projectName string, name string) (int64, error) {
+	stmt := "SELECT id FROM networks WHERE project_id = (SELECT id FROM projects WHERE name = ?) AND name=?"
+	ids, err := query.SelectIntegers(c.tx, stmt, projectName, name)
 	if err != nil {
 		return -1, err
 	}
@@ -156,7 +156,7 @@ func (c *ClusterTx) GetNetworkID(name string) (int64, error) {
 	case 1:
 		return int64(ids[0]), nil
 	default:
-		return -1, fmt.Errorf("more than one network has the given name")
+		return -1, fmt.Errorf("More than one network has the given name")
 	}
 }
 

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -242,13 +242,13 @@ func (c *ClusterTx) CreatePendingNetwork(node string, projectName string, name s
 		return []interface{}{&network.id, &network.state, &network.netType}
 	}
 
-	stmt, err := c.tx.Prepare("SELECT id, state, type FROM networks WHERE name=?")
+	stmt, err := c.tx.Prepare("SELECT id, state, type FROM networks WHERE project_id = (SELECT id FROM projects WHERE name = ?) AND name=?")
 	if err != nil {
 		return err
 	}
 	defer stmt.Close()
 
-	err = query.SelectObjects(stmt, dest, name)
+	err = query.SelectObjects(stmt, dest, projectName, name)
 	if err != nil {
 		return err
 	}

--- a/lxd/db/networks_test.go
+++ b/lxd/db/networks_test.go
@@ -50,7 +50,7 @@ func TestCreatePendingNetwork(t *testing.T) {
 	err = tx.CreatePendingNetwork("buzz", project.Default, "network1", db.NetworkTypeBridge, config)
 	require.NoError(t, err)
 
-	networkID, err := tx.GetNetworkID("network1")
+	networkID, err := tx.GetNetworkID(project.Default, "network1")
 	require.NoError(t, err)
 	assert.True(t, networkID > 0)
 

--- a/lxd/device/device_load.go
+++ b/lxd/device/device_load.go
@@ -10,13 +10,15 @@ import (
 )
 
 // load instantiates a device and initialises its internal state. It does not validate the config supplied.
-func load(inst instance.Instance, state *state.State, name string, conf deviceConfig.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) (device, error) {
+func load(inst instance.Instance, state *state.State, projectName string, name string, conf deviceConfig.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) (device, error) {
+	// Warning: When validating a profile, inst is expected to be provided as nil.
+
 	if conf["type"] == "" {
 		return nil, fmt.Errorf("Missing device type for device %q", name)
 	}
 
 	// NIC type is required to lookup network devices.
-	nicType, err := nictype.NICType(state, conf)
+	nicType, err := nictype.NICType(state, projectName, conf)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +84,7 @@ func load(inst instance.Instance, state *state.State, name string, conf deviceCo
 // is still returned with the validation error. If an unknown device is requested or the device is
 // not compatible with the instance type then an ErrUnsupportedDevType error is returned.
 func New(inst instance.Instance, state *state.State, name string, conf deviceConfig.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) (Device, error) {
-	dev, err := load(inst, state, name, conf, volatileGet, volatileSet)
+	dev, err := load(inst, state, inst.Project(), name, conf, volatileGet, volatileSet)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +100,7 @@ func New(inst instance.Instance, state *state.State, name string, conf deviceCon
 // Validate checks a device's config is valid. This only requires an instance.ConfigReader rather than an full
 // blown instance to allow profile devices to be validated too.
 func Validate(instConfig instance.ConfigReader, state *state.State, name string, conf deviceConfig.Device) error {
-	dev, err := load(nil, state, name, conf, nil, nil)
+	dev, err := load(nil, state, instConfig.Project(), name, conf, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/network"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/util"
@@ -360,7 +361,8 @@ func networkSetVethRoutes(s *state.State, m deviceConfig.Device) error {
 	// Decide whether the route should point to the veth parent or the bridge parent.
 	routeDev := m["host_name"]
 
-	nicType, err := nictype.NICType(s, m)
+	// Use project.Default here, as only networks in the default project can add routes on the host.
+	nicType, err := nictype.NICType(s, project.Default, m)
 	if err != nil {
 		return err
 	}
@@ -403,7 +405,9 @@ func networkSetVethRoutes(s *state.State, m deviceConfig.Device) error {
 func networkRemoveVethRoutes(s *state.State, m deviceConfig.Device) {
 	// Decide whether the route should point to the veth parent or the bridge parent
 	routeDev := m["host_name"]
-	nicType, err := nictype.NICType(s, m)
+
+	// Use project.Default here, as only networks in the default project can add routes on the host.
+	nicType, err := nictype.NICType(s, project.Default, m)
 	if err != nil {
 		logger.Errorf("Failed to get NIC type for %q", m["name"])
 		return

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/network"
 	"github.com/lxc/lxd/lxd/network/openvswitch"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -79,7 +80,8 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 		}
 
 		// If network property is specified, lookup network settings and apply them to the device's config.
-		n, err := network.LoadByName(d.state, d.config["network"])
+		// project.Default is used here as bridge networks don't suppprt projects.
+		n, err := network.LoadByName(d.state, project.Default, d.config["network"])
 		if err != nil {
 			return errors.Wrapf(err, "Error loading network config for %q", d.config["network"])
 		}
@@ -489,7 +491,8 @@ func (d *nicBridged) rebuildDnsmasqEntry() error {
 	dnsmasq.ConfigMutex.Lock()
 	defer dnsmasq.ConfigMutex.Unlock()
 
-	_, dbInfo, err := d.state.Cluster.GetNetworkInAnyState(d.config["parent"])
+	// Use project.Default here as bridge networks don't support projects.
+	_, dbInfo, err := d.state.Cluster.GetNetworkInAnyState(project.Default, d.config["parent"])
 	if err != nil {
 		return err
 	}
@@ -646,7 +649,8 @@ func (d *nicBridged) setFilters() (err error) {
 	IPv6 := net.ParseIP(d.config["ipv6.address"])
 
 	// Check if the parent is managed and load config. If parent is unmanaged continue anyway.
-	n, err := network.LoadByName(d.state, d.config["parent"])
+	// project.Default is used here as bridge networks don't suppprt projects.
+	n, err := network.LoadByName(d.state, project.Default, d.config["parent"])
 	if err != nil && err != db.ErrNoSuchObject {
 		return err
 	}

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/network"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -49,7 +50,8 @@ func (d *nicMACVLAN) validateConfig(instConf instance.ConfigReader) error {
 		}
 
 		// If network property is specified, lookup network settings and apply them to the device's config.
-		n, err := network.LoadByName(d.state, d.config["network"])
+		// project.Default is used here as macvlan networks don't suppprt projects.
+		n, err := network.LoadByName(d.state, project.Default, d.config["network"])
 		if err != nil {
 			return errors.Wrapf(err, "Error loading network config for %q", d.config["network"])
 		}

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/network"
 	"github.com/lxc/lxd/lxd/network/openvswitch"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -57,8 +58,14 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 		"boot.priority",
 	}
 
+	// The NIC's network may be a non-default project, so lookup project and get network's project name.
+	networkProjectName, err := project.NetworkProject(d.state.Cluster, instConf.Project())
+	if err != nil {
+		return errors.Wrapf(err, "Failed loading network project name")
+	}
+
 	// Lookup network settings and apply them to the device's config.
-	n, err := network.LoadByName(d.state, d.config["network"])
+	n, err := network.LoadByName(d.state, networkProjectName, d.config["network"])
 	if err != nil {
 		return errors.Wrapf(err, "Error loading network config for %q", d.config["network"])
 	}

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/network"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -59,7 +60,8 @@ func (d *nicSRIOV) validateConfig(instConf instance.ConfigReader) error {
 		}
 
 		// If network property is specified, lookup network settings and apply them to the device's config.
-		n, err := network.LoadByName(d.state, d.config["network"])
+		// project.Default is used here as macvlan networks don't suppprt projects.
+		n, err := network.LoadByName(d.state, project.Default, d.config["network"])
 		if err != nil {
 			return errors.Wrapf(err, "Error loading network config for %q", d.config["network"])
 		}

--- a/lxd/device/proxy.go
+++ b/lxd/device/proxy.go
@@ -356,7 +356,7 @@ func (d *proxy) setupNAT() error {
 			continue
 		}
 
-		nicType, err := nictype.NICType(d.state, devConfig)
+		nicType, err := nictype.NICType(d.state, d.inst.Project(), devConfig)
 		if err != nil {
 			return err
 		}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -476,7 +476,7 @@ func instanceCreateInternal(s *state.State, args db.InstanceArgs) (instance.Inst
 	}
 
 	// Validate container devices with the supplied container name and devices.
-	err = instance.ValidDevices(s, s.Cluster, args.Type, args.Devices, false)
+	err = instance.ValidDevices(s, s.Cluster, args.Project, args.Type, args.Devices, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "Invalid devices")
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1786,12 +1786,12 @@ func (c *lxc) deviceResetVolatile(devName string, oldConfig, newConfig deviceCon
 	volatileClear := make(map[string]string)
 	devicePrefix := fmt.Sprintf("volatile.%s.", devName)
 
-	newNICType, err := nictype.NICType(c.state, newConfig)
+	newNICType, err := nictype.NICType(c.state, c.Project(), newConfig)
 	if err != nil {
 		return err
 	}
 
-	oldNICType, err := nictype.NICType(c.state, oldConfig)
+	oldNICType, err := nictype.NICType(c.state, c.Project(), oldConfig)
 	if err != nil {
 		return err
 	}
@@ -3997,12 +3997,12 @@ func (c *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		// devices are otherwise identical except for the fields returned here, then the
 		// device is considered to be being "updated" rather than "added & removed".
 
-		oldNICType, err := nictype.NICType(c.state, newDevice)
+		oldNICType, err := nictype.NICType(c.state, c.Project(), newDevice)
 		if err != nil {
 			return []string{} // Cannot hot-update due to config error.
 		}
 
-		newNICType, err := nictype.NICType(c.state, oldDevice)
+		newNICType, err := nictype.NICType(c.state, c.Project(), oldDevice)
 		if err != nil {
 			return []string{} // Cannot hot-update due to config error.
 		}
@@ -6408,7 +6408,7 @@ func (c *lxc) FillNetworkDevice(name string, m deviceConfig.Device) (deviceConfi
 		return nil
 	}
 
-	nicType, err := nictype.NICType(c.state, m)
+	nicType, err := nictype.NICType(c.state, c.Project(), m)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -348,7 +348,7 @@ func lxcCreate(s *state.State, args db.InstanceArgs) (instance.Instance, error) 
 			err = c.deviceAdd(k, m)
 			if err != nil && err != device.ErrUnsupportedDevType {
 				c.Delete()
-				return nil, errors.Wrapf(err, "Failed to add device '%s'", k)
+				return nil, errors.Wrapf(err, "Failed to add device %q", k)
 			}
 		}
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -201,7 +201,7 @@ func lxcCreate(s *state.State, args db.InstanceArgs) (instance.Instance, error) 
 		return nil, err
 	}
 
-	err = instance.ValidDevices(s, s.Cluster, c.Type(), c.expandedDevices, true)
+	err = instance.ValidDevices(s, s.Cluster, c.Project(), c.Type(), c.expandedDevices, true)
 	if err != nil {
 		c.Delete()
 		logger.Error("Failed creating container", ctxMap)
@@ -3847,7 +3847,7 @@ func (c *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 
 		// Validate the new devices without using expanded devices validation (expensive checks disabled).
-		err = instance.ValidDevices(c.state, c.state.Cluster, c.Type(), args.Devices, false)
+		err = instance.ValidDevices(c.state, c.state.Cluster, c.Project(), c.Type(), args.Devices, false)
 		if err != nil {
 			return errors.Wrap(err, "Invalid devices")
 		}
@@ -4028,7 +4028,7 @@ func (c *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 
 		// Do full expanded validation of the devices diff.
-		err = instance.ValidDevices(c.state, c.state.Cluster, c.Type(), c.expandedDevices, true)
+		err = instance.ValidDevices(c.state, c.state.Cluster, c.Project(), c.Type(), c.expandedDevices, true)
 		if err != nil {
 			return errors.Wrap(err, "Invalid expanded devices")
 		}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2915,12 +2915,12 @@ func (vm *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		// between oldDevice and newDevice. The result of this is that as long as the
 		// devices are otherwise identical except for the fields returned here, then the
 		// device is considered to be being "updated" rather than "added & removed".
-		oldNICType, err := nictype.NICType(vm.state, newDevice)
+		oldNICType, err := nictype.NICType(vm.state, vm.Project(), newDevice)
 		if err != nil {
 			return []string{} // Cannot hot-update due to config error.
 		}
 
-		newNICType, err := nictype.NICType(vm.state, oldDevice)
+		newNICType, err := nictype.NICType(vm.state, vm.Project(), oldDevice)
 		if err != nil {
 			return []string{} // Cannot hot-update due to config error.
 		}
@@ -3105,12 +3105,12 @@ func (vm *qemu) deviceResetVolatile(devName string, oldConfig, newConfig deviceC
 	volatileClear := make(map[string]string)
 	devicePrefix := fmt.Sprintf("volatile.%s.", devName)
 
-	newNICType, err := nictype.NICType(vm.state, newConfig)
+	newNICType, err := nictype.NICType(vm.state, vm.Project(), newConfig)
 	if err != nil {
 		return err
 	}
 
-	oldNICType, err := nictype.NICType(vm.state, oldConfig)
+	oldNICType, err := nictype.NICType(vm.state, vm.Project(), oldConfig)
 	if err != nil {
 		return err
 	}
@@ -4082,7 +4082,7 @@ func (vm *qemu) RenderState() (*api.InstanceState, error) {
 			status.Processes = -1
 			networks := map[string]api.InstanceStateNetwork{}
 			for k, m := range vm.ExpandedDevices() {
-				nicType, err := nictype.NICType(vm.state, m)
+				nicType, err := nictype.NICType(vm.state, vm.Project(), m)
 				if err != nil {
 					return nil, err
 				}
@@ -4475,7 +4475,7 @@ func (vm *qemu) FillNetworkDevice(name string, m deviceConfig.Device) (deviceCon
 		return nil
 	}
 
-	nicType, err := nictype.NICType(vm.state, m)
+	nicType, err := nictype.NICType(vm.state, vm.Project(), m)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -219,7 +219,7 @@ func qemuCreate(s *state.State, args db.InstanceArgs) (instance.Instance, error)
 		return nil, err
 	}
 
-	err = instance.ValidDevices(s, s.Cluster, vm.Type(), vm.expandedDevices, true)
+	err = instance.ValidDevices(s, s.Cluster, vm.Project(), vm.Type(), vm.expandedDevices, true)
 	if err != nil {
 		logger.Error("Failed creating instance", ctxMap)
 		return nil, errors.Wrap(err, "Invalid devices")
@@ -2773,7 +2773,7 @@ func (vm *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 
 		// Validate the new devices without using expanded devices validation (expensive checks disabled).
-		err = instance.ValidDevices(vm.state, vm.state.Cluster, vm.Type(), args.Devices, false)
+		err = instance.ValidDevices(vm.state, vm.state.Cluster, vm.Project(), vm.Type(), args.Devices, false)
 		if err != nil {
 			return errors.Wrap(err, "Invalid devices")
 		}
@@ -2946,7 +2946,7 @@ func (vm *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 
 		// Do full expanded validation of the devices diff.
-		err = instance.ValidDevices(vm.state, vm.state.Cluster, vm.Type(), vm.expandedDevices, true)
+		err = instance.ValidDevices(vm.state, vm.state.Cluster, vm.Project(), vm.Type(), vm.expandedDevices, true)
 		if err != nil {
 			return errors.Wrap(err, "Invalid expanded devices")
 		}

--- a/lxd/instance/drivers/load.go
+++ b/lxd/instance/drivers/load.go
@@ -47,7 +47,7 @@ func load(s *state.State, args db.InstanceArgs, profiles []api.Profile) (instanc
 }
 
 // validDevices validate instance device configs.
-func validDevices(state *state.State, cluster *db.Cluster, instanceType instancetype.Type, devices deviceConfig.Devices, expanded bool) error {
+func validDevices(state *state.State, cluster *db.Cluster, projectName string, instanceType instancetype.Type, devices deviceConfig.Devices, expanded bool) error {
 	// Empty device list
 	if devices == nil {
 		return nil
@@ -56,6 +56,7 @@ func validDevices(state *state.State, cluster *db.Cluster, instanceType instance
 	instConf := &common{
 		dbType:       instanceType,
 		localDevices: devices.Clone(),
+		project:      projectName,
 	}
 
 	// In non-expanded validation expensive checks should be avoided.
@@ -70,7 +71,7 @@ func validDevices(state *state.State, cluster *db.Cluster, instanceType instance
 	for name, config := range instConf.localDevices {
 		err := device.Validate(instConf, state, name, config)
 		if err != nil {
-			return errors.Wrapf(err, "Device validation failed %q", name)
+			return errors.Wrapf(err, "Device validation failed for %q", name)
 		}
 
 	}

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -31,7 +31,7 @@ import (
 )
 
 // ValidDevices is linked from instance/drivers.validDevices to validate device config.
-var ValidDevices func(state *state.State, cluster *db.Cluster, instanceType instancetype.Type, devices deviceConfig.Devices, expanded bool) error
+var ValidDevices func(state *state.State, cluster *db.Cluster, projectName string, instanceType instancetype.Type, devices deviceConfig.Devices, expanded bool) error
 
 // Load is linked from instance/drivers.load to allow different instance types to be loaded.
 var Load func(s *state.State, args db.InstanceArgs, profiles []api.Profile) (Instance, error)

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -378,6 +378,17 @@ func (n *bridge) Validate(config map[string]string) error {
 	return nil
 }
 
+// Create checks whether the bridge interface name is used already.
+func (n *bridge) Create(clientType cluster.ClientType) error {
+	n.logger.Debug("Create", log.Ctx{"clientType": clientType, "config": n.config})
+
+	if shared.PathExists(fmt.Sprintf("/sys/class/net/%s", n.name)) {
+		return fmt.Errorf("Network interface %q already exists", n.name)
+	}
+
+	return nil
+}
+
 // isRunning returns whether the network is up.
 func (n *bridge) isRunning() bool {
 	return shared.PathExists(fmt.Sprintf("/sys/class/net/%s", n.name))

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -419,14 +419,8 @@ func (n *bridge) Delete(clientType cluster.ClientType) error {
 func (n *bridge) Rename(newName string) error {
 	n.logger.Debug("Rename", log.Ctx{"newName": newName})
 
-	// Sanity checks.
-	inUse, err := n.IsUsed()
-	if err != nil {
-		return err
-	}
-
-	if inUse {
-		return fmt.Errorf("The network is currently in use")
+	if shared.PathExists(fmt.Sprintf("/sys/class/net/%s", newName)) {
+		return fmt.Errorf("Network interface %q already exists", newName)
 	}
 
 	// Bring the network down.
@@ -447,7 +441,7 @@ func (n *bridge) Rename(newName string) error {
 	}
 
 	// Rename common steps.
-	err = n.common.rename(newName)
+	err := n.common.rename(newName)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -218,7 +218,7 @@ func (n *common) update(applyNetwork api.NetworkPut, targetNode string, clientTy
 			}
 
 			err = notifier(func(client lxd.InstanceServer) error {
-				return client.UpdateNetwork(n.name, sendNetwork, "")
+				return client.UseProject(n.project).UpdateNetwork(n.name, sendNetwork, "")
 			})
 			if err != nil {
 				return err
@@ -320,7 +320,7 @@ func (n *common) delete(clientType cluster.ClientType) error {
 			return err
 		}
 		err = notifier(func(client lxd.InstanceServer) error {
-			return client.DeleteNetwork(n.name)
+			return client.UseProject(n.project).DeleteNetwork(n.name)
 		})
 		if err != nil {
 			return err

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -43,18 +43,8 @@ func (n *macvlan) Delete(clientType cluster.ClientType) error {
 func (n *macvlan) Rename(newName string) error {
 	n.logger.Debug("Rename", log.Ctx{"newName": newName})
 
-	// Sanity checks.
-	inUse, err := n.IsUsed()
-	if err != nil {
-		return err
-	}
-
-	if inUse {
-		return fmt.Errorf("The network is currently in use")
-	}
-
 	// Rename common steps.
-	err = n.common.rename(newName)
+	err := n.common.rename(newName)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/locking"
 	"github.com/lxc/lxd/lxd/network/openvswitch"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -261,7 +262,8 @@ func (n *ovn) getIntSwitchInstancePortPrefix() string {
 // setupParentPort initialises the parent uplink connection. Returns the derived ovnParentVars settings used
 // during the initial creation of the logical network.
 func (n *ovn) setupParentPort(routerMAC net.HardwareAddr) (*ovnParentVars, error) {
-	parentNet, err := LoadByName(n.state, n.config["network"])
+	// Parent network must be in default project.
+	parentNet, err := LoadByName(n.state, project.Default, n.config["network"])
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed loading parent network")
 	}
@@ -481,7 +483,8 @@ func (n *ovn) parentAllocateIP(ipRanges []*shared.IPRange, allAllocated []net.IP
 
 // startParentPort performs any network start up logic needed to connect the parent uplink connection to OVN.
 func (n *ovn) startParentPort() error {
-	parentNet, err := LoadByName(n.state, n.config["network"])
+	// Parent network must be in default project.
+	parentNet, err := LoadByName(n.state, project.Default, n.config["network"])
 	if err != nil {
 		return errors.Wrapf(err, "Failed loading parent network")
 	}
@@ -609,7 +612,8 @@ func (n *ovn) startParentPortBridge(parentNet Network) error {
 
 // deleteParentPort deletes the parent uplink connection.
 func (n *ovn) deleteParentPort() error {
-	parentNet, err := LoadByName(n.state, n.config["network"])
+	// Parent network must be in default project.
+	parentNet, err := LoadByName(n.state, project.Default, n.config["network"])
 	if err != nil {
 		return errors.Wrapf(err, "Failed loading parent network")
 	}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1138,18 +1138,8 @@ func (n *ovn) Delete(clientType cluster.ClientType) error {
 func (n *ovn) Rename(newName string) error {
 	n.logger.Debug("Rename", log.Ctx{"newName": newName})
 
-	// Sanity checks.
-	inUse, err := n.IsUsed()
-	if err != nil {
-		return err
-	}
-
-	if inUse {
-		return fmt.Errorf("The network is currently in use")
-	}
-
 	// Rename common steps.
-	err = n.common.rename(newName)
+	err := n.common.rename(newName)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -43,18 +43,8 @@ func (n *sriov) Delete(clientType cluster.ClientType) error {
 func (n *sriov) Rename(newName string) error {
 	n.logger.Debug("Rename", log.Ctx{"newName": newName})
 
-	// Sanity checks.
-	inUse, err := n.IsUsed()
-	if err != nil {
-		return err
-	}
-
-	if inUse {
-		return fmt.Errorf("The network is currently in use")
-	}
-
 	// Rename common steps.
-	err = n.common.rename(newName)
+	err := n.common.rename(newName)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -12,7 +12,7 @@ import (
 // Network represents a LXD network.
 type Network interface {
 	// Load.
-	init(state *state.State, id int64, name string, netType string, description string, config map[string]string, status string)
+	init(state *state.State, id int64, projectName string, name string, netType string, description string, config map[string]string, status string)
 	fillConfig(config map[string]string) error
 
 	// Config.

--- a/lxd/network/network_load.go
+++ b/lxd/network/network_load.go
@@ -3,6 +3,7 @@ package network
 import (
 	"github.com/pkg/errors"
 
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -15,8 +16,8 @@ var drivers = map[string]func() Network{
 }
 
 // LoadByName loads the network info from the database by name.
-func LoadByName(s *state.State, name string) (Network, error) {
-	id, netInfo, err := s.Cluster.GetNetworkInAnyState(name)
+func LoadByName(s *state.State, project string, name string) (Network, error) {
+	id, netInfo, err := s.Cluster.GetNetworkInAnyState(project, name)
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +28,7 @@ func LoadByName(s *state.State, name string) (Network, error) {
 	}
 
 	n := driverFunc()
-	n.init(s, id, name, netInfo.Type, netInfo.Description, netInfo.Config, netInfo.Status)
+	n.init(s, id, project, name, netInfo.Type, netInfo.Description, netInfo.Config, netInfo.Status)
 
 	return n, nil
 }
@@ -40,7 +41,7 @@ func ValidateName(name string, netType string) error {
 	}
 
 	n := driverFunc()
-	n.init(nil, 0, name, netType, "", nil, "Unknown")
+	n.init(nil, 0, project.Default, name, netType, "", nil, "Unknown")
 
 	err := n.ValidateName(name)
 	if err != nil {
@@ -58,7 +59,7 @@ func Validate(name string, netType string, config map[string]string) error {
 	}
 
 	n := driverFunc()
-	n.init(nil, 0, name, netType, "", config, "Unknown")
+	n.init(nil, 0, project.Default, name, netType, "", config, "Unknown")
 
 	err := n.ValidateName(name)
 	if err != nil {
@@ -76,7 +77,7 @@ func FillConfig(req *api.NetworksPost) error {
 	}
 
 	n := driverFunc()
-	n.init(nil, 0, req.Name, req.Type, req.Description, req.Config, "Unknown")
+	n.init(nil, 0, project.Default, req.Name, req.Type, req.Description, req.Config, "Unknown")
 
 	err := n.fillConfig(req.Config)
 	if err != nil {

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -107,13 +107,13 @@ func IsInUseByProfile(s *state.State, profile api.Profile, networkName string) (
 	return isInUseByDevices(s, deviceConfig.NewDevices(profile.Devices), networkName)
 }
 
-func isInUseByDevices(s *state.State, devices deviceConfig.Devices, networkName string) (bool, error) {
+func isInUseByDevices(s *state.State, networkProjectName string, networkName string, devices deviceConfig.Devices) (bool, error) {
 	for _, d := range devices {
 		if d["type"] != "nic" {
 			continue
 		}
 
-		nicType, err := nictype.NICType(s, d)
+		nicType, err := nictype.NICType(s, networkProjectName, d)
 		if err != nil {
 			return false, err
 		}

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -745,7 +745,8 @@ func GetLeaseAddresses(s *state.State, networkName string, hwaddr string) ([]api
 		return addresses, nil
 	}
 
-	dbInfo, err := LoadByName(s, networkName)
+	// Pass project.Default here, as currently dnsmasq (bridged) networks do not support projects.
+	dbInfo, err := LoadByName(s, project.Default, networkName)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -283,7 +283,9 @@ func UpdateDNSMasqStatic(s *state.State, networkName string) error {
 	var networks []string
 	if networkName == "" {
 		var err error
-		networks, err = s.Cluster.GetNetworks()
+
+		// Pass project.Default here, as currently dnsmasq (bridged) networks do not support projects.
+		networks, err = s.Cluster.GetNetworks(project.Default)
 		if err != nil {
 			return err
 		}
@@ -307,7 +309,7 @@ func UpdateDNSMasqStatic(s *state.State, networkName string) error {
 				continue
 			}
 
-			nicType, err := nictype.NICType(s, d)
+			nicType, err := nictype.NICType(s, inst.Project(), d)
 			if err != nil || nicType != "bridged" {
 				continue
 			}
@@ -362,7 +364,8 @@ func UpdateDNSMasqStatic(s *state.State, networkName string) error {
 			continue
 		}
 
-		n, err := LoadByName(s, network)
+		// Pass project.Default here, as currently dnsmasq (bridged) networks do not support projects.
+		n, err := LoadByName(s, project.Default, network)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to load network %q in project %q for dnsmasq update", project.Default, network)
 		}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -588,8 +588,13 @@ func networkPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
+	projectName, err := project.NetworkProject(d.State().Cluster, projectParam(r))
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	// Get the existing network.
-	n, err := network.LoadByName(state, name)
+	n, err := network.LoadByName(state, projectName, name)
 	if err != nil {
 		if err == db.ErrNoSuchObject {
 			return response.NotFound(fmt.Errorf("Network not found"))
@@ -619,7 +624,7 @@ func networkPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Check that the name isn't already in used by an existing managed network.
-	networks, err := d.cluster.GetNetworks()
+	networks, err := d.cluster.GetNetworks(projectName)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -721,9 +721,9 @@ func networkPatch(d *Daemon, r *http.Request) response.Response {
 
 // doNetworkUpdate loads the current local network config, merges with the requested network config, validates
 // and applies the changes. Will also notify other cluster nodes of non-node specific config if needed.
-func doNetworkUpdate(d *Daemon, name string, req api.NetworkPut, targetNode string, clientType cluster.ClientType, httpMethod string, clustered bool) response.Response {
+func doNetworkUpdate(d *Daemon, projectName string, name string, req api.NetworkPut, targetNode string, clientType cluster.ClientType, httpMethod string, clustered bool) response.Response {
 	// Load the local node-specific network.
-	n, err := network.LoadByName(d.State(), name)
+	n, err := network.LoadByName(d.State(), projectName, name)
 	if err != nil {
 		return response.NotFound(err)
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -649,10 +649,15 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
+	projectName, err := project.NetworkProject(d.State().Cluster, projectParam(r))
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	name := mux.Vars(r)["name"]
 
 	// Get the existing network.
-	_, dbInfo, err := d.cluster.GetNetworkInAnyState(name)
+	_, dbInfo, err := d.cluster.GetNetworkInAnyState(projectName, name)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -707,7 +712,7 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 
 	clientType := cluster.UserAgentClientType(r.Header.Get("User-Agent"))
 
-	return doNetworkUpdate(d, name, req, targetNode, clientType, r.Method, clustered)
+	return doNetworkUpdate(d, projectName, name, req, targetNode, clientType, r.Method, clustered)
 }
 
 func networkPatch(d *Daemon, r *http.Request) response.Response {

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -364,7 +364,7 @@ func networksPostCluster(d *Daemon, projectName string, req api.NetworksPost, cl
 			nodeReq.Config[key] = value
 		}
 
-		return client.CreateNetwork(nodeReq)
+		return client.UseProject(projectName).CreateNetwork(nodeReq)
 	})
 	if err != nil {
 		return err

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -290,7 +290,7 @@ func networksPostCluster(d *Daemon, projectName string, req api.NetworksPost, cl
 	var networkID int64
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
 		// Fetch the network ID.
-		networkID, err = tx.GetNetworkID(req.Name)
+		networkID, err = tx.GetNetworkID(projectName, req.Name)
 		if err != nil {
 			return err
 		}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -415,9 +415,14 @@ func networkGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
+	projectName, err := project.NetworkProject(d.State().Cluster, projectParam(r))
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	name := mux.Vars(r)["name"]
 
-	n, err := doNetworkGet(d, name)
+	n, err := doNetworkGet(d, projectName, name)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -376,9 +376,9 @@ func networksPostCluster(d *Daemon, projectName string, req api.NetworksPost, cl
 
 // Create the network on the system. The clusterNotification flag is used to indicate whether creation request
 // is coming from a cluster notification (and if so we should not delete the database record on error).
-func doNetworksCreate(d *Daemon, req api.NetworksPost, clientType cluster.ClientType) error {
+func doNetworksCreate(d *Daemon, projectName string, req api.NetworksPost, clientType cluster.ClientType) error {
 	// Start the network.
-	n, err := network.LoadByName(d.State(), req.Name)
+	n, err := network.LoadByName(d.State(), projectName, req.Name)
 	if err != nil {
 		return err
 	}

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -41,32 +41,6 @@ func networkAutoAttach(cluster *db.Cluster, devName string) error {
 	return network.AttachInterface(dbInfo.Name, devName)
 }
 
-func networkGetInterfaces(cluster *db.Cluster) ([]string, error) {
-	networks, err := cluster.GetNetworks()
-	if err != nil {
-		return nil, err
-	}
-
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, iface := range ifaces {
-		// Ignore veth pairs (for performance reasons)
-		if strings.HasPrefix(iface.Name, "veth") {
-			continue
-		}
-
-		// Append to the list
-		if !shared.StringInSlice(iface.Name, networks) {
-			networks = append(networks, iface.Name)
-		}
-	}
-
-	return networks, nil
-}
-
 // networkUpdateForkdnsServersTask runs every 30s and refreshes the forkdns servers list.
 func networkUpdateForkdnsServersTask(s *state.State, heartbeatData *cluster.APIHeartbeat) error {
 	// Get a list of managed networks

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -111,7 +111,7 @@ func profilesPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// At this point we don't know the instance type, so just use instancetype.Any type for validation.
-	err = instance.ValidDevices(d.State(), d.cluster, instancetype.Any, deviceConfig.NewDevices(req.Devices), false)
+	err = instance.ValidDevices(d.State(), d.cluster, projectName, instancetype.Any, deviceConfig.NewDevices(req.Devices), false)
 	if err != nil {
 		return response.BadRequest(err)
 	}


### PR DESCRIPTION
- Introduces `features.networks` internally (but does not yet expose it to new projects).
- Adds it to default project.
- Makes networks project aware (although in some cases hard codes to `project.Default` for now).

This is lays the initial ground work for adding projects to networks to try and reduce the PR size.