### PR TITLE
Use Parse when parsing versions from external tools

### DIFF
--- a/lxd/apparmor/apparmor.go
+++ b/lxd/apparmor/apparmor.go
@@ -203,7 +203,7 @@ func getVersion(state *state.State) (*version.DottedVersion, error) {
 	}
 
 	fields := strings.Fields(strings.Split(out, "\n")[0])
-	return version.NewDottedVersion(fields[len(fields)-1])
+	return version.Parse(fields[len(fields)-1])
 }
 
 // getCacheDir returns the applicable AppArmor cache directory.

--- a/lxd/dnsmasq/dnsmasq.go
+++ b/lxd/dnsmasq/dnsmasq.go
@@ -107,7 +107,7 @@ func GetVersion() (*version.DottedVersion, error) {
 	}
 
 	lines := strings.Split(string(output), " ")
-	return version.NewDottedVersion(lines[2])
+	return version.Parse(lines[2])
 }
 
 // DHCPStaticAllocation retrieves the dnsmasq statically allocated MAC and IPs for an instance.

--- a/lxd/firewall/drivers/drivers_nftables.go
+++ b/lxd/firewall/drivers/drivers_nftables.go
@@ -167,7 +167,7 @@ func (d Nftables) hostVersion() (*version.DottedVersion, error) {
 	}
 
 	lines := strings.Split(string(output), " ")
-	return version.NewDottedVersion(strings.TrimPrefix(lines[1], "v"))
+	return version.Parse(strings.TrimPrefix(lines[1], "v"))
 }
 
 // NetworkSetupForwardingPolicy allows forwarding dependent on boolean argument

--- a/lxd/rsync/rsync.go
+++ b/lxd/rsync/rsync.go
@@ -390,7 +390,7 @@ func AtLeast(min string) bool {
 
 	versionStr := strings.TrimPrefix(fields[1], "version ")
 
-	ver, err := version.NewDottedVersion(versionStr)
+	ver, err := version.Parse(versionStr)
 	if err != nil {
 		return false
 	}

--- a/shared/version/version.go
+++ b/shared/version/version.go
@@ -49,12 +49,12 @@ func NewDottedVersion(versionString string) (*DottedVersion, error) {
 
 // Parse parses a string starting with a dotted version and returns it.
 func Parse(s string) (*DottedVersion, error) {
-	r, _ := regexp.Compile(`^([0-9]+.[0-9]+(.[0-9]+))?.*`)
-	matches := r.FindAllStringSubmatch(s, -1)
-	if len(matches[0]) < 2 {
+	r, _ := regexp.Compile(`^([0-9]+.[0-9]+(.[0-9]+)?).*`)
+	matches := r.FindStringSubmatch(s)
+	if len(matches) == 0 {
 		return nil, fmt.Errorf("Can't parse a version")
 	}
-	return NewDottedVersion(matches[0][1])
+	return NewDottedVersion(matches[1])
 }
 
 // String returns version as a string


### PR DESCRIPTION
Instead of using NewDottedVersion(), use Parse() which can handle
version strings containing suffixes, e.g. "3.0.0-beta1" or similar.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
