### PR TITLE
lxd/cgroup: Fix memory.swappiness detection

### DIFF
--- a/lxd/cgroup/init.go
+++ b/lxd/cgroup/init.go
@@ -392,6 +392,10 @@ func init() {
 			cgControllers["memory.max_usage_in_bytes"] = V1
 		}
 
+		if shared.PathExists("/sys/fs/cgroup/memory/memory.swappiness") {
+			cgControllers["memory.swappiness"] = V1
+		}
+
 		if shared.PathExists("/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes") {
 			cgControllers["memory.memsw.limit_in_bytes"] = V1
 		}


### PR DESCRIPTION
This fixes swappiness on CgroupV1.
CGroupV2 support is still missing though.

Closes #7916

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>