### PR TITLE
lxd/drivers/qemu: Use gic-version=max on aarch64

### DIFF
--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -14,7 +14,7 @@ type = "q35"
 {{end -}}
 {{if eq .architecture "aarch64" -}}
 type = "virt"
-gic-version = "host"
+gic-version = "max"
 {{end -}}
 {{if eq .architecture "ppc64le" -}}
 type = "pseries"


### PR DESCRIPTION
Despite max and host supposedly being equivalent when in KVM mode, on a
limited number of platforms, host fails to fallback to 2 when no kernel
irqchip support is detected whereas max will properly select 2 in such
cases.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>