### PR TITLE
Instance: Fixes crash when removing device that cant be loaded

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1565,8 +1565,7 @@ func (c *lxc) deviceStop(deviceName string, rawConfig deviceConfig.Device, stopH
 	if err != nil {
 		// If there is no device returned, then we cannot proceed, so return as error.
 		if d == nil {
-			return fmt.Errorf("Device stop validation failed for '%s': %v", deviceName, err)
-
+			return fmt.Errorf("Device stop validation failed for %q: %v", deviceName, err)
 		}
 
 		logger.Error("Device stop validation failed for", log.Ctx{"err": err})
@@ -1729,6 +1728,8 @@ func (c *lxc) deviceHandleMounts(mounts []deviceConfig.MountEntryItem) error {
 
 // deviceRemove loads a new device and calls its Remove() function.
 func (c *lxc) deviceRemove(deviceName string, rawConfig deviceConfig.Device) error {
+	logger := logging.AddContext(logger.Log, log.Ctx{"device": deviceName, "project": c.Project(), "instance": c.Name()})
+
 	d, _, err := c.deviceLoad(deviceName, rawConfig)
 
 	// If deviceLoad fails with unsupported device type then return.
@@ -1740,7 +1741,12 @@ func (c *lxc) deviceRemove(deviceName string, rawConfig deviceConfig.Device) err
 	// scenario that a new version of LXD has additional validation restrictions than older
 	// versions we still need to allow previously valid devices to be stopped.
 	if err != nil {
-		logger.Errorf("Device remove validation failed for '%s': %v", deviceName, err)
+		// If there is no device returned, then we cannot proceed, so return as error.
+		if d == nil {
+			return fmt.Errorf("Device remove validation failed for %q: %v", deviceName, err)
+		}
+
+		logger.Error("Device remove validation failed for", log.Ctx{"err": err})
 	}
 
 	return d.Remove()

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1147,11 +1147,11 @@ func (vm *qemu) deviceStop(deviceName string, rawConfig deviceConfig.Device) err
 	if err != nil {
 		// If there is no device returned, then we cannot proceed, so return as error.
 		if d == nil {
-			return fmt.Errorf("Device stop validation failed for '%s': %v", deviceName, err)
+			return fmt.Errorf("Device stop validation failed for %q: %v", deviceName, err)
 
 		}
 
-		logger.Error("Device stop validation failed for", log.Ctx{"err": err})
+		logger.Error("Device stop validation failed", log.Ctx{"err": err})
 	}
 
 	canHotPlug, _ := d.CanHotPlug()
@@ -3366,6 +3366,8 @@ func (vm *qemu) deviceAdd(deviceName string, rawConfig deviceConfig.Device) erro
 }
 
 func (vm *qemu) deviceRemove(deviceName string, rawConfig deviceConfig.Device) error {
+	logger := logging.AddContext(logger.Log, log.Ctx{"device": deviceName, "project": vm.Project(), "instance": vm.Name()})
+
 	d, _, err := vm.deviceLoad(deviceName, rawConfig)
 
 	// If deviceLoad fails with unsupported device type then return.
@@ -3377,7 +3379,12 @@ func (vm *qemu) deviceRemove(deviceName string, rawConfig deviceConfig.Device) e
 	// scenario that a new version of LXD has additional validation restrictions than older
 	// versions we still need to allow previously valid devices to be stopped.
 	if err != nil {
-		logger.Errorf("Device remove validation failed for '%s': %v", deviceName, err)
+		// If there is no device returned, then we cannot proceed, so return as error.
+		if d == nil {
+			return fmt.Errorf("Device remove validation failed for %q: %v", deviceName, err)
+		}
+
+		logger.Error("Device remove validation failed", log.Ctx{"err": err})
 	}
 
 	return d.Remove()


### PR DESCRIPTION
Also makes error logging and returned error messages consistent between lxc and qemu.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>