### PR TITLE
Fix thinpool typo

### DIFF
--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -885,7 +885,7 @@ var StoragePoolNodeConfigKeys = []string{
 	"source",
 	"volatile.initial_source",
 	"zfs.pool_name",
-	"lvm.thinpool",
+	"lvm.thinpool_name",
 	"lvm.vg_name",
 }
 

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -3714,7 +3714,7 @@ func patchUpdateFromV30(_ *sql.Tx) error {
 	return nil
 }
 
-//renames any config incorrectly set config file entries due to the lvm.thinpool_name typo
+//  renames any config incorrectly set config file entries due to the lvm.thinpool_name typo
 func patchThinpoolTypoFix(name string, d *Daemon) error {
 	tx, err := d.cluster.Begin()
 	if err != nil {

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -101,7 +101,7 @@ var patches = []patch{
 	{name: "clustering_drop_database_role", stage: patchPostDaemonStorage, run: patchClusteringDropDatabaseRole},
 	{name: "network_clear_bridge_volatile_hwaddr", stage: patchPostDaemonStorage, run: patchNetworkCearBridgeVolatileHwaddr},
 	{name: "move_backups_instances", stage: patchPostDaemonStorage, run: patchMoveBackupsInstances},
-	{name: "TEMPNAME", stage: TEMP, run: patchTEMPNAME},
+	{name: "thinpool_typo_fix", stage: patchPostDaemonStorage, run: patchThinpoolTypoFix},
 }
 
 type patch struct {
@@ -162,70 +162,6 @@ func patchesApply(d *Daemon, stage patchStage) error {
 	}
 
 	return nil
-}
-
-// Patches begin here
-
-//
-func patchTEMPNAME(name string, d *Daemon) error {
-	tx, err := d.cluster.Begin()
-	if err != nil {
-		return errors.Wrap(err, "failed to begin transaction")
-	}
-
-	// Fetch the IDs of all existing nodes.
-	nodeIDs, err := query.SelectIntegers(tx, "SELECT id FROM nodes")
-	if err != nil {
-		return errors.Wrap(err, "failed to get IDs of current nodes")
-	}
-
-	// Fetch the IDs of all existing lvm pools.
-	poolIDs, err := query.SelectIntegers(tx, "SELECT id FROM storage_pools WHERE driver='lvm'")
-	if err != nil {
-		return errors.Wrap(err, "failed to get IDs of current lvm pools")
-	}
-
-	for _, poolID := range poolIDs {
-		// Fetch the config for this lvm pool and check if it has the
-		// lvn.thinpool_name key.
-		config, err := query.SelectConfig(
-			tx, "storage_pools_config", "storage_pool_id=?", poolID)
-		if err != nil {
-			return errors.Wrap(err, "failed a fetch of lvm pool config")
-		}
-
-		value, ok := "lvm.thinpool"
-		if !ok {
-			continue
-		}
-
-		// Delete the current key
-		_, err = tx.Exec(`
-			DELETE FROM storage_pools_config WHERE key='lvm.thinpool' AND storage_pool_id=?`, poolID)
-		if err != nil {
-			return errors.Wrapf(err, "failed to delete %s config", key)
-		}
-		
-		// Add the config entry for each node
-		for _, nodeID := range nodeIDs {
-			_, err := tx.Exec(`
-			INSERT INTO storage_pools_config(storage_pool_id, node_id, key, value)
-		  	VALUES(?, ?, 'lvm.thinpool_name', ?)
-			`, poolID, curNodeID, value)
-			if err != nil {
-				return errors.Wrapf(err, "failed to create %s node config", key)
-			}
-		}
-	}
-	}
-		
-	err = tx.Commit()
-	if err != nil {
-		return errors.Wrap(err, "failed to commit transaction")
-	}
-		
-	return err
-
 }
 
 // Moves backups from shared.VarPath("backups") to shared.VarPath("backups", "instances").
@@ -3776,4 +3712,66 @@ func patchUpdateFromV30(_ *sql.Tx) error {
 	}
 
 	return nil
+}
+
+//renames any config incorrectly set config file entries due to the lvm.thinpool_name typo
+func patchThinpoolTypoFix(name string, d *Daemon) error {
+	tx, err := d.cluster.Begin()
+	if err != nil {
+		return errors.Wrap(err, "failed to begin transaction")
+	}
+
+	// Fetch the IDs of all existing nodes.
+	nodeIDs, err := query.SelectIntegers(tx, "SELECT id FROM nodes")
+	if err != nil {
+		return errors.Wrap(err, "failed to get IDs of current nodes")
+	}
+
+	// Fetch the IDs of all existing lvm pools.
+	poolIDs, err := query.SelectIntegers(tx, "SELECT id FROM storage_pools WHERE driver='lvm'")
+	if err != nil {
+		return errors.Wrap(err, "failed to get IDs of current lvm pools")
+	}
+
+	for _, poolID := range poolIDs {
+		// Fetch the config for this lvm pool and check if it has the
+		// lvn.thinpool_name key.
+		config, err := query.SelectConfig(
+			tx, "storage_pools_config", "storage_pool_id=?", poolID)
+		if err != nil {
+			return errors.Wrap(err, "failed a fetch of lvm pool config")
+		}
+
+		value, ok := "lvm.thinpool"
+		if !ok {
+			continue
+		}
+
+		// Delete the current key
+		_, err = tx.Exec(`
+			DELETE FROM storage_pools_config WHERE key='lvm.thinpool' AND storage_pool_id=?`, poolID)
+		if err != nil {
+			return errors.Wrapf(err, "failed to delete %s config", key)
+		}
+		
+		// Add the config entry for each node
+		for _, nodeID := range nodeIDs {
+			_, err := tx.Exec(`
+			INSERT INTO storage_pools_config(storage_pool_id, node_id, key, value)
+		  	VALUES(?, ?, 'lvm.thinpool_name', ?)
+			`, poolID, curNodeID, value)
+			if err != nil {
+				return errors.Wrapf(err, "failed to create %s node config", key)
+			}
+		}
+	}
+	}
+		
+	err = tx.Commit()
+	if err != nil {
+		return errors.Wrap(err, "failed to commit transaction")
+	}
+		
+	return err
+
 }


### PR DESCRIPTION
**lxd/db/storage_pools.go:**
renamed 'lvm.thinpool' to 'lvm.thinpool_name'

**lxd/patches.go**
created a patch to rename existing, incorrectly set configs from the typo