### PR TITLE
lxd: Ensure all use of db.InstanceFilter defines instance type

### DIFF
--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -324,7 +324,9 @@ SELECT instances.name, nodes.id, nodes.address, nodes.heartbeat
 // Load all instances across all projects and expands their config and devices
 // using the profiles they are associated to.
 func (c *ClusterTx) instanceListExpanded() ([]Instance, error) {
-	instances, err := c.GetInstances(InstanceFilter{})
+	instances, err := c.GetInstances(InstanceFilter{
+		Type: instancetype.Any,
+	})
 	if err != nil {
 		return nil, errors.Wrap(err, "Load instances")
 	}

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -854,7 +854,10 @@ func fetchProject(tx *db.ClusterTx, projectName string, skipIfNoLimits bool) (*p
 		return nil, errors.Wrap(err, "Fetch profiles from database")
 	}
 
-	instances, err := tx.GetInstances(db.InstanceFilter{Project: projectName})
+	instances, err := tx.GetInstances(db.InstanceFilter{
+		Type:    instancetype.Any,
+		Project: projectName,
+	})
 	if err != nil {
 		return nil, errors.Wrap(err, "Fetch project instances from database")
 	}

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -41,7 +41,14 @@ func AllowInstanceCreation(tx *db.ClusterTx, projectName string, req api.Instanc
 		req.Profiles = []string{"default"}
 	}
 
-	err = checkInstanceCountLimit(info.Project, len(info.Instances), instanceType)
+	instanceTypeCount := 0
+	for _, inst := range info.Instances {
+		if inst.Type == instanceType {
+			instanceTypeCount++
+		}
+	}
+
+	err = checkInstanceCountLimit(info.Project, instanceTypeCount, instanceType)
 	if err != nil {
 		return err
 	}

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -34,7 +34,7 @@ func AllowInstanceCreation(tx *db.ClusterTx, projectName string, req api.Instanc
 	case api.InstanceTypeVM:
 		instanceType = instancetype.VM
 	default:
-		return fmt.Errorf("Unexpected instance type '%s'", instanceType)
+		return fmt.Errorf("Unexpected instance type %q", instanceType)
 	}
 
 	if req.Profiles == nil {
@@ -86,19 +86,19 @@ func checkInstanceCountLimit(project *api.Project, instanceCount int, instanceTy
 	case instancetype.VM:
 		key = "limits.virtual-machines"
 	default:
-		return fmt.Errorf("Unexpected instance type '%s'", instanceType)
+		return fmt.Errorf("Unexpected instance type %q", instanceType)
 	}
 
 	value, ok := project.Config[key]
 	if ok {
 		limit, err := strconv.Atoi(value)
 		if err != nil || limit < 0 {
-			return fmt.Errorf("Unexpected '%s' value: '%s'", key, value)
+			return fmt.Errorf("Unexpected %q value: %q", key, value)
 		}
 
 		if instanceCount >= limit {
 			return fmt.Errorf(
-				"Reached maximum number of instances of type %s in project %s",
+				"Reached maximum number of instances of type %q in project %q",
 				instanceType, project.Name)
 		}
 	}

--- a/lxd/project/permissions_test.go
+++ b/lxd/project/permissions_test.go
@@ -88,7 +88,7 @@ func TestAllowInstanceCreation_Above(t *testing.T) {
 	}
 
 	err = project.AllowInstanceCreation(tx, "p1", req)
-	assert.EqualError(t, err, "Reached maximum number of instances of type container in project p1")
+	assert.EqualError(t, err, `Reached maximum number of instances of type "container" in project "p1"`)
 }
 
 // If a limit is configured, but for a different instance type, the check


### PR DESCRIPTION
To avoid unexpectedly only filtering for container types.

Fixes #7897

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>