### PR TITLE
lxd/apparmor: Allow unix sockets binding

### DIFF
--- a/lxd/apparmor/instance_forkproxy.go
+++ b/lxd/apparmor/instance_forkproxy.go
@@ -44,6 +44,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   network inet6 dgram,
   network inet stream,
   network inet6 stream,
+  network unix stream,
 
   # Forkproxy operation
   @{PROC}/** rw,


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>