### PR TITLE
Backup: Allow import of instances and custom volume under different names

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -446,6 +446,9 @@ type InstanceBackupArgs struct {
 
 	// Storage pool to use
 	PoolName string
+
+	// Name to import backup as
+	Name string
 }
 
 // The InstanceCopyArgs struct is used to pass additional options during instance copy.

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -437,6 +437,9 @@ type StoragePoolVolumeMoveArgs struct {
 type StoragePoolVolumeBackupArgs struct {
 	// The backup file
 	BackupFile io.Reader
+
+	// Name to import backup as
+	Name string
 }
 
 // The InstanceBackupArgs struct is used when creating a instance from a backup.

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1176,3 +1176,9 @@ This includes the following new endpoints (see [RESTful API](rest-api.md) for de
 The following existing endpoint has been modified:
 
  * `POST /1.0/storage-pools/<pool>/<type>/<volume>` accepts the new source type `backup`
+
+## backup\_override\_name
+Adds `Name` field to `InstanceBackupArgs` to allow specifying a different instance name when restoring a backup.
+
+Adds `Name` and `PoolName` fields to `StoragePoolVolumeBackupArgs` to allow specifying a different volume name
+when restoring a custom volume backup.

--- a/lxc/import.go
+++ b/lxc/import.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -23,7 +24,7 @@ type cmdImport struct {
 
 func (c *cmdImport) Command() *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.Use = usage("import", i18n.G("[<remote>:] <backup file>"))
+	cmd.Use = usage("import", i18n.G("[<remote>:] <backup file> [<instance name>]"))
 	cmd.Short = i18n.G("Import instance backups")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Import backups of instances including their snapshots.`))
@@ -38,16 +39,31 @@ func (c *cmdImport) Command() *cobra.Command {
 }
 
 func (c *cmdImport) Run(cmd *cobra.Command, args []string) error {
-	// Sanity checks
-	exit, err := c.global.CheckArgs(cmd, args, 1, 2)
+	// Sanity checks.
+	exit, err := c.global.CheckArgs(cmd, args, 1, 3)
 	if exit {
 		return err
 	}
 
-	// Parse remote
+	srcFilePosition := 0
+
+	// Parse remote (identify 1st argument is remote by looking for a colon at the end).
 	remote := ""
-	if len(args) > 1 {
+	if len(args) > 1 && strings.HasSuffix(args[0], ":") {
 		remote = args[0]
+		srcFilePosition = 1
+	}
+
+	// Parse source file (this could be 1st or 2nd argument depending on whether a remote is specified first).
+	srcFile := ""
+	if len(args) >= srcFilePosition+1 {
+		srcFile = args[srcFilePosition]
+	}
+
+	// Parse instance name.
+	instanceName := ""
+	if len(args) >= srcFilePosition+2 {
+		instanceName = args[srcFilePosition+1]
 	}
 
 	resources, err := c.global.ParseServers(remote)
@@ -57,7 +73,7 @@ func (c *cmdImport) Run(cmd *cobra.Command, args []string) error {
 
 	resource := resources[0]
 
-	file, err := os.Open(shared.HostPathFollow(args[len(args)-1]))
+	file, err := os.Open(shared.HostPathFollow(srcFile))
 	if err != nil {
 		return err
 	}
@@ -84,6 +100,7 @@ func (c *cmdImport) Run(cmd *cobra.Command, args []string) error {
 			},
 		},
 		PoolName: c.flagStorage,
+		Name:     instanceName,
 	}
 
 	op, err := resource.server.CreateInstanceFromBackup(createArgs)
@@ -91,7 +108,7 @@ func (c *cmdImport) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Wait for operation to finish
+	// Wait for operation to finish.
 	err = utils.CancelableWait(op, &progress)
 	if err != nil {
 		progress.Done("")

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -501,6 +501,10 @@ func internalImport(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	if req.AllowNameOverride && req.Name != "" {
+		backupConf.Container.Name = req.Name
+	}
+
 	if req.Name != backupConf.Container.Name {
 		return response.InternalError(fmt.Errorf("Instance name in request %q doesn't match instance name in backup config %q", req.Name, backupConf.Container.Name))
 	}

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -415,8 +415,9 @@ func internalSQLExec(tx *sql.Tx, query string, result *internalSQLResult) error 
 }
 
 type internalImportPost struct {
-	Name  string `json:"name" yaml:"name"`
-	Force bool   `json:"force" yaml:"force"`
+	Name              string `json:"name" yaml:"name"`
+	Force             bool   `json:"force" yaml:"force"`
+	AllowNameOverride bool   `json:"allow_name_override" yaml:"allow_name_override"`
 }
 
 func internalImport(d *Daemon, r *http.Request) response.Response {

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -545,7 +545,7 @@ func createFromCopy(d *Daemon, project string, req *api.InstancesPost) response.
 	return operations.OperationResponse(op)
 }
 
-func createFromBackup(d *Daemon, project string, data io.Reader, pool string) response.Response {
+func createFromBackup(d *Daemon, project string, data io.Reader, pool string, instanceName string) response.Response {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -607,6 +607,11 @@ func createFromBackup(d *Daemon, project string, data io.Reader, pool string) re
 	// Override pool.
 	if pool != "" {
 		bInfo.Pool = pool
+	}
+
+	// Override instance name.
+	if instanceName != "" {
+		bInfo.Name = instanceName
 	}
 
 	logger.Debug("Backup file info loaded", log.Ctx{
@@ -675,8 +680,9 @@ func createFromBackup(d *Daemon, project string, data io.Reader, pool string) re
 		runRevert.Add(revertHook)
 
 		body, err := json.Marshal(&internalImportPost{
-			Name:  bInfo.Name,
-			Force: true,
+			Name:              bInfo.Name,
+			Force:             true,
+			AllowNameOverride: instanceName != "",
 		})
 		if err != nil {
 			return errors.Wrap(err, "Marshal internal import request")

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -742,7 +742,7 @@ func containersPost(d *Daemon, r *http.Request) response.Response {
 
 	// If we're getting binary content, process separately
 	if r.Header.Get("Content-Type") == "application/octet-stream" {
-		return createFromBackup(d, project, r.Body, r.Header.Get("X-LXD-pool"))
+		return createFromBackup(d, project, r.Body, r.Header.Get("X-LXD-pool"), r.Header.Get("X-LXD-name"))
 	}
 
 	// Parse the request

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1232,7 +1232,7 @@ func storagePoolVolumeTypeImageDelete(d *Daemon, r *http.Request) response.Respo
 	return storagePoolVolumeTypeDelete(d, r, "image")
 }
 
-func createStoragePoolVolumeFromBackup(d *Daemon, project string, pool string, data io.Reader) response.Response {
+func createStoragePoolVolumeFromBackup(d *Daemon, project string, data io.Reader, pool string, volName string) response.Response {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -1294,6 +1294,11 @@ func createStoragePoolVolumeFromBackup(d *Daemon, project string, pool string, d
 	// Override pool.
 	if pool != "" {
 		bInfo.Pool = pool
+	}
+
+	// Override volume name.
+	if volName != "" {
+		bInfo.Name = volName
 	}
 
 	logger.Debug("Backup file info loaded", log.Ctx{

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -294,7 +294,7 @@ func storagePoolVolumesTypePost(d *Daemon, r *http.Request) response.Response {
 
 	// If we're getting binary content, process separately.
 	if r.Header.Get("Content-Type") == "application/octet-stream" {
-		return createStoragePoolVolumeFromBackup(d, projectName, poolName, r.Body)
+		return createStoragePoolVolumeFromBackup(d, projectName, r.Body, poolName, r.Header.Get("X-LXD-name"))
 	}
 
 	req := api.StorageVolumesPost{}

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -947,7 +947,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1520,16 +1520,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3495,8 +3495,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3702,7 +3702,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3961,7 +3961,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -947,7 +947,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1520,16 +1520,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3495,8 +3495,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3702,7 +3702,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3961,7 +3961,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -947,7 +947,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1520,16 +1520,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3495,8 +3495,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3702,7 +3702,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3961,7 +3961,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -1144,7 +1144,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1735,7 +1735,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1755,17 +1755,17 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 #, fuzzy
 msgid "Import instance backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -3424,7 +3424,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Storage pool %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 #, fuzzy
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -3870,9 +3870,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/import.go:26
+#: lxc/import.go:27
 #, fuzzy
-msgid "[<remote>:] <backup file>"
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 "Ändert den Laufzustand eines Containers in %s.\n"
 "\n"
@@ -4301,7 +4301,7 @@ msgstr ""
 
 #: lxc/storage_volume.go:1795
 #, fuzzy
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 "Ändert den Laufzustand eines Containers in %s.\n"
 "\n"
@@ -4704,7 +4704,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -951,7 +951,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1527,16 +1527,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3100,7 +3100,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3506,8 +3506,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3713,7 +3713,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3972,7 +3972,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1089,7 +1089,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1648,7 +1648,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1667,17 +1667,17 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 #, fuzzy
 msgid "Import instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3250,7 +3250,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3659,9 +3659,9 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/import.go:26
+#: lxc/import.go:27
 #, fuzzy
-msgid "[<remote>:] <backup file>"
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/config_trust.go:55
@@ -3916,7 +3916,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/storage_volume.go:1795
 #, fuzzy
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/storage.go:87
@@ -4208,7 +4208,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -947,7 +947,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1520,16 +1520,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3495,8 +3495,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3702,7 +3702,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3961,7 +3961,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -947,7 +947,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1520,16 +1520,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3495,8 +3495,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3702,7 +3702,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3961,7 +3961,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -1157,7 +1157,7 @@ msgstr "Copie de l'image : %s"
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1758,7 +1758,7 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1779,17 +1779,17 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr "Import de l'image : %s"
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 #, fuzzy
 msgid "Import instance backups"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -3510,7 +3510,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Storage pool %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
@@ -3960,9 +3960,9 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr "Serveur distant : %s"
 
-#: lxc/import.go:26
+#: lxc/import.go:27
 #, fuzzy
-msgid "[<remote>:] <backup file>"
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 "Change l'état d'un ou plusieurs conteneurs à %s.\n"
 "\n"
@@ -4457,7 +4457,7 @@ msgstr ""
 
 #: lxc/storage_volume.go:1795
 #, fuzzy
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 "Change l'état d'un ou plusieurs conteneurs à %s.\n"
 "\n"
@@ -4888,7 +4888,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -947,7 +947,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1520,16 +1520,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3495,8 +3495,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3702,7 +3702,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3961,7 +3961,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -947,7 +947,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1520,16 +1520,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3495,8 +3495,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3702,7 +3702,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3961,7 +3961,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1078,7 +1078,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1639,7 +1639,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1658,17 +1658,17 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 #, fuzzy
 msgid "Import instance backups"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Creazione del container in corso"
@@ -3246,7 +3246,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3660,9 +3660,9 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]"
 msgstr "Creazione del container in corso"
 
-#: lxc/import.go:26
+#: lxc/import.go:27
 #, fuzzy
-msgid "[<remote>:] <backup file>"
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "Creazione del container in corso"
 
 #: lxc/config_trust.go:55
@@ -3917,7 +3917,7 @@ msgstr "Creazione del container in corso"
 
 #: lxc/storage_volume.go:1795
 #, fuzzy
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
 
 #: lxc/storage.go:87
@@ -4209,7 +4209,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: 2020-09-25 15:37+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -1092,7 +1092,7 @@ msgstr "ストレージボリュームを削除します"
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1694,7 +1694,7 @@ msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 "インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 "インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
@@ -1719,16 +1719,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr "イメージをイメージストアにインポートします"
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr "インスタンスのバックアップをインポートします"
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "インスタンスのインポート中: %s"
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr "インスタンスのインポート中: %s"
@@ -3447,7 +3447,7 @@ msgstr "ストレージプール %s を削除しました"
 msgid "Storage pool %s pending on member %s"
 msgstr "ストレージプール %s はメンバ %s 上でペンディング状態です"
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
@@ -3885,8 +3885,9 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+#, fuzzy
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "[<remote>:] <backup file>"
 
 #: lxc/config_trust.go:55
@@ -4096,7 +4097,7 @@ msgstr "[<remote>:]<pool>"
 
 #: lxc/storage_volume.go:1795
 #, fuzzy
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:] <backup file>"
 
 #: lxc/storage.go:87
@@ -4392,7 +4393,7 @@ msgstr ""
 "lxc image edit <image> < image.yaml\n"
 "    YAML ファイルからイメージプロパティをロードします"
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -947,7 +947,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1520,16 +1520,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3495,8 +3495,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3702,7 +3702,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3961,7 +3961,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2020-09-25 23:34-0400\n"
+        "POT-Creation-Date: 2020-09-30 10:55+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -892,7 +892,7 @@ msgstr  ""
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154 lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422 lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52 lxc/config_metadata.go:174 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:129 lxc/image.go:277 lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840 lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20 lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109 lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379 lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730 lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024 lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384 lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626 lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:599 lxc/remote.go:661 lxc/remote.go:711 lxc/remote.go:749 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651 lxc/storage.go:735 lxc/storage_volume.go:37 lxc/storage_volume.go:152 lxc/storage_volume.go:235 lxc/storage_volume.go:322 lxc/storage_volume.go:484 lxc/storage_volume.go:563 lxc/storage_volume.go:639 lxc/storage_volume.go:721 lxc/storage_volume.go:802 lxc/storage_volume.go:1002 lxc/storage_volume.go:1093 lxc/storage_volume.go:1173 lxc/storage_volume.go:1204 lxc/storage_volume.go:1317 lxc/storage_volume.go:1393 lxc/storage_volume.go:1492 lxc/storage_volume.go:1525 lxc/storage_volume.go:1601 lxc/storage_volume.go:1662 lxc/storage_volume.go:1797 lxc/version.go:22
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154 lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422 lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52 lxc/config_metadata.go:174 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:129 lxc/image.go:277 lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840 lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20 lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109 lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379 lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730 lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024 lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384 lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626 lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:599 lxc/remote.go:661 lxc/remote.go:711 lxc/remote.go:749 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:27 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651 lxc/storage.go:735 lxc/storage_volume.go:37 lxc/storage_volume.go:152 lxc/storage_volume.go:235 lxc/storage_volume.go:322 lxc/storage_volume.go:484 lxc/storage_volume.go:563 lxc/storage_volume.go:639 lxc/storage_volume.go:721 lxc/storage_volume.go:802 lxc/storage_volume.go:1002 lxc/storage_volume.go:1093 lxc/storage_volume.go:1173 lxc/storage_volume.go:1204 lxc/storage_volume.go:1317 lxc/storage_volume.go:1393 lxc/storage_volume.go:1492 lxc/storage_volume.go:1525 lxc/storage_volume.go:1601 lxc/storage_volume.go:1662 lxc/storage_volume.go:1797 lxc/version.go:22
 msgid   "Description"
 msgstr  ""
 
@@ -1396,7 +1396,7 @@ msgstr  ""
 msgid   "Import backups of custom volumes including their snapshots."
 msgstr  ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid   "Import backups of instances including their snapshots."
 msgstr  ""
 
@@ -1414,16 +1414,16 @@ msgstr  ""
 msgid   "Import images into the image store"
 msgstr  ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid   "Import instance backups"
 msgstr  ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid   "Importing custom volume: %s"
 msgstr  ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid   "Importing instance: %s"
 msgstr  ""
@@ -2923,7 +2923,7 @@ msgstr  ""
 msgid   "Storage pool %s pending on member %s"
 msgstr  ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid   "Storage pool name"
 msgstr  ""
 
@@ -3308,8 +3308,8 @@ msgstr  ""
 msgid   "[<remote>:]"
 msgstr  ""
 
-#: lxc/import.go:26
-msgid   "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid   "[<remote>:] <backup file> [<instance name>]"
 msgstr  ""
 
 #: lxc/config_trust.go:55
@@ -3509,7 +3509,7 @@ msgid   "[<remote>:]<pool>"
 msgstr  ""
 
 #: lxc/storage_volume.go:1795
-msgid   "[<remote>:]<pool> <backup file>"
+msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
 #: lxc/storage.go:87
@@ -3750,7 +3750,7 @@ msgid   "lxc image edit <image>\n"
         "    Load the image properties from a YAML file"
 msgstr  ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid   "lxc import backup0.tar.gz\n"
         "    Create a new instance using backup0.tar.gz as the source."
 msgstr  ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -947,7 +947,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1520,16 +1520,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3495,8 +3495,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3702,7 +3702,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3961,7 +3961,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -1064,7 +1064,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1618,7 +1618,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1637,16 +1637,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3206,7 +3206,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3612,8 +3612,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3819,7 +3819,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -4078,7 +4078,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -947,7 +947,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1520,16 +1520,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3495,8 +3495,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3702,7 +3702,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3961,7 +3961,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1074,7 +1074,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1628,7 +1628,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1647,16 +1647,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3216,7 +3216,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3622,8 +3622,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3829,7 +3829,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -4088,7 +4088,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -1112,7 +1112,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1681,7 +1681,7 @@ msgstr "Anexar interfaces de rede aos perfis"
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1700,16 +1700,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Editar arquivos no container"
@@ -3291,7 +3291,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3702,9 +3702,10 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
-msgstr ""
+#: lxc/import.go:27
+#, fuzzy
+msgid "[<remote>:] <backup file> [<instance name>]"
+msgstr "Criar perfis"
 
 #: lxc/config_trust.go:55
 msgid "[<remote>:] <cert>"
@@ -3912,7 +3913,7 @@ msgstr ""
 
 #: lxc/storage_volume.go:1795
 #, fuzzy
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
 
 #: lxc/storage.go:87
@@ -4174,7 +4175,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: 2020-08-02 01:42+0000\n"
 "Last-Translator: Anthony <aemeltsev@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1111,7 +1111,7 @@ msgstr "Копирование образа: %s"
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1677,7 +1677,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1698,17 +1698,17 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr "Копирование образа: %s"
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 #, fuzzy
 msgid "Import instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, fuzzy, c-format
 msgid "Importing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3302,7 +3302,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3721,9 +3721,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/import.go:26
+#: lxc/import.go:27
 #, fuzzy
-msgid "[<remote>:] <backup file>"
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 "Изменение состояния одного или нескольких контейнеров %s.\n"
 "\n"
@@ -4129,7 +4129,7 @@ msgstr ""
 
 #: lxc/storage_volume.go:1795
 #, fuzzy
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 "Изменение состояния одного или нескольких контейнеров %s.\n"
 "\n"
@@ -4523,7 +4523,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -947,7 +947,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1520,16 +1520,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3495,8 +3495,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3702,7 +3702,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3961,7 +3961,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -947,7 +947,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1520,16 +1520,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3495,8 +3495,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3702,7 +3702,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3961,7 +3961,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -947,7 +947,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1520,16 +1520,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3495,8 +3495,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3702,7 +3702,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3961,7 +3961,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -947,7 +947,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1520,16 +1520,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3495,8 +3495,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3702,7 +3702,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3961,7 +3961,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -947,7 +947,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1520,16 +1520,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3495,8 +3495,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3702,7 +3702,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3961,7 +3961,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -947,7 +947,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1520,16 +1520,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3495,8 +3495,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3702,7 +3702,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3961,7 +3961,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -947,7 +947,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1520,16 +1520,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3495,8 +3495,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3702,7 +3702,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3961,7 +3961,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-09-25 23:34-0400\n"
+"POT-Creation-Date: 2020-09-30 10:55+0100\n"
 "PO-Revision-Date: 2018-09-11 19:15+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -950,7 +950,7 @@ msgstr ""
 #: lxc/image.go:328 lxc/image.go:453 lxc/image.go:612 lxc/image.go:840
 #: lxc/image.go:975 lxc/image.go:1273 lxc/image.go:1352 lxc/image_alias.go:25
 #: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
-#: lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
 #: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
@@ -1504,7 +1504,7 @@ msgstr ""
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
-#: lxc/import.go:28
+#: lxc/import.go:29
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
@@ -1523,16 +1523,16 @@ msgstr ""
 msgid "Import images into the image store"
 msgstr ""
 
-#: lxc/import.go:27
+#: lxc/import.go:28
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:1839
+#: lxc/storage_volume.go:1844
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
 
-#: lxc/import.go:72
+#: lxc/import.go:89
 #, c-format
 msgid "Importing instance: %s"
 msgstr ""
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:52 lxc/move.go:56
+#: lxc/copy.go:51 lxc/import.go:36 lxc/init.go:52 lxc/move.go:56
 msgid "Storage pool name"
 msgstr ""
 
@@ -3498,8 +3498,8 @@ msgstr ""
 msgid "[<remote>:]"
 msgstr ""
 
-#: lxc/import.go:26
-msgid "[<remote>:] <backup file>"
+#: lxc/import.go:27
+msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
 #: lxc/config_trust.go:55
@@ -3705,7 +3705,7 @@ msgid "[<remote>:]<pool>"
 msgstr ""
 
 #: lxc/storage_volume.go:1795
-msgid "[<remote>:]<pool> <backup file>"
+msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
 #: lxc/storage.go:87
@@ -3964,7 +3964,7 @@ msgid ""
 "    Load the image properties from a YAML file"
 msgstr ""
 
-#: lxc/import.go:30
+#: lxc/import.go:31
 msgid ""
 "lxc import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -227,6 +227,7 @@ var APIExtensions = []string{
 	"projects_networks",
 	"projects_networks_restricted_uplinks",
 	"custom_volume_backup",
+	"backup_override_name",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -221,33 +221,53 @@ test_backup_import_with_project() {
   lxc delete --force c2
 
   lxc import "${LXD_DIR}/c2.tar.gz"
+  lxc import "${LXD_DIR}/c2.tar.gz" c3
   lxc info c2 | grep snap0
+  lxc info c3 | grep snap0
   lxc start c2
+  lxc start c3
   lxc stop c2 --force
+  lxc stop c3 --force
 
   if [ "$#" -ne 0 ]; then
     # Import into different project (before deleting earlier import).
     lxc import "${LXD_DIR}/c2.tar.gz" --project "$project-b"
+    lxc import "${LXD_DIR}/c2.tar.gz" --project "$project-b" c3
     lxc info c2 --project "$project-b" | grep snap0
+    lxc info c3 --project "$project-b" | grep snap0
     lxc start c2 --project "$project-b"
+    lxc start c3 --project "$project-b"
     lxc stop c2 --project "$project-b" --force
+    lxc stop c3 --project "$project-b" --force
     lxc restore c2 snap0 --project "$project-b"
+    lxc restore c3 snap0 --project "$project-b"
     lxc delete --force c2 --project "$project-b"
+    lxc delete --force c3 --project "$project-b"
   fi
 
   lxc restore c2 snap0
+  lxc restore c3 snap0
   lxc start c2
+  lxc start c3
   lxc delete --force c2
+  lxc delete --force c3
+
 
   if [ "$lxd_backend" = "btrfs" ] || [ "$lxd_backend" = "zfs" ]; then
     lxc import "${LXD_DIR}/c2-optimized.tar.gz"
+    lxc import "${LXD_DIR}/c2-optimized.tar.gz" c3
     lxc info c2 | grep snap0
+    lxc info c3 | grep snap0
     lxc start c2
+    lxc start c3
     lxc stop c2 --force
-
+    lxc stop c3 --force
     lxc restore c2 snap0
+    lxc restore c3 snap0
     lxc start c2
+    lxc start c3
     lxc delete --force c2
+    lxc delete --force c3
   fi
 
   # Test hyphenated container and snapshot names

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -551,38 +551,52 @@ test_backup_volume_export_with_project() {
   lxc storage volume detach "${pool}" testvol c1
   lxc storage volume delete "${pool}" testvol
   lxc storage volume import "${pool}" "${LXD_DIR}/testvol.tar.gz"
+  lxc storage volume import "${pool}" "${LXD_DIR}/testvol.tar.gz" testvol2
   lxc storage volume attach "${pool}" testvol c1 /mnt
+  lxc storage volume attach "${pool}" testvol2 c1 /mnt2
   lxc start c1
   lxc exec c1 --project "$project" -- stat /mnt/test
+  lxc exec c1 --project "$project" -- stat /mnt2/test
   lxc stop -f c1
 
   if [ "$#" -ne 0 ]; then
     # Import into different project (before deleting earlier import).
     lxc storage volume import "${pool}" "${LXD_DIR}/testvol.tar.gz" --project "$project-b"
+    lxc storage volume import "${pool}" "${LXD_DIR}/testvol.tar.gz" --project "$project-b" testvol2
     lxc storage volume delete "${pool}" testvol --project "$project-b"
+    lxc storage volume delete "${pool}" testvol2 --project "$project-b"
   fi
 
   # Test optimized import.
   if [ "$lxd_backend" = "btrfs" ] || [ "$lxd_backend" = "zfs" ]; then
     lxc storage volume detach "${pool}" testvol c1
+    lxc storage volume detach "${pool}" testvol2 c1
     lxc storage volume delete "${pool}" testvol
+    lxc storage volume delete "${pool}" testvol2
     lxc storage volume import "${pool}" "${LXD_DIR}/testvol-optimized.tar.gz"
+    lxc storage volume import "${pool}" "${LXD_DIR}/testvol-optimized.tar.gz" testvol2
     lxc storage volume attach "${pool}" testvol c1 /mnt
+    lxc storage volume attach "${pool}" testvol2 c1 /mnt2
     lxc start c1
     lxc exec c1 --project "$project" -- stat /mnt/test
+    lxc exec c1 --project "$project" -- stat /mnt2/test
     lxc stop -f c1
 
     if [ "$#" -ne 0 ]; then
       # Import into different project (before deleting earlier import).
       lxc storage volume import "${pool}" "${LXD_DIR}/testvol-optimized.tar.gz" --project "$project-b"
+      lxc storage volume import "${pool}" "${LXD_DIR}/testvol-optimized.tar.gz" --project "$project-b" testvol2
       lxc storage volume delete "${pool}" testvol --project "$project-b"
+      lxc storage volume delete "${pool}" testvol2 --project "$project-b"
     fi
   fi
 
   # Clean up.
   rm -rf "${LXD_DIR}/non-optimized/"* "${LXD_DIR}/optimized/"*
   lxc storage volume detach "${pool}" testvol c1
+  lxc storage volume detach "${pool}" testvol2 c1
   lxc storage volume rm "${pool}" testvol
+  lxc storage volume rm "${pool}" testvol2
   lxc rm -f c1
   rmdir "${LXD_DIR}/optimized"
   rmdir "${LXD_DIR}/non-optimized"


### PR DESCRIPTION
Adds optional last argument to `lxc import` and `lxc storage volume import` commands to allow importing an existing backup as a different instance or volume name respectively.