### PR TITLE
lxc/copy.go: Remove unneeded for-loop in c.Run()

### DIFF
--- a/lxc/image.go
+++ b/lxc/image.go
@@ -254,9 +254,7 @@ func (c *cmdImageCopy) Run(cmd *cobra.Command, args []string) error {
 
 	if c.flagCopyAliases {
 		// Also add the original aliases
-		for _, alias := range imgInfo.Aliases {
-			aliases = append(aliases, alias)
-		}
+		aliases = append(aliases, imgInfo.Aliases...)
 	}
 
 	err = ensureImageAliases(destinationServer, aliases, fp)


### PR DESCRIPTION
* Removed unneeded for-loop in lxc/copy.go

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>