### PR TITLE
network: Adds physical network type and adds OVN support for using it as an uplink

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1186,3 +1186,8 @@ when restoring a custom volume backup.
 ## storage\_rsync\_compression
 Adds `rsync.compression` config key to storage pools. This key can be used
 to disable compression in rsync while migrating storage pools.
+
+## network\_type\_physical
+Adds support for additional network type `physical` that can be used as an uplink for `ovn` networks.
+
+The interface specified by `parent` on the `physical` network will be connected to the `ovn` network's gateway.

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -6,6 +6,7 @@ LXD supports the following network types:
  - [macvlan](#network-macvlan): Provides preset configuration to use when connecting instances to a parent macvlan interface.
  - [sriov](#network-sriov): Provides preset configuration to use when connecting instances to a parent SR-IOV interface.
  - [ovn](#network-ovn): Creates a logical network using the OVN software defined networking system.
+ - [physical](#network-physical): Provides preset configuration to use when connecting OVN networks to a parent interface.
 
 The desired type can be specified using the `--type` argument, e.g.
 
@@ -299,3 +300,22 @@ ipv4.address                    | string    | standard mode         | random unu
 ipv6.address                    | string    | standard mode         | random unused subnet      | IPv6 address for the bridge (CIDR notation). Use "none" to turn off IPv6 or "auto" to generate a new one
 ipv6.dhcp.stateful              | boolean   | ipv6 dhcp             | false                     | Whether to allocate addresses using DHCP
 network                         | string    | -                     | -                         | Parent network to use for outbound external network access
+
+## network: physical
+
+The physical network type allows one to specify presets to use when connecting OVN networks to a parent interface.
+
+Network configuration properties:
+
+Key                             | Type      | Condition             | Default                   | Description
+:--                             | :--       | :--                   | :--                       | :--
+maas.subnet.ipv4                | string    | ipv4 address          | -                         | MAAS IPv4 subnet to register instances in (when using `network` property on nic)
+maas.subnet.ipv6                | string    | ipv6 address          | -                         | MAAS IPv6 subnet to register instances in (when using `network` property on nic)
+mtu                             | integer   | -                     | -                         | The MTU of the new interface
+parent                          | string    | -                     | -                         | Parent interface to create sriov NICs on
+vlan                            | integer   | -                     | -                         | The VLAN ID to attach to
+ipv4.gateway                    | string    | standard mode         | -                         | IPv4 address for the gateway and network (CIDR notation)
+ipv4.ovn.ranges                 | string    | -                     | none                      | Comma separate list of IPv4 ranges to use for child OVN network routers (FIRST-LAST format)
+ipv6.gateway                    | string    | standard mode         | -                         | IPv6 address for the gateway and network  (CIDR notation)
+ipv6.ovn.ranges                 | string    | -                     | none                      | Comma separate list of IPv6 ranges to use for child OVN network routers (FIRST-LAST format)
+dns.nameservers                 | string    | standard mode         | -                         | List of DNS server IPs on physical network

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -83,7 +83,7 @@ ipv4.firewall                   | boolean   | ipv4 address          | true      
 ipv4.nat.address                | string    | ipv4 address          | -                         | The source address used for outbound traffic from the bridge
 ipv4.nat                        | boolean   | ipv4 address          | false                     | Whether to NAT (will default to true if unset and a random ipv4.address is generated)
 ipv4.nat.order                  | string    | ipv4 address          | before                    | Whether to add the required NAT rules before or after any pre-existing rules
-ipv4.ovn.ranges                 | string    | -                     | none                      | Comma separate list of IPv4 ranges to use for child OVN networks (FIRST-LAST format)
+ipv4.ovn.ranges                 | string    | -                     | none                      | Comma separate list of IPv4 ranges to use for child OVN network routers (FIRST-LAST format)
 ipv4.routes                     | string    | ipv4 address          | -                         | Comma separated list of additional IPv4 CIDR subnets to route to the bridge
 ipv4.routing                    | boolean   | ipv4 address          | true                      | Whether to route traffic in and out of the bridge
 ipv6.address                    | string    | standard mode         | random unused subnet      | IPv6 address for the bridge (CIDR notation). Use "none" to turn off IPv6 or "auto" to generate a new one
@@ -95,7 +95,7 @@ ipv6.firewall                   | boolean   | ipv6 address          | true      
 ipv6.nat.address                | string    | ipv6 address          | -                         | The source address used for outbound traffic from the bridge
 ipv6.nat                        | boolean   | ipv6 address          | false                     | Whether to NAT (will default to true if unset and a random ipv6.address is generated)
 ipv6.nat.order                  | string    | ipv6 address          | before                    | Whether to add the required NAT rules before or after any pre-existing rules
-ipv6.ovn.ranges                 | string    | -                     | none                      | Comma separate list of IPv6 ranges to use for child OVN networks (FIRST-LAST format)
+ipv6.ovn.ranges                 | string    | -                     | none                      | Comma separate list of IPv6 ranges to use for child OVN network routers (FIRST-LAST format)
 ipv6.routes                     | string    | ipv6 address          | -                         | Comma separated list of additional IPv6 CIDR subnets to route to the bridge
 ipv6.routing                    | boolean   | ipv6 address          | true                      | Whether to route traffic in and out of the bridge
 maas.subnet.ipv4                | string    | ipv4 address          | -                         | MAAS IPv4 subnet to register instances in (when using `network` property on nic)

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -425,10 +425,11 @@ type NetworkType int
 
 // Network types.
 const (
-	NetworkTypeBridge  NetworkType = iota // Network type bridge.
-	NetworkTypeMacvlan                    // Network type macvlan.
-	NetworkTypeSriov                      // Network type sriov.
-	NetworkTypeOVN                        // Network type ovn.
+	NetworkTypeBridge   NetworkType = iota // Network type bridge.
+	NetworkTypeMacvlan                     // Network type macvlan.
+	NetworkTypeSriov                       // Network type sriov.
+	NetworkTypeOVN                         // Network type ovn.
+	NetworkTypePhysical                    // Network type physical.
 )
 
 // GetNetworkInAnyState returns the network with the given name.
@@ -510,6 +511,8 @@ func networkFillType(network *api.Network, netType NetworkType) {
 		network.Type = "sriov"
 	case NetworkTypeOVN:
 		network.Type = "ovn"
+	case NetworkTypePhysical:
+		network.Type = "physical"
 	default:
 		network.Type = "" // Unknown
 	}

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -73,12 +73,6 @@ func NetworkSetDevMAC(devName string, mac string) error {
 	return nil
 }
 
-// NetworkRemoveInterface removes a network interface by name.
-func NetworkRemoveInterface(nic string) error {
-	_, err := shared.RunCommand("ip", "link", "del", "dev", nic)
-	return err
-}
-
 // networkRemoveInterfaceIfNeeded removes a network interface by name but only if no other instance is using it.
 func networkRemoveInterfaceIfNeeded(state *state.State, nic string, current instance.Instance, parent string, vlanID string) error {
 	// Check if it's used by another instance.

--- a/lxd/device/infiniband_physical.go
+++ b/lxd/device/infiniband_physical.go
@@ -6,6 +6,7 @@ import (
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/lxd/network"
 	"github.com/lxc/lxd/lxd/resources"
 	"github.com/lxc/lxd/shared"
 )
@@ -97,9 +98,9 @@ func (d *infinibandPhysical) Start() (*deviceConfig.RunConfig, error) {
 
 	// Set the MTU.
 	if d.config["mtu"] != "" {
-		_, err := shared.RunCommand("ip", "link", "set", "dev", saveData["host_name"], "mtu", d.config["mtu"])
+		err = network.InterfaceSetMTU(saveData["host_name"], d.config["mtu"])
 		if err != nil {
-			return nil, fmt.Errorf("Failed to set the MTU: %s", err)
+			return nil, err
 		}
 	}
 

--- a/lxd/device/infiniband_sriov.go
+++ b/lxd/device/infiniband_sriov.go
@@ -6,6 +6,7 @@ import (
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/lxd/network"
 	"github.com/lxc/lxd/lxd/resources"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -119,9 +120,9 @@ func (d *infinibandSRIOV) Start() (*deviceConfig.RunConfig, error) {
 
 	// Set the MTU.
 	if d.config["mtu"] != "" {
-		_, err := shared.RunCommand("ip", "link", "set", "dev", saveData["host_name"], "mtu", d.config["mtu"])
+		err = network.InterfaceSetMTU(saveData["host_name"], d.config["mtu"])
 		if err != nil {
-			return nil, fmt.Errorf("Failed to set the MTU: %s", err)
+			return nil, err
 		}
 	}
 

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -265,7 +265,7 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 		return nil, err
 	}
 
-	revert.Add(func() { NetworkRemoveInterface(saveData["host_name"]) })
+	revert.Add(func() { network.InterfaceRemove(saveData["host_name"]) })
 
 	// Populate device config with volatile fields if needed.
 	networkVethFillFromVolatile(d.config, saveData)
@@ -441,7 +441,7 @@ func (d *nicBridged) postStop() error {
 		}
 
 		// Removing host-side end of veth pair will delete the peer end too.
-		err = NetworkRemoveInterface(d.config["host_name"])
+		err = network.InterfaceRemove(d.config["host_name"])
 		if err != nil {
 			return errors.Wrapf(err, "Failed to remove interface %q", d.config["host_name"])
 		}

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -165,9 +165,9 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 
 	// Set the MTU.
 	if d.config["mtu"] != "" {
-		_, err := shared.RunCommand("ip", "link", "set", "dev", saveData["host_name"], "mtu", d.config["mtu"])
+		err = network.InterfaceSetMTU(saveData["host_name"], d.config["mtu"])
 		if err != nil {
-			return nil, fmt.Errorf("Failed to set the MTU: %s", err)
+			return nil, err
 		}
 	}
 

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -153,7 +153,7 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 		}
 	}
 
-	revert.Add(func() { NetworkRemoveInterface(saveData["host_name"]) })
+	revert.Add(func() { network.InterfaceRemove(saveData["host_name"]) })
 
 	// Set the MAC address.
 	if d.config["hwaddr"] != "" {
@@ -231,7 +231,7 @@ func (d *nicMACVLAN) postStop() error {
 
 	// Delete the detached device.
 	if v["host_name"] != "" && shared.PathExists(fmt.Sprintf("/sys/class/net/%s", v["host_name"])) {
-		err := NetworkRemoveInterface(v["host_name"])
+		err := network.InterfaceRemove(v["host_name"])
 		if err != nil {
 			errs = append(errs, err)
 		}

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -201,7 +201,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 		return nil, err
 	}
 
-	revert.Add(func() { NetworkRemoveInterface(saveData["host_name"]) })
+	revert.Add(func() { network.InterfaceRemove(saveData["host_name"]) })
 
 	// Populate device config with volatile fields if needed.
 	networkVethFillFromVolatile(d.config, saveData)
@@ -381,7 +381,7 @@ func (d *nicOVN) postStop() error {
 		}
 
 		// Removing host-side end of veth pair will delete the peer end too.
-		err = NetworkRemoveInterface(d.config["host_name"])
+		err = network.InterfaceRemove(d.config["host_name"])
 		if err != nil {
 			return errors.Wrapf(err, "Failed to remove interface %q", d.config["host_name"])
 		}

--- a/lxd/device/nic_p2p.go
+++ b/lxd/device/nic_p2p.go
@@ -89,7 +89,7 @@ func (d *nicP2P) Start() (*deviceConfig.RunConfig, error) {
 		return nil, err
 	}
 
-	revert.Add(func() { NetworkRemoveInterface(saveData["host_name"]) })
+	revert.Add(func() { network.InterfaceRemove(saveData["host_name"]) })
 
 	// Populate device config with volatile fields if needed.
 	networkVethFillFromVolatile(d.config, saveData)
@@ -185,7 +185,7 @@ func (d *nicP2P) postStop() error {
 
 	if d.config["host_name"] != "" && shared.PathExists(fmt.Sprintf("/sys/class/net/%s", d.config["host_name"])) {
 		// Removing host-side end of veth pair will delete the peer end too.
-		err := NetworkRemoveInterface(d.config["host_name"])
+		err := network.InterfaceRemove(d.config["host_name"])
 		if err != nil {
 			return fmt.Errorf("Failed to remove interface %s: %s", d.config["host_name"], err)
 		}

--- a/lxd/device/nic_physical.go
+++ b/lxd/device/nic_physical.go
@@ -121,9 +121,9 @@ func (d *nicPhysical) Start() (*deviceConfig.RunConfig, error) {
 
 		// Set the MTU.
 		if d.config["mtu"] != "" {
-			_, err := shared.RunCommand("ip", "link", "set", "dev", saveData["host_name"], "mtu", d.config["mtu"])
+			err = network.InterfaceSetMTU(saveData["host_name"], d.config["mtu"])
 			if err != nil {
-				return nil, fmt.Errorf("Failed to set the MTU: %s", err)
+				return nil, err
 			}
 		}
 	} else if d.inst.Type() == instancetype.VM {

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -160,9 +160,9 @@ func (d *nicSRIOV) Start() (*deviceConfig.RunConfig, error) {
 
 		// Set the MTU.
 		if d.config["mtu"] != "" {
-			_, err := shared.RunCommand("ip", "link", "set", "dev", saveData["host_name"], "mtu", d.config["mtu"])
+			err = network.InterfaceSetMTU(saveData["host_name"], d.config["mtu"])
 			if err != nil {
-				return nil, fmt.Errorf("Failed to set the MTU: %s", err)
+				return nil, err
 			}
 		}
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -393,7 +393,7 @@ func (n *bridge) Validate(config map[string]string) error {
 func (n *bridge) Create(clientType cluster.ClientType) error {
 	n.logger.Debug("Create", log.Ctx{"clientType": clientType, "config": n.config})
 
-	if shared.PathExists(fmt.Sprintf("/sys/class/net/%s", n.name)) {
+	if InterfaceExists(n.name) {
 		return fmt.Errorf("Network interface %q already exists", n.name)
 	}
 
@@ -402,7 +402,7 @@ func (n *bridge) Create(clientType cluster.ClientType) error {
 
 // isRunning returns whether the network is up.
 func (n *bridge) isRunning() bool {
-	return shared.PathExists(fmt.Sprintf("/sys/class/net/%s", n.name))
+	return InterfaceExists(n.name)
 }
 
 // Delete deletes a network.
@@ -430,7 +430,7 @@ func (n *bridge) Delete(clientType cluster.ClientType) error {
 func (n *bridge) Rename(newName string) error {
 	n.logger.Debug("Rename", log.Ctx{"newName": newName})
 
-	if shared.PathExists(fmt.Sprintf("/sys/class/net/%s", newName)) {
+	if InterfaceExists(newName) {
 		return fmt.Errorf("Network interface %q already exists", newName)
 	}
 
@@ -1563,7 +1563,7 @@ func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clientType
 				continue
 			}
 
-			if !shared.StringInSlice(dev, devices) && shared.PathExists(fmt.Sprintf("/sys/class/net/%s", dev)) {
+			if !shared.StringInSlice(dev, devices) && InterfaceExists(dev) {
 				err = DetachInterface(n.name, dev)
 				if err != nil {
 					return err

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1572,7 +1572,7 @@ func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clientType
 		}
 	}
 
-	// Apply changes to database.
+	// Apply changes to all nodes and databse.
 	err = n.common.update(newNetwork, targetNode, clientType)
 	if err != nil {
 		return err

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -104,7 +104,7 @@ func (n *macvlan) Update(newNetwork api.NetworkPut, targetNode string, clientTyp
 		n.common.update(oldNetwork, targetNode, clientType)
 	})
 
-	// Apply changes to database.
+	// Apply changes to all nodes and databse.
 	err = n.common.update(newNetwork, targetNode, clientType)
 	if err != nil {
 		return err

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -663,7 +663,7 @@ func (n *ovn) startParentPortBridge(parentNet Network) error {
 	defer revert.Fail()
 
 	// Create veth pair if needed.
-	if !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", vars.parentEnd)) && !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", vars.ovsEnd)) {
+	if !InterfaceExists(vars.parentEnd) && !InterfaceExists(vars.ovsEnd) {
 		_, err := shared.RunCommand("ip", "link", "add", "dev", vars.parentEnd, "type", "veth", "peer", "name", vars.ovsEnd)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to create the uplink veth interfaces %q and %q", vars.parentEnd, vars.ovsEnd)
@@ -774,7 +774,7 @@ func (n *ovn) deleteParentPortBridge(parentNet Network) error {
 	// Check OVS uplink bridge exists, if it does, check how many ports it has.
 	removeVeths := false
 	vars := n.parentPortBridgeVars(parentNet)
-	if shared.PathExists(fmt.Sprintf("/sys/class/net/%s", vars.ovsBridge)) {
+	if InterfaceExists(vars.ovsBridge) {
 		ovs := openvswitch.NewOVS()
 		ports, err := ovs.BridgePortList(vars.ovsBridge)
 		if err != nil {
@@ -801,14 +801,14 @@ func (n *ovn) deleteParentPortBridge(parentNet Network) error {
 
 	// Remove the veth interfaces if they exist.
 	if removeVeths {
-		if shared.PathExists(fmt.Sprintf("/sys/class/net/%s", vars.parentEnd)) {
+		if InterfaceExists(vars.parentEnd) {
 			_, err := shared.RunCommand("ip", "link", "delete", "dev", vars.parentEnd)
 			if err != nil {
 				return errors.Wrapf(err, "Failed to delete the uplink veth interface %q", vars.parentEnd)
 			}
 		}
 
-		if shared.PathExists(fmt.Sprintf("/sys/class/net/%s", vars.ovsEnd)) {
+		if InterfaceExists(vars.ovsEnd) {
 			_, err := shared.RunCommand("ip", "link", "delete", "dev", vars.ovsEnd)
 			if err != nil {
 				return errors.Wrapf(err, "Failed to delete the uplink veth interface %q", vars.ovsEnd)

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1513,7 +1513,7 @@ func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clientType cl
 		}
 	})
 
-	// Apply changes to database.
+	// Apply changes to all nodes and databse.
 	err = n.common.update(newNetwork, targetNode, clientType)
 	if err != nil {
 		return err

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -687,11 +687,11 @@ func (n *ovn) startParentPortBridge(parentNet Network) error {
 	}
 
 	// Ensure correct sysctls are set on uplink veth interfaces to avoid getting IPv6 link-local addresses.
-	_, err := shared.RunCommand("sysctl",
-		fmt.Sprintf("net.ipv6.conf.%s.disable_ipv6=1", vars.parentEnd),
-		fmt.Sprintf("net.ipv6.conf.%s.disable_ipv6=1", vars.ovsEnd),
-		fmt.Sprintf("net.ipv6.conf.%s.forwarding=0", vars.parentEnd),
-		fmt.Sprintf("net.ipv6.conf.%s.forwarding=0", vars.ovsEnd),
+	err := util.SysctlSet(
+		fmt.Sprintf("net/ipv6/conf/%s/disable_ipv6", vars.parentEnd), "1",
+		fmt.Sprintf("net/ipv6/conf/%s/disable_ipv6", vars.ovsEnd), "1",
+		fmt.Sprintf("net/ipv6/conf/%s/forwarding", vars.parentEnd), "0",
+		fmt.Sprintf("net/ipv6/conf/%s/forwarding", vars.ovsEnd), "0",
 	)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to configure uplink veth interfaces %q and %q", vars.parentEnd, vars.ovsEnd)

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -1,0 +1,298 @@
+package network
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/pkg/errors"
+
+	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/revert"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+	log "github.com/lxc/lxd/shared/log15"
+	"github.com/lxc/lxd/shared/validate"
+)
+
+// physical represents a LXD physical network.
+type physical struct {
+	common
+}
+
+// Type returns the network type.
+func (n *physical) Type() string {
+	return "physical"
+}
+
+// DBType returns the network type DB ID.
+func (n *physical) DBType() db.NetworkType {
+	return db.NetworkTypePhysical
+}
+
+// Validate network config.
+func (n *physical) Validate(config map[string]string) error {
+	rules := map[string]func(value string) error{
+		"parent":                      validate.Required(validate.IsNotEmpty, validInterfaceName),
+		"mtu":                         validate.Optional(validate.IsNetworkMTU),
+		"vlan":                        validate.Optional(validate.IsNetworkVLAN),
+		"maas.subnet.ipv4":            validate.IsAny,
+		"maas.subnet.ipv6":            validate.IsAny,
+		"ipv4.gateway":                validate.Optional(validate.IsNetworkAddressCIDRV4),
+		"ipv6.gateway":                validate.Optional(validate.IsNetworkAddressCIDRV6),
+		"ipv4.ovn.ranges":             validate.Optional(validate.IsNetworkRangeV4List),
+		"ipv6.ovn.ranges":             validate.Optional(validate.IsNetworkRangeV6List),
+		"dns.nameservers":             validate.Optional(validate.IsNetworkAddressList),
+		"volatile.last_state.created": validate.Optional(validate.IsBool),
+	}
+
+	err := n.validate(config, rules)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// checkParentUse checks if parent is already in use by another network or instance device.
+func (n *physical) checkParentUse(ourConfig map[string]string) error {
+	// Get all managed networks across all projects.
+	var err error
+	var projectNetworks map[string]map[int64]api.Network
+
+	err = n.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
+		projectNetworks, err = tx.GetNonPendingNetworks()
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "Failed to load all networks")
+	}
+
+	for projectName, networks := range projectNetworks {
+		if projectName != project.Default {
+			continue // Only default project networks can possible reference a physical interface.
+		}
+
+		for _, network := range networks {
+			if network.Name == n.name {
+				continue // Ignore our own DB record.
+			}
+
+			// Check if another network is using our parent.
+			if network.Config["parent"] == ourConfig["parent"] {
+				// If either network doesn't specify a vlan, or both specify same vlan,
+				// then we can't use this parent.
+				if (network.Config["vlan"] == "" || ourConfig["vlan"] == "") || network.Config["vlan"] == ourConfig["vlan"] {
+					return fmt.Errorf("Parent interface %q in use by another network", ourConfig["parent"])
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// Create checks whether the referenced parent interface is used by other networks or instance devices, as we
+// need to have exclusive access to the interface.
+func (n *physical) Create(clientType cluster.ClientType) error {
+	n.logger.Debug("Create", log.Ctx{"clientType": clientType, "config": n.config})
+
+	// We only need to check in the database once, not on every clustered node.
+	if clientType == cluster.ClientTypeNormal {
+		err := n.checkParentUse(n.config)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Delete deletes a network.
+func (n *physical) Delete(clientType cluster.ClientType) error {
+	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
+
+	err := n.Stop()
+	if err != nil {
+		return err
+	}
+
+	return n.common.delete(clientType)
+}
+
+// Rename renames a network.
+func (n *physical) Rename(newName string) error {
+	n.logger.Debug("Rename", log.Ctx{"newName": newName})
+
+	// Rename common steps.
+	err := n.common.rename(newName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Start starts is a no-op.
+func (n *physical) Start() error {
+	n.logger.Debug("Start")
+
+	if n.status == api.NetworkStatusPending {
+		return fmt.Errorf("Cannot start pending network")
+	}
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	hostName := GetHostDevice(n.config["parent"], n.config["vlan"])
+	created, err := VLANInterfaceCreate(n.config["parent"], hostName, n.config["vlan"])
+	if err != nil {
+		return err
+	}
+	if created {
+		revert.Add(func() { InterfaceRemove(hostName) })
+	}
+
+	// Set the MTU.
+	if n.config["mtu"] != "" {
+		err = InterfaceSetMTU(hostName, n.config["mtu"])
+		if err != nil {
+			return err
+		}
+	}
+
+	// Record if we created this device or not (if we have not already recorded that we created it previously),
+	// so it can be removed on stop. This way we won't overwrite the setting on LXD restart.
+	if !shared.IsTrue(n.config["volatile.last_state.created"]) {
+		n.config["volatile.last_state.created"] = fmt.Sprintf("%t", created)
+		err = n.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
+			return tx.UpdateNetwork(n.id, n.description, n.config)
+		})
+		if err != nil {
+			return errors.Wrapf(err, "Failed saving volatile config")
+		}
+	}
+
+	revert.Success()
+	return nil
+}
+
+// Stop stops is a no-op.
+func (n *physical) Stop() error {
+	n.logger.Debug("Stop")
+
+	hostName := GetHostDevice(n.config["parent"], n.config["vlan"])
+
+	// Only try and remove created VLAN interfaces.
+	if n.config["vlan"] != "" && shared.IsTrue(n.config["volatile.last_state.created"]) && InterfaceExists(hostName) {
+		err := InterfaceRemove(hostName)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Reset MTU back to 1500 if overridden in config.
+	if n.config["mtu"] != "" && InterfaceExists(hostName) {
+		err := InterfaceSetMTU(hostName, "1500")
+		if err != nil {
+			return err
+		}
+	}
+
+	// Remove last state config.
+	delete(n.config, "volatile.last_state.created")
+	err := n.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
+		return tx.UpdateNetwork(n.id, n.description, n.config)
+	})
+	if err != nil {
+		return errors.Wrapf(err, "Failed removing volatile config")
+	}
+
+	return nil
+}
+
+// Update updates the network. Accepts notification boolean indicating if this update request is coming from a
+// cluster notification, in which case do not update the database, just apply local changes needed.
+func (n *physical) Update(newNetwork api.NetworkPut, targetNode string, clientType cluster.ClientType) error {
+	n.logger.Debug("Update", log.Ctx{"clientType": clientType, "newNetwork": newNetwork})
+
+	dbUpdateNeeeded, changedKeys, oldNetwork, err := n.common.configChanged(newNetwork)
+	if err != nil {
+		return err
+	}
+
+	if !dbUpdateNeeeded {
+		return nil // Nothing changed.
+	}
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	hostNameChanged := shared.StringInSlice("vlan", changedKeys) || shared.StringInSlice("parent", changedKeys)
+
+	// We only need to check in the database once, not on every clustered node.
+	if clientType == cluster.ClientTypeNormal {
+		if hostNameChanged {
+			isUsed, err := n.IsUsed()
+			if isUsed || err != nil {
+				return fmt.Errorf("Cannot update network host name when in use")
+			}
+
+			err = n.checkParentUse(newNetwork.Config)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if hostNameChanged {
+		err = n.Stop()
+		if err != nil {
+			return err
+		}
+
+		// Remove the volatile last state from submitted new config if present.
+		delete(newNetwork.Config, "volatile.last_state.created")
+	}
+
+	// Define a function which reverts everything.
+	revert.Add(func() {
+		// Reset changes to all nodes and database.
+		n.common.update(oldNetwork, targetNode, clientType)
+	})
+
+	// Apply changes to all nodes and databse.
+	err = n.common.update(newNetwork, targetNode, clientType)
+	if err != nil {
+		return err
+	}
+
+	err = n.Start()
+	if err != nil {
+		return err
+	}
+
+	revert.Success()
+	return nil
+}
+
+// DHCPv4Subnet returns the DHCPv4 subnet (if DHCP is enabled on network).
+func (n *physical) DHCPv4Subnet() *net.IPNet {
+	_, subnet, err := net.ParseCIDR(n.config["ipv4.gateway"])
+	if err != nil {
+		return nil
+	}
+
+	return subnet
+}
+
+// DHCPv6Subnet returns the DHCPv6 subnet (if DHCP or SLAAC is enabled on network).
+func (n *physical) DHCPv6Subnet() *net.IPNet {
+	_, subnet, err := net.ParseCIDR(n.config["ipv6.gateway"])
+	if err != nil {
+		return nil
+	}
+
+	return subnet
+}

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -104,7 +104,7 @@ func (n *sriov) Update(newNetwork api.NetworkPut, targetNode string, clientType 
 		n.common.update(oldNetwork, targetNode, clientType)
 	})
 
-	// Apply changes to database.
+	// Apply changes to all nodes and databse.
 	err = n.common.update(newNetwork, targetNode, clientType)
 	if err != nil {
 		return err

--- a/lxd/network/network_load.go
+++ b/lxd/network/network_load.go
@@ -5,10 +5,11 @@ import (
 )
 
 var drivers = map[string]func() Network{
-	"bridge":  func() Network { return &bridge{} },
-	"macvlan": func() Network { return &macvlan{} },
-	"sriov":   func() Network { return &sriov{} },
-	"ovn":     func() Network { return &ovn{} },
+	"bridge":   func() Network { return &bridge{} },
+	"macvlan":  func() Network { return &macvlan{} },
+	"sriov":    func() Network { return &sriov{} },
+	"ovn":      func() Network { return &ovn{} },
+	"physical": func() Network { return &physical{} },
 }
 
 // LoadByType loads a network by driver type.

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -1060,3 +1060,15 @@ func InterfaceExists(nic string) bool {
 
 	return false
 }
+
+// InterfaceSetMTU sets the MTU of a network interface.
+func InterfaceSetMTU(nic string, mtu string) error {
+	if mtu != "" {
+		_, err := shared.RunCommand("ip", "link", "set", "dev", nic, "mtu", mtu)
+		if err != nil {
+			return errors.Wrapf(err, "Failed setting MTU %q on %q", mtu, nic)
+		}
+	}
+
+	return nil
+}

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -1045,3 +1045,18 @@ func VLANInterfaceCreate(parent string, vlanDevice string, vlanID string) (bool,
 	// We created a new vlan interface, return true.
 	return true, nil
 }
+
+// InterfaceRemove removes a network interface by name.
+func InterfaceRemove(nic string) error {
+	_, err := shared.RunCommand("ip", "link", "del", "dev", nic)
+	return err
+}
+
+// InterfaceExists returns true if network interface exists.
+func InterfaceExists(nic string) bool {
+	if shared.PathExists(fmt.Sprintf("/sys/class/net/%s", nic)) {
+		return true
+	}
+
+	return false
+}

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -26,6 +26,7 @@ import (
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/state"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -1013,4 +1014,34 @@ func parseIPRanges(ipRangesList string, allowedNets ...*net.IPNet) ([]*shared.IP
 	}
 
 	return netIPRanges, nil
+}
+
+// VLANInterfaceCreate creates a VLAN interface on parent interface (if needed).
+// Returns boolean indicating if VLAN interface was created.
+func VLANInterfaceCreate(parent string, vlanDevice string, vlanID string) (bool, error) {
+	if vlanID == "" {
+		return false, nil
+	}
+
+	if shared.PathExists(fmt.Sprintf("/sys/class/net/%s", vlanDevice)) {
+		return false, nil
+	}
+
+	// Bring the parent interface up so we can add a vlan to it.
+	_, err := shared.RunCommand("ip", "link", "set", "dev", parent, "up")
+	if err != nil {
+		return false, errors.Wrapf(err, "Failed to bring up parent %q", parent)
+	}
+
+	// Add VLAN interface on top of parent.
+	_, err = shared.RunCommand("ip", "link", "add", "link", parent, "name", vlanDevice, "up", "type", "vlan", "id", vlanID)
+	if err != nil {
+		return false, errors.Wrapf(err, "Failed to create VLAN interface %q on %q", vlanDevice, parent)
+	}
+
+	// Attempt to disable IPv6 router advertisement acceptance.
+	util.SysctlSet(fmt.Sprintf("net/ipv6/conf/%s/accept_ra", vlanDevice), "0")
+
+	// We created a new vlan interface, return true.
+	return true, nil
 }

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -1023,7 +1023,7 @@ func VLANInterfaceCreate(parent string, vlanDevice string, vlanID string) (bool,
 		return false, nil
 	}
 
-	if shared.PathExists(fmt.Sprintf("/sys/class/net/%s", vlanDevice)) {
+	if InterfaceExists(vlanDevice) {
 		return false, nil
 	}
 

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -171,6 +171,19 @@ func IsNetworkAddress(value string) error {
 	return nil
 }
 
+// IsNetworkAddressList validates a comma delimited list of IPv4 or IPv6 addresses.
+func IsNetworkAddressList(value string) error {
+	for _, v := range strings.Split(value, ",") {
+		v = strings.TrimSpace(v)
+		err := IsNetworkAddress(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // IsNetworkV4 validates an IPv4 CIDR string. If string is empty, returns valid.
 func IsNetworkV4(value string) error {
 	ip, subnet, err := net.ParseCIDR(value)

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -229,6 +229,7 @@ var APIExtensions = []string{
 	"custom_volume_backup",
 	"backup_override_name",
 	"storage_rsync_compression",
+	"network_type_physical",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
- Adds `physical` network type.
- Updates `ovn` networks to allow the use of a `physical` network as an uplink network.
- Updates `ovn`network's veth uplink interconnect to inherit parent network's `bridge.mtu` setting when used with a `bridge` network.