### PR TITLE
Storage: Allow instances to be created with root disks smaller than pool's cached image volume

### DIFF
--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -415,11 +415,11 @@ func instanceCreateAsSnapshot(s *state.State, args db.InstanceArgs, sourceInstan
 	}
 
 	// Mount volume for backup.yaml writing.
-	ourStart, err := pool.MountInstance(sourceInstance, op)
+	mountInfo, err := pool.MountInstance(sourceInstance, op)
 	if err != nil {
 		return nil, errors.Wrap(err, "Create instance snapshot (mount source)")
 	}
-	if ourStart {
+	if mountInfo.OurMount {
 		defer pool.UnmountInstance(sourceInstance, op)
 	}
 

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -1513,13 +1513,13 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 				err = func() error {
 					// In case the new LVM logical volume for the container is not mounted mount it.
 					if !shared.IsMountPoint(newContainerMntPoint) {
-						ourMount, err := pool.MountInstance(ctStruct, nil)
+						mountInfo, err := pool.MountInstance(ctStruct, nil)
 						if err != nil {
 							logger.Errorf("Failed to mount new empty LVM logical volume for container %s: %s", ct, err)
 							return err
 						}
 
-						if ourMount {
+						if mountInfo.OurMount {
 							defer pool.UnmountInstance(ctStruct, nil)
 						}
 					}
@@ -1679,13 +1679,13 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 					err = func() error {
 						// In case the new LVM logical volume for the snapshot is not mounted mount it.
 						if !shared.IsMountPoint(newSnapshotMntPoint) {
-							ourMount, err := pool.MountInstanceSnapshot(csStruct, nil)
+							mountInfo, err := pool.MountInstanceSnapshot(csStruct, nil)
 							if err != nil {
 								logger.Errorf("Failed to mount new empty LVM logical volume for container %s: %s", cs, err)
 								return err
 							}
 
-							if ourMount {
+							if mountInfo.OurMount {
 								defer pool.UnmountInstanceSnapshot(csStruct, nil)
 							}
 						}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1591,7 +1591,7 @@ func (b *lxdBackend) GetInstanceUsage(inst instance.Instance) (int64, error) {
 // Returns ErrRunningQuotaResizeNotSupported if the instance is running and the storage driver
 // doesn't support resizing whilst the instance is running.
 func (b *lxdBackend) SetInstanceQuota(inst instance.Instance, size string, op *operations.Operation) error {
-	logger := logging.AddContext(b.logger, log.Ctx{"project": inst.Project(), "instance": inst.Name()})
+	logger := logging.AddContext(b.logger, log.Ctx{"project": inst.Project(), "instance": inst.Name(), "size": size})
 	logger.Debug("SetInstanceQuota started")
 	defer logger.Debug("SetInstanceQuota finished")
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1673,10 +1673,10 @@ func (b *lxdBackend) UnmountInstance(inst instance.Instance, op *operations.Oper
 	return b.driver.UnmountVolume(vol, false, op)
 }
 
-// GetInstanceDisk returns the location of the disk.
-func (b *lxdBackend) GetInstanceDisk(inst instance.Instance) (string, error) {
+// getInstanceDisk returns the location of the disk.
+func (b *lxdBackend) getInstanceDisk(inst instance.Instance) (string, error) {
 	if inst.Type() != instancetype.VM {
-		return "", ErrNotImplemented
+		return "", drivers.ErrNotSupported
 	}
 
 	// Check we can convert the instance to the volume type needed.

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -127,16 +127,12 @@ func (b *mockBackend) SetInstanceQuota(inst instance.Instance, size string, op *
 	return nil
 }
 
-func (b *mockBackend) MountInstance(inst instance.Instance, op *operations.Operation) (bool, error) {
-	return true, nil
+func (b *mockBackend) MountInstance(inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
+	return &MountInfo{OurMount: true}, nil
 }
 
 func (b *mockBackend) UnmountInstance(inst instance.Instance, op *operations.Operation) (bool, error) {
 	return true, nil
-}
-
-func (b *mockBackend) GetInstanceDisk(inst instance.Instance) (string, error) {
-	return "", nil
 }
 
 func (b *mockBackend) CreateInstanceSnapshot(i instance.Instance, src instance.Instance, op *operations.Operation) error {
@@ -155,8 +151,8 @@ func (b *mockBackend) RestoreInstanceSnapshot(inst instance.Instance, src instan
 	return nil
 }
 
-func (b *mockBackend) MountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (bool, error) {
-	return true, nil
+func (b *mockBackend) MountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
+	return &MountInfo{OurMount: true}, nil
 }
 
 func (b *mockBackend) UnmountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (bool, error) {

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -767,8 +767,7 @@ func (d *ceph) deleteVolumeSnapshot(vol Volume, snapshotName string) (int, error
 		}
 
 		// Unmap.
-		err = d.rbdUnmapVolumeSnapshot(vol, snapshotName,
-			true)
+		err = d.rbdUnmapVolumeSnapshot(vol, snapshotName, true)
 		if err != nil {
 			return -1, err
 		}

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -843,6 +843,12 @@ func (d *ceph) SetVolumeQuota(vol Volume, size string, op *operations.Operation)
 		return nil
 	}
 
+	// Block image volumes cannot be resized because they have a readonly snapshot that doesn't get
+	// updated when the volume's size is changed, and this is what instances are created from.
+	if vol.volType == VolumeTypeImage {
+		return ErrNotSupported
+	}
+
 	// Resize filesystem if needed.
 	if sizeBytes < oldSizeBytes {
 		if vol.contentType == ContentTypeBlock && !vol.allowUnsafeResize {

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -78,11 +78,11 @@ func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 			return err
 		}
 
-		// If the cached volume is larger than the pool volume size, then we can't use the
+		// If the cached volume size is different than the pool volume size, then we can't use the
 		// deleted cached image volume and instead we will rename it to a random UUID so it can't
 		// be restored in the future and a new cached image volume will be created instead.
-		if volSizeBytes > poolVolSizeBytes {
-			d.logger.Debug("Renaming deleted cached image volume so that regeneration is used")
+		if volSizeBytes != poolVolSizeBytes {
+			d.logger.Debug("Renaming deleted cached image volume so that regeneration is used", "fingerprint", vol.Name())
 			randomVol := NewVolume(d, d.name, deletedVol.volType, deletedVol.contentType, strings.Replace(uuid.NewRandom().String(), "-", "", -1), deletedVol.config, deletedVol.poolConfig)
 			err = renameVolume(d.getRBDVolumeName(deletedVol, "", false, true), d.getRBDVolumeName(randomVol, "", false, true))
 			if err != nil {

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -104,6 +104,7 @@ func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 
 		// Restore the image.
 		if canRestore {
+			d.logger.Debug("Restoring previously deleted cached image volume", "fingerprint", vol.Name())
 			err = renameVolume(d.getRBDVolumeName(deletedVol, "", false, true), d.getRBDVolumeName(vol, "", false, true))
 			if err != nil {
 				return err

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -162,8 +162,6 @@ func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 		revert.Add(func() { d.DeleteVolume(fsVol, op) })
 	}
 
-	// Run the volume filler function if supplied.
-
 	err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
 		// Run the volume filler function if supplied.
 		if filler != nil && filler.Fill != nil {

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -928,7 +928,7 @@ func (d *ceph) MountVolume(vol Volume, op *operations.Operation) (bool, error) {
 	mountPath := vol.MountPath()
 
 	// Activate RBD volume if needed.
-	_, RBDDevPath, err := d.getRBDMappedDevPath(vol, true)
+	ourMount, RBDDevPath, err := d.getRBDMappedDevPath(vol, true)
 	if err != nil {
 		return false, err
 	}
@@ -956,7 +956,7 @@ func (d *ceph) MountVolume(vol Volume, op *operations.Operation) (bool, error) {
 		return d.MountVolume(fsVol, op)
 	}
 
-	return false, nil
+	return ourMount, nil
 }
 
 // UnmountVolume simulates unmounting a volume.

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -105,6 +105,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 
 		// Restore the image.
 		if canRestore {
+			d.logger.Debug("Restoring previously deleted cached image volume", "fingerprint", vol.Name())
 			_, err := shared.RunCommand("/proc/self/exe", "forkzfs", "--", "rename", d.dataset(vol, true), d.dataset(vol, false))
 			if err != nil {
 				return err

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -75,11 +75,11 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 			// Round to block boundary.
 			poolVolSizeBytes = (poolVolSizeBytes / MinBlockBoundary) * MinBlockBoundary
 
-			// If the cached volume is larger than the pool volume size, then we can't use the
+			// If the cached volume size is different than the pool volume size, then we can't use the
 			// deleted cached image volume and instead we will rename it to a random UUID so it can't
 			// be restored in the future and a new cached image volume will be created instead.
-			if volSizeBytes > poolVolSizeBytes {
-				d.logger.Debug("Renaming deleted cached image volume so that regeneration is used")
+			if volSizeBytes != poolVolSizeBytes {
+				d.logger.Debug("Renaming deleted cached image volume so that regeneration is used", "fingerprint", vol.Name())
 				randomVol := NewVolume(d, d.name, vol.volType, vol.contentType, uuid.NewRandom().String(), vol.config, vol.poolConfig)
 
 				_, err := shared.RunCommand("/proc/self/exe", "forkzfs", "--", "rename", d.dataset(vol, true), d.dataset(randomVol, true))

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -932,6 +932,12 @@ func (d *zfs) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 			return nil
 		}
 
+		// Block image volumes cannot be resized because they have a readonly snapshot that doesn't get
+		// updated when the volume's size is changed, and this is what instances are created from.
+		if vol.volType == VolumeTypeImage {
+			return ErrNotSupported
+		}
+
 		if sizeBytes < oldVolSizeBytes && !vol.allowUnsafeResize {
 			return errors.Wrap(ErrCannotBeShrunk, "You cannot shrink block volumes")
 		}

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -144,25 +144,16 @@ func genericVFSRenameVolumeSnapshot(d Driver, snapVol Volume, newSnapshotName st
 // genericVFSMigrateVolume is a generic MigrateVolume implementation for VFS-only drivers.
 func genericVFSMigrateVolume(d Driver, s *state.State, vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
 	bwlimit := d.Config()["rsync.bwlimit"]
-
 	var rsyncArgs []string
 
-	// For VM volumes, if the root volume disk path is a file image in the volume's mount path then exclude it
-	// from being transferred via rsync during the filesystem volume transfer, as it will be transferred later
-	// using a different method.
+	// For VM volumes, exclude the generic root disk image file from being transferred via rsync, as it will
+	// be transferred later using a different method.
 	if vol.IsVMBlock() {
 		if volSrcArgs.MigrationType.FSType != migration.MigrationFSType_BLOCK_AND_RSYNC {
 			return ErrNotSupported
 		}
 
-		diskPath, err := d.GetVolumeDiskPath(vol)
-		if err != nil {
-			return errors.Wrapf(err, "Error getting VM block volume disk path")
-		}
-
-		if strings.HasPrefix(diskPath, vol.MountPath()) {
-			rsyncArgs = []string{"--exclude", filepath.Base(diskPath)}
-		}
+		rsyncArgs = []string{"--exclude", genericVolumeDiskFile}
 	} else if vol.contentType == ContentTypeBlock && volSrcArgs.MigrationType.FSType != migration.MigrationFSType_BLOCK_AND_RSYNC || vol.contentType == ContentTypeFS && volSrcArgs.MigrationType.FSType != migration.MigrationFSType_RSYNC {
 		return ErrNotSupported
 	}
@@ -176,7 +167,7 @@ func genericVFSMigrateVolume(d Driver, s *state.State, vol Volume, conn io.ReadW
 
 		path := shared.AddSlash(mountPath)
 
-		d.Logger().Debug("Sending filesystem volume", log.Ctx{"volName": vol.name, "path": path})
+		d.Logger().Debug("Sending filesystem volume", log.Ctx{"volName": vol.name, "path": path, "bwlimit": bwlimit, "rsyncArgs": rsyncArgs})
 		return rsync.Send(vol.name, path, conn, wrapper, volSrcArgs.MigrationType.Features, bwlimit, s.OS.ExecPath, rsyncArgs...)
 	}
 

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -25,6 +25,9 @@ import (
 	"github.com/lxc/lxd/shared/logger"
 )
 
+// genericVolumeDiskFile used to indicate the file name used for block volume disk files.
+const genericVolumeDiskFile = "root.img"
+
 // genericVFSGetResources is a generic GetResources implementation for VFS-only drivers.
 func genericVFSGetResources(d Driver) (*api.ResourcesStoragePool, error) {
 	// Get the VFS information

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -439,7 +439,7 @@ func genericVFSGetVolumeDiskPath(vol Volume) (string, error) {
 		return "", ErrNotSupported
 	}
 
-	return filepath.Join(vol.MountPath(), "root.img"), nil
+	return filepath.Join(vol.MountPath(), genericVolumeDiskFile), nil
 }
 
 // genericVFSBackupVolume is a generic BackupVolume implementation for VFS-only drivers.

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -428,7 +428,7 @@ func (v Volume) ConfigSizeFromSource(srcVol Volume) (string, error) {
 		return volSize, nil
 	}
 
-	// If volume/pool size is not specified, then fallback to default volume size if relevant and compare.
+	// If volume/pool size not specified above, then fallback to default volume size (if relevant) and compare.
 	volSize = v.ConfigSize()
 	if volSize != "" && volSize != "0" {
 		volSizeBytes, err := units.ParseByteSizeString(volSize)

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -54,16 +54,15 @@ type Pool interface {
 	GetInstanceUsage(inst instance.Instance) (int64, error)
 	SetInstanceQuota(inst instance.Instance, size string, op *operations.Operation) error
 
-	MountInstance(inst instance.Instance, op *operations.Operation) (bool, error)
+	MountInstance(inst instance.Instance, op *operations.Operation) (*MountInfo, error)
 	UnmountInstance(inst instance.Instance, op *operations.Operation) (bool, error)
-	GetInstanceDisk(inst instance.Instance) (string, error)
 
 	// Instance snapshots.
 	CreateInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error
 	RenameInstanceSnapshot(inst instance.Instance, newName string, op *operations.Operation) error
 	DeleteInstanceSnapshot(inst instance.Instance, op *operations.Operation) error
 	RestoreInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error
-	MountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (bool, error)
+	MountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (*MountInfo, error)
 	UnmountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (bool, error)
 	UpdateInstanceSnapshot(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
 

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -13,6 +13,12 @@ import (
 	"github.com/lxc/lxd/shared/instancewriter"
 )
 
+// MountInfo represents info about the result of a mount operation.
+type MountInfo struct {
+	OurMount bool   // Whether a mount was needed.
+	DiskPath string // The location of the block disk (if supported).
+}
+
 // Pool represents a LXD storage pool.
 type Pool interface {
 	// Pool.

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -850,13 +850,24 @@ func RenderSnapshotUsage(s *state.State, snapInst instance.Instance) func(respon
 // InstanceDiskBlockSize returns the block device size for the instance's disk.
 // This will mount the instance if not already mounted and will unmount at the end if needed.
 func InstanceDiskBlockSize(pool Pool, inst instance.Instance, op *operations.Operation) (int64, error) {
-	ourMount, err := pool.MountInstance(inst, op)
-	if err != nil {
-		return -1, err
-	}
+	if inst.IsSnapshot() {
+		ourMount, err := pool.MountInstanceSnapshot(inst, op)
+		if err != nil {
+			return -1, err
+		}
 
-	if ourMount {
-		defer pool.UnmountInstance(inst, op)
+		if ourMount {
+			defer pool.UnmountInstanceSnapshot(inst, op)
+		}
+	} else {
+		ourMount, err := pool.MountInstance(inst, op)
+		if err != nil {
+			return -1, err
+		}
+
+		if ourMount {
+			defer pool.UnmountInstance(inst, op)
+		}
 	}
 
 	rootDrivePath, err := pool.GetInstanceDisk(inst)

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -850,34 +850,36 @@ func RenderSnapshotUsage(s *state.State, snapInst instance.Instance) func(respon
 // InstanceDiskBlockSize returns the block device size for the instance's disk.
 // This will mount the instance if not already mounted and will unmount at the end if needed.
 func InstanceDiskBlockSize(pool Pool, inst instance.Instance, op *operations.Operation) (int64, error) {
+	var err error
+	var mountInfo *MountInfo
+
 	if inst.IsSnapshot() {
-		ourMount, err := pool.MountInstanceSnapshot(inst, op)
+		mountInfo, err = pool.MountInstanceSnapshot(inst, op)
 		if err != nil {
 			return -1, err
 		}
 
-		if ourMount {
+		if mountInfo.OurMount {
 			defer pool.UnmountInstanceSnapshot(inst, op)
 		}
 	} else {
-		ourMount, err := pool.MountInstance(inst, op)
+		mountInfo, err = pool.MountInstance(inst, op)
 		if err != nil {
 			return -1, err
 		}
 
-		if ourMount {
+		if mountInfo.OurMount {
 			defer pool.UnmountInstance(inst, op)
 		}
 	}
 
-	rootDrivePath, err := pool.GetInstanceDisk(inst)
-	if err != nil {
-		return -1, err
+	if mountInfo.DiskPath == "" {
+		return -1, fmt.Errorf("No disk path available from mount")
 	}
 
-	blockDiskSize, err := drivers.BlockDiskSizeBytes(rootDrivePath)
+	blockDiskSize, err := drivers.BlockDiskSizeBytes(mountInfo.DiskPath)
 	if err != nil {
-		return -1, errors.Wrapf(err, "Error getting block disk size %q", rootDrivePath)
+		return -1, errors.Wrapf(err, "Error getting block disk size %q", mountInfo.DiskPath)
 	}
 
 	return blockDiskSize, nil


### PR DESCRIPTION
Fixes #8114 

- Moves responsibility for resizing/regenerating an existing cached image volume from `CreateInstanceFromImage` to `EnsureImage`.
- Updates `CreateInstanceFromImage` to create a one-off non-optimized instance volume when the existing cached image volume is larger than the instance's root disk device and cannot be shrunk.