### PR TITLE
Network: OVN NIC fallback state info

### DIFF
--- a/lxd/device/device_interface.go
+++ b/lxd/device/device_interface.go
@@ -4,6 +4,7 @@ import (
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/state"
+	"github.com/lxc/lxd/shared/api"
 )
 
 // VolatileSetter is a function that accepts one or more key/value strings to save into the LXD
@@ -63,4 +64,9 @@ type device interface {
 
 	// validateConfig checks Config stored by init() is valid for the instance type.
 	validateConfig(instance.ConfigReader) error
+}
+
+// NICState provides the ability to access NIC state.
+type NICState interface {
+	State() (*api.InstanceStateNetwork, error)
 }

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -1083,3 +1083,51 @@ func (d *nicBridged) setupOVSBridgePortVLANs(hostName string) error {
 
 	return nil
 }
+
+// State gets the state of a bridged NIC by parsing the local DHCP server leases file.
+func (d *nicBridged) State() (*api.InstanceStateNetwork, error) {
+	v := d.volatileGet()
+
+	// Populate device config with volatile fields if needed.
+	networkVethFillFromVolatile(d.config, v)
+
+	if d.config["hwaddr"] == "" {
+		return nil, nil
+	}
+
+	// Parse the leases file.
+	addresses, err := network.GetLeaseAddresses(d.state, d.config["parent"], d.config["hwaddr"])
+	if err != nil {
+		return nil, err
+	}
+
+	if len(addresses) == 0 {
+		return nil, nil
+	}
+
+	// Get MTU.
+	iface, err := net.InterfaceByName(d.config["parent"])
+	if err != nil {
+		return nil, err
+	}
+
+	// Retrieve the host counters, as we report the values from the instance's point of view,
+	// those counters need to be reversed below.
+	hostCounters := shared.NetworkGetCounters(d.config["host_name"])
+	network := api.InstanceStateNetwork{
+		Addresses: addresses,
+		Counters: api.InstanceStateNetworkCounters{
+			BytesReceived:   hostCounters.BytesSent,
+			BytesSent:       hostCounters.BytesReceived,
+			PacketsReceived: hostCounters.PacketsSent,
+			PacketsSent:     hostCounters.PacketsReceived,
+		},
+		Hwaddr:   d.config["hwaddr"],
+		HostName: d.config["host_name"],
+		Mtu:      iface.MTU,
+		State:    "up",
+		Type:     "broadcast",
+	}
+
+	return &network, nil
+}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1543,6 +1543,18 @@ func (n *ovn) instanceDevicePortAdd(instanceID int, instanceName string, deviceN
 	return instancePortName, nil
 }
 
+// instanceDevicePortIPs returns the dynamically allocated IPs for a device port.
+func (n *ovn) instanceDevicePortDynamicIPs(instanceID int, deviceName string) ([]net.IP, error) {
+	instancePortName := n.getInstanceDevicePortName(instanceID, deviceName)
+
+	client, err := n.getClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return client.LogicalSwitchPortDynamicIPs(instancePortName)
+}
+
 // instanceDevicePortDelete deletes an instance device port from the internal logical switch.
 func (n *ovn) instanceDevicePortDelete(instanceID int, deviceName string) error {
 	instancePortName := n.getInstanceDevicePortName(instanceID, deviceName)

--- a/lxd/network/network_utils_ovn.go
+++ b/lxd/network/network_utils_ovn.go
@@ -19,6 +19,17 @@ func OVNInstanceDevicePortAdd(network Network, instanceID int, instanceName stri
 	return n.instanceDevicePortAdd(instanceID, instanceName, deviceName, mac, ips)
 }
 
+// OVNInstanceDevicePortDynamicIPs gets a logical port's dynamic IPs stored in the OVN network's internal switch.
+func OVNInstanceDevicePortDynamicIPs(network Network, instanceID int, deviceName string) ([]net.IP, error) {
+	// Check network is of type OVN.
+	n, ok := network.(*ovn)
+	if !ok {
+		return nil, fmt.Errorf("Network is not OVN type")
+	}
+
+	return n.instanceDevicePortDynamicIPs(instanceID, deviceName)
+}
+
 // OVNInstanceDevicePortDelete deletes a logical port from the OVN network's internal switch.
 func OVNInstanceDevicePortDelete(network Network, instanceID int, deviceName string) error {
 	// Check network is of type OVN.

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -612,10 +612,9 @@ func (o *OVN) LogicalSwitchPortDynamicIPs(portName OVNSwitchPort) ([]net.IP, err
 func (o *OVN) LogicalSwitchPortSetDNS(switchName OVNSwitch, portName OVNSwitchPort, dnsName string) error {
 	var dnsIPv4, dnsIPv6 net.IP
 
-	// parseAndStoreIP checks if the supplied IP string is valid and can be used for a missing DNS IP variable.
+	// checkAndStoreIP checks if the supplied IP is valid and can be used for a missing DNS IP variable.
 	// If the found IP is needed, stores into the relevant dnsIPvP{X} variable and returns true.
-	parseAndStoreIP := func(ipRaw string) bool {
-		ip := net.ParseIP(ipRaw)
+	checkAndStoreIP := func(ip net.IP) bool {
 		if ip != nil {
 			isV4 := ip.To4() != nil
 			if dnsIPv4 == nil && isV4 {
@@ -646,7 +645,7 @@ func (o *OVN) LogicalSwitchPortSetDNS(switchName OVNSwitch, portName OVNSwitchPo
 		}
 
 		// Try and find the first IPv4 and IPv6 addresses from the static address list.
-		if parseAndStoreIP(staticAddress) {
+		if checkAndStoreIP(net.ParseIP(staticAddress)) {
 			if dnsIPv4 != nil && dnsIPv6 != nil {
 				break // We've found all we wanted.
 			}
@@ -655,20 +654,14 @@ func (o *OVN) LogicalSwitchPortSetDNS(switchName OVNSwitch, portName OVNSwitchPo
 
 	// Get dynamic IPs for switch port if indicated and needed.
 	if hasDynamic && (dnsIPv4 == nil || dnsIPv6 == nil) {
-		dynamicAddressesRaw, err := o.nbctl("get", "logical_switch_port", string(portName), "dynamic_addresses")
+		dynamicIPs, err := o.LogicalSwitchPortDynamicIPs(portName)
 		if err != nil {
 			return err
 		}
 
-		dynamicAddressesRaw, err = strconv.Unquote(strings.TrimSpace(dynamicAddressesRaw))
-		if err != nil {
-			return err
-		}
-
-		dynamicAddresses := strings.Split(strings.TrimSpace(dynamicAddressesRaw), " ")
-		for _, dynamicAddress := range dynamicAddresses {
+		for _, dynamicIP := range dynamicIPs {
 			// Try and find the first IPv4 and IPv6 addresses from the dynamic address list.
-			if parseAndStoreIP(dynamicAddress) {
+			if checkAndStoreIP(dynamicIP) {
 				if dnsIPv4 != nil && dnsIPv6 != nil {
 					break // We've found all we wanted.
 				}


### PR DESCRIPTION
- Adds `device.NICState` interface for detecting and retrieving NIC state from devices that support it.
- Updates `qemu.RenderState()` to use the `NICState` interface.
- Implements the `NICState` interface on `bridged` NIC type.