### PR TITLE
AppArmor: Fix invalid aa profile generation when lxd binary has changed/gone

### DIFF
--- a/lxd/util/sys.go
+++ b/lxd/util/sys.go
@@ -167,5 +167,8 @@ func GetExecPath() string {
 	if err != nil {
 		execPath = "bad-exec-path"
 	}
-	return execPath
+
+	// The execPath from /proc/self/exe can end with " (deleted)" if the lxd binary has been removed/changed
+	// since the lxd process was started, strip this so that we only return a valid path.
+	return strings.TrimSuffix(execPath, " (deleted)")
 }


### PR DESCRIPTION
During development I noticed that a long running lxd process would fail to start a VM after the underlying lxd binary had changed with the error:

```
lxc start v1
Error: Failed to run: apparmor_parser -rWL /var/lib/lxd/security/apparmor/cache /var/lib/lxd/security/apparmor/profiles/lxd-v1: AppArmor parser error for /var/lib/lxd/security/apparmor/profiles/lxd-v1 in /var/lib/lxd/security/apparmor/profiles/lxd-v1 at line 41: syntax error, unexpected TOK_OPENPAREN, expecting TOK_MODE
```

I found this was due to the aa profile exec path variable containing " (deleted)" at the end. 

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>