### PR TITLE
Prevent empty passwords during init if password authentication is enabled

### DIFF
--- a/shared/cmd/ask.go
+++ b/shared/cmd/ask.go
@@ -110,7 +110,8 @@ func AskPassword(question string) string {
 		inSecond := string(pwd)
 		inSecond = strings.TrimSuffix(inSecond, "\n")
 
-		if inFirst == inSecond {
+		// refuse empty password or if password inputs do not match
+		if len(inFirst) > 0 && inFirst == inSecond {
 			return inFirst
 		}
 
@@ -122,11 +123,19 @@ func AskPassword(question string) string {
 //
 // It's the same as AskPassword, but it won't ask to enter it again.
 func AskPasswordOnce(question string) string {
-	fmt.Printf(question)
-	pwd, _ := terminal.ReadPassword(0)
-	fmt.Println("")
+	for {
+		fmt.Printf(question)
+		pwd, _ := terminal.ReadPassword(0)
+		fmt.Println("")
 
-	return string(pwd)
+		// refuse empty password
+		spwd := string(pwd)
+		if len(spwd) > 0 {
+			return spwd
+		}
+
+		invalidInput()
+	}
 }
 
 // Ask a question on the output stream and read the answer from the input stream


### PR DESCRIPTION
fixes #7944 

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>

**Summary**
When initializing using `lxd init`, don't allow for a user to initialize a cluster with an empty password if password authentication is enabled.

**Change Description**
- Updated `AskPassword()` to ensure that checking for empty input from the user will result in a call to `invalidInput()`
- Updated `AskPasswordOnce()` to do the same check, which required putting it into a `for` loop (previously it did not have any validation). I also converted it to a string one line earlier so that the length check matches what was done in `AskPassword()`.

Thanks for participating in Hacktoberfest!