### PR TITLE
VM: Add support for live shrinking of limits.memory

### DIFF
--- a/lxd/device/config/devices.go
+++ b/lxd/device/config/devices.go
@@ -114,7 +114,7 @@ func (list Devices) Update(newlist Devices, updateFields func(Device, Device) []
 		newDevice := srcNewDevice.Clone()
 
 		// Detect keys different between old and new device and append to the all changed keys list.
-		allChangedKeys = deviceEqualsDiffKeys(oldDevice, newDevice)
+		allChangedKeys = append(allChangedKeys, deviceEqualsDiffKeys(oldDevice, newDevice)...)
 
 		// Remove any fields that can be live-updated without adding/removing the device from instance.
 		for _, k := range updateFields(oldDevice, newDevice) {

--- a/lxd/device/config/devices.go
+++ b/lxd/device/config/devices.go
@@ -117,9 +117,11 @@ func (list Devices) Update(newlist Devices, updateFields func(Device, Device) []
 		allChangedKeys = append(allChangedKeys, deviceEqualsDiffKeys(oldDevice, newDevice)...)
 
 		// Remove any fields that can be live-updated without adding/removing the device from instance.
-		for _, k := range updateFields(oldDevice, newDevice) {
-			delete(oldDevice, k)
-			delete(newDevice, k)
+		if updateFields != nil {
+			for _, k := range updateFields(oldDevice, newDevice) {
+				delete(oldDevice, k)
+				delete(newDevice, k)
+			}
 		}
 
 		// If after removing the live-updatable keys the devices are equal, then we know the device has

--- a/lxd/device/config/devices.go
+++ b/lxd/device/config/devices.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 )
 
-// Device represents a LXD container device
+// Device represents a LXD container device.
 type Device map[string]string
 
 // Clone returns a copy of the Device.
@@ -53,7 +53,7 @@ func (device Device) Validate(rules map[string]func(value string) error) error {
 	return nil
 }
 
-// Devices represents a set of LXD container devices
+// Devices represents a set of LXD container devices.
 type Devices map[string]Device
 
 // NewDevices creates a new Devices set from a native map[string]map[string]string set.
@@ -71,8 +71,7 @@ func NewDevices(nativeSet map[string]map[string]string) Devices {
 	return newDevices
 }
 
-// Contains checks if a given device exists in the set and if it's
-// identical to that provided
+// Contains checks if a given device exists in the set and if it's identical to that provided.
 func (list Devices) Contains(k string, d Device) bool {
 	// If it didn't exist, it's different
 	if list[k] == nil {

--- a/lxd/device/config/devices_utils.go
+++ b/lxd/device/config/devices_utils.go
@@ -1,7 +1,7 @@
 package config
 
+// deviceEquals checks for any difference and addition/removal of properties.
 func deviceEquals(old Device, d Device) bool {
-	// Check for any difference and addition/removal of properties
 	for k := range d {
 		if d[k] != old[k] {
 			return false
@@ -17,10 +17,10 @@ func deviceEquals(old Device, d Device) bool {
 	return true
 }
 
+// deviceEqualsDiffKeys checks for any difference and addition/removal of properties and returns a list of changes.
 func deviceEqualsDiffKeys(old Device, d Device) []string {
 	keys := []string{}
 
-	// Check for any difference and addition/removal of properties
 	for k := range d {
 		if d[k] != old[k] {
 			keys = append(keys, k)

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3996,7 +3996,6 @@ func (c *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		// between oldDevice and newDevice. The result of this is that as long as the
 		// devices are otherwise identical except for the fields returned here, then the
 		// device is considered to be being "updated" rather than "added & removed".
-
 		oldNICType, err := nictype.NICType(c.state, c.Project(), newDevice)
 		if err != nil {
 			return []string{} // Cannot hot-update due to config error.


### PR DESCRIPTION
- Cleans up VM Update() to remove duplicated logic and reject device config changes when running.
- Adds support for shrinking the memory limit of VM (when hugepages are not being used) using `lxc config set limits.memory`.
- Fixes detection of all updated device keys which triggers a MAAS update.