### PR TITLE
network: Only add pseudo pending node records when in cluster in networksPost

### DIFF
--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -229,31 +229,6 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		return resp
-	} else if !netTypeInfo.NodeSpecificConfig && clientType != cluster.ClientTypeJoiner {
-		// Simulate adding pending node network config when the driver doesn't support per-node config.
-		revert.Add(func() {
-			d.cluster.DeleteNetwork(projectName, req.Name)
-		})
-
-		// Create pending entry for each node.
-		err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
-			nodes, err := tx.GetNodes()
-			if err != nil {
-				return err
-			}
-
-			for _, node := range nodes {
-				err = tx.CreatePendingNetwork(node.Name, projectName, req.Name, netType.DBType(), req.Config)
-				if err != nil {
-					return errors.Wrapf(err, "Failed creating pending network for node %q", node.Name)
-				}
-			}
-
-			return nil
-		})
-		if err != nil {
-			return response.SmartError(err)
-		}
 	}
 
 	// Check if we're clustered.
@@ -263,6 +238,33 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if count > 1 {
+		// Simulate adding pending node network config when the driver doesn't support per-node config.
+		if !netTypeInfo.NodeSpecificConfig && clientType != cluster.ClientTypeJoiner {
+			revert.Add(func() {
+				d.cluster.DeleteNetwork(projectName, req.Name)
+			})
+
+			// Create pending entry for each node.
+			err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
+				nodes, err := tx.GetNodes()
+				if err != nil {
+					return err
+				}
+
+				for _, node := range nodes {
+					err = tx.CreatePendingNetwork(node.Name, projectName, req.Name, netType.DBType(), req.Config)
+					if err != nil {
+						return errors.Wrapf(err, "Failed creating pending network for node %q", node.Name)
+					}
+				}
+
+				return nil
+			})
+			if err != nil {
+				return response.SmartError(err)
+			}
+		}
+
 		err = networksPostCluster(d, projectName, req, clientType, netType)
 		if err != nil {
 			return response.SmartError(err)


### PR DESCRIPTION
Fixes single node OVN network creation.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>