### PR TITLE
Network: Reverts ovn.name and ovn.ovs_bridge settings and defers network start until after cluster pre-join phase

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1158,7 +1158,3 @@ Adds the `ovn.ovs_bridge` setting to `bridge` networks to allow the `ovn` networ
 
 If missing, the first `ovn` network to specify a `bridge` network as its parent `network` will cause the
 setting to be populated with a random interface name prefixed with "ovn".
-
-## network\_ovn\_name
-Adds the `ovn.name` setting to `ovn` networks to allow nodes joining cluster to access the logical OVN network
-name during the pre-join stage before the node is connected to the cluster database.

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1151,10 +1151,3 @@ Also introduces two new global config keys that apply to all `ovn` networks and 
 
  - network.ovn.integration\_bridge - the OVS integration bridge to use.
  - network.ovn.northbound\_connection - the OVN northbound database connection string.
-
-## network\_bridge\_ovn\_bridge
-Adds the `ovn.ovs_bridge` setting to `bridge` networks to allow the `ovn` networks that use it as their parent
-`network` to access the name of the OVS bridge (and prefix for the related veth pair interfaces).
-
-If missing, the first `ovn` network to specify a `bridge` network as its parent `network` will cause the
-setting to be populated with a random interface name prefixed with "ovn".

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -298,4 +298,3 @@ dns.search                      | string    | -                     | -         
 ipv4.address                    | string    | standard mode         | random unused subnet      | IPv4 address for the bridge (CIDR notation). Use "none" to turn off IPv4 or "auto" to generate a new one
 ipv6.address                    | string    | standard mode         | random unused subnet      | IPv6 address for the bridge (CIDR notation). Use "none" to turn off IPv6 or "auto" to generate a new one
 network                         | string    | -                     | -                         | Parent network to use for outbound external network access
-ovn.name                        | string    | -                     | -                         | Name of OVN logical network (populated automatically at network setup time)

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -109,7 +109,6 @@ tunnel.NAME.port                | integer   | vxlan                 | 0         
 tunnel.NAME.protocol            | string    | standard mode         | -                         | Tunneling protocol ("vxlan" or "gre")
 tunnel.NAME.remote              | string    | gre or vxlan          | -                         | Remote address for the tunnel (not necessary for multicast vxlan)
 tunnel.NAME.ttl                 | integer   | vxlan                 | 1                         | Specific TTL to use for multicast routing topologies
-ovn.ovs\_bridge                 | string    | -                     | -                         | Name of OVS bridge that OVN networks use to connect to this network.
 
 Those keys can be set using the lxc tool with:
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -550,6 +550,13 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) response.Response {
 			}
 		}
 
+		// Start up networks so any post-join changes can be applied now that we have a Node ID.
+		logger.Debug("Starting networks after cluster join")
+		err = networkStartup(d.State())
+		if err != nil {
+			logger.Errorf("Failed starting networks: %v", err)
+		}
+
 		client, err = cluster.Connect(req.ClusterAddress, d.endpoints.NetworkCert(), true)
 		if err != nil {
 			return err

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -226,8 +226,6 @@ func (n *bridge) Validate(config map[string]string) error {
 
 		"raw.dnsmasq": validate.IsAny,
 
-		ovnParentOVSBridge: validate.Optional(validInterfaceName),
-
 		"maas.subnet.ipv4": validate.IsAny,
 		"maas.subnet.ipv6": validate.IsAny,
 	}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -361,12 +361,7 @@ func (n *ovn) setupParentPortBridge(parentNet Network, routerMAC net.HardwareAdd
 				n.config[ovnVolatileParentIPv6] = routerExtPortIPv6.String()
 			}
 
-			networkID, err := tx.GetNetworkID(n.name)
-			if err != nil {
-				return errors.Wrapf(err, "Failed to get network ID for network %q", n.name)
-			}
-
-			err = tx.UpdateNetwork(networkID, n.description, n.config)
+			err = tx.UpdateNetwork(n.id, n.description, n.config)
 			if err != nil {
 				return errors.Wrapf(err, "Failed saving allocated parent network IPs")
 			}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -499,7 +499,6 @@ func (n *ovn) parentOperationLockName(parentNet Network) string {
 
 // parentPortBridgeVars returns the parent port bridge variables needed for port start/stop.
 func (n *ovn) parentPortBridgeVars(parentNet Network) *ovnParentPortBridgeVars {
-
 	ovsBridge := fmt.Sprintf("lxdovn%d", parentNet.ID())
 
 	return &ovnParentPortBridgeVars{

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -19,7 +19,6 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/locking"
 	"github.com/lxc/lxd/lxd/network/openvswitch"
-	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1189,6 +1189,8 @@ func (n *ovn) Stop() error {
 		return err
 	}
 
+	time.Sleep(2 * time.Second) // Give some time for the chassis deletion to tear down patch ports.
+
 	// Delete local parent uplink port.
 	// This must occur after the local OVS chassis ID is removed from the OVN HA chassis group so that the
 	// OVN patch port connection is removed for this network and we can correctly detect whether there are

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/locking"
 	"github.com/lxc/lxd/lxd/network/openvswitch"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -33,10 +34,6 @@ const ovnGeneveTunnelMTU = 1442
 const ovnChassisPriorityMax = 32767
 const ovnVolatileParentIPv4 = "volatile.network.ipv4.address"
 const ovnVolatileParentIPv6 = "volatile.network.ipv6.address"
-
-// ovnParentOVSBridge setting on the parent network indicating the name to use for the OVS bridge and prefix for
-// associated veth interfaces when using the parent network as an OVN uplink.
-const ovnParentOVSBridge = "ovn.ovs_bridge"
 
 // ovnParentVars OVN object variables derived from parent network.
 type ovnParentVars struct {
@@ -507,40 +504,21 @@ func (n *ovn) parentOperationLockName(parentNet Network) string {
 }
 
 // parentPortBridgeVars returns the parent port bridge variables needed for port start/stop.
-func (n *ovn) parentPortBridgeVars(parentNet Network) (*ovnParentPortBridgeVars, error) {
-	parentConfig := parentNet.Config()
-	if parentConfig[ovnParentOVSBridge] == "" {
-		// Generate random OVS bridge name for parent uplink.
-		parentConfig[ovnParentOVSBridge] = RandomDevName("ovn")
+func (n *ovn) parentPortBridgeVars(parentNet Network) *ovnParentPortBridgeVars {
 
-		// Store in parent config.
-		err := n.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
-			err := tx.UpdateNetwork(parentNet.ID(), parentNet.Description(), parentConfig)
-			if err != nil {
-				return errors.Wrapf(err, "Failed saving parent network OVN OVS bridge name")
-			}
-
-			return nil
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
+	ovsBridge := fmt.Sprintf("lxdovn%d", parentNet.ID())
 
 	return &ovnParentPortBridgeVars{
-		ovsBridge: parentConfig[ovnParentOVSBridge],
-		parentEnd: fmt.Sprintf("%sa", parentConfig[ovnParentOVSBridge]),
-		ovsEnd:    fmt.Sprintf("%sb", parentConfig[ovnParentOVSBridge]),
-	}, nil
+		ovsBridge: ovsBridge,
+		parentEnd: fmt.Sprintf("%sa", ovsBridge),
+		ovsEnd:    fmt.Sprintf("%sb", ovsBridge),
+	}
 }
 
 // startParentPortBridge creates veth pair (if doesn't exist), creates OVS bridge (if doesn't exist) and
 // connects veth pair to parent bridge and OVS bridge.
 func (n *ovn) startParentPortBridge(parentNet Network) error {
-	vars, err := n.parentPortBridgeVars(parentNet)
-	if err != nil {
-		return err
-	}
+	vars := n.parentPortBridgeVars(parentNet)
 
 	// Lock parent network so that if multiple OVN networks are trying to connect to the same parent we don't
 	// race each other setting up the connection.
@@ -562,7 +540,7 @@ func (n *ovn) startParentPortBridge(parentNet Network) error {
 	}
 
 	// Ensure correct sysctls are set on uplink veth interfaces to avoid getting IPv6 link-local addresses.
-	_, err = shared.RunCommand("sysctl",
+	_, err := shared.RunCommand("sysctl",
 		fmt.Sprintf("net.ipv6.conf.%s.disable_ipv6=1", vars.parentEnd),
 		fmt.Sprintf("net.ipv6.conf.%s.disable_ipv6=1", vars.ovsEnd),
 		fmt.Sprintf("net.ipv6.conf.%s.forwarding=0", vars.parentEnd),
@@ -657,11 +635,7 @@ func (n *ovn) deleteParentPortBridge(parentNet Network) error {
 
 	// Check OVS uplink bridge exists, if it does, check how many ports it has.
 	removeVeths := false
-	vars, err := n.parentPortBridgeVars(parentNet)
-	if err != nil {
-		return err
-	}
-
+	vars := n.parentPortBridgeVars(parentNet)
 	if shared.PathExists(fmt.Sprintf("/sys/class/net/%s", vars.ovsBridge)) {
 		ovs := openvswitch.NewOVS()
 		ports, err := ovs.BridgePortList(vars.ovsBridge)

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -364,10 +364,14 @@ func doNetworksCreate(d *Daemon, req api.NetworksPost, clientType cluster.Client
 		return err
 	}
 
-	err = n.Start()
-	if err != nil {
-		n.Delete(clientType)
-		return err
+	// Only start networks when not doing a cluster pre-join phase (this ensures that networks are only started
+	// once the node has fully joined the clustered database and has consistent config with rest of the nodes).
+	if clientType != cluster.ClientTypeJoiner {
+		err = n.Start()
+		if err != nil {
+			n.Delete(clientType)
+			return err
+		}
 	}
 
 	return nil

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -225,7 +225,6 @@ var APIExtensions = []string{
 	"container_syscall_intercept_bpf_devices",
 	"network_type_ovn",
 	"network_bridge_ovn_bridge",
-	"network_ovn_name",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -224,7 +224,6 @@ var APIExtensions = []string{
 	"network_type_sriov",
 	"container_syscall_intercept_bpf_devices",
 	"network_type_ovn",
-	"network_bridge_ovn_bridge",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
When joining a node to a cluster, there is a "pre-join" phase where the joining node is asked to create each network locally so that its config will match the existing cluster's when it asks to join.

This is achieved by calling `doNetworksCreate()` on the local node, which in turn calls the `n.Start()` function to start the network once it has been created in the local database.

Unfortunately this is causing problems with both `bridge` and `ovn` network types as they both rely on cluster state to start up correctly, and this "pre-join" phase start up is leaving the networks in an inconsistent state on the joining node.

For `bridge` networks the recently added stable random MAC address for the bridge interface itself is derived from the cluster's certificate when in cluster mode. During the pre-join phase the network is started in non-cluster mode, and so the bridge's MAC address is incorrectly generated. The correct MAC address isn't applied until the next time LXD is restarted.

For `ovn` networks there are two cluster state issues; firstly the node-local OVS uplink bridge name is derived from the parent network's DB ID. As such if the local parent network's ID differs from the clustered database's ID for the same network, the OVS uplink interface will get created with the wrong name. Secondly, when the OVN network starts up on each node it contacts the central OVN northbound database and adds its local OVS chassis ID into the OVN HA Chassis group (so it can be used for external network access). Again, the OVN chassis group name is derived from the OVN network's DB ID, and if the local ID differs from the clustered network ID then the start up will fail because the chassis group doesn't exist.

To solve these problems I initially tried adding automatically generated config variables that stored the cluster ID derived names so that they could be used consistently during pre-join phase. However this didn't solve the bridge issue that relied on the cluster's certificate.

Instead we agreed to restart the the networks after the cluster join has completed so apply any changes that need to occur.
However if this step is needed, then it is simpler to just defer the network start during cluster join until after the pre-join phase has been completed. This way the networks are only ever started once the node is connected to the cluster database.

This simplifies several things:

1. It no longer requires the `ovn.name` and `ovn.ovs_bridge` settings.
2. It does not need to copy the global `network.ovn.northbound_connection` setting in order to perform network pre-join of OVN networks.
3. It does not need to start the networks twice during cluster join (now only once after join has succeeded).
4. It avoids calling `n.Start()` with local network IDs during pre-join, that can lead to inconsistent setups.

The `n.Create()` function is still called during pre-join, so any local node environment validation or setup steps can still be performed (and this function has the `clientType` argument so that pre-join phase can be detected by the network driver and the relevant steps can be taken as needed).