### PR TITLE
Network: Only call Validate in OVN's FillConfig if state is set

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1168,7 +1168,7 @@ func (n *ovn) FillConfig(config map[string]string) error {
 		changedConfig = true
 	}
 
-	if changedConfig {
+	if changedConfig && n.state != nil {
 		return n.Validate(config)
 	}
 


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>