### PR TITLE
Network: Pick default network type based on project

### DIFF
--- a/lxc/network.go
+++ b/lxc/network.go
@@ -255,7 +255,7 @@ func (c *cmdNetworkCreate) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`Create new networks`))
 
 	cmd.Flags().StringVar(&c.network.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
-	cmd.Flags().StringVarP(&c.network.flagType, "type", "t", "bridge", i18n.G("Network type"))
+	cmd.Flags().StringVarP(&c.network.flagType, "type", "t", "", i18n.G("Network type"))
 
 	cmd.RunE = c.Run
 

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -144,7 +144,11 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if req.Type == "" {
-		req.Type = "bridge"
+		if projectName != project.Default {
+			req.Type = "ovn" // Only OVN networks are allowed inside network enabled projects.
+		} else {
+			req.Type = "bridge" // Default to bridge for non-network enabled projects.
+		}
 	}
 
 	if req.Config == nil {


### PR DESCRIPTION
If non-default network project in use, and network type not specified by user, default to `ovn` type. Otherwise default to `bridge` type.