### PR TITLE
Network: Fixes inconsistency between normal bridge and fan bridge default ipv4.nat value

### DIFF
--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1169,7 +1169,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		}
 
 		// Configure NAT.
-		if n.config["ipv4.nat"] == "" || shared.IsTrue(n.config["ipv4.nat"]) {
+		if shared.IsTrue(n.config["ipv4.nat"]) {
 			if n.config["ipv4.nat.order"] == "after" {
 				err = n.state.Firewall.NetworkSetupOutboundNAT(n.name, overlaySubnet, nil, true)
 				if err != nil {


### PR DESCRIPTION
Normal bridge (and docs) say if unset, the default is false, however the fan bridge was defaulting to true if unset.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>