### PR TITLE
revert/revert.go: remove a for-loop from Clone() method

### DIFF
--- a/lxd/revert/revert.go
+++ b/lxd/revert/revert.go
@@ -37,11 +37,7 @@ func (r *Reverter) Success() {
 // execute the previously deferred reverter.Fail() function.
 func (r *Reverter) Clone() *Reverter {
 	rNew := New()
-	rNew.revertFuncs = make([]func(), 0, len(r.revertFuncs))
-
-	for _, f := range r.revertFuncs {
-		rNew.revertFuncs = append(rNew.revertFuncs, f)
-	}
+	rNew.revertFuncs = append(make([]func(), 0, len(r.revertFuncs)), r.revertFuncs...)
 
 	return rNew
 }


### PR DESCRIPTION
Use a single append to concatenate two slices

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>