### PR TITLE
VM: Call MountInstanceSnapshot when mounting vm snapshots

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -413,6 +413,15 @@ func (vm *qemu) mount() (bool, error) {
 		return false, err
 	}
 
+	if vm.IsSnapshot() {
+		ourMount, err := pool.MountInstanceSnapshot(vm, nil)
+		if err != nil {
+			return false, err
+		}
+
+		return ourMount, nil
+	}
+
 	ourMount, err := pool.MountInstance(vm, nil)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
- Detect when instance being mounted is snapshot and call `MountInstanceSnapshot` on pool.
- Unify the mount behaviour when restoring snapshot for both LXC and Qemu.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>