### PR TITLE
VM: Fixes disk resize regression

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -231,6 +231,8 @@ func (d *disk) validateEnvironment() error {
 
 // CanHotPlug returns whether the device can be managed whilst the instance is running, it also
 // returns a list of fields that can be updated without triggering a device remove & add.
+// Note: At current time VM instances rely on this function indicating live update of "size" field is possible
+// to allow disk resize when VM is stopped.
 func (d *disk) CanHotPlug() (bool, []string) {
 	return true, []string{"limits.max", "limits.read", "limits.write", "size"}
 }


### PR DESCRIPTION
 - Moves check for preventing update of devices when VM is running into updateDevices().
 - Fixes regression introduced by 6697599#diff-8ac4860b5f669c17c92c37545fe2ecfd.
 - Removes 1 call to IsRunning() by passing into updateDevices() from Update().