### PR TITLE
Network: Adds DHCPv6 stateful support

### DIFF
--- a/doc/networks.md
+++ b/doc/networks.md
@@ -266,16 +266,17 @@ This will create a standalone OVN network that is connected to the parent networ
 Install the OVN tools and configure the OVN integration bridge on the local node:
 
 ```
-apt install ovn-host ovn-central
-ovs-vsctl set open_vswitch . \
+sudo apt install ovn-host ovn-central
+sudo ovs-vsctl set open_vswitch . \
   external_ids:ovn-remote=unix:/var/run/ovn/ovnsb_db.sock \
   external_ids:ovn-encap-type=geneve \
-  external_ids:ovn-encap-ip=n.n.n.n \ # The IP of your LXD host on the LAN
+  external_ids:ovn-encap-ip=127.0.0.1
 ```
 
 Create an OVN network and an instance using it:
 
 ```
+lxc network set lxdbr0 ipv4.dhcp.ranges=... ipv4.ovn.ranges=... # Allocate IP range for OVN gateways.
 lxc network create ovntest --type=ovn network=lxdbr0
 lxc init images:ubuntu/focal c1
 lxc config device override c1 eth0 network=ovntest

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -297,4 +297,5 @@ dns.domain                      | string    | -                     | lxd       
 dns.search                      | string    | -                     | -                         | Full comma separated domain search list, defaulting to `dns.domain` value
 ipv4.address                    | string    | standard mode         | random unused subnet      | IPv4 address for the bridge (CIDR notation). Use "none" to turn off IPv4 or "auto" to generate a new one
 ipv6.address                    | string    | standard mode         | random unused subnet      | IPv6 address for the bridge (CIDR notation). Use "none" to turn off IPv6 or "auto" to generate a new one
+ipv6.dhcp.stateful              | boolean   | ipv6 dhcp             | false                     | Whether to allocate addresses using DHCP
 network                         | string    | -                     | -                         | Parent network to use for outbound external network access

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -237,7 +237,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 	// Add new OVN logical switch port for instance.
 	logicalPortName, err := network.OVNInstanceDevicePortAdd(d.network, d.inst.ID(), d.inst.Name(), d.name, mac, ips)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "Failed adding OVN port")
 	}
 
 	revert.Add(func() { network.OVNInstanceDevicePortDelete(d.network, d.inst.ID(), d.name) })

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1558,3 +1558,33 @@ func (n *ovn) instanceDevicePortDelete(instanceID int, deviceName string) error 
 
 	return nil
 }
+
+// DHCPv4Subnet returns the DHCPv4 subnet (if DHCP is enabled on network).
+func (n *ovn) DHCPv4Subnet() *net.IPNet {
+	// DHCP is disabled on this network (an empty ipv4.dhcp setting indicates enabled by default).
+	if n.config["ipv4.dhcp"] != "" && !shared.IsTrue(n.config["ipv4.dhcp"]) {
+		return nil
+	}
+
+	_, subnet, err := net.ParseCIDR(n.config["ipv4.address"])
+	if err != nil {
+		return nil
+	}
+
+	return subnet
+}
+
+// DHCPv6Subnet returns the DHCPv6 subnet (if DHCP or SLAAC is enabled on network).
+func (n *ovn) DHCPv6Subnet() *net.IPNet {
+	// DHCP is disabled on this network (an empty ipv6.dhcp setting indicates enabled by default).
+	if n.config["ipv6.dhcp"] != "" && !shared.IsTrue(n.config["ipv6.dhcp"]) {
+		return nil
+	}
+
+	_, subnet, err := net.ParseCIDR(n.config["ipv6.address"])
+	if err != nil {
+		return nil
+	}
+
+	return subnet
+}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -98,8 +98,9 @@ func (n *ovn) Validate(config map[string]string) error {
 
 			return validate.Optional(validate.IsNetworkAddressCIDRV6)(value)
 		},
-		"dns.domain": validate.IsAny,
-		"dns.search": validate.IsAny,
+		"ipv6.dhcp.stateful": validate.Optional(validate.IsBool),
+		"dns.domain":         validate.IsAny,
+		"dns.search":         validate.IsAny,
 
 		// Volatile keys populated automatically as needed.
 		ovnVolatileParentIPv4: validate.Optional(validate.IsNetworkAddressV4),
@@ -1208,8 +1209,13 @@ func (n *ovn) setup(update bool) error {
 
 	// Set IPv6 router advertisement settings.
 	if routerIntPortIPv6Net != nil {
+		adressMode := openvswitch.OVNIPv6AddressModeSLAAC
+		if shared.IsTrue(n.config["ipv6.dhcp.stateful"]) {
+			adressMode = openvswitch.OVNIPv6AddressModeDHCPStateful
+		}
+
 		err = client.LogicalRouterPortSetIPv6Advertisements(n.getRouterIntPortName(), &openvswitch.OVNIPv6RAOpts{
-			AddressMode:        openvswitch.OVNIPv6AddressModeSLAAC,
+			AddressMode:        adressMode,
 			SendPeriodic:       true,
 			DNSSearchList:      n.getDNSSearchList(),
 			RecursiveDNSServer: parent.dnsIPv6,

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -39,10 +39,10 @@ type OVNIPv6AddressMode string
 const OVNIPv6AddressModeSLAAC OVNIPv6AddressMode = "slaac"
 
 // OVNIPv6AddressModeDHCPStateful IPv6 DHCPv6 stateful mode.
-const OVNIPv6AddressModeDHCPStateful OVNIPv6AddressMode = "dhcp_stateful"
+const OVNIPv6AddressModeDHCPStateful OVNIPv6AddressMode = "dhcpv6_stateful"
 
 // OVNIPv6AddressModeDHCPStateless IPv6 DHCPv6 stateless mode.
-const OVNIPv6AddressModeDHCPStateless OVNIPv6AddressMode = "dhcp_stateless"
+const OVNIPv6AddressModeDHCPStateless OVNIPv6AddressMode = "dhcpv6_stateless"
 
 // OVNIPv6RAOpts IPv6 router advertisements options that can be applied to a router.
 type OVNIPv6RAOpts struct {


### PR DESCRIPTION
- Allows OVN networks to enable `ipv6.dhcp.stateful` and allows OVN NICs to specify `ipv6.address` statically.
- Allows OVN NICs to specify `ipv4.address` statically.