### PR TITLE
Network: Generates EUI64 IPv6 DNS record for OVN NICs when static IPv4 address is defined

### DIFF
--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -300,7 +300,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 
 		internalRoutes, err = network.SubnetParseAppend(internalRoutes, strings.Split(d.config[key], ",")...)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Invalid %s", key)
+			return nil, errors.Wrapf(err, "Invalid %q value", key)
 		}
 	}
 
@@ -312,7 +312,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 
 		externalRoutes, err = network.SubnetParseAppend(externalRoutes, strings.Split(d.config[key], ",")...)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Invalid %s", key)
+			return nil, errors.Wrapf(err, "Invalid %q value", key)
 		}
 	}
 
@@ -439,7 +439,7 @@ func (d *nicOVN) Stop() (*deviceConfig.RunConfig, error) {
 
 		internalRoutes, err = network.SubnetParseAppend(internalRoutes, strings.Split(d.config[key], ",")...)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Invalid %s", key)
+			return nil, errors.Wrapf(err, "Invalid %q value", key)
 		}
 	}
 
@@ -451,7 +451,7 @@ func (d *nicOVN) Stop() (*deviceConfig.RunConfig, error) {
 
 		externalRoutes, err = network.SubnetParseAppend(externalRoutes, strings.Split(d.config[key], ",")...)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Invalid %s", key)
+			return nil, errors.Wrapf(err, "Invalid %q value", key)
 		}
 	}
 


### PR DESCRIPTION
Fixes an issue where if a static IPv4 address was set for a NIC using ipv4.address, as OVN does not allow a mixture of static and dynamic IPs on a port, this would prevent a dynamic IPv6 address from being added to the port, which in turn prevented a DNS name from being created. 

We now populate the logical port with a static EUI64 address if only static IPv4 addresses are set, and IPv6 is enabled on the bridge.