### PR TITLE
Network: OVN NIC external route overlap validation

### DIFF
--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -179,7 +179,7 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 			}
 		}
 
-		err = d.network.InstanceDevicePortValidateExternalRoutes(externalRoutes)
+		err = d.network.InstanceDevicePortValidateExternalRoutes(d.inst, d.name, externalRoutes)
 		if err != nil {
 			return err
 		}

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -28,7 +28,7 @@ import (
 type ovnNet interface {
 	network.Network
 
-	InstanceDevicePortValidateExternalRoutes(externalRoutes []*net.IPNet) error
+	InstanceDevicePortValidateExternalRoutes(deviceInstance instance.Instance, deviceName string, externalRoutes []*net.IPNet) error
 	InstanceDevicePortAdd(instanceID int, instanceName string, deviceName string, mac net.HardwareAddr, ips []net.IP, internalRoutes []*net.IPNet, externalRoutes []*net.IPNet) (openvswitch.OVNSwitchPort, error)
 	InstanceDevicePortDelete(instanceID int, deviceName string, internalRoutes []*net.IPNet, externalRoutes []*net.IPNet) error
 	InstanceDevicePortDynamicIPs(instanceID int, deviceName string) ([]net.IP, error)

--- a/lxd/project/project.go
+++ b/lxd/project/project.go
@@ -79,26 +79,26 @@ func StorageVolumeProject(c *db.Cluster, projectName string, volumeType int) (st
 		return "", errors.Wrapf(err, "Failed to load project %q", projectName)
 	}
 
-	return StorageVolumeProjectFromRecord(project, volumeType)
+	return StorageVolumeProjectFromRecord(project, volumeType), nil
 }
 
-// StorageVolumeProjectFromRecord returns the project name to use to for the volume based on the requested project.
-// For custom volume type, if the project specified has the "features.storage.volumes" flag enabled then the
+// StorageVolumeProjectFromRecord returns the project name to use to for the volume based on the supplied project.
+// For custom volume type, if the project supplied has the "features.storage.volumes" flag enabled then the
 // project name is returned, otherwise the default project name is returned. For all other volume types the
 // supplied project's name is returned.
-func StorageVolumeProjectFromRecord(p *api.Project, volumeType int) (string, error) {
+func StorageVolumeProjectFromRecord(p *api.Project, volumeType int) string {
 	// Non-custom volumes always use the project specified.
 	if volumeType != db.StoragePoolVolumeTypeCustom {
-		return p.Name, nil
+		return p.Name
 	}
 
 	// Custom volumes only use the project specified if the project has the features.storage.volumes feature
 	// enabled, otherwise the legacy behaviour of using the default project for custom volumes is used.
 	if shared.IsTrue(p.Config["features.storage.volumes"]) {
-		return p.Name, nil
+		return p.Name
 	}
 
-	return Default, nil
+	return Default
 }
 
 // NetworkProject returns the project name to use for the network based on the requested project.

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -701,7 +701,7 @@ func VolumeUsedByInstances(s *state.State, poolName string, projectName string, 
 	volumeNameWithType := fmt.Sprintf("%s/%s", volumeTypeName, volumeName)
 
 	return s.Cluster.InstanceList(func(inst db.Instance, p api.Project, profiles []api.Profile) error {
-		instStorageProject, err := project.StorageVolumeProjectFromRecord(&p, volumeType)
+		instStorageProject := project.StorageVolumeProjectFromRecord(&p, volumeType)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR adds validation of OVN NIC external routes (`ipv4.routes.external` and `ipv6.routes.external`) settings to check they do not overlap with any other OVN NICs that are connected to networks that use the same uplink, and that they do not overlap with any OVN networks (including the OVN network the OVN NIC we are validating is connected to) that use external subnets and also use the same uplink.