### PR TITLE
Instance: Mount instance volume before devices start

### DIFF
--- a/lxd/device/config/devices_sort.go
+++ b/lxd/device/config/devices_sort.go
@@ -31,7 +31,18 @@ func (devices DevicesSortable) Less(i, j int) bool {
 			return false
 		}
 
-		return a.Config["type"] < b.Config["type"]
+		// Start disks before other non-nic devices so that any unmounts triggered by pre-start resize
+		// occur first and the rest of the devices can rely on the instance's root disk being mounted.
+		if a.Config["type"] == "disk" {
+			return true
+		}
+
+		if b.Config["type"] == "disk" {
+			return false
+		}
+
+		// Otherwise start devices of same type together.
+		return a.Config["type"] > b.Config["type"]
 	}
 
 	// Special case disk paths.

--- a/lxd/device/config/devices_sort.go
+++ b/lxd/device/config/devices_sort.go
@@ -45,7 +45,7 @@ func (devices DevicesSortable) Less(i, j int) bool {
 		return a.Config["type"] > b.Config["type"]
 	}
 
-	// Special case disk paths.
+	// Start disk devices in path order.
 	if a.Config["type"] == "disk" && b.Config["type"] == "disk" {
 		if a.Config["path"] != b.Config["path"] {
 			return a.Config["path"] < b.Config["path"]

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1936,17 +1936,15 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 	revert := revert.New()
 	defer revert.Fail()
 
-	postStartHooks := []func() error{}
-
 	// Load the go-lxc struct
 	err := c.initLXC(true)
 	if err != nil {
-		return "", postStartHooks, errors.Wrap(err, "Load go-lxc struct")
+		return "", nil, errors.Wrap(err, "Load go-lxc struct")
 	}
 
 	// Check that we're not already running
 	if c.IsRunning() {
-		return "", postStartHooks, fmt.Errorf("The container is already running")
+		return "", nil, fmt.Errorf("The container is already running")
 	}
 
 	// Load any required kernel modules
@@ -1956,7 +1954,7 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 			module = strings.TrimPrefix(module, " ")
 			err := util.LoadModule(module)
 			if err != nil {
-				return "", postStartHooks, fmt.Errorf("Failed to load kernel module '%s': %s", module, err)
+				return "", nil, fmt.Errorf("Failed to load kernel module '%s': %s", module, err)
 			}
 		}
 	}
@@ -1964,17 +1962,17 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 	/* Deal with idmap changes */
 	nextIdmap, err := c.NextIdmap()
 	if err != nil {
-		return "", postStartHooks, errors.Wrap(err, "Set ID map")
+		return "", nil, errors.Wrap(err, "Set ID map")
 	}
 
 	diskIdmap, err := c.DiskIdmap()
 	if err != nil {
-		return "", postStartHooks, errors.Wrap(err, "Set last ID map")
+		return "", nil, errors.Wrap(err, "Set last ID map")
 	}
 
 	if !nextIdmap.Equals(diskIdmap) && !(diskIdmap == nil && c.state.OS.Shiftfs) {
 		if shared.IsTrue(c.expandedConfig["security.protection.shift"]) {
-			return "", postStartHooks, fmt.Errorf("Container is protected against filesystem shifting")
+			return "", nil, fmt.Errorf("Container is protected against filesystem shifting")
 		}
 
 		logger.Debugf("Container idmap changed, remapping")
@@ -1982,12 +1980,12 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 
 		ourStart, err = c.mount()
 		if err != nil {
-			return "", postStartHooks, errors.Wrap(err, "Storage start")
+			return "", nil, errors.Wrap(err, "Storage start")
 		}
 
 		storageType, err := c.getStorageType()
 		if err != nil {
-			return "", postStartHooks, errors.Wrap(err, "Storage type")
+			return "", nil, errors.Wrap(err, "Storage type")
 		}
 
 		if diskIdmap != nil {
@@ -2002,7 +2000,7 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 				if ourStart {
 					c.unmount()
 				}
-				return "", postStartHooks, err
+				return "", nil, err
 			}
 		}
 
@@ -2018,7 +2016,7 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 				if ourStart {
 					c.unmount()
 				}
-				return "", postStartHooks, err
+				return "", nil, err
 			}
 		}
 
@@ -2026,14 +2024,14 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 		if nextIdmap != nil && !c.state.OS.Shiftfs {
 			idmapBytes, err := json.Marshal(nextIdmap.Idmap)
 			if err != nil {
-				return "", postStartHooks, err
+				return "", nil, err
 			}
 			jsonDiskIdmap = string(idmapBytes)
 		}
 
 		err = c.VolatileSet(map[string]string{"volatile.last_state.idmap": jsonDiskIdmap})
 		if err != nil {
-			return "", postStartHooks, errors.Wrapf(err, "Set volatile.last_state.idmap config key on container %q (id %d)", c.name, c.id)
+			return "", nil, errors.Wrapf(err, "Set volatile.last_state.idmap config key on container %q (id %d)", c.name, c.id)
 		}
 
 		c.updateProgress("")
@@ -2045,20 +2043,20 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 	} else {
 		idmapBytes, err = json.Marshal(nextIdmap.Idmap)
 		if err != nil {
-			return "", postStartHooks, err
+			return "", nil, err
 		}
 	}
 
 	if c.localConfig["volatile.idmap.current"] != string(idmapBytes) {
 		err = c.VolatileSet(map[string]string{"volatile.idmap.current": string(idmapBytes)})
 		if err != nil {
-			return "", postStartHooks, errors.Wrapf(err, "Set volatile.idmap.current config key on container %q (id %d)", c.name, c.id)
+			return "", nil, errors.Wrapf(err, "Set volatile.idmap.current config key on container %q (id %d)", c.name, c.id)
 		}
 	}
 
 	// Generate the Seccomp profile
 	if err := seccomp.CreateProfile(c.state, c); err != nil {
-		return "", postStartHooks, err
+		return "", nil, err
 	}
 
 	// Cleanup any existing leftover devices
@@ -2068,17 +2066,17 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 	// Create any missing directories.
 	err = os.MkdirAll(c.LogPath(), 0700)
 	if err != nil {
-		return "", postStartHooks, err
+		return "", nil, err
 	}
 
 	err = os.MkdirAll(c.DevicesPath(), 0711)
 	if err != nil {
-		return "", postStartHooks, err
+		return "", nil, err
 	}
 
 	err = os.MkdirAll(c.ShmountsPath(), 0711)
 	if err != nil {
-		return "", postStartHooks, err
+		return "", nil, err
 	}
 
 	// Rotate the log file.
@@ -2087,17 +2085,18 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 		os.Remove(logfile + ".old")
 		err := os.Rename(logfile, logfile+".old")
 		if err != nil {
-			return "", postStartHooks, err
+			return "", nil, err
 		}
 	}
 
 	// Mount instance root volume.
 	ourStart, err = c.mount()
 	if err != nil {
-		return "", postStartHooks, err
+		return "", nil, err
 	}
 
 	// Create the devices
+	postStartHooks := []func() error{}
 	nicID := -1
 
 	// Setup devices in sorted order, this ensures that device mounts are added in path order.
@@ -2107,7 +2106,7 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 		// Start the device.
 		runConf, err := c.deviceStart(dev.Name, dev.Config, false)
 		if err != nil {
-			return "", postStartHooks, errors.Wrapf(err, "Failed to start device %q", dev.Name)
+			return "", nil, errors.Wrapf(err, "Failed to start device %q", dev.Name)
 		}
 
 		// Stop device on failure to setup container, pass non-empty stopHookNetnsPath so that stop code
@@ -2143,13 +2142,13 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 			}
 
 			if err != nil {
-				return "", postStartHooks, errors.Wrapf(err, "Failed to setup device rootfs '%s'", dev.Name)
+				return "", nil, errors.Wrapf(err, "Failed to setup device rootfs '%s'", dev.Name)
 			}
 
 			if len(runConf.RootFS.Opts) > 0 {
 				err = lxcSetConfigItem(c.c, "lxc.rootfs.options", strings.Join(runConf.RootFS.Opts, ","))
 				if err != nil {
-					return "", postStartHooks, errors.Wrapf(err, "Failed to setup device rootfs '%s'", dev.Name)
+					return "", nil, errors.Wrapf(err, "Failed to setup device rootfs '%s'", dev.Name)
 				}
 			}
 
@@ -2157,19 +2156,19 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 				// Host side mark mount.
 				err = lxcSetConfigItem(c.c, "lxc.hook.pre-start", fmt.Sprintf("/bin/mount -t shiftfs -o mark,passthrough=3 %s %s", c.RootfsPath(), c.RootfsPath()))
 				if err != nil {
-					return "", postStartHooks, errors.Wrapf(err, "Failed to setup device mount shiftfs '%s'", dev.Name)
+					return "", nil, errors.Wrapf(err, "Failed to setup device mount shiftfs '%s'", dev.Name)
 				}
 
 				// Container side shift mount.
 				err = lxcSetConfigItem(c.c, "lxc.hook.pre-mount", fmt.Sprintf("/bin/mount -t shiftfs -o passthrough=3 %s %s", c.RootfsPath(), c.RootfsPath()))
 				if err != nil {
-					return "", postStartHooks, errors.Wrapf(err, "Failed to setup device mount shiftfs '%s'", dev.Name)
+					return "", nil, errors.Wrapf(err, "Failed to setup device mount shiftfs '%s'", dev.Name)
 				}
 
 				// Host side umount of mark mount.
 				err = lxcSetConfigItem(c.c, "lxc.hook.start-host", fmt.Sprintf("/bin/umount -l %s", c.RootfsPath()))
 				if err != nil {
-					return "", postStartHooks, errors.Wrapf(err, "Failed to setup device mount shiftfs '%s'", dev.Name)
+					return "", nil, errors.Wrapf(err, "Failed to setup device mount shiftfs '%s'", dev.Name)
 				}
 			}
 		}
@@ -2179,7 +2178,7 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 			for _, rule := range runConf.CGroups {
 				err = lxcSetConfigItem(c.c, fmt.Sprintf("lxc.cgroup.%s", rule.Key), rule.Value)
 				if err != nil {
-					return "", postStartHooks, errors.Wrapf(err, "Failed to setup device cgroup '%s'", dev.Name)
+					return "", nil, errors.Wrapf(err, "Failed to setup device cgroup '%s'", dev.Name)
 				}
 			}
 		}
@@ -2188,34 +2187,34 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 		if len(runConf.Mounts) > 0 {
 			for _, mount := range runConf.Mounts {
 				if shared.StringInSlice("propagation", mount.Opts) && !util.RuntimeLiblxcVersionAtLeast(3, 0, 0) {
-					return "", postStartHooks, errors.Wrapf(fmt.Errorf("liblxc 3.0 is required for mount propagation configuration"), "Failed to setup device mount '%s'", dev.Name)
+					return "", nil, errors.Wrapf(fmt.Errorf("liblxc 3.0 is required for mount propagation configuration"), "Failed to setup device mount '%s'", dev.Name)
 				}
 
 				if mount.OwnerShift == deviceConfig.MountOwnerShiftDynamic && !c.IsPrivileged() {
 					if !c.state.OS.Shiftfs {
-						return "", postStartHooks, errors.Wrapf(fmt.Errorf("shiftfs is required but isn't supported on system"), "Failed to setup device mount '%s'", dev.Name)
+						return "", nil, errors.Wrapf(fmt.Errorf("shiftfs is required but isn't supported on system"), "Failed to setup device mount '%s'", dev.Name)
 					}
 
 					err = lxcSetConfigItem(c.c, "lxc.hook.pre-start", fmt.Sprintf("/bin/mount -t shiftfs -o mark,passthrough=3 %s %s", mount.DevPath, mount.DevPath))
 					if err != nil {
-						return "", postStartHooks, errors.Wrapf(err, "Failed to setup device mount shiftfs '%s'", dev.Name)
+						return "", nil, errors.Wrapf(err, "Failed to setup device mount shiftfs '%s'", dev.Name)
 					}
 
 					err = lxcSetConfigItem(c.c, "lxc.hook.pre-mount", fmt.Sprintf("/bin/mount -t shiftfs -o passthrough=3 %s %s", mount.DevPath, mount.DevPath))
 					if err != nil {
-						return "", postStartHooks, errors.Wrapf(err, "Failed to setup device mount shiftfs '%s'", dev.Name)
+						return "", nil, errors.Wrapf(err, "Failed to setup device mount shiftfs '%s'", dev.Name)
 					}
 
 					err = lxcSetConfigItem(c.c, "lxc.hook.start-host", fmt.Sprintf("/bin/umount -l %s", mount.DevPath))
 					if err != nil {
-						return "", postStartHooks, errors.Wrapf(err, "Failed to setup device mount shiftfs '%s'", dev.Name)
+						return "", nil, errors.Wrapf(err, "Failed to setup device mount shiftfs '%s'", dev.Name)
 					}
 				}
 
 				mntVal := fmt.Sprintf("%s %s %s %s %d %d", shared.EscapePathFstab(mount.DevPath), shared.EscapePathFstab(mount.TargetPath), mount.FSType, strings.Join(mount.Opts, ","), mount.Freq, mount.PassNo)
 				err = lxcSetConfigItem(c.c, "lxc.mount.entry", mntVal)
 				if err != nil {
-					return "", postStartHooks, errors.Wrapf(err, "Failed to setup device mount '%s'", dev.Name)
+					return "", nil, errors.Wrapf(err, "Failed to setup device mount '%s'", dev.Name)
 				}
 			}
 		}
@@ -2233,7 +2232,7 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 			for _, nicItem := range runConf.NetworkInterface {
 				err = lxcSetConfigItem(c.c, fmt.Sprintf("%s.%d.%s", networkKeyPrefix, nicID, nicItem.Key), nicItem.Value)
 				if err != nil {
-					return "", postStartHooks, errors.Wrapf(err, "Failed to setup device network interface '%s'", dev.Name)
+					return "", nil, errors.Wrapf(err, "Failed to setup device network interface '%s'", dev.Name)
 				}
 			}
 		}
@@ -2249,7 +2248,7 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 	err = c.c.SaveConfigFile(configPath)
 	if err != nil {
 		os.Remove(configPath)
-		return "", postStartHooks, err
+		return "", nil, err
 	}
 
 	// Set ownership to match container root
@@ -2258,7 +2257,7 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 		if ourStart {
 			c.unmount()
 		}
-		return "", postStartHooks, err
+		return "", nil, err
 	}
 
 	uid := int64(0)
@@ -2271,7 +2270,7 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 		if ourStart {
 			c.unmount()
 		}
-		return "", postStartHooks, err
+		return "", nil, err
 	}
 
 	// We only need traversal by root in the container
@@ -2280,7 +2279,7 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 		if ourStart {
 			c.unmount()
 		}
-		return "", postStartHooks, err
+		return "", nil, err
 	}
 
 	// Update the backup.yaml file
@@ -2289,7 +2288,7 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 		if ourStart {
 			c.unmount()
 		}
-		return "", postStartHooks, err
+		return "", nil, err
 	}
 
 	// If starting stateless, wipe state

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2936,7 +2936,7 @@ func (c *lxc) onStop(args map[string]string) error {
 
 // cleanupDevices performs any needed device cleanup steps when container is stopped.
 func (c *lxc) cleanupDevices(netns string) {
-	for _, dev := range c.expandedDevices.Sorted() {
+	for _, dev := range c.expandedDevices.Reversed() {
 		// Use the device interface if device supports it.
 		err := c.deviceStop(dev.Name, dev.Config, netns)
 		if err == device.ErrUnsupportedDevType {

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1389,6 +1389,9 @@ func (c *lxc) deviceAdd(deviceName string, rawConfig deviceConfig.Device) error 
 // config returned from Start(), it also runs the device's Register() function irrespective of
 // whether the container is running or not.
 func (c *lxc) deviceStart(deviceName string, rawConfig deviceConfig.Device, isRunning bool) (*deviceConfig.RunConfig, error) {
+	logger := logging.AddContext(logger.Log, log.Ctx{"device": deviceName, "type": rawConfig["type"], "project": c.Project(), "instance": c.Name()})
+	logger.Debug("Starting device")
+
 	d, configCopy, err := c.deviceLoad(deviceName, rawConfig)
 	if err != nil {
 		return nil, err
@@ -1549,8 +1552,9 @@ func (c *lxc) deviceUpdate(deviceName string, rawConfig deviceConfig.Device, old
 
 // deviceStop loads a new device and calls its Stop() function.
 func (c *lxc) deviceStop(deviceName string, rawConfig deviceConfig.Device, stopHookNetnsPath string) error {
-	logger := logging.AddContext(logger.Log, log.Ctx{"device": deviceName, "project": c.Project(), "instance": c.Name()})
+	logger := logging.AddContext(logger.Log, log.Ctx{"device": deviceName, "type": rawConfig["type"], "project": c.Project(), "instance": c.Name()})
 	logger.Debug("Stopping device")
+
 	d, configCopy, err := c.deviceLoad(deviceName, rawConfig)
 
 	// If deviceLoad fails with unsupported device type then return.
@@ -1727,7 +1731,7 @@ func (c *lxc) deviceHandleMounts(mounts []deviceConfig.MountEntryItem) error {
 
 // deviceRemove loads a new device and calls its Remove() function.
 func (c *lxc) deviceRemove(deviceName string, rawConfig deviceConfig.Device) error {
-	logger := logging.AddContext(logger.Log, log.Ctx{"device": deviceName, "project": c.Project(), "instance": c.Name()})
+	logger := logging.AddContext(logger.Log, log.Ctx{"device": deviceName, "type": rawConfig["type"], "project": c.Project(), "instance": c.Name()})
 
 	d, _, err := c.deviceLoad(deviceName, rawConfig)
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3332,7 +3332,7 @@ func (vm *qemu) cleanup() {
 
 // cleanupDevices performs any needed device cleanup steps when instance is stopped.
 func (vm *qemu) cleanupDevices() {
-	for _, dev := range vm.expandedDevices.Sorted() {
+	for _, dev := range vm.expandedDevices.Reversed() {
 		// Use the device interface if device supports it.
 		err := vm.deviceStop(dev.Name, dev.Config)
 		if err == device.ErrUnsupportedDevType {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1151,6 +1151,9 @@ func (vm *qemu) deviceLoad(deviceName string, rawConfig deviceConfig.Device) (de
 // config returned from Start(), it also runs the device's Register() function irrespective of
 // whether the instance is running or not.
 func (vm *qemu) deviceStart(deviceName string, rawConfig deviceConfig.Device, isRunning bool) (*deviceConfig.RunConfig, error) {
+	logger := logging.AddContext(logger.Log, log.Ctx{"device": deviceName, "type": rawConfig["type"], "project": vm.Project(), "instance": vm.Name()})
+	logger.Debug("Starting device")
+
 	d, _, err := vm.deviceLoad(deviceName, rawConfig)
 	if err != nil {
 		return nil, err
@@ -1170,8 +1173,9 @@ func (vm *qemu) deviceStart(deviceName string, rawConfig deviceConfig.Device, is
 
 // deviceStop loads a new device and calls its Stop() function.
 func (vm *qemu) deviceStop(deviceName string, rawConfig deviceConfig.Device) error {
-	logger := logging.AddContext(logger.Log, log.Ctx{"device": deviceName, "project": vm.Project(), "instance": vm.Name()})
+	logger := logging.AddContext(logger.Log, log.Ctx{"device": deviceName, "type": rawConfig["type"], "project": vm.Project(), "instance": vm.Name()})
 	logger.Debug("Stopping device")
+
 	d, _, err := vm.deviceLoad(deviceName, rawConfig)
 
 	// If deviceLoad fails with unsupported device type then return.
@@ -3470,7 +3474,7 @@ func (vm *qemu) deviceAdd(deviceName string, rawConfig deviceConfig.Device) erro
 }
 
 func (vm *qemu) deviceRemove(deviceName string, rawConfig deviceConfig.Device) error {
-	logger := logging.AddContext(logger.Log, log.Ctx{"device": deviceName, "project": vm.Project(), "instance": vm.Name()})
+	logger := logging.AddContext(logger.Log, log.Ctx{"device": deviceName, "type": rawConfig["type"], "project": vm.Project(), "instance": vm.Name()})
 
 	d, _, err := vm.deviceLoad(deviceName, rawConfig)
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -661,6 +661,16 @@ func (vm *qemu) Start(stateful bool) error {
 	// Start accumulating device paths.
 	vm.devPaths = []string{}
 
+	// Rotate the log file.
+	logfile := vm.LogFilePath()
+	if shared.PathExists(logfile) {
+		os.Remove(logfile + ".old")
+		err := os.Rename(logfile, logfile+".old")
+		if err != nil {
+			return err
+		}
+	}
+
 	// Mount the instance's config volume.
 	_, err = vm.mount()
 	if err != nil {

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1652,7 +1652,7 @@ func (b *lxdBackend) UnmountInstance(inst instance.Instance, op *operations.Oper
 	// Get the volume.
 	vol := b.newVolume(volType, contentType, volStorageName, rootDiskConf)
 
-	return b.driver.UnmountVolume(vol, op)
+	return b.driver.UnmountVolume(vol, false, op)
 }
 
 // GetInstanceDisk returns the location of the disk.
@@ -2976,7 +2976,7 @@ func (b *lxdBackend) UnmountCustomVolume(projectName, volName string, op *operat
 	volStorageName := project.StorageVolume(projectName, volName)
 	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volStorageName, volume.Config)
 
-	return b.driver.UnmountVolume(vol, op)
+	return b.driver.UnmountVolume(vol, false, op)
 }
 
 // CreateCustomVolumeSnapshot creates a snapshot of a custom volume.

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -771,7 +771,8 @@ func (d *btrfs) MountVolume(vol Volume, op *operations.Operation) (bool, error) 
 }
 
 // UnmountVolume simulates unmounting a volume.
-func (d *btrfs) UnmountVolume(vol Volume, op *operations.Operation) (bool, error) {
+// As driver doesn't have volumes to unmount it returns false indicating the volume was already unmounted.
+func (d *btrfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
 	return false, nil
 }
 

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -610,7 +610,7 @@ func (d *ceph) DeleteVolume(vol Volume, op *operations.Operation) error {
 
 	if vol.volType == VolumeTypeImage {
 		// Try to umount but don't fail.
-		d.UnmountVolume(vol, op)
+		d.UnmountVolume(vol, false, op)
 
 		// Check if image has dependant snapshots.
 		_, err := d.rbdListSnapshotClones(vol, "readonly")
@@ -658,7 +658,7 @@ func (d *ceph) DeleteVolume(vol Volume, op *operations.Operation) error {
 			return err
 		}
 	} else {
-		_, err := d.UnmountVolume(vol, op)
+		_, err := d.UnmountVolume(vol, false, op)
 		if err != nil {
 			return err
 		}
@@ -980,7 +980,7 @@ func (d *ceph) UnmountVolume(vol Volume, op *operations.Operation) (bool, error)
 	// For VMs, unmount the filesystem volume.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		return d.UnmountVolume(fsVol, op)
+		return d.UnmountVolume(fsVol, false, op)
 	}
 
 	return false, nil
@@ -991,7 +991,7 @@ func (d *ceph) RenameVolume(vol Volume, newName string, op *operations.Operation
 	revert := revert.New()
 	defer revert.Fail()
 
-	_, err := d.UnmountVolume(vol, op)
+	_, err := d.UnmountVolume(vol, false, op)
 	if err != nil {
 		return err
 	}
@@ -1419,7 +1419,7 @@ func (d *ceph) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, 
 
 // RestoreVolume restores a volume from a snapshot.
 func (d *ceph) RestoreVolume(vol Volume, snapshotName string, op *operations.Operation) error {
-	ourUmount, err := d.UnmountVolume(vol, op)
+	ourUmount, err := d.UnmountVolume(vol, false, op)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -343,7 +343,8 @@ func (d *cephfs) MountVolume(vol Volume, op *operations.Operation) (bool, error)
 }
 
 // UnmountVolume clears any runtime state for the volume.
-func (d *cephfs) UnmountVolume(vol Volume, op *operations.Operation) (bool, error) {
+// As driver doesn't have volumes to unmount it returns false indicating the volume was already unmounted.
+func (d *cephfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
 	return false, nil
 }
 

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -322,9 +322,9 @@ func (d *dir) MountVolume(vol Volume, op *operations.Operation) (bool, error) {
 	return false, nil
 }
 
-// UnmountVolume simulates unmounting a volume. As dir driver doesn't have volumes to unmount it
-// returns false indicating the volume was already unmounted.
-func (d *dir) UnmountVolume(vol Volume, op *operations.Operation) (bool, error) {
+// UnmountVolume simulates unmounting a volume.
+// As driver doesn't have volumes to unmount it returns false indicating the volume was already unmounted.
+func (d *dir) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
 	return false, nil
 }
 

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -580,7 +580,7 @@ func (d *lvm) RenameVolume(vol Volume, newVolName string, op *operations.Operati
 
 		revert.Success()
 		return nil
-	}, op)
+	}, false, op)
 }
 
 // MigrateVolume sends a volume for migration.

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -188,7 +188,7 @@ func (d *lvm) DeleteVolume(vol Volume, op *operations.Operation) error {
 
 	if lvExists {
 		if vol.contentType == ContentTypeFS {
-			_, err = d.UnmountVolume(vol, op)
+			_, err = d.UnmountVolume(vol, false, op)
 			if err != nil {
 				return errors.Wrapf(err, "Error unmounting LVM logical volume")
 			}
@@ -502,7 +502,7 @@ func (d *lvm) UnmountVolume(vol Volume, op *operations.Operation) (bool, error) 
 	// For VMs, unmount the filesystem volume.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		return d.UnmountVolume(fsVol, op)
+		return d.UnmountVolume(fsVol, false, op)
 	}
 
 	return deactivated, nil
@@ -661,7 +661,7 @@ func (d *lvm) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 	}
 
 	if lvExists {
-		_, err = d.UnmountVolume(snapVol, op)
+		_, err = d.UnmountVolume(snapVol, false, op)
 		if err != nil {
 			return errors.Wrapf(err, "Error unmounting LVM logical volume")
 		}
@@ -923,7 +923,7 @@ func (d *lvm) RestoreVolume(vol Volume, snapshotName string, op *operations.Oper
 	// 2. Create a writable snapshot with the original name from the snapshot being restored.
 	// 3. Delete the renamed original volume.
 	if d.usesThinpool() {
-		_, err = d.UnmountVolume(vol, op)
+		_, err = d.UnmountVolume(vol, false, op)
 		if err != nil {
 			return errors.Wrapf(err, "Error unmounting LVM logical volume")
 		}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1073,21 +1073,22 @@ func (d *zfs) MountVolume(vol Volume, op *operations.Operation) (bool, error) {
 }
 
 // UnmountVolume simulates unmounting a volume.
-func (d *zfs) UnmountVolume(vol Volume, op *operations.Operation) (bool, error) {
+// keepBlockDev indicates if backing block device should be not be deactivated if volume is unmounted.
+func (d *zfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
 	mountPath := vol.MountPath()
 	dataset := d.dataset(vol, false)
 
 	// For VMs, also mount the filesystem dataset.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		_, err := d.UnmountVolume(fsVol, op)
+		_, err := d.UnmountVolume(fsVol, false, op)
 		if err != nil {
 			return false, err
 		}
 	}
 
 	// For block devices, we make them disappear.
-	if vol.contentType == ContentTypeBlock {
+	if vol.contentType == ContentTypeBlock && !keepBlockDev {
 		err := d.setDatasetProperties(dataset, "volmode=none")
 		if err != nil {
 			return false, err

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -416,7 +416,7 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 		}
 
 		postHook = func(vol Volume) error {
-			_, err := d.UnmountVolume(vol, op)
+			_, err := d.UnmountVolume(vol, false, op)
 			return err
 		}
 	}
@@ -1184,7 +1184,7 @@ func (d *zfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mig
 			return err
 		}
 		if ourMount {
-			defer d.UnmountVolume(parentVol, op)
+			defer d.UnmountVolume(parentVol, false, op)
 		}
 
 		return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
@@ -1288,7 +1288,7 @@ func (d *zfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWrit
 			}
 
 			if ourMount {
-				defer d.UnmountVolume(parentVol, op)
+				defer d.UnmountVolume(parentVol, false, op)
 			}
 		}
 

--- a/lxd/storage/drivers/drivers_mock.go
+++ b/lxd/storage/drivers/drivers_mock.go
@@ -149,7 +149,7 @@ func (d *mock) MountVolume(vol Volume, op *operations.Operation) (bool, error) {
 
 // UnmountVolume simulates unmounting a volume. As dir driver doesn't have volumes to unmount it
 // returns false indicating the volume was already unmounted.
-func (d *mock) UnmountVolume(vol Volume, op *operations.Operation) (bool, error) {
+func (d *mock) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
 	return false, nil
 }
 

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -816,7 +816,7 @@ func genericVFSBackupUnpack(d Driver, vol Volume, snapshots []string, srcData io
 		// backup restore process to unmount the volume if needed.
 		postHook = func(vol Volume) error {
 			if ourMount {
-				d.UnmountVolume(vol, op)
+				d.UnmountVolume(vol, false, op)
 			}
 
 			return nil
@@ -824,7 +824,7 @@ func genericVFSBackupUnpack(d Driver, vol Volume, snapshots []string, srcData io
 	} else {
 		// For custom volumes unmount now, there is no post hook as there is no backup.yaml to generate.
 		if ourMount {
-			d.UnmountVolume(vol, op)
+			d.UnmountVolume(vol, false, op)
 		}
 	}
 

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -67,7 +67,7 @@ type Driver interface {
 
 	// UnmountVolume unmounts a storage volume, returns true if unmounted, false if was not
 	// mounted.
-	UnmountVolume(vol Volume, op *operations.Operation) (bool, error)
+	UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error)
 
 	// UnmountVolume unmounts a storage volume snapshot, returns true if unmounted, false if was
 	// not mounted.

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -505,7 +505,7 @@ func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64)
 			}
 
 			return nil
-		}, nil)
+		}, true, nil)
 	case "btrfs":
 		return vol.MountTask(func(mountPath string, op *operations.Operation) error {
 			_, err := shared.RunCommand("btrfs", "filesystem", "resize", strSize, mountPath)

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -227,9 +227,10 @@ func (v Volume) MountTask(task func(mountPath string, op *operations.Operation) 
 	return task(v.MountPath(), op)
 }
 
-// UnmountTask runs the supplied task after unmounting the volume if needed. If the volume was unmounted
-// for this then it is mounted when the task finishes.
-func (v Volume) UnmountTask(task func(op *operations.Operation) error, op *operations.Operation) error {
+// UnmountTask runs the supplied task after unmounting the volume if needed.
+// If the volume was unmounted for this then it is mounted when the task finishes.
+// keepBlockDev indicates if backing block device should be not be deactivated if volume is unmounted.
+func (v Volume) UnmountTask(task func(op *operations.Operation) error, keepBlockDev bool, op *operations.Operation) error {
 	// If the volume is a snapshot then call the snapshot specific mount/unmount functions as
 	// these will mount the snapshot read only.
 	if v.IsSnapshot() {
@@ -253,7 +254,7 @@ func (v Volume) UnmountTask(task func(op *operations.Operation) error, op *opera
 	} else {
 		unlock := locking.Lock(OperationLockName(v.pool, string(v.volType), v.name))
 
-		ourUnmount, err := v.driver.UnmountVolume(v, op)
+		ourUnmount, err := v.driver.UnmountVolume(v, keepBlockDev, op)
 		if err != nil {
 			unlock()
 			return err

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -218,7 +218,7 @@ func (v Volume) MountTask(task func(mountPath string, op *operations.Operation) 
 		if ourMount {
 			defer func() {
 				unlock := locking.Lock(OperationLockName(v.pool, string(v.volType), v.name))
-				v.driver.UnmountVolume(v, op)
+				v.driver.UnmountVolume(v, false, op)
 				unlock()
 			}()
 		}


### PR DESCRIPTION
This is to accommodate TPM devices (https://github.com/lxc/lxd/pull/8041) that need to write their state to the instance's root/config volume during start.

- Mount instance volume before starting devices.
- Adds ability to prevent block backed storage drivers from deactivating their block device when unmounting (allows the block device to be left for `UnmountTask()` used when shrinking filesystems that need to be unmounted first).
- Previously this was implicit and relied upon the volume not being mounted to avoid block device deactivation (which is now not the case when doing pre-start disk shrinking after initial mount).
- Modifies device start order to ensure `disk` type devices are started between `nic` types and other types. This ensures that (with the exception of `nic` types) other device types can rely on the instance volume not being unmounted (during pre-start resize, as this will have already happened during disk device start).
- Stops devices in reverse order to what they were started in (consistency with device removal).
- Device lifecycle logging.
- Adds missing qemu log rotation on start.