### PR TITLE
lxd/instances: Fix ceph cluster target move

### DIFF
--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -474,7 +474,7 @@ func containerPostClusteringMigrateWithCeph(d *Daemon, c instance.Instance, proj
 				return errors.Wrap(err, "Failed to create mount point on target node")
 			}
 		} else {
-			path := fmt.Sprintf("/internal/cluster/container-moved/%s", newName)
+			path := fmt.Sprintf("/internal/cluster/container-moved/%s?project=%s", newName, projectName)
 			resp, _, err := client.RawQuery("POST", path, nil, "")
 			if err != nil {
 				return errors.Wrap(err, "Failed to create mount point on target node")


### PR DESCRIPTION
Without this, the notification to create the mountpath is incorrectly
received for the default project.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>