### PR TITLE
Backup: Change Type field type in index.yaml to own backup.Type

### DIFF
--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -187,12 +187,17 @@ func backupWriteIndex(sourceInst instance.Instance, pool storagePools.Pool, opti
 		poolDriverOptimizedHeader = pool.Driver().Info().OptimizedBackupHeader
 	}
 
+	backupType := backup.InstanceTypeToBackupType(api.InstanceType(sourceInst.Type().String()))
+	if backupType == backup.TypeUnknown {
+		return fmt.Errorf("Unrecognised instance type for backup type conversion")
+	}
+
 	indexInfo := backup.Info{
 		Name:             sourceInst.Name(),
 		Pool:             pool.Name(),
 		Snapshots:        []string{},
 		Backend:          pool.Driver().Info().Name,
-		Type:             api.InstanceType(sourceInst.Type().String()),
+		Type:             backupType,
 		OptimizedStorage: &optimized,
 		OptimizedHeader:  &poolDriverOptimizedHeader,
 	}

--- a/lxd/backup/backup_info.go
+++ b/lxd/backup/backup_info.go
@@ -80,8 +80,8 @@ func GetInfo(r io.ReadSeeker) (*Info, error) {
 			hasIndexFile = true
 
 			// Default to container if index doesn't specify instance type.
-			if result.Type == api.InstanceTypeAny {
-				result.Type = api.InstanceTypeContainer
+			if result.Type == TypeUnknown {
+				result.Type = TypeContainer
 			}
 
 			// Default to no optimized header if not specified.

--- a/lxd/backup/backup_info.go
+++ b/lxd/backup/backup_info.go
@@ -1,27 +1,49 @@
 package backup
 
 import (
-	"context"
 	"fmt"
 	"io"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
-	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
 
+// Type indicates the type of backup.
+type Type string
+
+// TypeUnknown defines the backup type value for unknown backups.
+const TypeUnknown = Type("")
+
+// TypeContainer defines the backup type value for a container.
+const TypeContainer = Type("container")
+
+// TypeVM defines the backup type value for a virtual-machine.
+const TypeVM = Type("virtual-machine")
+
+// InstanceTypeToBackupType converts instance type to backup type.
+func InstanceTypeToBackupType(instanceType api.InstanceType) Type {
+	switch instanceType {
+	case api.InstanceTypeContainer:
+		return TypeContainer
+	case api.InstanceTypeVM:
+		return TypeVM
+	}
+
+	return TypeUnknown
+}
+
 // Info represents exported backup information.
 type Info struct {
-	Project          string           `json:"-" yaml:"-"` // Project is set during import based on current project.
-	Name             string           `json:"name" yaml:"name"`
-	Backend          string           `json:"backend" yaml:"backend"`
-	Pool             string           `json:"pool" yaml:"pool"`
-	Snapshots        []string         `json:"snapshots,omitempty" yaml:"snapshots,omitempty"`
-	OptimizedStorage *bool            `json:"optimized,omitempty" yaml:"optimized,omitempty"`               // Optional field to handle older optimized backups that don't have this field.
-	OptimizedHeader  *bool            `json:"optimized_header,omitempty" yaml:"optimized_header,omitempty"` // Optional field to handle older optimized backups that don't have this field.
-	Type             api.InstanceType `json:"type" yaml:"type"`
+	Project          string   `json:"-" yaml:"-"` // Project is set during import based on current project.
+	Name             string   `json:"name" yaml:"name"`
+	Backend          string   `json:"backend" yaml:"backend"`
+	Pool             string   `json:"pool" yaml:"pool"`
+	Snapshots        []string `json:"snapshots,omitempty" yaml:"snapshots,omitempty"`
+	OptimizedStorage *bool    `json:"optimized,omitempty" yaml:"optimized,omitempty"`               // Optional field to handle older optimized backups that don't have this field.
+	OptimizedHeader  *bool    `json:"optimized_header,omitempty" yaml:"optimized_header,omitempty"` // Optional field to handle older optimized backups that don't have this field.
+	Type             Type     `json:"type,omitempty" yaml:"type,omitempty"`                         // Type of backup.
 }
 
 // GetInfo extracts backup information from a given ReadSeeker.

--- a/lxd/backup/backup_info.go
+++ b/lxd/backup/backup_info.go
@@ -101,6 +101,9 @@ func GetInfo(r io.ReadSeeker) (*Info, error) {
 		}
 
 		// If the tarball contains a binary dump of the container, then this is an optimized backup.
+		// This check is only for legacy backups before we introduced the Type and OptimizedStorage fields
+		// in index.yaml, so there is no need to perform this type of check for other types of backups that
+		// have always had these fields populated.
 		if hdr.Name == "backup/container.bin" {
 			optimizedStorageTrue := true
 			result.OptimizedStorage = &optimizedStorageTrue

--- a/lxd/backup/backup_info.go
+++ b/lxd/backup/backup_info.go
@@ -65,7 +65,7 @@ func GetInfo(r io.ReadSeeker) (*Info, error) {
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
-			break // End of archive
+			break // End of archive.
 		}
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error reading backup file info")

--- a/lxd/backup/backup_utils.go
+++ b/lxd/backup/backup_utils.go
@@ -1,0 +1,30 @@
+package backup
+
+import (
+	"archive/tar"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/lxc/lxd/shared"
+)
+
+// TarReader rewinds backup file handle r and returns new tar reader and process cleanup function.
+func TarReader(r io.ReadSeeker) (*tar.Reader, context.CancelFunc, error) {
+	r.Seek(0, 0)
+	_, _, unpacker, err := shared.DetectCompressionFile(r)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if unpacker == nil {
+		return nil, nil, fmt.Errorf("Unsupported backup compression")
+	}
+
+	tr, cancelFunc, err := shared.CompressedTarReader(context.Background(), r, unpacker)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return tr, cancelFunc, nil
+}

--- a/lxd/db/backups.go
+++ b/lxd/db/backups.go
@@ -39,7 +39,7 @@ func (c *Cluster) getInstanceBackupID(name string) (int, error) {
 }
 
 // GetInstanceBackup returns the backup with the given name.
-func (c *Cluster) GetInstanceBackup(project, name string) (InstanceBackup, error) {
+func (c *Cluster) GetInstanceBackup(projectName string, name string) (InstanceBackup, error) {
 	args := InstanceBackup{}
 	args.Name = name
 
@@ -54,7 +54,7 @@ SELECT instances_backups.id, instances_backups.instance_id,
     JOIN projects ON projects.id=instances.project_id
     WHERE projects.name=? AND instances_backups.name=?
 `
-	arg1 := []interface{}{project, name}
+	arg1 := []interface{}{projectName, name}
 	arg2 := []interface{}{&args.ID, &args.InstanceID, &args.CreationDate,
 		&args.ExpiryDate, &instanceOnlyInt, &optimizedStorageInt}
 	err := dbQueryRowScan(c, q, arg1, arg2)
@@ -79,14 +79,14 @@ SELECT instances_backups.id, instances_backups.instance_id,
 
 // GetInstanceBackups returns the names of all backups of the instance with the
 // given name.
-func (c *Cluster) GetInstanceBackups(project, name string) ([]string, error) {
+func (c *Cluster) GetInstanceBackups(projectName string, name string) ([]string, error) {
 	var result []string
 
 	q := `SELECT instances_backups.name FROM instances_backups
 JOIN instances ON instances_backups.instance_id=instances.id
 JOIN projects ON projects.id=instances.project_id
 WHERE projects.name=? AND instances.name=?`
-	inargs := []interface{}{project, name}
+	inargs := []interface{}{projectName, name}
 	outfmt := []interface{}{name}
 	dbResults, err := queryScan(c, q, inargs, outfmt)
 	if err != nil {

--- a/lxd/db/backups.go
+++ b/lxd/db/backups.go
@@ -12,7 +12,7 @@ import (
 	log "github.com/lxc/lxd/shared/log15"
 )
 
-// InstanceBackup is a value object holding all db-related details about a backup.
+// InstanceBackup is a value object holding all db-related details about an instance backup.
 type InstanceBackup struct {
 	ID                   int
 	InstanceID           int

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -257,6 +257,7 @@ SELECT storage_volumes_snapshots.name, storage_volumes_snapshots.description FRO
 		row := StorageVolumeArgs{
 			Name:        volumeName + shared.SnapshotDelimiter + r[0].(string),
 			Description: r[1].(string),
+			Snapshot:    true,
 		}
 		result = append(result, row)
 	}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -119,6 +119,7 @@ func instanceCreateFromImage(d *Daemon, args db.InstanceArgs, hash string, op *o
 	if err != nil {
 		return nil, errors.Wrapf(err, "Locate image %q in the cluster", hash)
 	}
+
 	if nodeAddress != "" {
 		// The image is available from another node, let's try to import it.
 		err = instanceImageTransfer(d, args.Project, img.Fingerprint, nodeAddress)

--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -418,7 +418,7 @@ func (d *btrfs) loadOptimizedBackupHeader(r io.ReadSeeker) (*BTRFSMetaDataHeader
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
-			break // End of archive
+			break // End of archive.
 		}
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error reading backup file for optimized backup header file")

--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -1,7 +1,6 @@
 package drivers
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -16,6 +15,7 @@ import (
 	"golang.org/x/sys/unix"
 	"gopkg.in/yaml.v2"
 
+	"github.com/lxc/lxd/lxd/backup"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/ioprogress"
 	"github.com/lxc/lxd/shared/logger"
@@ -408,18 +408,8 @@ func (d *btrfs) restorationHeader(vol Volume, snapshots []string) (*BTRFSMetaDat
 func (d *btrfs) loadOptimizedBackupHeader(r io.ReadSeeker) (*BTRFSMetaDataHeader, error) {
 	header := BTRFSMetaDataHeader{}
 
-	// Extract
-	r.Seek(0, 0)
-	_, _, unpacker, err := shared.DetectCompressionFile(r)
-	if err != nil {
-		return nil, err
-	}
-
-	if unpacker == nil {
-		return nil, fmt.Errorf("Unsupported backup compression")
-	}
-
-	tr, cancelFunc, err := shared.CompressedTarReader(context.Background(), r, unpacker)
+	// Extract.
+	tr, cancelFunc, err := backup.TarReader(r)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -195,7 +195,7 @@ func (d *btrfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcDat
 		for {
 			hdr, err := tr.Next()
 			if err == io.EOF {
-				break // End of archive
+				break // End of archive.
 			}
 			if err != nil {
 				return "", err

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -299,7 +299,7 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 		for {
 			hdr, err := tr.Next()
 			if err == io.EOF {
-				break // End of archive
+				break // End of archive.
 			}
 			if err != nil {
 				return err

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -640,7 +640,7 @@ func genericVFSBackupUnpack(d Driver, vol Volume, snapshots []string, srcData io
 			for {
 				hdr, err := tr.Next()
 				if err == io.EOF {
-					break // End of archive
+					break // End of archive.
 				}
 				if err != nil {
 					return err


### PR DESCRIPTION
- To allow for custom volume backups in future.
- Fixes removal of instance backup parent directory when instance is renamed.
- And various other small tweaks that are not directly related to custom volume backups.