### PR TITLE
Network: Sets ipv4.nat=true by default for new fan bridges and adds the setting if missing to existing fan bridges

### DIFF
--- a/doc/networks.md
+++ b/doc/networks.md
@@ -82,7 +82,7 @@ ipv4.dhcp.gateway               | string    | ipv4 dhcp             | ipv4.addre
 ipv4.dhcp.ranges                | string    | ipv4 dhcp             | all addresses             | Comma separated list of IP ranges to use for DHCP (FIRST-LAST format)
 ipv4.firewall                   | boolean   | ipv4 address          | true                      | Whether to generate filtering firewall rules for this network
 ipv4.nat.address                | string    | ipv4 address          | -                         | The source address used for outbound traffic from the bridge
-ipv4.nat                        | boolean   | ipv4 address          | false                     | Whether to NAT (will default to true if unset and a random ipv4.address is generated)
+ipv4.nat                        | boolean   | ipv4 address          | false                     | Whether to NAT (defaults to true for regular bridges where ipv4.address is generated and always defaults to true for fan bridges)
 ipv4.nat.order                  | string    | ipv4 address          | before                    | Whether to add the required NAT rules before or after any pre-existing rules
 ipv4.ovn.ranges                 | string    | -                     | none                      | Comma separate list of IPv4 ranges to use for child OVN network routers (FIRST-LAST format)
 ipv4.routes                     | string    | ipv4 address          | -                         | Comma separated list of additional IPv4 CIDR subnets to route to the bridge

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -89,6 +89,11 @@ func (n *bridge) FillConfig(config map[string]string) error {
 		if config["fan.underlay_subnet"] == "" {
 			config["fan.underlay_subnet"] = "auto"
 		}
+
+		// We enable NAT by default even if address is manually specified.
+		if config["ipv4.nat"] == "" {
+			config["ipv4.nat"] = "true"
+		}
 	} else {
 		if config["ipv4.address"] == "" {
 			config["ipv4.address"] = "auto"

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -103,6 +103,7 @@ var patches = []patch{
 	{name: "move_backups_instances", stage: patchPostDaemonStorage, run: patchMoveBackupsInstances},
 	{name: "network_ovn_enable_nat", stage: patchPostDaemonStorage, run: patchNetworkOVNEnableNAT},
 	{name: "network_ovn_remove_routes", stage: patchPostDaemonStorage, run: patchNetworkOVNRemoveRoutes},
+	{name: "network_fan_enable_nat", stage: patchPostDaemonStorage, run: patchNetworkFANEnableNAT},
 }
 
 type patch struct {
@@ -166,6 +167,54 @@ func patchesApply(d *Daemon, stage patchStage) error {
 }
 
 // Patches begin here
+
+// patchNetworkFANEnableNAT sets "ipv4.nat=true" on fan bridges that are missing the "ipv4.nat" setting.
+// This prevents outbound connectivity breaking on existing fan networks now that the default behaviour of not
+// having "ipv4.nat" set is to disable NAT (bringing in line with the non-fan bridge behavior and docs).
+func patchNetworkFANEnableNAT(name string, d *Daemon) error {
+	err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
+		projectNetworks, err := tx.GetNonPendingNetworks()
+		if err != nil {
+			return err
+		}
+
+		for _, networks := range projectNetworks {
+			for networkID, network := range networks {
+				if network.Type != "bridge" {
+					continue
+				}
+
+				if network.Config["bridge.mode"] != "fan" {
+					continue
+				}
+
+				modified := false
+
+				// Enable ipv4.nat if setting not specified.
+				if _, found := network.Config["ipv4.nat"]; !found {
+					modified = true
+					network.Config["ipv4.nat"] = "true"
+				}
+
+				if modified {
+					err = tx.UpdateNetwork(networkID, network.Description, network.Config)
+					if err != nil {
+						return errors.Wrapf(err, "Failed setting ipv4.nat=true for fan network %q (%d)", network.Name, networkID)
+					}
+
+					logger.Debugf("Set ipv4.nat=true for fan network %q (%d)", network.Name, networkID)
+				}
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
 
 // patchNetworkOVNRemoveRoutes removes the "ipv4.routes.external" and "ipv6.routes.external" settings from OVN
 // networks. It was decided that the OVN NIC level equivalent settings were sufficient.


### PR DESCRIPTION
Fixes an issue introduced by https://github.com/lxc/lxd/pull/8037 where fan bridges do not have `ipv4.nat` setting by default which broke external connectivity.