### PR TITLE
Network: Adds ovn.ovs_bridge setting to bridge networks to specify OVS uplink bridge name for OVN networks

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1151,3 +1151,10 @@ Also introduces two new global config keys that apply to all `ovn` networks and 
 
  - network.ovn.integration\_bridge - the OVS integration bridge to use.
  - network.ovn.northbound\_connection - the OVN northbound database connection string.
+
+## network\_bridge\_ovn\_bridge
+Adds the `ovn.ovs_bridge` setting to `bridge` networks to allow the `ovn` networks that use it as their parent
+`network` to access the name of the OVS bridge (and prefix for the related veth pair interfaces).
+
+If missing, the first `ovn` network to specify a `bridge` network as its parent `network` will cause the
+setting to be populated with a random interface name prefixed with "ovn".

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -577,7 +577,7 @@ This introduces the new candid.api.url config option and removes
 core.macaroon.endpoint.
 
 ## backup\_compression
-This introduces a new backups.compression\_algorithm config key which
+This introduces a new `backups.compression_algorithm` config key which
 allows configuration of backup compression.
 
 ## candid\_config
@@ -680,9 +680,9 @@ option `snapshots.expiry` takes an expression in the form of `1M 2H 3d 4w 5m
 parts have to be used.
 
 Snapshots which are then created will be given an expiry date based on the
-expression. This expiry date, defined by `expires\_at`, can be manually edited
+expression. This expiry date, defined by `expires_at`, can be manually edited
 using the API or `lxc config edit`. Snapshots with a valid expiry date will be
-removed when the task in run. Expiry can be disabled by setting `expires\_at` to
+removed when the task in run. Expiry can be disabled by setting `expires_at` to
 an empty string or `0001-01-01T00:00:00Z` (zero time). This is the default if
 `snapshots.expiry` is not set.
 
@@ -717,7 +717,7 @@ used to track the current mapping for the container.
 
 This effectively gives us:
 
- - `volatile.last\_state.idmap` => On-disk idmap
+ - `volatile.last_state.idmap` => On-disk idmap
  - `volatile.idmap.current` => Current kernel map
  - `volatile.idmap.next` => Next on-disk idmap
 
@@ -760,7 +760,7 @@ by a container that a registered syscall has been performed. LXD can then
 decide to trigger various actions.
 
 ## lxc\_features
-This introduces the `lxc\_features` section output from the `lxc info` command
+This introduces the `lxc_features` section output from the `lxc info` command
 via the `GET /1.0/` route. It outputs the result of checks for key features being present in the
 underlying LXC library.
 
@@ -768,7 +768,7 @@ underlying LXC library.
 This introduces the `ipvlan` "nic" device type.
 
 ## network\_vlan\_sriov
-This introduces VLAN (`vlan`) and MAC filtering (`security.mac\_filtering`) support for SR-IOV devices.
+This introduces VLAN (`vlan`) and MAC filtering (`security.mac_filtering`) support for SR-IOV devices.
 
 ## storage\_cephfs
 Add support for CEPHFS as a storage pool driver. This can only be used
@@ -776,7 +776,7 @@ for custom volumes, images and containers should be on CEPH (RBD)
 instead.
 
 ## container\_nic\_ipfilter
-This introduces container IP filtering (`security.ipv4\_filtering` and `security.ipv6\_filtering`) support for `bridged` nic devices.
+This introduces container IP filtering (`security.ipv4_filtering` and `security.ipv6_filtering`) support for `bridged` nic devices.
 
 ## resources\_v2
 Rework the resources API at /1.0/resources, especially:
@@ -822,8 +822,8 @@ This makes use of shiftfs as an overlay filesystem.
 Export infiniband character device information (issm, umad, uverb) as part of the resources API.
 
 ## daemon\_storage
-This introduces two new configuration keys `storage.images\_volume` and
-`storage.backups\_volume` to allow for a storage volume on an existing
+This introduces two new configuration keys `storage.images_volume` and
+`storage.backups_volume` to allow for a storage volume on an existing
 pool be used for storing the daemon-wide images and backups artifacts.
 
 ## instances
@@ -853,15 +853,15 @@ This allows for editing of the expiry date on images.
 Adds a FirmwareVersion field to network card entries.
 
 ## backup\_compression\_algorithm
-This adds support for a `compression\_algorithm` property when creating a backup (`POST /1.0/containers/<name>/backups`).
+This adds support for a `compression_algorithm` property when creating a backup (`POST /1.0/containers/<name>/backups`).
 
-Setting this property overrides the server default value (`backups.compression\_algorithm`).
+Setting this property overrides the server default value (`backups.compression_algorithm`).
 
 ## ceph\_data\_pool\_name
-This adds support for an optional argument (`ceph.osd.data\_pool\_name`) when creating
+This adds support for an optional argument (`ceph.osd.data_pool_name`) when creating
 storage pools using Ceph RBD, when this argument is used the pool will store it's
-actual data in the pool specified with `data\_pool\_name` while keeping the metadata
-in the pool specified by `pool\_name`.
+actual data in the pool specified with `data_pool_name` while keeping the metadata
+in the pool specified by `pool_name`.
 
 ## container\_syscall\_intercept\_mount
 Adds the `security.syscalls.intercept.mount`,
@@ -918,7 +918,7 @@ This allows it to inherit some of the network's settings and allows better valid
 
 ## clustering\_sizing
 Support specifying a custom values for database voters and standbys.
-The new cluster.max\_voters and cluster.max\_standby configuration keys were introduced
+The new `cluster.max_voters` and `cluster.max_standby` configuration keys were introduced
 to specify to the ideal number of database voter and standbys.
 
 ## firewall\_driver
@@ -965,7 +965,7 @@ configuration keys: `snapshots.schedule` and
 
 ## trust\_ca\_certificates
 This allows for checking client certificates trusted by the provided CA (`server.ca`).
-It can be enabled by setting `core.trust\_ca\_certificates` to true.
+It can be enabled by setting `core.trust_ca_certificates` to true.
 If enabled, it will perform the check, and bypass the trusted password if true.
 An exception will be made if the connecting client certificate is in the provided CRL (`ca.crl`).
 In this case, it will ask for the password.
@@ -977,17 +977,17 @@ This adds a new `size` field to the output of `/1.0/instances/<name>/snapshots/<
 This adds a writable endpoint for cluster members, allowing the editing of their roles.
 
 ## container\_nic\_routed\_host\_address
-This introduces the `ipv4.host\_address` and `ipv6.host\_address` NIC config keys that can be used to control the
+This introduces the `ipv4.host_address` and `ipv6.host_address` NIC config keys that can be used to control the
 host-side veth interface's IP addresses. This can be useful when using multiple routed NICs at the same time and
 needing a predictable next-hop address to use.
 
 This also alters the behaviour of `ipv4.gateway` and `ipv6.gateway` NIC config keys. When they are set to "auto"
-the container will have its default gateway set to the value of `ipv4.host\_address` or `ipv6.host\_address` respectively.
+the container will have its default gateway set to the value of `ipv4.host_address` or `ipv6.host_address` respectively.
 
 The default values are:
 
-`ipv4.host\_address`: 169.254.0.1
-`ipv6.host\_address`: fe80::1
+`ipv4.host_address`: 169.254.0.1
+`ipv6.host_address`: fe80::1
 
 This is backward compatible with the previous default behaviour.
 
@@ -1007,19 +1007,19 @@ rather than per core as some hardware apparently puts threads in
 different NUMA domains.
 
 ## resources\_cpu\_core\_die
-Exposes the die\_id information on each core.
+Exposes the `die_id` information on each core.
 
 ## api\_os
-This introduces two new fields in `/1.0`, `os` and `os\_version`.
+This introduces two new fields in `/1.0`, `os` and `os_version`.
 
 Those are taken from the os-release data on the system.
 
 ## container\_nic\_routed\_host\_table
-This introduces the `ipv4.host\_table` and `ipv6.host\_table` NIC config keys that can be used to add static routes
+This introduces the `ipv4.host_table` and `ipv6.host_table` NIC config keys that can be used to add static routes
 for the instance's IPs to a custom policy routing table by ID.
 
 ## container\_nic\_ipvlan\_host\_table
-This introduces the `ipv4.host\_table` and `ipv6.host\_table` NIC config keys that can be used to add static routes
+This introduces the `ipv4.host_table` and `ipv6.host_table` NIC config keys that can be used to add static routes
 for the instance's IPs to a custom policy routing table by ID.
 
 ## container\_nic\_ipvlan\_mode

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -109,6 +109,7 @@ tunnel.NAME.port                | integer   | vxlan                 | 0         
 tunnel.NAME.protocol            | string    | standard mode         | -                         | Tunneling protocol ("vxlan" or "gre")
 tunnel.NAME.remote              | string    | gre or vxlan          | -                         | Remote address for the tunnel (not necessary for multicast vxlan)
 tunnel.NAME.ttl                 | integer   | vxlan                 | 1                         | Specific TTL to use for multicast routing topologies
+ovn.ovs\_bridge                 | string    | -                     | -                         | Name of OVS bridge that OVN networks use to connect to this network.
 
 Those keys can be set using the lxc tool with:
 

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -1,8 +1,6 @@
 package device
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"strconv"
@@ -208,21 +206,6 @@ func networkRestorePhysicalNic(hostName string, volatile map[string]string) erro
 	}
 
 	return nil
-}
-
-// networkRandomDevName returns a random device name with prefix.
-// If the random string combined with the prefix exceeds 13 characters then empty string is returned.
-// This is to ensure we support buggy dhclient applications: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=858580
-func networkRandomDevName(prefix string) string {
-	// Return a new random veth device name
-	randBytes := make([]byte, 4)
-	rand.Read(randBytes)
-	iface := prefix + hex.EncodeToString(randBytes)
-	if len(iface) > 13 {
-		return ""
-	}
-
-	return iface
 }
 
 // networkCreateVethPair creates and configures a veth pair. It will set the hwaddr and mtu settings

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -213,7 +213,7 @@ func networkRestorePhysicalNic(hostName string, volatile map[string]string) erro
 // is supplied in config, then the MTU of the new peer interface will inherit the parent MTU.
 // Accepts the name of the host side interface as a parameter and returns the peer interface name.
 func networkCreateVethPair(hostName string, m deviceConfig.Device) (string, error) {
-	peerName := networkRandomDevName("veth")
+	peerName := network.RandomDevName("veth")
 
 	_, err := shared.RunCommand("ip", "link", "add", "dev", hostName, "type", "veth", "peer", "name", peerName)
 	if err != nil {

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -247,12 +247,12 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 	// Create veth pair and configure the peer end with custom hwaddr and mtu if supplied.
 	if d.inst.Type() == instancetype.Container {
 		if saveData["host_name"] == "" {
-			saveData["host_name"] = networkRandomDevName("veth")
+			saveData["host_name"] = network.RandomDevName("veth")
 		}
 		peerName, err = networkCreateVethPair(saveData["host_name"], d.config)
 	} else if d.inst.Type() == instancetype.VM {
 		if saveData["host_name"] == "" {
-			saveData["host_name"] = networkRandomDevName("tap")
+			saveData["host_name"] = network.RandomDevName("tap")
 		}
 		peerName = saveData["host_name"] // VMs use the host_name to link to the TAP FD.
 		err = networkCreateTap(saveData["host_name"], d.config)

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -120,7 +120,7 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 	actualParentName := network.GetHostDevice(d.config["parent"], d.config["vlan"])
 
 	// Record the temporary device name used for deletion later.
-	saveData["host_name"] = networkRandomDevName("mac")
+	saveData["host_name"] = network.RandomDevName("mac")
 
 	// Create VLAN parent device if needed.
 	statusDev, err := networkCreateVlanDeviceIfNeeded(d.state, d.config["parent"], actualParentName, d.config["vlan"])

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -183,12 +183,12 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 	// Create veth pair and configure the peer end with custom hwaddr and mtu if supplied.
 	if d.inst.Type() == instancetype.Container {
 		if saveData["host_name"] == "" {
-			saveData["host_name"] = networkRandomDevName("veth")
+			saveData["host_name"] = network.RandomDevName("veth")
 		}
 		peerName, err = networkCreateVethPair(saveData["host_name"], d.config)
 	} else if d.inst.Type() == instancetype.VM {
 		if saveData["host_name"] == "" {
-			saveData["host_name"] = networkRandomDevName("tap")
+			saveData["host_name"] = network.RandomDevName("tap")
 		}
 		peerName = saveData["host_name"] // VMs use the host_name to link to the TAP FD.
 		err = networkCreateTap(saveData["host_name"], d.config)

--- a/lxd/device/nic_p2p.go
+++ b/lxd/device/nic_p2p.go
@@ -6,6 +6,7 @@ import (
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/lxd/network"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/shared"
 )
@@ -73,12 +74,12 @@ func (d *nicP2P) Start() (*deviceConfig.RunConfig, error) {
 	// Create veth pair and configure the peer end with custom hwaddr and mtu if supplied.
 	if d.inst.Type() == instancetype.Container {
 		if saveData["host_name"] == "" {
-			saveData["host_name"] = networkRandomDevName("veth")
+			saveData["host_name"] = network.RandomDevName("veth")
 		}
 		peerName, err = networkCreateVethPair(saveData["host_name"], d.config)
 	} else if d.inst.Type() == instancetype.VM {
 		if saveData["host_name"] == "" {
-			saveData["host_name"] = networkRandomDevName("tap")
+			saveData["host_name"] = network.RandomDevName("tap")
 		}
 		peerName = saveData["host_name"] // VMs use the host_name to link to the TAP FD.
 		err = networkCreateTap(saveData["host_name"], d.config)

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -193,7 +193,7 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 
 	hostName := d.config["host_name"]
 	if hostName == "" {
-		hostName = networkRandomDevName("veth")
+		hostName = network.RandomDevName("veth")
 	}
 	saveData["host_name"] = hostName
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -226,6 +226,8 @@ func (n *bridge) Validate(config map[string]string) error {
 
 		"raw.dnsmasq": validate.IsAny,
 
+		ovnParentOVSBridge: validate.Optional(validInterfaceName),
+
 		"maas.subnet.ipv4": validate.IsAny,
 		"maas.subnet.ipv6": validate.IsAny,
 	}

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -109,6 +109,11 @@ func (n *common) Name() string {
 	return n.name
 }
 
+// Description returns the network description.
+func (n *common) Description() string {
+	return n.description
+}
+
 // Status returns the network status.
 func (n *common) Status() string {
 	return n.status

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
-	"github.com/lxc/lxd/lxd/dnsmasq"
 	"github.com/lxc/lxd/lxd/locking"
 	"github.com/lxc/lxd/lxd/network/openvswitch"
 	"github.com/lxc/lxd/lxd/project"
@@ -506,6 +505,7 @@ func (n *ovn) parentOperationLockName(parentNet Network) string {
 
 // parentPortBridgeVars returns the parent port bridge variables needed for port start/stop.
 func (n *ovn) parentPortBridgeVars(parentNet Network) *ovnParentPortBridgeVars {
+
 	ovsBridge := fmt.Sprintf("lxdovn%d", parentNet.ID())
 
 	return &ovnParentPortBridgeVars{
@@ -629,18 +629,7 @@ func (n *ovn) deleteParentPort() error {
 
 // deleteParentPortBridge deletes the dnsmasq static lease and removes parent uplink OVS bridge if not in use.
 func (n *ovn) deleteParentPortBridge(parentNet Network) error {
-	err := dnsmasq.RemoveStaticEntry(parentNet.Name(), project.Default, n.getNetworkPrefix())
-	if err != nil {
-		return err
-	}
-
-	// Reload dnsmasq.
-	err = dnsmasq.Kill(parentNet.Name(), true)
-	if err != nil {
-		return err
-	}
-
-	// Lock parent network so we don;t race each other networks using the OVS uplink bridge.
+	// Lock parent network so we don't race each other networks using the OVS uplink bridge.
 	unlock := locking.Lock(n.parentOperationLockName(parentNet))
 	defer unlock()
 

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -21,6 +21,7 @@ type Network interface {
 	ID() int64
 	Name() string
 	Type() string
+	Description() string
 	Status() string
 	Config() map[string]string
 	IsUsed() (bool, error)

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -68,6 +68,21 @@ func networkValidPort(value string) error {
 	return nil
 }
 
+// RandomDevName returns a random device name with prefix.
+// If the random string combined with the prefix exceeds 13 characters then empty string is returned.
+// This is to ensure we support buggy dhclient applications: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=858580
+func RandomDevName(prefix string) string {
+	// Return a new random veth device name.
+	randBytes := make([]byte, 4)
+	rand.Read(randBytes)
+	iface := prefix + hex.EncodeToString(randBytes)
+	if len(iface) > 13 {
+		return ""
+	}
+
+	return iface
+}
+
 // IsInUseByInstance indicates if network is referenced by an instance's NIC devices.
 // Checks if the device's parent or network properties match the network name.
 func IsInUseByInstance(s *state.State, c instance.Instance, networkName string) (bool, error) {

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -224,6 +224,7 @@ var APIExtensions = []string{
 	"network_type_sriov",
 	"container_syscall_intercept_bpf_devices",
 	"network_type_ovn",
+	"network_bridge_ovn_bridge",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR introduces the `ovn.ovs_bridge` bridge network setting. It is used by OVN networks that specify the bridge network as its parent `network` in order to create an OVS uplink bridge using the setting's name (and as a name prefix for the associated veth interfaces). 

This is being introduced to work around an issue when joining an node to an existing cluster that has an OVN network, because previously the internal DB network row ID was used as part of the OVS bridge name. However this caused issues during the pre-join phase because potentially a different local network ID would be used to create the OVS bridge than is used in the rest of the cluster.

This removes the use of internal DB IDs for interface names and uses config setting instead, which will be used in the pre-join phase of network creation too.