### PR TITLE
Network: Exclude /32 underlay addresses from fan overlay address generation

### DIFF
--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1819,8 +1819,15 @@ func (n *bridge) addressForSubnet(subnet *net.IPNet) (net.IP, string, error) {
 		}
 
 		for _, addr := range addrs {
-			ip, _, err := net.ParseCIDR(addr.String())
+			ip, network, err := net.ParseCIDR(addr.String())
 			if err != nil {
+				continue
+			}
+
+			// Skip /32 addresses on interfaces in case VIPs are being used on a different interface
+			// than the intended underlay subnet interface.
+			maskOnes, maskSize := network.Mask.Size()
+			if maskOnes == 32 && maskSize == 32 {
 				continue
 			}
 


### PR DESCRIPTION
Avoids detecting the incorrect fan underlay address when /32 VIPs from the underlay subnet are added to a different interface than the underlay subnet is being used on.

Fixes https://discuss.linuxcontainers.org/t/delete-a-stopped-container-bring-down-the-fan-interface/8803

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>