### PR TITLE
Network: Add EUI64 guessing for bridged NIC state

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
+	"github.com/mdlayher/netx/eui64"
 	"github.com/pkg/errors"
 
 	"github.com/lxc/lxd/lxd/db"
@@ -1091,24 +1092,103 @@ func (d *nicBridged) State() (*api.InstanceStateNetwork, error) {
 	// Populate device config with volatile fields if needed.
 	networkVethFillFromVolatile(d.config, v)
 
-	if d.config["hwaddr"] == "" {
-		return nil, nil
+	ips := []net.IP{}
+	var v4mask string
+	var v6mask string
+
+	// ipStore appends an IP to ips if not already stored.
+	ipStore := func(newIP net.IP) {
+		for _, ip := range ips {
+			if ip.Equal(newIP) {
+				return
+			}
+		}
+
+		ips = append(ips, newIP)
 	}
 
-	// Parse the leases file.
-	addresses, err := network.GetLeaseAddresses(d.state, d.config["parent"], d.config["hwaddr"])
-	if err != nil {
-		return nil, err
+	// Check if parent is managed network and load config.
+	// Pass project.Default here, as currently dnsmasq (bridged) networks do not support projects.
+	n, err := network.LoadByName(d.state, project.Default, d.config["parent"])
+	if err == nil {
+		// Extract subnet sizes from bridge addresses if available.
+		netConfig := n.Config()
+		_, v4subnet, _ := net.ParseCIDR(netConfig["ipv4.address"])
+		_, v6subnet, _ := net.ParseCIDR(netConfig["ipv6.address"])
+
+		if v4subnet != nil {
+			mask, _ := v4subnet.Mask.Size()
+			v4mask = fmt.Sprintf("%d", mask)
+		}
+
+		if v6subnet != nil {
+			mask, _ := v6subnet.Mask.Size()
+			v6mask = fmt.Sprintf("%d", mask)
+		}
+
+		if d.config["hwaddr"] != "" {
+			// Parse the leases file if parent network is managed.
+			leaseIPs, err := network.GetLeaseAddresses(n.Name(), d.config["hwaddr"])
+			if err == nil {
+				for _, leaseIP := range leaseIPs {
+					ipStore(leaseIP)
+				}
+			}
+
+			if !shared.IsTrue(n.Config()["ipv6.dhcp.stateful"]) && v6subnet != nil {
+				// If stateful DHCPv6 is disabled, and IPv6 is enabled on the bridge, the the NIC
+				// is likely to use its MAC and SLAAC to configure its address.
+				hwAddr, err := net.ParseMAC(d.config["hwaddr"])
+				if err == nil {
+					ip, err := eui64.ParseMAC(v6subnet.IP, hwAddr)
+					if err == nil {
+						ipStore(ip)
+					}
+				}
+			}
+		}
 	}
 
-	if len(addresses) == 0 {
-		return nil, nil
+	// Get IP addresses from IP neighbour cache if present.
+	neighIPs, err := network.GetNeighbourIPs(d.config["parent"], d.config["hwaddr"])
+	if err == nil {
+		for _, neighIP := range neighIPs {
+			ipStore(neighIP)
+		}
+	}
+
+	// Convert IPs to InstanceStateNetworkAddresses.
+	addresses := []api.InstanceStateNetworkAddress{}
+	for _, ip := range ips {
+		addr := api.InstanceStateNetworkAddress{}
+		addr.Address = ip.String()
+		addr.Family = "inet"
+		addr.Netmask = v4mask
+
+		if ip.To4() == nil {
+			addr.Family = "inet6"
+			addr.Netmask = v6mask
+		}
+
+		if ip.IsLinkLocalUnicast() {
+			addr.Scope = "link"
+
+			if addr.Family == "inet6" {
+				addr.Netmask = "64" // Link-local IPv6 addresses are /64.
+			} else {
+				addr.Netmask = "16" // Link-local IPv4 addresses are /16.
+			}
+		} else {
+			addr.Scope = "global"
+		}
+
+		addresses = append(addresses, addr)
 	}
 
 	// Get MTU.
-	iface, err := net.InterfaceByName(d.config["parent"])
+	iface, err := net.InterfaceByName(d.config["host_name"])
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "Failed getting host interface state")
 	}
 
 	// Retrieve the host counters, as we report the values from the instance's point of view,

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -834,48 +834,10 @@ func GetNeighbourIPs(interfaceName string, hwaddr string) ([]net.IP, error) {
 }
 
 // GetLeaseAddresses returns the lease addresses for a network and hwaddr.
-func GetLeaseAddresses(s *state.State, networkName string, hwaddr string) ([]api.InstanceStateNetworkAddress, error) {
-	addresses := []api.InstanceStateNetworkAddress{}
-
-	// Look for neighborhood entries for IPv6.
-	out, err := shared.RunCommand("ip", "-6", "neigh", "show", "dev", networkName)
-	if err == nil {
-		for _, line := range strings.Split(out, "\n") {
-			// Split fields and early validation.
-			fields := strings.Fields(line)
-			if len(fields) != 4 {
-				continue
-			}
-
-			if fields[2] != hwaddr {
-				continue
-			}
-
-			// Prepare the entry.
-			addr := api.InstanceStateNetworkAddress{}
-			addr.Address = fields[0]
-			addr.Family = "inet6"
-
-			if strings.HasPrefix(fields[0], "fe80::") {
-				addr.Scope = "link"
-			} else {
-				addr.Scope = "global"
-			}
-
-			addresses = append(addresses, addr)
-		}
-	}
-
-	// Look for DHCP leases.
+func GetLeaseAddresses(networkName string, hwaddr string) ([]net.IP, error) {
 	leaseFile := shared.VarPath("networks", networkName, "dnsmasq.leases")
 	if !shared.PathExists(leaseFile) {
-		return addresses, nil
-	}
-
-	// Pass project.Default here, as currently dnsmasq (bridged) networks do not support projects.
-	dbInfo, err := LoadByName(s, project.Default, networkName)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Leases file not found for network %q", networkName)
 	}
 
 	content, err := ioutil.ReadFile(leaseFile)
@@ -883,13 +845,15 @@ func GetLeaseAddresses(s *state.State, networkName string, hwaddr string) ([]api
 		return nil, err
 	}
 
+	addresses := []net.IP{}
+
 	for _, lease := range strings.Split(string(content), "\n") {
 		fields := strings.Fields(lease)
 		if len(fields) < 5 {
 			continue
 		}
 
-		// Parse the MAC
+		// Parse the MAC.
 		mac := GetMACSlice(fields[1])
 		macStr := strings.Join(mac, ":")
 
@@ -901,36 +865,11 @@ func GetLeaseAddresses(s *state.State, networkName string, hwaddr string) ([]api
 			continue
 		}
 
-		// Parse the IP
-		addr := api.InstanceStateNetworkAddress{
-			Address: fields[2],
-			Scope:   "global",
+		// Parse the IP.
+		ip := net.ParseIP(fields[2])
+		if ip != nil {
+			addresses = append(addresses, ip)
 		}
-
-		ip := net.ParseIP(addr.Address)
-		if ip == nil {
-			continue
-		}
-
-		if ip.To4() != nil {
-			addr.Family = "inet"
-
-			_, subnet, _ := net.ParseCIDR(dbInfo.Config()["ipv4.address"])
-			if subnet != nil {
-				mask, _ := subnet.Mask.Size()
-				addr.Netmask = fmt.Sprintf("%d", mask)
-			}
-		} else {
-			addr.Family = "inet6"
-
-			_, subnet, _ := net.ParseCIDR(dbInfo.Config()["ipv6.address"])
-			if subnet != nil {
-				mask, _ := subnet.Mask.Size()
-				addr.Netmask = fmt.Sprintf("%d", mask)
-			}
-		}
-
-		addresses = append(addresses, addr)
 	}
 
 	return addresses, nil

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -805,6 +805,34 @@ func GetHostDevice(parent string, vlan string) string {
 	return defaultVlan
 }
 
+// GetNeighbourIPs returns the IP addresses in the neighbour cache for a particular interface and MAC.
+func GetNeighbourIPs(interfaceName string, hwaddr string) ([]net.IP, error) {
+	addresses := []net.IP{}
+
+	// Look for neighbour entries for IPv.
+	out, err := shared.RunCommand("ip", "neigh", "show", "dev", interfaceName)
+	if err == nil {
+		for _, line := range strings.Split(out, "\n") {
+			// Split fields and early validation.
+			fields := strings.Fields(line)
+			if len(fields) != 4 {
+				continue
+			}
+
+			if fields[2] != hwaddr {
+				continue
+			}
+
+			ip := net.ParseIP(fields[0])
+			if ip != nil {
+				addresses = append(addresses, ip)
+			}
+		}
+	}
+
+	return addresses, nil
+}
+
 // GetLeaseAddresses returns the lease addresses for a network and hwaddr.
 func GetLeaseAddresses(s *state.State, networkName string, hwaddr string) ([]api.InstanceStateNetworkAddress, error) {
 	addresses := []api.InstanceStateNetworkAddress{}


### PR DESCRIPTION
Improves bridged NIC IP detection & guessing when the actual instance IP data cannot be retrieved from inside the container or VM.

 - Only tries to parse dnsmasq leases file if parent network is managed.
 - If parent is managed and has stateless IPv6 then guess NIC's IPv6 address using EUI64.
 - If parent network is not managed, no longer treat this as complete failure.
 - Try and find IP addresses from IP neighbour cache using network.GetNeighbourAddresses.
 - Load interface MTU using NIC's `host_name` rather than parent interface (should be the same but more consistent with how OVN NIC does it).
 - Also means that if the NIC's host veth interface is missing, then this call will not return any results.
 - If interface is available, will return interface stats even with no IPs found.
 - Guess link-local address netmask size based on IP family.