### PR TITLE
lxc/move: Bypass security.protection.delete

### DIFF
--- a/lxc/move.go
+++ b/lxc/move.go
@@ -198,6 +198,7 @@ func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 
 	del := cmdDelete{global: c.global}
 	del.flagForce = true
+	del.flagForceProtected = true
 	err = del.Run(cmd, args[:1])
 	if err != nil {
 		return errors.Wrap(err, "Failed to delete original instance after copying it")


### PR DESCRIPTION
Closes #8075

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>