### PR TITLE
shared/simplestreams: Fix stream's index download url

### DIFF
--- a/shared/simplestreams/simplestreams.go
+++ b/shared/simplestreams/simplestreams.go
@@ -148,7 +148,7 @@ func (s *SimpleStreams) parseStream() (*Stream, error) {
 		return s.cachedStream, nil
 	}
 
-	body, err := s.cachedDownload("/streams/v1/index.json")
+	body, err := s.cachedDownload("streams/v1/index.json")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Since commit aef8f1928 ("shared/simplestreams: Implement caching support")
the index url contains double '/' between the host part and the path part,
so the resulting url looks like:
  https://STREAMSERVER//streams/v1/index.json

Certain servers will literaly take '/streams/v1/index.json' as the path,
and therefore return 404 or 403.

Fix parseStream(), by removing the prepended '/' passed to
s.cachedDownload().

Signed-off-by: Shmulik Ladkani <shmulik.ladkani@gmail.com>