### PR TITLE
Network: OVN uplink terminology

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1157,7 +1157,7 @@ Adds the `features.networks` config key to projects and the ability for a projec
 
 ## projects\_networks\_restricted\_uplinks
 Adds the `restricted.networks.uplinks` project config key to indicate (as a comma delimited list) which networks
-the networks created inside the project can use as their uplink parent network.
+the networks created inside the project can use as their uplink network.
 
 ## custom\_volume\_backup
 Add custom volume backup support.

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -299,7 +299,7 @@ dns.search                      | string    | -                     | -         
 ipv4.address                    | string    | standard mode         | random unused subnet      | IPv4 address for the bridge (CIDR notation). Use "none" to turn off IPv4 or "auto" to generate a new one
 ipv6.address                    | string    | standard mode         | random unused subnet      | IPv6 address for the bridge (CIDR notation). Use "none" to turn off IPv6 or "auto" to generate a new one
 ipv6.dhcp.stateful              | boolean   | ipv6 dhcp             | false                     | Whether to allocate addresses using DHCP
-network                         | string    | -                     | -                         | Parent network to use for outbound external network access
+network                         | string    | -                     | -                         | Uplink network to use for external network access
 
 ## network: physical
 

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -26,7 +26,7 @@ import (
 type nicOVN struct {
 	deviceCommon
 
-	network network.Network
+	network network.Network // Populated in validateConfig().
 }
 
 // getIntegrationBridgeName returns the OVS integration bridge to use.

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -101,7 +101,16 @@ func (n *common) validate(config map[string]string, driverRules map[string]func(
 
 // ValidateName validates network name.
 func (n *common) ValidateName(name string) error {
-	return validate.IsURLSegmentSafe(name)
+	err := validate.IsURLSegmentSafe(name)
+	if err != nil {
+		return err
+	}
+
+	if strings.Contains(name, ":") {
+		return fmt.Errorf("Cannot contain %q", ":")
+	}
+
+	return nil
 }
 
 // ID returns the network ID.

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -184,6 +184,32 @@ func IsNetworkAddressList(value string) error {
 	return nil
 }
 
+// IsNetwork validates an IP network CIDR string.
+func IsNetwork(value string) error {
+	ip, subnet, err := net.ParseCIDR(value)
+	if err != nil {
+		return err
+	}
+
+	if ip.String() != subnet.IP.String() {
+		return fmt.Errorf("Not an IP network address %q", value)
+	}
+
+	return nil
+}
+
+// IsNetworkList validates a comma delimited list of IP network CIDR strings.
+func IsNetworkList(value string) error {
+	for _, network := range strings.Split(value, ",") {
+		err := IsNetwork(strings.TrimSpace(network))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // IsNetworkV4 validates an IPv4 CIDR string.
 func IsNetworkV4(value string) error {
 	ip, subnet, err := net.ParseCIDR(value)

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -228,29 +228,24 @@ func IsNetworkV4(value string) error {
 	return nil
 }
 
-// IsNetworkAddressV4 validates an IPv4 addresss string.
-func IsNetworkAddressV4(value string) error {
-	ip := net.ParseIP(value)
-	if ip == nil || ip.To4() == nil {
-		return fmt.Errorf("Not an IPv4 address %q", value)
+// IsNetworkV4List validates a comma delimited list of IPv4 CIDR strings.
+func IsNetworkV4List(value string) error {
+	for _, network := range strings.Split(value, ",") {
+		network = strings.TrimSpace(network)
+		err := IsNetworkV4(network)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-// IsNetworkAddressCIDRV4 validates an IPv4 addresss string in CIDR format.
-func IsNetworkAddressCIDRV4(value string) error {
-	ip, subnet, err := net.ParseCIDR(value)
-	if err != nil {
-		return err
-	}
-
-	if ip.To4() == nil {
+// IsNetworkAddressV4 validates an IPv4 addresss string.
+func IsNetworkAddressV4(value string) error {
+	ip := net.ParseIP(value)
+	if ip == nil || ip.To4() == nil {
 		return fmt.Errorf("Not an IPv4 address %q", value)
-	}
-
-	if ip.String() == subnet.IP.String() {
-		return fmt.Errorf("Not a usable IPv4 address %q", value)
 	}
 
 	return nil
@@ -269,85 +264,19 @@ func IsNetworkAddressV4List(value string) error {
 	return nil
 }
 
-// IsNetworkV4List validates a comma delimited list of IPv4 CIDR strings.
-func IsNetworkV4List(value string) error {
-	for _, network := range strings.Split(value, ",") {
-		network = strings.TrimSpace(network)
-		err := IsNetworkV4(network)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// IsNetworkV6 validates an IPv6 CIDR string.
-func IsNetworkV6(value string) error {
+// IsNetworkAddressCIDRV4 validates an IPv4 addresss string in CIDR format.
+func IsNetworkAddressCIDRV4(value string) error {
 	ip, subnet, err := net.ParseCIDR(value)
 	if err != nil {
 		return err
 	}
 
-	if ip == nil || ip.To4() != nil {
-		return fmt.Errorf("Not an IPv6 network %q", value)
-	}
-
-	if ip.String() != subnet.IP.String() {
-		return fmt.Errorf("Not an IPv6 network address %q", value)
-	}
-
-	return nil
-}
-
-// IsNetworkAddressV6 validates an IPv6 addresss string.
-func IsNetworkAddressV6(value string) error {
-	ip := net.ParseIP(value)
-	if ip == nil || ip.To4() != nil {
-		return fmt.Errorf("Not an IPv6 address %q", value)
-	}
-
-	return nil
-}
-
-// IsNetworkAddressCIDRV6 validates an IPv6 addresss string in CIDR format.
-func IsNetworkAddressCIDRV6(value string) error {
-	ip, subnet, err := net.ParseCIDR(value)
-	if err != nil {
-		return err
-	}
-
-	if ip.To4() != nil {
-		return fmt.Errorf("Not an IPv6 address %q", value)
+	if ip.To4() == nil {
+		return fmt.Errorf("Not an IPv4 address %q", value)
 	}
 
 	if ip.String() == subnet.IP.String() {
-		return fmt.Errorf("Not a usable IPv6 address %q", value)
-	}
-
-	return nil
-}
-
-// IsNetworkAddressV6List validates a comma delimited list of IPv6 addresses.
-func IsNetworkAddressV6List(value string) error {
-	for _, v := range strings.Split(value, ",") {
-		v = strings.TrimSpace(v)
-		err := IsNetworkAddressV6(v)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// IsNetworkV6List validates a comma delimited list of IPv6 CIDR strings.
-func IsNetworkV6List(value string) error {
-	for _, network := range strings.Split(value, ",") {
-		network = strings.TrimSpace(network)
-		err := IsNetworkV6(network)
-		if err != nil {
-			return err
-		}
+		return fmt.Errorf("Not a usable IPv4 address %q", value)
 	}
 
 	return nil
@@ -377,6 +306,77 @@ func IsNetworkRangeV4List(value string) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+// IsNetworkV6 validates an IPv6 CIDR string.
+func IsNetworkV6(value string) error {
+	ip, subnet, err := net.ParseCIDR(value)
+	if err != nil {
+		return err
+	}
+
+	if ip == nil || ip.To4() != nil {
+		return fmt.Errorf("Not an IPv6 network %q", value)
+	}
+
+	if ip.String() != subnet.IP.String() {
+		return fmt.Errorf("Not an IPv6 network address %q", value)
+	}
+
+	return nil
+}
+
+// IsNetworkV6List validates a comma delimited list of IPv6 CIDR strings.
+func IsNetworkV6List(value string) error {
+	for _, network := range strings.Split(value, ",") {
+		network = strings.TrimSpace(network)
+		err := IsNetworkV6(network)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// IsNetworkAddressV6 validates an IPv6 addresss string.
+func IsNetworkAddressV6(value string) error {
+	ip := net.ParseIP(value)
+	if ip == nil || ip.To4() != nil {
+		return fmt.Errorf("Not an IPv6 address %q", value)
+	}
+
+	return nil
+}
+
+// IsNetworkAddressV6List validates a comma delimited list of IPv6 addresses.
+func IsNetworkAddressV6List(value string) error {
+	for _, v := range strings.Split(value, ",") {
+		v = strings.TrimSpace(v)
+		err := IsNetworkAddressV6(v)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// IsNetworkAddressCIDRV6 validates an IPv6 addresss string in CIDR format.
+func IsNetworkAddressCIDRV6(value string) error {
+	ip, subnet, err := net.ParseCIDR(value)
+	if err != nil {
+		return err
+	}
+
+	if ip.To4() != nil {
+		return fmt.Errorf("Not an IPv6 address %q", value)
+	}
+
+	if ip.String() == subnet.IP.String() {
+		return fmt.Errorf("Not a usable IPv6 address %q", value)
 	}
 
 	return nil

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -161,7 +161,7 @@ func IsNetworkMAC(value string) error {
 	return nil
 }
 
-// IsNetworkAddress validates an IP (v4 or v6) address string. If string is empty, returns valid.
+// IsNetworkAddress validates an IP (v4 or v6) address string.
 func IsNetworkAddress(value string) error {
 	ip := net.ParseIP(value)
 	if ip == nil {
@@ -184,7 +184,7 @@ func IsNetworkAddressList(value string) error {
 	return nil
 }
 
-// IsNetworkV4 validates an IPv4 CIDR string. If string is empty, returns valid.
+// IsNetworkV4 validates an IPv4 CIDR string.
 func IsNetworkV4(value string) error {
 	ip, subnet, err := net.ParseCIDR(value)
 	if err != nil {
@@ -202,7 +202,7 @@ func IsNetworkV4(value string) error {
 	return nil
 }
 
-// IsNetworkAddressV4 validates an IPv4 addresss string. If string is empty, returns valid.
+// IsNetworkAddressV4 validates an IPv4 addresss string.
 func IsNetworkAddressV4(value string) error {
 	ip := net.ParseIP(value)
 	if ip == nil || ip.To4() == nil {
@@ -212,7 +212,7 @@ func IsNetworkAddressV4(value string) error {
 	return nil
 }
 
-// IsNetworkAddressCIDRV4 validates an IPv4 addresss string in CIDR format. If string is empty, returns valid.
+// IsNetworkAddressCIDRV4 validates an IPv4 addresss string in CIDR format.
 func IsNetworkAddressCIDRV4(value string) error {
 	ip, subnet, err := net.ParseCIDR(value)
 	if err != nil {
@@ -256,7 +256,7 @@ func IsNetworkV4List(value string) error {
 	return nil
 }
 
-// IsNetworkV6 validates an IPv6 CIDR string. If string is empty, returns valid.
+// IsNetworkV6 validates an IPv6 CIDR string.
 func IsNetworkV6(value string) error {
 	ip, subnet, err := net.ParseCIDR(value)
 	if err != nil {
@@ -274,7 +274,7 @@ func IsNetworkV6(value string) error {
 	return nil
 }
 
-// IsNetworkAddressV6 validates an IPv6 addresss string. If string is empty, returns valid.
+// IsNetworkAddressV6 validates an IPv6 addresss string.
 func IsNetworkAddressV6(value string) error {
 	ip := net.ParseIP(value)
 	if ip == nil || ip.To4() != nil {
@@ -284,7 +284,7 @@ func IsNetworkAddressV6(value string) error {
 	return nil
 }
 
-// IsNetworkAddressCIDRV6 validates an IPv6 addresss string in CIDR format. If string is empty, returns valid.
+// IsNetworkAddressCIDRV6 validates an IPv6 addresss string in CIDR format.
 func IsNetworkAddressCIDRV6(value string) error {
 	ip, subnet, err := net.ParseCIDR(value)
 	if err != nil {


### PR DESCRIPTION
- Ensures consistent use of uplink terminology rather than parent in docs and code.
- Adds new validators for forthcoming restricted subnets feature
- Bans colon char from network name. 