### PR TITLE
network: Adds OVN ipv4.nat and ipv6.nat keys

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1200,3 +1200,11 @@ allowed to be used in child OVN networks in their `ipv4.routes.external` and `ip
 
 Introduces the `restricted.networks.subnets` project setting that specifies which external subnets are allowed to
 be used by OVN networks inside the project (if not set then all routes defined on the uplink network are allowed).
+
+## network\_ovn\_nat
+Adds support for `ipv4.nat` and `ipv6.nat` settings on `ovn` networks.
+
+When creating the network if these settings are unspecified, and an equivalent IP address is being generated for
+the subnet, then the appropriate NAT setting will added set to `true`.
+
+If the setting is missing then the value is taken as `false`.

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -317,9 +317,11 @@ mtu                             | integer   | -                     | -         
 parent                          | string    | -                     | -                         | Parent interface to create sriov NICs on
 vlan                            | integer   | -                     | -                         | The VLAN ID to attach to
 ipv4.gateway                    | string    | standard mode         | -                         | IPv4 address for the gateway and network (CIDR notation)
+ipv4.nat                        | boolean   | ipv4 address          | false                     | Whether to NAT (will default to true if unset and a random ipv4.address is generated)
 ipv4.ovn.ranges                 | string    | -                     | none                      | Comma separate list of IPv4 ranges to use for child OVN network routers (FIRST-LAST format)
 ipv4.routes                     | string    | ipv4 address          | -                         | Comma separated list of additional IPv4 CIDR subnets that can be used with child OVN networks ipv4.routes.external setting
 ipv6.gateway                    | string    | standard mode         | -                         | IPv6 address for the gateway and network  (CIDR notation)
+ipv6.nat                        | boolean   | ipv6 address          | false                     | Whether to NAT (will default to true if unset and a random ipv6.address is generated)
 ipv6.ovn.ranges                 | string    | -                     | none                      | Comma separate list of IPv6 ranges to use for child OVN network routers (FIRST-LAST format)
 ipv6.routes                     | string    | ipv6 address          | -                         | Comma separated list of additional IPv6 CIDR subnets that can be used with child OVN networks ipv6.routes.external setting
 dns.nameservers                 | string    | standard mode         | -                         | List of DNS server IPs on physical network

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -101,6 +101,8 @@ func (n *ovn) Validate(config map[string]string) error {
 		"ipv6.dhcp.stateful":   validate.Optional(validate.IsBool),
 		"ipv4.routes.external": validate.Optional(validate.IsNetworkV4List),
 		"ipv6.routes.external": validate.Optional(validate.IsNetworkV6List),
+		"ipv4.nat":             validate.Optional(validate.IsBool),
+		"ipv6.nat":             validate.Optional(validate.IsBool),
 		"dns.domain":           validate.IsAny,
 		"dns.search":           validate.IsAny,
 
@@ -1112,6 +1114,10 @@ func (n *ovn) FillConfig(config map[string]string) error {
 		}
 
 		config["ipv4.address"] = subnet
+
+		if config["ipv4.nat"] == "" {
+			config["ipv4.nat"] = "true"
+		}
 	}
 
 	if config["ipv6.address"] == "auto" {
@@ -1121,6 +1127,10 @@ func (n *ovn) FillConfig(config map[string]string) error {
 		}
 
 		config["ipv6.address"] = subnet
+
+		if config["ipv6.nat"] == "" {
+			config["ipv6.nat"] = "true"
+		}
 	}
 
 	return nil
@@ -1373,14 +1383,14 @@ func (n *ovn) setup(update bool) error {
 	}
 
 	// Add SNAT rules.
-	if routerIntPortIPv4Net != nil && routerExtPortIPv4 != nil {
+	if shared.IsTrue(n.config["ipv4.nat"]) && routerIntPortIPv4Net != nil && routerExtPortIPv4 != nil {
 		err = client.LogicalRouterSNATAdd(n.getRouterName(), routerIntPortIPv4Net, routerExtPortIPv4)
 		if err != nil {
 			return err
 		}
 	}
 
-	if routerIntPortIPv6Net != nil && routerExtPortIPv6 != nil {
+	if shared.IsTrue(n.config["ipv6.nat"]) && routerIntPortIPv6Net != nil && routerExtPortIPv6 != nil {
 		err = client.LogicalRouterSNATAdd(n.getRouterName(), routerIntPortIPv6Net, routerExtPortIPv6)
 		if err != nil {
 			return err

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -231,6 +231,7 @@ var APIExtensions = []string{
 	"storage_rsync_compression",
 	"network_type_physical",
 	"network_ovn_external_subnets",
+	"network_ovn_nat",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
These will be automatically added to new OVN networks when the associated IP address setting is being auto-generated.

Otherwise if these settings are missing then the default is to disable NAT.

