### PR TITLE
Instance: Fix a class of bugs related to incorrect log path generation when instance is in non-default project

### DIFF
--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -640,14 +640,14 @@ func instanceCreateInternal(s *state.State, args db.InstanceArgs) (instance.Inst
 		s.Cluster.DeleteInstance(dbInst.Project, dbInst.Name)
 	}()
 
-	// Wipe any existing log for this instance name.
-	os.RemoveAll(shared.LogPath(args.Name))
-
 	args = db.InstanceToArgs(&dbInst)
 	inst, err := instance.Create(s, args)
 	if err != nil {
 		return nil, errors.Wrap(err, "Create instance")
 	}
+
+	// Wipe any existing log for this instance name.
+	os.RemoveAll(inst.LogPath())
 
 	revert = false
 	return inst, nil

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -4815,7 +4815,7 @@ func (c *lxc) Export(w io.Writer, properties map[string]string) (api.ImageMetada
 
 func collectCRIULogFile(c instance.Instance, imagesDir string, function string, method string) error {
 	t := time.Now().Format(time.RFC3339)
-	newPath := shared.LogPath(c.Name(), fmt.Sprintf("%s_%s_%s.log", function, method, t))
+	newPath := filepath.Join(c.LogPath(), fmt.Sprintf("%s_%s_%s.log", function, method, t))
 	return shared.FileCopy(filepath.Join(imagesDir, fmt.Sprintf("%s.log", method)), newPath)
 }
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3682,9 +3682,10 @@ func (c *lxc) Rename(newName string) error {
 	}
 
 	// Rename the logging path.
-	os.RemoveAll(shared.LogPath(newName))
+	newFullName := project.Instance(c.Project(), c.Name())
+	os.RemoveAll(shared.LogPath(newFullName))
 	if shared.PathExists(c.LogPath()) {
-		err := os.Rename(c.LogPath(), shared.LogPath(newName))
+		err := os.Rename(c.LogPath(), shared.LogPath(newFullName))
 		if err != nil {
 			logger.Error("Failed renaming container", ctxMap)
 			return err

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2647,9 +2647,10 @@ func (vm *qemu) Rename(newName string) error {
 	}
 
 	// Rename the logging path.
-	os.RemoveAll(shared.LogPath(newName))
+	newFullName := project.Instance(vm.Project(), vm.Name())
+	os.RemoveAll(shared.LogPath(newFullName))
 	if shared.PathExists(vm.LogPath()) {
-		err := os.Rename(vm.LogPath(), shared.LogPath(newName))
+		err := os.Rename(vm.LogPath(), shared.LogPath(newFullName))
 		if err != nil {
 			logger.Error("Failed renaming instance", ctxMap)
 			return err

--- a/lxd/instance_logs.go
+++ b/lxd/instance_logs.go
@@ -53,11 +53,11 @@ func containerLogsGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	project := projectParam(r)
+	projectName := projectParam(r)
 	name := mux.Vars(r)["name"]
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, project, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -72,7 +72,8 @@ func containerLogsGet(d *Daemon, r *http.Request) response.Response {
 
 	result := []string{}
 
-	dents, err := ioutil.ReadDir(shared.LogPath(name))
+	fullName := project.Instance(projectName, name)
+	dents, err := ioutil.ReadDir(shared.LogPath(fullName))
 	if err != nil {
 		return response.SmartError(err)
 	}


### PR DESCRIPTION
I noticed this issue whilst working on OVN CI tests.

The reproducer was:

```
lxc launch images:ubuntu/focal c1 --project default
lxc exec c1 -- whoami --project default # Succeeds
lxc init images:ubuntu/focal c1 --project test
lxc exec c1 -- whoami --project default # Fails. Because the /var/log/lxd/c1/lxc.conf was removed when creating c1 in test project.
```

Further inspection revealed several issues with the use of `shared.LogPath()` function when in a project context.