### PR TITLE
Instance: Moves backups from shared.VarPath("backups") to  shared.VarPath("backups", "instances")

### DIFF
--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -83,7 +83,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 	}
 
 	// Create the target path if needed.
-	backupsPath := shared.VarPath("backups", project.Instance(sourceInst.Project(), sourceInst.Name()))
+	backupsPath := shared.VarPath("backups", "instances", project.Instance(sourceInst.Project(), sourceInst.Name()))
 	if !shared.PathExists(backupsPath) {
 		err := os.MkdirAll(backupsPath, 0700)
 		if err != nil {
@@ -93,7 +93,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 		revert.Add(func() { os.Remove(backupsPath) })
 	}
 
-	target := shared.VarPath("backups", project.Instance(sourceInst.Project(), b.Name()))
+	target := shared.VarPath("backups", "instances", project.Instance(sourceInst.Project(), b.Name()))
 
 	// Setup the tarball writer.
 	logger.Debug("Opening backup tarball for writing", log.Ctx{"path": target})

--- a/lxd/backup/backup.go
+++ b/lxd/backup/backup.go
@@ -17,6 +17,9 @@ import (
 	"github.com/lxc/lxd/shared/api"
 )
 
+// WorkingDirPrefix is used when temporary working directories are needed.
+const WorkingDirPrefix = "lxd_backup"
+
 // Instance represents the backup relevant subset of a LXD instance.
 // This is used rather than instance.Instance to avoid import loops.
 type Instance interface {

--- a/lxd/backup/backup.go
+++ b/lxd/backup/backup.go
@@ -179,13 +179,13 @@ func (b *Backup) OptimizedStorage() bool {
 	return b.optimizedStorage
 }
 
-// Rename renames a container backup
+// Rename renames an instance backup.
 func (b *Backup) Rename(newName string) error {
-	oldBackupPath := shared.VarPath("backups", project.Instance(b.instance.Project(), b.name))
-	newBackupPath := shared.VarPath("backups", project.Instance(b.instance.Project(), newName))
+	oldBackupPath := shared.VarPath("backups", "instances", project.Instance(b.instance.Project(), b.name))
+	newBackupPath := shared.VarPath("backups", "instances", project.Instance(b.instance.Project(), newName))
 
-	// Create the new backup path
-	backupsPath := shared.VarPath("backups", project.Instance(b.instance.Project(), b.instance.Name()))
+	// Create the new backup path.
+	backupsPath := shared.VarPath("backups", "instances", project.Instance(b.instance.Project(), b.instance.Name()))
 	if !shared.PathExists(backupsPath) {
 		err := os.MkdirAll(backupsPath, 0700)
 		if err != nil {

--- a/lxd/backup/backup.go
+++ b/lxd/backup/backup.go
@@ -256,7 +256,7 @@ func DoBackupDelete(s *state.State, projectName, backupName, instanceName string
 		}
 	}
 
-	// Remove the database record
+	// Remove the database record.
 	err := s.Cluster.DeleteInstanceBackup(backupName)
 	if err != nil {
 		return err

--- a/lxd/backup/backup.go
+++ b/lxd/backup/backup.go
@@ -235,10 +235,10 @@ func (b *Backup) Render() *api.InstanceBackup {
 }
 
 // DoBackupDelete deletes a backup.
-func DoBackupDelete(s *state.State, projectName, backupName, containerName string) error {
-	backupPath := shared.VarPath("backups", project.Instance(projectName, backupName))
+func DoBackupDelete(s *state.State, projectName, backupName, instanceName string) error {
+	backupPath := shared.VarPath("backups", "instances", project.Instance(projectName, backupName))
 
-	// Delete the on-disk data
+	// Delete the on-disk data.
 	if shared.PathExists(backupPath) {
 		err := os.RemoveAll(backupPath)
 		if err != nil {
@@ -246,8 +246,8 @@ func DoBackupDelete(s *state.State, projectName, backupName, containerName strin
 		}
 	}
 
-	// Check if we can remove the container directory
-	backupsPath := shared.VarPath("backups", project.Instance(projectName, containerName))
+	// Check if we can remove the instance directory.
+	backupsPath := shared.VarPath("backups", "instances", project.Instance(projectName, instanceName))
 	empty, _ := shared.PathIsEmpty(backupsPath)
 	if empty {
 		err := os.Remove(backupsPath)

--- a/lxd/backup/backup.go
+++ b/lxd/backup/backup.go
@@ -193,13 +193,13 @@ func (b *Backup) Rename(newName string) error {
 		}
 	}
 
-	// Rename the backup directory
+	// Rename the backup directory.
 	err := os.Rename(oldBackupPath, newBackupPath)
 	if err != nil {
 		return err
 	}
 
-	// Check if we can remove the container directory
+	// Check if we can remove the instance directory.
 	empty, _ := shared.PathIsEmpty(backupsPath)
 	if empty {
 		err := os.Remove(backupsPath)
@@ -208,7 +208,7 @@ func (b *Backup) Rename(newName string) error {
 		}
 	}
 
-	// Rename the database record
+	// Rename the database record.
 	err = b.state.Cluster.RenameInstanceBackup(b.name, newName)
 	if err != nil {
 		return err

--- a/lxd/instance_backup.go
+++ b/lxd/instance_backup.go
@@ -351,7 +351,7 @@ func containerBackupExportGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	ent := response.FileResponseEntry{
-		Path: shared.VarPath("backups", project.Instance(proj, backup.Name())),
+		Path: shared.VarPath("backups", "instances", project.Instance(proj, backup.Name())),
 	}
 
 	return response.FileResponse(r, []response.FileResponseEntry{ent}, nil, false)

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -550,7 +550,7 @@ func createFromBackup(d *Daemon, project string, data io.Reader, pool string) re
 	defer revert.Fail()
 
 	// Create temporary file to store uploaded backup data.
-	backupFile, err := ioutil.TempFile(shared.VarPath("backups"), "lxd_backup_")
+	backupFile, err := ioutil.TempFile(shared.VarPath("backups"), fmt.Sprintf("%s_", backup.WorkingDirPrefix))
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -575,7 +575,7 @@ func createFromBackup(d *Daemon, project string, data io.Reader, pool string) re
 		decomArgs := append(decomArgs, backupFile.Name())
 
 		// Create temporary file to store the decompressed tarball in.
-		tarFile, err := ioutil.TempFile(shared.VarPath("backups"), "lxd_backup_decompress_")
+		tarFile, err := ioutil.TempFile(shared.VarPath("backups"), fmt.Sprintf("%s_decompress_", backup.WorkingDirPrefix))
 		if err != nil {
 			return response.InternalError(err)
 		}

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -1029,7 +1029,7 @@ func (d *btrfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWr
 
 		// Create temporary file to store output of btrfs send.
 		backupsPath := shared.VarPath("backups")
-		tmpFile, err := ioutil.TempFile(backupsPath, "lxd_backup_btrfs")
+		tmpFile, err := ioutil.TempFile(backupsPath, fmt.Sprintf("%s_btrfs", backup.WorkingDirPrefix))
 		if err != nil {
 			return errors.Wrapf(err, "Failed to open temporary file for BTRFS backup")
 		}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1390,7 +1390,7 @@ func (d *zfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWrit
 
 		// Create temporary file to store output of ZFS send.
 		backupsPath := shared.VarPath("backups")
-		tmpFile, err := ioutil.TempFile(backupsPath, "lxd_backup_zfs")
+		tmpFile, err := ioutil.TempFile(backupsPath, fmt.Sprintf("%s_zfs", backup.WorkingDirPrefix))
 		if err != nil {
 			return errors.Wrapf(err, "Failed to open temporary file for ZFS backup")
 		}

--- a/lxd/sys/fs.go
+++ b/lxd/sys/fs.go
@@ -43,6 +43,8 @@ func (s *OS) initDirs() error {
 	}{
 		{s.VarDir, 0711},
 		{filepath.Join(s.VarDir, "backups"), 0700},
+		{filepath.Join(s.VarDir, "backups", "custom"), 0700},
+		{filepath.Join(s.VarDir, "backups", "instances"), 0700},
 		{s.CacheDir, 0700},
 		// containers is 0711 because liblxc needs to traverse dir to get to each container.
 		{filepath.Join(s.VarDir, "containers"), 0711},


### PR DESCRIPTION
This is to accommodate custom future custom volume backups that will go in `shared.VarPath("backups", "custom")` without conflict.