### PR TITLE
lxc: Better handle arguments

### DIFF
--- a/lxc/main_aliases.go
+++ b/lxc/main_aliases.go
@@ -48,7 +48,7 @@ func expandAlias(conf *config.Config, args []string) ([]string, bool) {
 	var newArgs []string
 	var origArgs []string
 
-	for _, arg := range args {
+	for _, arg := range args[1:] {
 		if arg[0] != '-' {
 			break
 		}
@@ -56,7 +56,7 @@ func expandAlias(conf *config.Config, args []string) ([]string, bool) {
 		newArgs = append(newArgs, arg)
 	}
 
-	origArgs = args[len(newArgs):]
+	origArgs = append([]string{args[0]}, args[len(newArgs)+1:]...)
 
 	aliasKey, aliasValue, foundAlias := findAlias(conf.Aliases, origArgs)
 	if !foundAlias {
@@ -67,7 +67,7 @@ func expandAlias(conf *config.Config, args []string) ([]string, bool) {
 	}
 
 	if !strings.HasPrefix(aliasValue[0], "/") {
-		newArgs = append(newArgs, origArgs[0])
+		newArgs = append([]string{origArgs[0]}, newArgs...)
 	}
 	hasReplacedArgsVar := false
 


### PR DESCRIPTION
This allows things like:

 - lxc --project=blah shell abc
 - lxc --debug shell abc

Not that it aliases cannot support leading flags with value separated by
spaces as the alias handling logic does not know what flag is a boolean
and what flag takes a value.

As a result, use `lxc --project=blah shell` and not `lxc --project blah shell`
as the latter cannot work and will lead to a confusing error.

Closes #7625

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>