### PR TITLE
Network: Don't require --target arg when adding networks in a cluster that don't require per-node config 

### DIFF
--- a/lxd/db/errors.go
+++ b/lxd/db/errors.go
@@ -7,7 +7,7 @@ import (
 var (
 	// ErrAlreadyDefined hapens when the given entry already exists,
 	// for example a container.
-	ErrAlreadyDefined = fmt.Errorf("The instance/snapshot already exists")
+	ErrAlreadyDefined = fmt.Errorf("The record already exists")
 
 	// ErrNoSuchObject is in the case of joins (and probably other) queries,
 	// we don't get back sql.ErrNoRows when no rows are returned, even though we do

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -365,7 +365,14 @@ func (c *cmdInit) askNetworking(config *cmdInitData, d lxd.InstanceServer) error
 		net.Project = project.Default
 
 		// Network name
-		net.Name = cli.AskString("What should the new bridge be called? [default=lxdbr0]: ", "lxdbr0", func(netName string) error { return network.ValidateNameAndProject(netName, project.Default, "bridge") })
+		net.Name = cli.AskString("What should the new bridge be called? [default=lxdbr0]: ", "lxdbr0", func(netName string) error {
+			netType, err := network.LoadByType("bridge")
+			if err != nil {
+				return err
+			}
+
+			return netType.ValidateName(netName)
+		})
 		_, _, err := d.GetNetwork(net.Name)
 		if err == nil {
 			fmt.Printf("The requested network bridge \"%s\" already exists. Please choose another name.\n", net.Name)

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -48,6 +48,11 @@ type bridge struct {
 	common
 }
 
+// Type returns the network type.
+func (n *bridge) Type() string {
+	return "bridge"
+}
+
 // checkClusterWideMACSafe returns whether it is safe to use the same MAC address for the bridge interface on all
 // cluster nodes. It is not suitable to use a static MAC address when "bridge.external_interfaces" is non-empty an
 // the bridge interface has no IPv4 or IPv6 address set. This is because in a clustered environment the same bridge

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lxc/lxd/lxd/apparmor"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/daemon"
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/dnsmasq"
 	"github.com/lxc/lxd/lxd/dnsmasq/dhcpalloc"
 	"github.com/lxc/lxd/lxd/network/openvswitch"
@@ -51,6 +52,11 @@ type bridge struct {
 // Type returns the network type.
 func (n *bridge) Type() string {
 	return "bridge"
+}
+
+// DBType returns the network type DB ID.
+func (n *bridge) DBType() db.NetworkType {
+	return db.NetworkTypeBridge
 }
 
 // checkClusterWideMACSafe returns whether it is safe to use the same MAC address for the bridge interface on all

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -71,8 +71,8 @@ func (n *bridge) checkClusterWideMACSafe(config map[string]string) error {
 	return nil
 }
 
-// fillConfig fills requested config with any default values.
-func (n *bridge) fillConfig(config map[string]string) error {
+// FillConfig fills requested config with any default values.
+func (n *bridge) FillConfig(config map[string]string) error {
 	// Set some default values where needed.
 	if config["bridge.mode"] == "fan" {
 		if config["fan.underlay_subnet"] == "" {
@@ -1504,7 +1504,7 @@ func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clientType
 	n.logger.Debug("Update", log.Ctx{"clientType": clientType, "newNetwork": newNetwork})
 
 	// Populate default values if they are missing.
-	err := n.fillConfig(newNetwork.Config)
+	err := n.FillConfig(newNetwork.Config)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -44,15 +44,14 @@ func (n *common) init(state *state.State, id int64, projectName string, name str
 	n.id = id
 	n.project = projectName
 	n.name = name
-	n.netType = netType
 	n.config = config
 	n.state = state
 	n.description = description
 	n.status = status
 }
 
-// fillConfig fills requested config with any default values, by default this is a no-op.
-func (n *common) fillConfig(config map[string]string) error {
+// FillConfig fills requested config with any default values, by default this is a no-op.
+func (n *common) FillConfig(config map[string]string) error {
 	return nil
 }
 

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -22,7 +22,8 @@ import (
 
 // Info represents information about a network driver.
 type Info struct {
-	Projects bool // Indicates if driver can be used in network enabled projects.
+	Projects           bool // Indicates if driver can be used in network enabled projects.
+	NodeSpecificConfig bool // Whether driver has cluster node specific config as a prerequisite for creation.
 }
 
 // common represents a generic LXD network.
@@ -131,7 +132,8 @@ func (n *common) Config() map[string]string {
 // Config returns the common network driver info.
 func (n *common) Info() Info {
 	return Info{
-		Projects: false,
+		Projects:           false,
+		NodeSpecificConfig: true,
 	}
 }
 

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -32,7 +32,6 @@ type common struct {
 	id          int64
 	project     string
 	name        string
-	netType     string
 	description string
 	config      map[string]string
 	status      string
@@ -124,11 +123,6 @@ func (n *common) Status() string {
 	return n.status
 }
 
-// Type returns the network type.
-func (n *common) Type() string {
-	return n.netType
-}
-
 // Config returns the network config.
 func (n *common) Config() map[string]string {
 	return n.config
@@ -205,7 +199,8 @@ func (n *common) DHCPv6Ranges() []shared.IPRange {
 func (n *common) update(applyNetwork api.NetworkPut, targetNode string, clientType cluster.ClientType) error {
 	// Update internal config before database has been updated (so that if update is a notification we apply
 	// the config being supplied and not that in the database).
-	n.init(n.state, n.id, n.project, n.name, n.netType, applyNetwork.Description, applyNetwork.Config, n.status)
+	n.description = applyNetwork.Description
+	n.config = applyNetwork.Config
 
 	// If this update isn't coming via a cluster notification itself, then notify all nodes of change and then
 	// update the database.
@@ -316,7 +311,7 @@ func (n *common) rename(newName string) error {
 	}
 
 	// Reinitialise internal name variable and logger context with new name.
-	n.init(n.state, n.id, n.project, newName, n.netType, n.description, n.config, n.status)
+	n.name = newName
 
 	return nil
 }

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -15,6 +15,11 @@ type macvlan struct {
 	common
 }
 
+// Type returns the network type.
+func (n *macvlan) Type() string {
+	return "macvlan"
+}
+
 // Validate network config.
 func (n *macvlan) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/shared/api"
 	log "github.com/lxc/lxd/shared/log15"
@@ -18,6 +19,11 @@ type macvlan struct {
 // Type returns the network type.
 func (n *macvlan) Type() string {
 	return "macvlan"
+}
+
+// DBType returns the network type DB ID.
+func (n *macvlan) DBType() db.NetworkType {
+	return db.NetworkTypeMacvlan
 }
 
 // Validate network config.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -685,8 +685,8 @@ func (n *ovn) deleteParentPortBridge(parentNet Network) error {
 	return nil
 }
 
-// fillConfig fills requested config with any default values.
-func (n *ovn) fillConfig(config map[string]string) error {
+// FillConfig fills requested config with any default values.
+func (n *ovn) FillConfig(config map[string]string) error {
 	if config["ipv4.address"] == "" {
 		config["ipv4.address"] = "auto"
 	}
@@ -1209,7 +1209,7 @@ func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clientType cl
 	n.logger.Debug("Update", log.Ctx{"clientType": clientType, "newNetwork": newNetwork})
 
 	// Populate default values if they are missing.
-	err := n.fillConfig(newNetwork.Config)
+	err := n.FillConfig(newNetwork.Config)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -68,6 +68,11 @@ func (n *ovn) Type() string {
 	return "ovn"
 }
 
+// DBType returns the network type DB ID.
+func (n *ovn) DBType() db.NetworkType {
+	return db.NetworkTypeOVN
+}
+
 // Config returns the network driver info.
 func (n *ovn) Info() Info {
 	return Info{

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -63,6 +63,11 @@ type ovn struct {
 	common
 }
 
+// Type returns the network type.
+func (n *ovn) Type() string {
+	return "ovn"
+}
+
 // Config returns the network driver info.
 func (n *ovn) Info() Info {
 	return Info{

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -76,7 +76,8 @@ func (n *ovn) DBType() db.NetworkType {
 // Config returns the network driver info.
 func (n *ovn) Info() Info {
 	return Info{
-		Projects: true,
+		Projects:           true,
+		NodeSpecificConfig: false,
 	}
 }
 

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/shared/api"
 	log "github.com/lxc/lxd/shared/log15"
@@ -18,6 +19,11 @@ type sriov struct {
 // Type returns the network type.
 func (n *sriov) Type() string {
 	return "sriov"
+}
+
+// DBType returns the network type DB ID.
+func (n *sriov) DBType() db.NetworkType {
+	return db.NetworkTypeSriov
 }
 
 // Validate network config.

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -15,6 +15,11 @@ type sriov struct {
 	common
 }
 
+// Type returns the network type.
+func (n *sriov) Type() string {
+	return "sriov"
+}
+
 // Validate network config.
 func (n *sriov) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -11,7 +11,7 @@ import (
 
 // Type represents an LXD network driver type.
 type Type interface {
-	fillConfig(config map[string]string) error
+	FillConfig(config map[string]string) error
 	Info() Info
 	ValidateName(name string) error
 	Type() string

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -4,6 +4,7 @@ import (
 	"net"
 
 	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -15,6 +16,7 @@ type Type interface {
 	Info() Info
 	ValidateName(name string) error
 	Type() string
+	DBType() db.NetworkType
 }
 
 // Network represents an instantiated LXD network.

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -9,19 +9,25 @@ import (
 	"github.com/lxc/lxd/shared/api"
 )
 
-// Network represents a LXD network.
-type Network interface {
-	// Load.
-	init(state *state.State, id int64, projectName string, name string, netType string, description string, config map[string]string, status string)
+// Type represents an LXD network driver type.
+type Type interface {
 	fillConfig(config map[string]string) error
 	Info() Info
+	ValidateName(name string) error
+	Type() string
+}
+
+// Network represents an instantiated LXD network.
+type Network interface {
+	Type
+
+	// Load.
+	init(state *state.State, id int64, projectName string, name string, netType string, description string, config map[string]string, status string)
 
 	// Config.
-	ValidateName(name string) error
 	Validate(config map[string]string) error
 	ID() int64
 	Name() string
-	Type() string
 	Description() string
 	Status() string
 	Config() map[string]string

--- a/lxd/network/network_load.go
+++ b/lxd/network/network_load.go
@@ -1,8 +1,6 @@
 package network
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 
 	"github.com/lxc/lxd/lxd/project"
@@ -17,7 +15,19 @@ var drivers = map[string]func() Network{
 	"ovn":     func() Network { return &ovn{} },
 }
 
-// LoadByName loads the network info from the database by name.
+// LoadByType loads a network by driver type.
+func LoadByType(driverType string) (Type, error) {
+	driverFunc, ok := drivers[driverType]
+	if !ok {
+		return nil, ErrUnknownDriver
+	}
+
+	n := driverFunc()
+
+	return n, nil
+}
+
+// LoadByName loads an instantiated network from the database by name.
 func LoadByName(s *state.State, project string, name string) (Network, error) {
 	id, netInfo, err := s.Cluster.GetNetworkInAnyState(project, name)
 	if err != nil {
@@ -33,28 +43,6 @@ func LoadByName(s *state.State, project string, name string) (Network, error) {
 	n.init(s, id, project, name, netInfo.Type, netInfo.Description, netInfo.Config, netInfo.Status)
 
 	return n, nil
-}
-
-// ValidateNameAndProject validates the supplied network name and project support for the specified network type.
-func ValidateNameAndProject(name string, networkProjectName string, netType string) error {
-	driverFunc, ok := drivers[netType]
-	if !ok {
-		return ErrUnknownDriver
-	}
-
-	n := driverFunc()
-	n.init(nil, 0, networkProjectName, name, netType, "", nil, "Unknown")
-
-	err := n.ValidateName(name)
-	if err != nil {
-		return errors.Wrapf(err, "Network name invalid")
-	}
-
-	if networkProjectName != project.Default && !n.Info().Projects {
-		return fmt.Errorf("Network type does not support non-default projects")
-	}
-
-	return nil
 }
 
 // Validate validates the supplied network name and configuration for the specified network type.

--- a/lxd/network/network_load.go
+++ b/lxd/network/network_load.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/state"
-	"github.com/lxc/lxd/shared/api"
 )
 
 var drivers = map[string]func() Network{
@@ -61,22 +60,4 @@ func Validate(name string, netType string, config map[string]string) error {
 	}
 
 	return n.Validate(config)
-}
-
-// FillConfig populates the supplied api.NetworkPost with automatically populated values.
-func FillConfig(req *api.NetworksPost) error {
-	driverFunc, ok := drivers[req.Type]
-	if !ok {
-		return ErrUnknownDriver
-	}
-
-	n := driverFunc()
-	n.init(nil, 0, project.Default, req.Name, req.Type, req.Description, req.Config, "Unknown")
-
-	err := n.fillConfig(req.Config)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -483,8 +483,7 @@ func networkGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	// If no target node is specified and the daemon is clustered, we omit
-	// the node-specific fields.
+	// If no target node is specified and the daemon is clustered, we omit the node-specific fields.
 	if targetNode == "" && clustered {
 		for _, key := range db.NodeSpecificNetworkConfig {
 			delete(n.Config, key)

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -246,7 +246,7 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if count > 1 {
-		err = networksPostCluster(d, projectName, req, clientType)
+		err = networksPostCluster(d, projectName, req, clientType, netType)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -255,7 +255,7 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Non-clustered network creation.
-	err = network.FillConfig(&req)
+	err = netType.FillConfig(req.Config)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -291,7 +291,7 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	return resp
 }
 
-func networksPostCluster(d *Daemon, projectName string, req api.NetworksPost, clientType cluster.ClientType) error {
+func networksPostCluster(d *Daemon, projectName string, req api.NetworksPost, clientType cluster.ClientType, netType network.Type) error {
 	// Check that no node-specific config key has been defined.
 	for key := range req.Config {
 		if shared.StringInSlice(key, db.NodeSpecificNetworkConfig) {
@@ -311,7 +311,7 @@ func networksPostCluster(d *Daemon, projectName string, req api.NetworksPost, cl
 	}
 
 	// Add default values.
-	err = network.FillConfig(&req)
+	err = netType.FillConfig(req.Config)
 	if err != nil {
 		return err
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -151,9 +151,19 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		req.Config = map[string]string{}
 	}
 
-	err = network.ValidateNameAndProject(req.Name, projectName, req.Type)
+	netType, err := network.LoadByType(req.Type)
 	if err != nil {
 		return response.BadRequest(err)
+	}
+
+	err = netType.ValidateName(req.Name)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	netTypeInfo := netType.Info()
+	if projectName != project.Default && !netTypeInfo.Projects {
+		return response.BadRequest(fmt.Errorf("Network type does not support non-default projects"))
 	}
 
 	// Check if project has limits.network and if so check we are allowed to create another network.

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -186,21 +186,6 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	// Convert requested network type to DB type code.
-	var dbNetType db.NetworkType
-	switch req.Type {
-	case "bridge":
-		dbNetType = db.NetworkTypeBridge
-	case "macvlan":
-		dbNetType = db.NetworkTypeMacvlan
-	case "sriov":
-		dbNetType = db.NetworkTypeSriov
-	case "ovn":
-		dbNetType = db.NetworkTypeOVN
-	default:
-		return response.BadRequest(fmt.Errorf("Unrecognised network type"))
-	}
-
 	url := fmt.Sprintf("/%s/networks/%s", version.APIVersion, req.Name)
 	resp := response.SyncResponseLocation(true, nil, url)
 
@@ -218,6 +203,10 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 
 	targetNode := queryParam(r, "target")
 	if targetNode != "" {
+		if !netTypeInfo.NodeSpecificConfig {
+			return response.BadRequest(fmt.Errorf("Network type %q does not support node specific config", netType.Type()))
+		}
+
 		// A targetNode was specified, let's just define the node's network without actually creating it.
 		// Check that only NodeSpecificNetworkConfig keys are specified.
 		for key := range req.Config {
@@ -227,7 +216,7 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
-			return tx.CreatePendingNetwork(targetNode, projectName, req.Name, dbNetType, req.Config)
+			return tx.CreatePendingNetwork(targetNode, projectName, req.Name, netType.DBType(), req.Config)
 		})
 		if err != nil {
 			if err == db.ErrAlreadyDefined {
@@ -269,15 +258,20 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("The network already exists"))
 	}
 
+	// Populate default config.
+	err = netType.FillConfig(req.Config)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	revert := revert.New()
 	defer revert.Fail()
 
 	// Create the database entry.
-	_, err = d.cluster.CreateNetwork(projectName, req.Name, req.Description, dbNetType, req.Config)
+	_, err = d.cluster.CreateNetwork(projectName, req.Name, req.Description, netType.DBType(), req.Config)
 	if err != nil {
 		return response.SmartError(errors.Wrapf(err, "Error inserting %q into database", req.Name))
 	}
-
 	revert.Add(func() {
 		d.cluster.DeleteNetwork(projectName, req.Name)
 	})

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -308,7 +308,7 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 }
 
 func networksPostCluster(d *Daemon, projectName string, req api.NetworksPost, clientType cluster.ClientType, netType network.Type) error {
-	// Check that no node-specific config key has been defined.
+	// Check that no node-specific config key has been supplied in request.
 	for key := range req.Config {
 		if shared.StringInSlice(key, db.NodeSpecificNetworkConfig) {
 			return fmt.Errorf("Config key %q is node-specific", key)
@@ -368,6 +368,8 @@ func networksPostCluster(d *Daemon, projectName string, req api.NetworksPost, cl
 
 	// Create the network on this node.
 	nodeReq := req
+
+	// Merge node specific config items into global config.
 	for key, value := range configs[nodeName] {
 		nodeReq.Config[key] = value
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -646,7 +646,7 @@ func networkPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("New network name not provided"))
 	}
 
-	err = network.ValidateNameAndProject(req.Name, projectName, n.Type())
+	err = n.ValidateName(req.Name)
 	if err != nil {
 		return response.BadRequest(err)
 	}


### PR DESCRIPTION
- Removes network loader helpers that don't require a DB record and replace it with a generic `LoadByType` that returns an interface that is safe to use without a DB record.
- Adds `DBType()` and `Type()` functions to each network driver.
- Adds `NodeSpecificConfig` flag to driver `Info` type indicating whether the network driver supports per-node cluster config.
- Updates network creation to populate "pending" network node entries automatically when network driver doesn't support per-node cluster config, to avoid needing to specify `--target` when creating a network of that type.
- Fixes dependent network start order, so that networks specifying another network always start after their parent.