### PR TITLE
doc/index: Add libsqlite3-dev back to dependencies

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -42,7 +42,7 @@ later to work. On ubuntu, you can get those with:
 
 ```bash
 sudo apt update
-sudo apt install acl autoconf dnsmasq-base git golang libacl1-dev libcap-dev liblxc1 liblxc-dev libtool libudev-dev libuv1-dev make pkg-config rsync squashfs-tools tar tcl xz-utils ebtables
+sudo apt install acl autoconf dnsmasq-base git golang libacl1-dev libcap-dev liblxc1 liblxc-dev libsqlite3-dev libtool libudev-dev libuv1-dev make pkg-config rsync squashfs-tools tar tcl xz-utils ebtables
 ```
 
 Note that when building LXC yourself, ensure to build it with the appropriate


### PR DESCRIPTION
Since we don't ship our own anymore.

Closes #7978

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>