### PR TITLE
Instance: Write out updated backup.yaml after rename

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3747,6 +3747,11 @@ func (c *lxc) Rename(newName string) error {
 	// Update lease files.
 	network.UpdateDNSMasqStatic(c.state, "")
 
+	err = c.UpdateBackupFile()
+	if err != nil {
+		return err
+	}
+
 	logger.Info("Renamed container", ctxMap)
 
 	if c.IsSnapshot() {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2751,6 +2751,11 @@ func (vm *qemu) Rename(newName string) error {
 	// Update lease files.
 	network.UpdateDNSMasqStatic(vm.state, "")
 
+	err = vm.UpdateBackupFile()
+	if err != nil {
+		return err
+	}
+
 	logger.Info("Renamed instance", ctxMap)
 
 	if vm.IsSnapshot() {


### PR DESCRIPTION
Fixes #8071

Tested using dir and btrfs backends using `lxd import` after renaming a container before starting and then removing the database.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>