### PR TITLE
simplestreams.go: remove unneeded fmt.Sprintf and simplify getImages()

### DIFF
--- a/shared/simplestreams/simplestreams.go
+++ b/shared/simplestreams/simplestreams.go
@@ -82,7 +82,7 @@ func (s *SimpleStreams) readCache(path string) ([]byte, bool) {
 		return nil, false
 	}
 
-	expired := time.Now().Sub(fi.ModTime()) > s.cacheExpiry
+	expired := time.Since(fi.ModTime()) > s.cacheExpiry
 
 	return body, expired
 }
@@ -248,7 +248,7 @@ func (s *SimpleStreams) applyAliases(images []api.Image) ([]api.Image, []extende
 
 			for _, entry := range aliases {
 				// Short
-				alias := addAlias(image.Type, image.Architecture, fmt.Sprintf("%s", entry.Name), image.Fingerprint)
+				alias := addAlias(image.Type, image.Architecture, entry.Name, image.Fingerprint)
 				if alias != nil && architectureName == image.Architecture {
 					image.Aliases = append(image.Aliases, *alias)
 				}
@@ -298,10 +298,7 @@ func (s *SimpleStreams) getImages() ([]api.Image, []extendedAlias, error) {
 		}
 
 		streamImages, _ := products.ToLXD()
-
-		for _, image := range streamImages {
-			images = append(images, image)
-		}
+		images = append(images, streamImages...)
 	}
 
 	// Setup the aliases


### PR DESCRIPTION
* use time.Since() instead of time.Now().Sub() for readability
* entry.Name is already string type, no need for fmt.Sprintf
* remove unneeded for-loop in getImages()

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>