### PR TITLE
VM: Detect broken/hung qemu process and reflect in LXD state output

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4221,7 +4221,7 @@ func (vm *qemu) agentGetState() (*api.InstanceState, error) {
 // IsRunning returns whether or not the instance is running.
 func (vm *qemu) IsRunning() bool {
 	state := vm.State()
-	return state != "BROKEN" && state != "STOPPED"
+	return state != "STOPPED"
 }
 
 // IsFrozen returns whether the instance frozen or not.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4304,6 +4304,13 @@ func (vm *qemu) statusCode() api.StatusCode {
 	// Connect to the monitor.
 	monitor, err := qmp.Connect(vm.monitorPath(), qemuSerialChardevName, vm.getMonitorEventHandler())
 	if err != nil {
+		// If cannot connect to monitor, but qemu process in pid file still exists, then likely qemu
+		// has crashed/hung and this instance is in an error state.
+		pid, _ := vm.pid()
+		if pid > 0 && shared.PathExists(fmt.Sprintf("/proc/%d", pid)) {
+			return api.Error
+		}
+
 		// If we fail to connect, chances are the VM isn't running.
 		return api.Stopped
 	}


### PR DESCRIPTION
This PR should help detect scenarios such as those in https://github.com/lxc/lxd/issues/7962 where the QMP monitor isn't reachable, but the qemu process is still running. 

The way I've simulated this is to start a VM, then remove the qmp socket file, and restart lxd so that it cannot open a monitor connection. This simulates a broken/unreachable qemu process.

Fixes https://github.com/lxc/lxd/issues/7962