### PR TITLE
Storage: Cache supported drivers

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -828,7 +828,7 @@ func (d *Daemon) init() error {
 	}
 
 	// Have the db package determine remote storage drivers
-	db.GetRemoteDrivers = storageDrivers.RemoteDriverNames(d.State())
+	db.StorageRemoteDriverNames = storageDrivers.RemoteDriverNames(d.State())
 
 	/* Open the cluster database */
 	for {

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -657,7 +657,7 @@ func (c *ClusterTx) GetInstancePool(projectName string, instanceName string) (st
 	// as that must always be the same as the snapshot's storage pool.
 	instanceName, _, _ = shared.InstanceGetParentAndSnapshotName(instanceName)
 
-	remoteDrivers := GetRemoteDrivers()
+	remoteDrivers := StorageRemoteDriverNames()
 
 	// Get container storage volume. Since container names are globally
 	// unique, and their storage volumes carry the same name, their storage

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -200,7 +200,7 @@ func TestInstanceListExpanded(t *testing.T) {
 }
 
 func TestCreateInstance(t *testing.T) {
-	db.GetRemoteDrivers = func() []string {
+	db.StorageRemoteDriverNames = func() []string {
 		return []string{"ceph", "cephfs"}
 	}
 

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -80,7 +80,7 @@ func (c *ClusterTx) GetStoragePoolUsedBy(name string) ([]string, error) {
 		return []interface{}{&vols[i].volName, &vols[i].volType, &vols[i].projectName, &vols[i].nodeID}
 	}
 
-	remoteDrivers := GetRemoteDrivers()
+	remoteDrivers := StorageRemoteDriverNames()
 
 	s := fmt.Sprintf(`
 SELECT storage_volumes.name, storage_volumes.type, projects.name, storage_volumes.node_id
@@ -898,7 +898,7 @@ func (c *Cluster) isRemoteStorage(poolID int64) (bool, error) {
 			return err
 		}
 
-		isRemoteStorage = shared.StringInSlice(driver, GetRemoteDrivers())
+		isRemoteStorage = shared.StringInSlice(driver, StorageRemoteDriverNames())
 
 		return nil
 	})

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -15,8 +15,8 @@ import (
 	"github.com/lxc/lxd/shared/api"
 )
 
-// GetRemoteDrivers returns a list of remote storage driver names.
-var GetRemoteDrivers func() []string
+// StorageRemoteDriverNames returns a list of remote storage driver names.
+var StorageRemoteDriverNames func() []string
 
 // GetStoragePoolsLocalConfig returns a map associating each storage pool name to
 // its node-specific config values (i.e. the ones where node_id is not NULL).

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -89,7 +89,7 @@ WHERE storage_volumes.type = ?
 func (c *Cluster) GetStoragePoolVolumes(project string, poolID int64, volumeTypes []int) ([]*api.StorageVolume, error) {
 	var nodeIDs []int
 
-	remoteDrivers := GetRemoteDrivers()
+	remoteDrivers := StorageRemoteDriverNames()
 
 	err := c.Transaction(func(tx *ClusterTx) error {
 		var err error
@@ -187,7 +187,7 @@ func (c *Cluster) storagePoolVolumesGet(project string, poolID, nodeID int64, vo
 func (c *Cluster) storagePoolVolumesGetType(project string, volumeType int, poolID, nodeID int64) ([]string, error) {
 	var poolName string
 
-	remoteDrivers := GetRemoteDrivers()
+	remoteDrivers := StorageRemoteDriverNames()
 
 	query := fmt.Sprintf(`
 SELECT storage_volumes_all.name
@@ -223,7 +223,7 @@ SELECT storage_volumes_all.name
 // Returns snapshots slice ordered by when they were created, oldest first.
 func (c *Cluster) GetLocalStoragePoolVolumeSnapshotsWithType(projectName string, volumeName string, volumeType int, poolID int64) ([]StorageVolumeArgs, error) {
 	result := []StorageVolumeArgs{}
-	remoteDrivers := GetRemoteDrivers()
+	remoteDrivers := StorageRemoteDriverNames()
 
 	// ORDER BY id is important here as the users of this function can expect that the results
 	// will be returned in the order that the snapshots were created. This is specifically used
@@ -433,7 +433,7 @@ func storagePoolVolumeReplicateIfCeph(tx *sql.Tx, volumeID int64, project, volum
 	}
 	volumeIDs := []int64{volumeID}
 
-	remoteDrivers := GetRemoteDrivers()
+	remoteDrivers := StorageRemoteDriverNames()
 
 	// If this is a ceph volume, we want to duplicate the change across the
 	// the rows for all other nodes.
@@ -463,7 +463,7 @@ func (c *Cluster) CreateStoragePoolVolume(project, volumeName, volumeDescription
 		return -1, fmt.Errorf("Volume name may not be a snapshot")
 	}
 
-	remoteDrivers := GetRemoteDrivers()
+	remoteDrivers := StorageRemoteDriverNames()
 
 	err := c.Transaction(func(tx *ClusterTx) error {
 		driver, err := tx.GetStoragePoolDriver(poolID)
@@ -525,7 +525,7 @@ func (c *Cluster) storagePoolVolumeGetTypeID(project string, volumeName string, 
 }
 
 func (c *ClusterTx) storagePoolVolumeGetTypeID(project string, volumeName string, volumeType int, poolID, nodeID int64) (int64, error) {
-	remoteDrivers := GetRemoteDrivers()
+	remoteDrivers := StorageRemoteDriverNames()
 
 	s := fmt.Sprintf(`
 SELECT storage_volumes_all.id

--- a/lxd/storage/drivers/load.go
+++ b/lxd/storage/drivers/load.go
@@ -73,12 +73,12 @@ func SupportedDrivers(s *state.State) []Info {
 
 // AllDriverNames returns a list of all storage driver names.
 func AllDriverNames() []string {
-	supportDriverNames := make([]string, 0, len(drivers))
+	driverNames := make([]string, 0, len(drivers))
 	for driverName := range drivers {
-		supportDriverNames = append(supportDriverNames, driverName)
+		driverNames = append(driverNames, driverName)
 	}
 
-	return supportDriverNames
+	return driverNames
 }
 
 // RemoteDriverNames returns a list of remote storage driver names.

--- a/lxd/storage/drivers/load.go
+++ b/lxd/storage/drivers/load.go
@@ -46,9 +46,18 @@ func Load(state *state.State, driverName string, name string, config map[string]
 	return d, nil
 }
 
+// supportedDrivers cache of supported drivers to avoid inspecting the storage layer every time.
+var supportedDrivers []Info
+
 // SupportedDrivers returns a list of supported storage drivers.
 func SupportedDrivers(s *state.State) []Info {
-	supportedDrivers := make([]Info, 0, len(drivers))
+	// Return cached list if available.
+	if supportedDrivers != nil {
+		return supportedDrivers
+	}
+
+	// Initialise fresh cache and populate.
+	supportedDrivers = make([]Info, 0, len(drivers))
 
 	for driverName := range drivers {
 		driver, err := Load(s, driverName, "", nil, nil, nil, nil)


### PR DESCRIPTION
Now that `StorageRemoteDriverNames()` is being used to generate frequently used DB queries, there is a cost implication to calling `SupportedDrivers()` when a particular driver isn't supported and the time taken to discover this is significant.

If a driver load fails then it (correctly) doesn't set its `loaded` boolean to true, meaning that the discovery process occurs on every call to `SupportedDrivers()` for every non-supported driver.

Instead we now cache (negatively - for unsupported drivers) the list of supported drivers, which in turn improves the performance of `StorageRemoteDriverNames()`.

This should fix the speed issues introduced with commits https://github.com/lxc/lxd/commit/d83e73d17b9a2b576ef436dc9bd8db319b8fe60e and https://github.com/lxc/lxd/commit/ae337c2f3cab475658e56339cf0101d2cd2423c6

CC @stgraber @freeekanayaka @monstermunchkin 