### PR TITLE
Network: Adds optimal MTU detection for bridge.mtu setting based on OVN's underlay MTU and address family

### DIFF
--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -29,7 +29,7 @@ import (
 var networkCreateSharedDeviceLock sync.Mutex
 
 // NetworkSetDevMTU sets the MTU setting for a named network device if different from current.
-func NetworkSetDevMTU(devName string, mtu uint64) error {
+func NetworkSetDevMTU(devName string, mtu uint32) error {
 	curMTU, err := network.GetDevMTU(devName)
 	if err != nil {
 		return err

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -192,7 +192,7 @@ func networkRestorePhysicalNic(hostName string, volatile map[string]string) erro
 			return fmt.Errorf("Failed to convert mtu for \"%s\" mtu \"%s\": %v", hostName, volatile["last_state.mtu"], err)
 		}
 
-		err = NetworkSetDevMTU(hostName, mtuInt)
+		err = NetworkSetDevMTU(hostName, uint32(mtuInt))
 		if err != nil {
 			return fmt.Errorf("Failed to restore physical dev \"%s\" mtu to \"%d\": %v", hostName, mtuInt, err)
 		}
@@ -238,18 +238,18 @@ func networkCreateVethPair(hostName string, m deviceConfig.Device) (string, erro
 
 	// Set the MTU on peer. If not specified and has parent, will inherit MTU from parent.
 	if m["mtu"] != "" {
-		MTU, err := strconv.ParseUint(m["mtu"], 10, 32)
+		mtu, err := strconv.ParseUint(m["mtu"], 10, 32)
 		if err != nil {
 			return "", fmt.Errorf("Invalid MTU specified: %v", err)
 		}
 
-		err = NetworkSetDevMTU(peerName, MTU)
+		err = NetworkSetDevMTU(peerName, uint32(mtu))
 		if err != nil {
 			NetworkRemoveInterface(peerName)
 			return "", fmt.Errorf("Failed to set the MTU: %v", err)
 		}
 
-		err = NetworkSetDevMTU(hostName, MTU)
+		err = NetworkSetDevMTU(hostName, uint32(mtu))
 		if err != nil {
 			NetworkRemoveInterface(peerName)
 			return "", fmt.Errorf("Failed to set the MTU: %v", err)
@@ -294,12 +294,12 @@ func networkCreateTap(hostName string, m deviceConfig.Device) error {
 
 	// Set the MTU on peer. If not specified and has parent, will inherit MTU from parent.
 	if m["mtu"] != "" {
-		MTU, err := strconv.ParseUint(m["mtu"], 10, 32)
+		mtu, err := strconv.ParseUint(m["mtu"], 10, 32)
 		if err != nil {
 			return errors.Wrap(err, "Invalid MTU specified")
 		}
 
-		err = NetworkSetDevMTU(hostName, MTU)
+		err = NetworkSetDevMTU(hostName, uint32(mtu))
 		if err != nil {
 			return errors.Wrap(err, "Failed to set the MTU")
 		}

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -125,12 +125,7 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 	}
 
 	// Apply network level config options to device config before validation.
-	mtu, err := network.OVNInstanceDeviceMTU(n)
-	if err != nil {
-		return err
-	}
-
-	d.config["mtu"] = fmt.Sprintf("%d", mtu)
+	d.config["mtu"] = fmt.Sprintf("%s", netConfig["bridge.mtu"])
 
 	rules := nicValidationRules(requiredFields, optionalFields)
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -127,19 +127,19 @@ func (n *ovn) getClient() (*openvswitch.OVN, error) {
 	return client, nil
 }
 
-// getBridgeMTU returns MTU that should be used for the bridge and instance devices. Will also be used to configure
-// the OVN DHCP and IPv6 RA options.
+// getBridgeMTU returns MTU that should be used for the bridge and instance devices.
+// Will also be used to configure the OVN DHCP and IPv6 RA options. Returns 0 if the bridge.mtu is not set/invalid.
 func (n *ovn) getBridgeMTU() uint32 {
 	if n.config["bridge.mtu"] != "" {
 		mtu, err := strconv.ParseUint(n.config["bridge.mtu"], 10, 32)
 		if err != nil {
-			return ovnGeneveTunnelMTU
+			return 0
 		}
 
 		return uint32(mtu)
 	}
 
-	return ovnGeneveTunnelMTU
+	return 0
 }
 
 // getNetworkPrefix returns OVN network prefix to use for object names.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -28,9 +28,6 @@ import (
 	"github.com/lxc/lxd/shared/validate"
 )
 
-// ovnGeneveTunnelMTU is the MTU that is safe to use when tunneling using geneve.
-const ovnGeneveTunnelMTU = 1442
-
 const ovnChassisPriorityMax = 32767
 const ovnVolatileParentIPv4 = "volatile.network.ipv4.address"
 const ovnVolatileParentIPv6 = "volatile.network.ipv6.address"

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -292,7 +292,7 @@ func DetachInterface(bridgeName string, devName string) error {
 }
 
 // GetDevMTU retrieves the current MTU setting for a named network device.
-func GetDevMTU(devName string) (uint64, error) {
+func GetDevMTU(devName string) (uint32, error) {
 	content, err := ioutil.ReadFile(fmt.Sprintf("/sys/class/net/%s/mtu", devName))
 	if err != nil {
 		return 0, err
@@ -304,7 +304,7 @@ func GetDevMTU(devName string) (uint64, error) {
 		return 0, err
 	}
 
-	return mtu, nil
+	return uint32(mtu), nil
 }
 
 // DefaultGatewaySubnetV4 returns subnet of default gateway interface.

--- a/lxd/network/network_utils_ovn.go
+++ b/lxd/network/network_utils_ovn.go
@@ -29,14 +29,3 @@ func OVNInstanceDevicePortDelete(network Network, instanceID int, deviceName str
 
 	return n.instanceDevicePortDelete(instanceID, deviceName)
 }
-
-// OVNInstanceDeviceMTU returns the MTU that should be used for an OVN instance device.
-func OVNInstanceDeviceMTU(network Network) (uint32, error) {
-	// Check network is of type OVN.
-	n, ok := network.(*ovn)
-	if !ok {
-		return 0, fmt.Errorf("Network is not OVN type")
-	}
-
-	return n.getBridgeMTU(), nil
-}

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -389,7 +389,7 @@ func IsNetworkVLAN(value string) error {
 // Anything below 68 and the kernel doesn't allow IPv4, anything below 1280 and the kernel doesn't allow IPv6.
 // So require an IPv6-compatible MTU as the low value and cap at the max ethernet jumbo frame size.
 func IsNetworkMTU(value string) error {
-	mtu, err := strconv.ParseInt(value, 10, 32)
+	mtu, err := strconv.ParseUint(value, 10, 32)
 	if err != nil {
 		return fmt.Errorf("Invalid MTU %q", value)
 	}


### PR DESCRIPTION
- Auto generates `bridge.mtu` setting for OVN networks if not specified (on create and update).
- Bridge MTU setting is derived from OVN's underlay network's `ovn-encap-ip`, which is used to ascertain the underlay network interface's MTU and IP address family (which both influence the maximum MTU size that can be used without fragmentation in the overlay network due to geneve tunnel overhead).