### PR TITLE
Images: Handle downloading images from other cluster nodes across projects

### DIFF
--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -155,20 +155,20 @@ func (d *Daemon) ImageDownload(op *operations.Operation, server string, protocol
 		}
 
 		if shared.Int64InSlice(poolID, poolIDs) {
-			logger.Debugf("Image already exists on storage pool \"%s\"", storagePool)
+			logger.Debugf("Image already exists on storage pool %q", storagePool)
 			return info, nil
 		}
 
 		// Import the image in the pool
-		logger.Debugf("Image does not exist on storage pool \"%s\"", storagePool)
+		logger.Debugf("Image does not exist on storage pool %q", storagePool)
 
 		err = imageCreateInPool(d, info, storagePool)
 		if err != nil {
-			logger.Debugf("Failed to create image on storage pool \"%s\": %s", storagePool, err)
+			logger.Debugf("Failed to create image on storage pool %q: %v", storagePool, err)
 			return nil, err
 		}
 
-		logger.Debugf("Created image on storage pool \"%s\"", storagePool)
+		logger.Debugf("Created image on storage pool %q", storagePool)
 		return info, nil
 	}
 
@@ -368,7 +368,7 @@ func (d *Daemon) ImageDownload(op *operations.Operation, server string, protocol
 		}
 
 		if raw.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("Unable to fetch %s: %s", server, raw.Status)
+			return nil, fmt.Errorf("Unable to fetch %q: %s", server, raw.Status)
 		}
 
 		// Progress handler
@@ -402,7 +402,7 @@ func (d *Daemon) ImageDownload(op *operations.Operation, server string, protocol
 		// Validate hash
 		result := fmt.Sprintf("%x", sha256.Sum(nil))
 		if result != fp {
-			return nil, fmt.Errorf("Hash mismatch for %s: %s != %s", server, result, fp)
+			return nil, fmt.Errorf("Hash mismatch for %q: %s != %s", server, result, fp)
 		}
 
 		// Parse the image

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -610,7 +610,7 @@ WHERE images.fingerprint = ?
 		return "", err
 	}
 	if len(addresses) == 0 {
-		return "", fmt.Errorf("image not available on any online node")
+		return "", fmt.Errorf("Image not available on any online node")
 	}
 
 	for _, address := range addresses {

--- a/lxd/db/images_test.go
+++ b/lxd/db/images_test.go
@@ -37,7 +37,7 @@ func TestLocateImage(t *testing.T) {
 
 	address, err = cluster.LocateImage("abc")
 	require.Equal(t, "", address)
-	require.EqualError(t, err, "image not available on any online node")
+	require.EqualError(t, err, "Image not available on any online node")
 }
 
 func TestImageExists(t *testing.T) {

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -1199,7 +1199,17 @@ test_clustering_projects() {
   LXD_DIR="${LXD_ONE_DIR}" lxc list | grep -q c1
   LXD_DIR="${LXD_TWO_DIR}" lxc list | grep -q c1
 
-  LXD_DIR="${LXD_ONE_DIR}" lxc delete c1
+  LXD_DIR="${LXD_ONE_DIR}" lxc delete -f c1
+
+  # Remove the image file and DB record from node1.
+  rm "${LXD_ONE_DIR}"/images/*
+  LXD_DIR="${LXD_TWO_DIR}" lxd sql global 'delete from images_nodes where node_id = 1'
+
+  # Check image import from node2 by creating container on node1 in other project.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster list
+  LXD_DIR="${LXD_ONE_DIR}" lxc init --target node1 testimage c2 --project p1
+  LXD_DIR="${LXD_ONE_DIR}" lxc delete -f c2 --project p1
+
   LXD_DIR="${LXD_ONE_DIR}" lxc image delete testimage
 
   LXD_DIR="${LXD_ONE_DIR}" lxc project switch default


### PR DESCRIPTION
This PR fixes an issue reported at https://discuss.linuxcontainers.org/t/cannot-launch-container-in-a-project-on-ubuntu-20-04-cluster/8744 where if an image is initially download into a project and then the next instance created is on a different node AND a different project then the image wouldn't be transferred from the first node and instance creation would fail.