### PR TITLE
Storage: Don't remove empty LVM thinpool and volume group if lvm.vg.force_reuse enabled

### DIFF
--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -333,7 +333,7 @@ func (d *lvm) Delete(op *operations.Operation) error {
 	}
 
 	removeVg := false
-	if vgExists {
+	if vgExists && !shared.IsTrue(d.config["lvm.vg.force_reuse"]) {
 		// Count normal and thin volumes.
 		lvCount, err := d.countLogicalVolumes(d.config["lvm.vg_name"])
 		if err != nil && err != errLVMNotFound {


### PR DESCRIPTION
Discussed here https://discuss.linuxcontainers.org/t/lvm-lxc-storage-delete-xxx-removes-lvm-volumegroup-by-default/9143

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>