### PR TITLE
Network: Skip lo interface addresses when deriving a fan overlay address

### DIFF
--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1824,15 +1824,8 @@ func (n *bridge) addressForSubnet(subnet *net.IPNet) (net.IP, string, error) {
 		}
 
 		for _, addr := range addrs {
-			ip, network, err := net.ParseCIDR(addr.String())
+			ip, _, err := net.ParseCIDR(addr.String())
 			if err != nil {
-				continue
-			}
-
-			// Skip /32 addresses on interfaces in case VIPs are being used on a different interface
-			// than the intended underlay subnet interface.
-			maskOnes, maskSize := network.Mask.Size()
-			if maskOnes == 32 && maskSize == 32 {
 				continue
 			}
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1818,6 +1818,12 @@ func (n *bridge) addressForSubnet(subnet *net.IPNet) (net.IP, string, error) {
 	}
 
 	for _, iface := range ifaces {
+		// Skip addresses on lo interface in case VIPs are being used on that interface that are part of
+		// the underlay subnet as is unlikely to be the actual intended underlay subnet interface.
+		if iface.Name == "lo" {
+			continue
+		}
+
 		addrs, err := iface.Addrs()
 		if err != nil {
 			continue


### PR DESCRIPTION
Fixes issue https://discuss.linuxcontainers.org/t/lxd-container-stuck-in-running-without-ip-address/8973 caused by https://github.com/lxc/lxd/pull/7833 whilst also not regressing https://discuss.linuxcontainers.org/t/delete-a-stopped-container-bring-down-the-fan-interface/8803 

