### PR TITLE
lxd/qmp: Ensure checkbuffer is called

### DIFF
--- a/lxd/instance/drivers/qmp/monitor.go
+++ b/lxd/instance/drivers/qmp/monitor.go
@@ -130,6 +130,9 @@ func (m *Monitor) run() error {
 					continue
 				}
 
+				// Check if the ringbuffer was updated (non-blocking).
+				go checkBuffer()
+
 				if m.eventHandler != nil {
 					m.eventHandler(e.Event, e.Data)
 				}


### PR DESCRIPTION
VMs tend to have events every few seconds, as a result the timeout was
never hit and the agent never detected.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>