### PR TITLE
Storage: Make remote driver list not depend on loading storage driver (and performing driver version inspection)

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -828,7 +828,7 @@ func (d *Daemon) init() error {
 	}
 
 	// Have the db package determine remote storage drivers
-	db.StorageRemoteDriverNames = storageDrivers.RemoteDriverNames(d.State())
+	db.StorageRemoteDriverNames = storageDrivers.RemoteDriverNames
 
 	/* Open the cluster database */
 	for {

--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -77,7 +77,7 @@ func (d *btrfs) Info() Info {
 		OptimizedBackups:      true,
 		OptimizedBackupHeader: true,
 		PreservesInodes:       !d.state.OS.RunningInUserNS,
-		Remote:                false,
+		Remote:                d.isRemote(),
 		VolumeTypes:           []VolumeType{VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
 		BlockBacking:          false,
 		RunningQuotaResize:    true,

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -64,6 +64,11 @@ func (d *ceph) load() error {
 	return nil
 }
 
+// isRemote returns true indicating this driver uses remote storage.
+func (d *ceph) isRemote() bool {
+	return true
+}
+
 // Info returns info about the driver and its environment.
 func (d *ceph) Info() Info {
 	return Info{

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -71,7 +71,7 @@ func (d *ceph) Info() Info {
 		Version:               cephVersion,
 		OptimizedImages:       true,
 		PreservesInodes:       false,
-		Remote:                true,
+		Remote:                d.isRemote(),
 		VolumeTypes:           []VolumeType{VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
 		BlockBacking:          true,
 		RunningQuotaResize:    false,

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -63,6 +63,11 @@ func (d *cephfs) load() error {
 	return nil
 }
 
+// isRemote returns true indicating this driver uses remote storage.
+func (d *cephfs) isRemote() bool {
+	return true
+}
+
 // Info returns the pool driver information.
 func (d *cephfs) Info() Info {
 	return Info{

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -70,7 +70,7 @@ func (d *cephfs) Info() Info {
 		Version:               cephfsVersion,
 		OptimizedImages:       false,
 		PreservesInodes:       false,
-		Remote:                true,
+		Remote:                d.isRemote(),
 		VolumeTypes:           []VolumeType{VolumeTypeCustom},
 		BlockBacking:          false,
 		RunningQuotaResize:    true,

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -33,6 +33,11 @@ func (d *common) init(state *state.State, name string, config map[string]string,
 	d.logger = logger
 }
 
+// isRemote returns false indicating this driver does not use remote storage.
+func (d *common) isRemote() bool {
+	return false
+}
+
 // validatePool validates a pool config against common rules and optional driver specific rules.
 func (d *common) validatePool(config map[string]string, driverRules map[string]func(value string) error) error {
 	checkedFields := map[string]struct{}{}

--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -38,7 +38,7 @@ func (d *dir) Info() Info {
 		Version:               "1",
 		OptimizedImages:       false,
 		PreservesInodes:       false,
-		Remote:                false,
+		Remote:                d.isRemote(),
 		VolumeTypes:           []VolumeType{VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
 		BlockBacking:          false,
 		RunningQuotaResize:    true,

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -91,7 +91,7 @@ func (d *lvm) Info() Info {
 		Version:               lvmVersion,
 		OptimizedImages:       d.usesThinpool(), // Only thinpool pools support optimized images.
 		PreservesInodes:       false,
-		Remote:                false,
+		Remote:                d.isRemote(),
 		VolumeTypes:           []VolumeType{VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
 		BlockBacking:          true,
 		RunningQuotaResize:    false,

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -108,7 +108,7 @@ func (d *zfs) Info() Info {
 		OptimizedImages:       true,
 		OptimizedBackups:      true,
 		PreservesInodes:       true,
-		Remote:                false,
+		Remote:                d.isRemote(),
 		VolumeTypes:           []VolumeType{VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
 		BlockBacking:          false,
 		RunningQuotaResize:    true,

--- a/lxd/storage/drivers/drivers_mock.go
+++ b/lxd/storage/drivers/drivers_mock.go
@@ -26,7 +26,7 @@ func (d *mock) Info() Info {
 		Version:               "1",
 		OptimizedImages:       false,
 		PreservesInodes:       false,
-		Remote:                false,
+		Remote:                d.isRemote(),
 		VolumeTypes:           []VolumeType{VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
 		BlockBacking:          false,
 		RunningQuotaResize:    true,

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -18,6 +18,7 @@ type driver interface {
 
 	init(state *state.State, name string, config map[string]string, logger logger.Logger, volIDFunc func(volType VolumeType, volName string) (int64, error), commonRules *Validators)
 	load() error
+	isRemote() bool
 }
 
 // Driver represents a low-level storage driver.

--- a/lxd/storage/drivers/load.go
+++ b/lxd/storage/drivers/load.go
@@ -46,18 +46,10 @@ func Load(state *state.State, driverName string, name string, config map[string]
 	return d, nil
 }
 
-// supportedDrivers cache of supported drivers to avoid inspecting the storage layer every time.
-var supportedDrivers []Info
-
-// SupportedDrivers returns a list of supported storage drivers.
+// SupportedDrivers returns a list of supported storage drivers by loading each storage driver and running its
+// compatibility inspection process. This can take a long time if a driver is not supported.
 func SupportedDrivers(s *state.State) []Info {
-	// Return cached list if available.
-	if supportedDrivers != nil {
-		return supportedDrivers
-	}
-
-	// Initialise fresh cache and populate.
-	supportedDrivers = make([]Info, 0, len(drivers))
+	supportedDrivers := make([]Info, 0, len(drivers))
 
 	for driverName := range drivers {
 		driver, err := Load(s, driverName, "", nil, nil, nil, nil)

--- a/lxd/storage/drivers/load.go
+++ b/lxd/storage/drivers/load.go
@@ -74,16 +74,15 @@ func AllDriverNames() []string {
 }
 
 // RemoteDriverNames returns a list of remote storage driver names.
-func RemoteDriverNames(s *state.State) func() []string {
-	return func() []string {
-		var remoteDriverNames []string
-
-		for _, driver := range SupportedDrivers(s) {
-			if driver.Remote {
-				remoteDriverNames = append(remoteDriverNames, driver.Name)
-			}
+func RemoteDriverNames() []string {
+	driverNames := make([]string, 0, len(drivers))
+	for driverName, driverFunc := range drivers {
+		if !driverFunc().isRemote() {
+			continue
 		}
 
-		return remoteDriverNames
+		driverNames = append(driverNames, driverName)
 	}
+
+	return driverNames
 }


### PR DESCRIPTION
Hot on the heals of https://github.com/lxc/lxd/pull/7822 this PR removes the cache added in that last PR as the cache invalidation logic (when combined with the required locking) was getting complicated.

It occurred to me that the "is remote" property is a static property of the driver and not related to the version probing.

So this PR decouples the two concepts and simplifies the `RemoteDriverNames` function.