### PR TITLE
Storage: Fix custom volume attach and resource usage reporting when volumes exist on multiple nodes

### DIFF
--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -194,22 +194,12 @@ func (c *cmdStorageVolumeAttach) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf(i18n.G("Only \"custom\" volumes can be attached to instances"))
 	}
 
-	// Check if the requested storage volume actually exists
-	vol, _, err := resource.server.GetStoragePoolVolume(resource.name, volType, volName)
-	if err != nil {
-		return err
-	}
-
 	// Prepare the instance's device entry
 	device := map[string]string{
 		"type":   "disk",
 		"pool":   resource.name,
-		"source": vol.Name,
-	}
-
-	// Ignore path for block volumes
-	if vol.ContentType != "block" {
-		device["path"] = devPath
+		"source": volName,
+		"path":   devPath,
 	}
 
 	// Add the device to the instance

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -140,7 +140,6 @@ func ConnectIfVolumeIsRemote(s *state.State, poolName string, projectName string
 
 		return nil
 	})
-
 	if err != nil && err != db.ErrNoClusterMember {
 		return nil, err
 	}

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -677,8 +677,23 @@ func (c *ClusterTx) GetStorageVolumeNodeAddresses(poolID int64, projectName stri
 
 	sort.Strings(addresses)
 
-	if len(addresses) == 0 {
+	addressCount := len(addresses)
+	if addressCount == 0 {
 		return nil, ErrNoSuchObject
+	} else if addressCount > 1 {
+		driver, err := c.GetStoragePoolDriver(poolID)
+		if err != nil {
+			return nil, err
+		}
+
+		// Earlier schema versions created a volume DB record for each cluster member for remote storage
+		// pools, so if the storage driver is one of those remote pools and the addressCount is >1 then we
+		// take this to mean that the volume doesn't have an explicit cluster member and is therefore
+		// equivalent to db.ErrNoClusterMember that is used in newer schemas where a single remote volume
+		// DB record is created that is not associated to any single member.
+		if driver == "ceph" || driver == "cephfs" {
+			return nil, ErrNoClusterMember
+		}
 	}
 
 	return addresses, nil

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -5,7 +5,6 @@ package db
 import (
 	"database/sql"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -622,27 +621,20 @@ type StorageVolumeArgs struct {
 	ContentType string
 }
 
-// GetStorageVolumeNodeAddresses returns the addresses of all nodes on which the
-// volume with the given name if defined.
-//
+// GetStorageVolumeNodes returns the node info of all nodes on which the volume with the given name is defined.
 // The volume name can be either a regular name or a volume snapshot name.
-//
-// The empty string is used in place of the address of the current node.
-func (c *ClusterTx) GetStorageVolumeNodeAddresses(poolID int64, projectName string, volumeName string, volumeType int) ([]string, error) {
-	nodes := []struct {
-		id      int64
-		address string
-	}{}
-	dest := func(i int) []interface{} {
-		nodes = append(nodes, struct {
-			id      int64
-			address string
-		}{})
-		return []interface{}{&nodes[i].id, &nodes[i].address}
+// If the volume is defined, but without a specific node, then the ErrNoClusterMember error is returned.
+// If the volume is not found then the ErrNoSuchObject error is returned.
+func (c *ClusterTx) GetStorageVolumeNodes(poolID int64, projectName string, volumeName string, volumeType int) ([]NodeInfo, error) {
+	nodes := []NodeInfo{}
 
+	dest := func(i int) []interface{} {
+		nodes = append(nodes, NodeInfo{})
+		return []interface{}{&nodes[i].ID, &nodes[i].Address, &nodes[i].Name}
 	}
+
 	sql := `
-	SELECT coalesce(nodes.id,0) AS nodeID, coalesce(nodes.address,"") AS nodeAddress
+	SELECT coalesce(nodes.id,0) AS nodeID, coalesce(nodes.address,"") AS nodeAddress, coalesce(nodes.name,"") AS nodeName
 	FROM storage_volumes_all
 	JOIN projects ON projects.id = storage_volumes_all.project_id
 	LEFT JOIN nodes ON storage_volumes_all.node_id=nodes.id
@@ -661,26 +653,21 @@ func (c *ClusterTx) GetStorageVolumeNodeAddresses(poolID int64, projectName stri
 		return nil, err
 	}
 
-	addresses := []string{}
-	for _, node := range nodes {
-		// Volume is defined without a cluster member.
-		if node.id == 0 && node.address == "" {
-			return nil, ErrNoClusterMember
-		}
-
-		address := node.address
-		if node.id == c.nodeID {
-			address = ""
-		}
-		addresses = append(addresses, address)
+	if len(nodes) == 0 {
+		return nil, ErrNoSuchObject
 	}
 
-	sort.Strings(addresses)
+	for _, node := range nodes {
+		// Volume is defined without a cluster member.
+		if node.ID == 0 {
+			return nil, ErrNoClusterMember
+		}
+	}
 
-	addressCount := len(addresses)
-	if addressCount == 0 {
+	nodeCount := len(nodes)
+	if nodeCount == 0 {
 		return nil, ErrNoSuchObject
-	} else if addressCount > 1 {
+	} else if nodeCount > 1 {
 		driver, err := c.GetStoragePoolDriver(poolID)
 		if err != nil {
 			return nil, err
@@ -691,12 +678,17 @@ func (c *ClusterTx) GetStorageVolumeNodeAddresses(poolID int64, projectName stri
 		// take this to mean that the volume doesn't have an explicit cluster member and is therefore
 		// equivalent to db.ErrNoClusterMember that is used in newer schemas where a single remote volume
 		// DB record is created that is not associated to any single member.
-		if driver == "ceph" || driver == "cephfs" {
+		if StorageRemoteDriverNames == nil {
+			return nil, fmt.Errorf("No remote storage drivers function defined")
+		}
+
+		remoteDrivers := StorageRemoteDriverNames()
+		if shared.StringInSlice(driver, remoteDrivers) {
 			return nil, ErrNoClusterMember
 		}
 	}
 
-	return addresses, nil
+	return nodes, nil
 }
 
 // Return the name of the node a storage volume is on.

--- a/lxd/db/storage_volumes_test.go
+++ b/lxd/db/storage_volumes_test.go
@@ -11,7 +11,11 @@ import (
 )
 
 // Addresses of all nodes with matching volume name are returned.
-func TestStorageVolumeNodeAddresses(t *testing.T) {
+func TestGetStorageVolumeNodes(t *testing.T) {
+	db.StorageRemoteDriverNames = func() []string {
+		return []string{"ceph", "cephfs"}
+	}
+
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
@@ -29,10 +33,21 @@ func TestStorageVolumeNodeAddresses(t *testing.T) {
 	addVolume(t, tx, poolID, nodeID3, "volume2")
 	addVolume(t, tx, poolID, nodeID2, "volume2")
 
-	addresses, err := tx.GetStorageVolumeNodeAddresses(poolID, "default", "volume1", 1)
+	nodes, err := tx.GetStorageVolumeNodes(poolID, "default", "volume1", 1)
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"", "1.2.3.4:666"}, addresses)
+	assert.Equal(t, []db.NodeInfo{
+		{
+			ID:      nodeID1,
+			Name:    "none",
+			Address: "0.0.0.0",
+		},
+		{
+			ID:      nodeID2,
+			Name:    "node2",
+			Address: "1.2.3.4:666",
+		},
+	}, nodes)
 }
 
 func addPool(t *testing.T, tx *db.ClusterTx, name string) int64 {

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -202,8 +202,14 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 				return err
 			}
 
-			if contentType == db.StoragePoolVolumeContentTypeBlock && instConf.Type() != instancetype.VM {
-				return fmt.Errorf("Custom block volumes cannot be used on containers")
+			if contentType == db.StoragePoolVolumeContentTypeBlock {
+				if instConf.Type() != instancetype.VM {
+					return fmt.Errorf("Custom block volumes cannot be used on containers")
+				}
+
+				if d.config["path"] != "" {
+					return fmt.Errorf("Custom block volumes cannot have a path defined")
+				}
 			}
 		}
 	}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -166,50 +166,44 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 			return fmt.Errorf("Storage volumes cannot be specified as absolute paths")
 		}
 
-		poolID, err := d.state.Cluster.GetStoragePoolID(d.config["pool"])
-		if err != nil {
-			return fmt.Errorf("The %q storage pool doesn't exist", d.config["pool"])
-		}
+		// Only perform expensive instance custom volume checks when not validating a profile and after
+		// device expansion has occurred (to avoid doing it twice).
+		if instConf.Type() != instancetype.Any && len(instConf.ExpandedDevices()) > 0 && d.config["source"] != "" && d.config["path"] != "/" {
+			poolID, err := d.state.Cluster.GetStoragePoolID(d.config["pool"])
+			if err != nil {
+				return fmt.Errorf("The %q storage pool doesn't exist", d.config["pool"])
+			}
 
-		// If instance is supplied, use it's project to derive the effective storage project name.
-		var storageProjectName string
-		if d.inst != nil {
-			storageProjectName, err = project.StorageVolumeProject(d.state.Cluster, d.inst.Project(), db.StoragePoolVolumeTypeCustom)
+			// Derive the effective storage project name from the instance config's project.
+			storageProjectName, err := project.StorageVolumeProject(d.state.Cluster, instConf.Project(), db.StoragePoolVolumeTypeCustom)
 			if err != nil {
 				return err
 			}
-		}
 
-		// Only check storate volume is available if we are validating an instance device and not a profile
-		// device (check for instancetype.Any), and we have least one expanded device (this is so we only
-		// do this expensive check after devices have been expanded).
-		if instConf.Type() != instancetype.Any && len(instConf.ExpandedDevices()) > 0 && d.config["source"] != "" && d.config["path"] != "/" {
-			remoteInstance, err := storagePools.VolumeUsedByExclusiveRemoteInstancesWithProfiles(d.state, d.config["pool"], storageProjectName, d.config["source"], db.StoragePoolVolumeTypeNameCustom)
+			// GetLocalStoragePoolVolume returns a volume with an empty Location field for remote drivers.
+			_, vol, err := d.state.Cluster.GetLocalStoragePoolVolume(storageProjectName, d.config["source"], db.StoragePoolVolumeTypeCustom, poolID)
 			if err != nil {
-				return errors.Wrapf(err, "Failed checking if volume is exclusively attached")
+				return errors.Wrapf(err, "Failed loading custom volume")
+			}
+
+			// Check storage volume is available to mount on this cluster member.
+			remoteInstance, err := storagePools.VolumeUsedByExclusiveRemoteInstancesWithProfiles(d.state, d.config["pool"], storageProjectName, vol)
+			if err != nil {
+				return errors.Wrapf(err, "Failed checking if custom volume is exclusively attached to another instance")
 			}
 
 			if remoteInstance != nil {
-				return fmt.Errorf("Storage volume %q is already attached to an instance on a different node", d.config["source"])
+				return fmt.Errorf("Custom volume is already attached to an instance on a different node")
 			}
 
-			return nil
-		}
-
-		// Block volumes may only be attached to VMs.
-		if d.inst != nil && d.config["path"] != "/" {
-			_, volume, err := d.state.Cluster.GetLocalStoragePoolVolume(storageProjectName, d.config["source"], db.StoragePoolVolumeTypeCustom, poolID)
+			// Check only block type volumes are attached to VM instances.
+			contentType, err := storagePools.VolumeContentTypeNameToContentType(vol.ContentType)
 			if err != nil {
 				return err
 			}
 
-			contentType, err := storagePools.VolumeContentTypeNameToContentType(volume.ContentType)
-			if err != nil {
-				return err
-			}
-
-			if contentType == db.StoragePoolVolumeContentTypeBlock && d.inst.Type() != instancetype.VM {
-				return fmt.Errorf("Block volumes cannot be used on containers")
+			if contentType == db.StoragePoolVolumeContentTypeBlock && instConf.Type() != instancetype.VM {
+				return fmt.Errorf("Custom block volumes cannot be used on containers")
 			}
 		}
 	}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1067,13 +1067,8 @@ func (d *disk) storagePoolVolumeAttachShift(projectName, poolName, volumeName st
 		logger.Debugf("Shifting storage volume")
 
 		if !shared.IsTrue(poolVolumePut.Config["security.shifted"]) {
-			volumeTypeName, err := storagePools.VolumeDBTypeToTypeName(volumeType)
-			if err != nil {
-				return err
-			}
-
 			volumeUsedBy := []instance.Instance{}
-			err = storagePools.VolumeUsedByInstances(d.state, poolName, projectName, volumeName, volumeTypeName, true, func(dbInst db.Instance, project api.Project, profiles []api.Profile) error {
+			err = storagePools.VolumeUsedByInstances(d.state, poolName, projectName, volume, true, func(dbInst db.Instance, project api.Project, profiles []api.Profile) error {
 				inst, err := instance.Load(d.state, db.InstanceToArgs(&dbInst), profiles)
 				if err != nil {
 					return err

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -42,6 +42,16 @@ const (
 	patchPostDaemonStorage
 )
 
+// Leave the string type in here! This guarantees that go treats this is as a
+// typed string constant. Removing it causes go to treat these as untyped string
+// constants which is not what we want.
+const (
+	patchStoragePoolVolumeAPIEndpointContainers string = "containers"
+	patchStoragePoolVolumeAPIEndpointVMs        string = "virtual-machines"
+	patchStoragePoolVolumeAPIEndpointImages     string = "images"
+	patchStoragePoolVolumeAPIEndpointCustom     string = "custom"
+)
+
 /* Patches are one-time actions that are sometimes needed to update
    existing container configuration or move things around on the
    filesystem.
@@ -1453,8 +1463,8 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 		// permissions and ownership.
 		newContainerMntPoint := driver.GetContainerMountPoint("default", defaultPoolName, ct)
 		ctLvName := lvmNameToLVName(ct)
-		newContainerLvName := fmt.Sprintf("%s_%s", storagePoolVolumeAPIEndpointContainers, ctLvName)
-		containerLvDevPath := lvmDevPath("default", defaultPoolName, storagePoolVolumeAPIEndpointContainers, ctLvName)
+		newContainerLvName := fmt.Sprintf("%s_%s", patchStoragePoolVolumeAPIEndpointContainers, ctLvName)
+		containerLvDevPath := lvmDevPath("default", defaultPoolName, patchStoragePoolVolumeAPIEndpointContainers, ctLvName)
 		if !shared.PathExists(containerLvDevPath) {
 			oldLvDevPath := fmt.Sprintf("/dev/%s/%s", defaultPoolName, ctLvName)
 			// If the old LVM device path for the logical volume
@@ -1615,8 +1625,8 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 
 			// Make sure we use a valid lv name.
 			csLvName := lvmNameToLVName(cs)
-			newSnapshotLvName := fmt.Sprintf("%s_%s", storagePoolVolumeAPIEndpointContainers, csLvName)
-			snapshotLvDevPath := lvmDevPath("default", defaultPoolName, storagePoolVolumeAPIEndpointContainers, csLvName)
+			newSnapshotLvName := fmt.Sprintf("%s_%s", patchStoragePoolVolumeAPIEndpointContainers, csLvName)
+			snapshotLvDevPath := lvmDevPath("default", defaultPoolName, patchStoragePoolVolumeAPIEndpointContainers, csLvName)
 			if !shared.PathExists(snapshotLvDevPath) {
 				oldLvDevPath := fmt.Sprintf("/dev/%s/%s", defaultPoolName, csLvName)
 				if shared.PathExists(oldLvDevPath) {
@@ -1807,8 +1817,8 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 		}
 
 		// Rename the logical volume device.
-		newImageLvName := fmt.Sprintf("%s_%s", storagePoolVolumeAPIEndpointImages, img)
-		imageLvDevPath := lvmDevPath("default", defaultPoolName, storagePoolVolumeAPIEndpointImages, img)
+		newImageLvName := fmt.Sprintf("%s_%s", patchStoragePoolVolumeAPIEndpointImages, img)
+		imageLvDevPath := lvmDevPath("default", defaultPoolName, patchStoragePoolVolumeAPIEndpointImages, img)
 		oldLvDevPath := fmt.Sprintf("/dev/%s/%s", defaultPoolName, img)
 		// Only create logical volumes for images that have a logical
 		// volume on the pre-storage-api LXD instance. If not, we don't
@@ -2737,6 +2747,21 @@ func patchStorageApiDetectLVSize(name string, d *Daemon) error {
 		if poolName == "" {
 			logger.Errorf("The \"lvm.vg_name\" key should not be empty")
 			return fmt.Errorf("The \"lvm.vg_name\" key should not be empty")
+		}
+
+		storagePoolVolumeTypeNameToAPIEndpoint := func(volumeTypeName string) (string, error) {
+			switch volumeTypeName {
+			case db.StoragePoolVolumeTypeNameContainer:
+				return patchStoragePoolVolumeAPIEndpointContainers, nil
+			case db.StoragePoolVolumeTypeNameVM:
+				return patchStoragePoolVolumeAPIEndpointVMs, nil
+			case db.StoragePoolVolumeTypeNameImage:
+				return patchStoragePoolVolumeAPIEndpointImages, nil
+			case db.StoragePoolVolumeTypeNameCustom:
+				return patchStoragePoolVolumeAPIEndpointCustom, nil
+			}
+
+			return "", fmt.Errorf("Invalid storage volume type name")
 		}
 
 		for _, volume := range volumes {

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3261,8 +3261,18 @@ func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotNa
 		return fmt.Errorf("Invalid snapshot name")
 	}
 
+	// Get current volume.
+	_, curVol, err := b.state.Cluster.GetLocalStoragePoolVolume(projectName, volName, db.StoragePoolVolumeTypeCustom, b.ID())
+	if err != nil {
+		if err == db.ErrNoSuchObject {
+			return fmt.Errorf("Volume doesn't exist")
+		}
+
+		return err
+	}
+
 	// Check that the volume isn't in use by running instances.
-	err := VolumeUsedByInstances(b.state, b.Name(), projectName, volName, db.StoragePoolVolumeTypeNameCustom, true, func(dbInst db.Instance, project api.Project, profiles []api.Profile) error {
+	err = VolumeUsedByInstances(b.state, b.Name(), projectName, curVol, true, func(dbInst db.Instance, project api.Project, profiles []api.Profile) error {
 		inst, err := instance.Load(b.state, db.InstanceToArgs(&dbInst), profiles)
 		if err != nil {
 			return err

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2842,7 +2842,7 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 
 		// Check for config changing that is not allowed when running instances are using it.
 		if (changedConfig["size"] != "" && !runningQuotaResize) || newConfig["security.shifted"] != curVol.Config["security.shifted"] {
-			err = VolumeUsedByInstances(b.state, b.name, projectName, volName, db.StoragePoolVolumeTypeNameCustom, true, func(dbInst db.Instance, project api.Project, profiles []api.Profile) error {
+			err = VolumeUsedByInstances(b.state, b.name, projectName, curVol, true, func(dbInst db.Instance, project api.Project, profiles []api.Profile) error {
 				inst, err := instance.Load(b.state, db.InstanceToArgs(&dbInst), profiles)
 				if err != nil {
 					return err

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -706,6 +706,12 @@ func VolumeUsedByInstances(s *state.State, poolName string, projectName string, 
 	volumeNameWithType := fmt.Sprintf("%s/%s", vol.Type, vol.Name)
 
 	return s.Cluster.InstanceList(func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+		//If the volume has a specific cluster member which is different than the instance then skip as
+		// instance cannot be using this volume.
+		if vol.Location != "" && inst.Node != vol.Location {
+			return nil
+		}
+
 		instStorageProject := project.StorageVolumeProjectFromRecord(&p, volumeType)
 		if err != nil {
 			return err

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -754,7 +754,7 @@ func VolumeUsedByInstances(s *state.State, poolName string, projectName string, 
 
 // VolumeUsedByExclusiveRemoteInstancesWithProfiles checks if custom volume is exclusively attached to a remote
 // instance. Returns the remote instance that has the volume exclusively attached. Returns nil if volume available.
-func VolumeUsedByExclusiveRemoteInstancesWithProfiles(s *state.State, poolName string, projectName string, volumeName string, volumeTypeName string) (*db.Instance, error) {
+func VolumeUsedByExclusiveRemoteInstancesWithProfiles(s *state.State, poolName string, projectName string, vol *api.StorageVolume) (*db.Instance, error) {
 	pool, err := GetPoolByName(s, poolName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed loading storage pool %q", poolName)
@@ -780,7 +780,7 @@ func VolumeUsedByExclusiveRemoteInstancesWithProfiles(s *state.State, poolName s
 	// Find if volume is attached to a remote instance.
 	var errAttached = fmt.Errorf("Volume is remotely attached")
 	var remoteInstance *db.Instance
-	VolumeUsedByInstances(s, poolName, projectName, volumeName, volumeTypeName, true, func(dbInst db.Instance, project api.Project, profiles []api.Profile) error {
+	VolumeUsedByInstances(s, poolName, projectName, vol, true, func(dbInst db.Instance, project api.Project, profiles []api.Profile) error {
 		if dbInst.Node != localNode {
 			remoteInstance = &dbInst
 			return errAttached // Stop the search, this volume is attached to a remote instance.

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -804,19 +804,19 @@ func storagePoolVolumeTypePostMove(d *Daemon, projectName, poolName, volumeName 
 }
 
 func storagePoolVolumeTypeContainerPost(d *Daemon, r *http.Request) response.Response {
-	return storagePoolVolumeTypePost(d, r, "container")
+	return storagePoolVolumeTypePost(d, r, db.StoragePoolVolumeTypeNameContainer)
 }
 
 func storagePoolVolumeTypeVMPost(d *Daemon, r *http.Request) response.Response {
-	return storagePoolVolumeTypePost(d, r, "virtual-machine")
+	return storagePoolVolumeTypePost(d, r, db.StoragePoolVolumeTypeNameVM)
 }
 
 func storagePoolVolumeTypeCustomPost(d *Daemon, r *http.Request) response.Response {
-	return storagePoolVolumeTypePost(d, r, "custom")
+	return storagePoolVolumeTypePost(d, r, db.StoragePoolVolumeTypeNameCustom)
 }
 
 func storagePoolVolumeTypeImagePost(d *Daemon, r *http.Request) response.Response {
-	return storagePoolVolumeTypePost(d, r, "image")
+	return storagePoolVolumeTypePost(d, r, db.StoragePoolVolumeTypeNameImage)
 }
 
 // storageGetVolumeNameFromURL retrieves the volume name from the URL name segment.

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -864,12 +864,6 @@ func storagePoolVolumeTypeGet(d *Daemon, r *http.Request, volumeTypeName string)
 		return response.SmartError(err)
 	}
 
-	// Get the ID of the storage pool the storage volume is supposed to be attached to.
-	poolID, err := d.cluster.GetStoragePoolID(poolName)
-	if err != nil {
-		return response.SmartError(err)
-	}
-
 	resp := forwardedResponseIfTargetIsRemote(d, r)
 	if resp != nil {
 		return resp
@@ -880,13 +874,19 @@ func storagePoolVolumeTypeGet(d *Daemon, r *http.Request, volumeTypeName string)
 		return resp
 	}
 
+	// Get the ID of the storage pool the storage volume is supposed to be attached to.
+	poolID, err := d.cluster.GetStoragePoolID(poolName)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	// Get the storage volume.
 	_, volume, err := d.cluster.GetLocalStoragePoolVolume(projectName, volumeName, volumeType, poolID)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	volumeUsedBy, err := storagePoolVolumeUsedByGet(d.State(), projectName, poolName, volume.Name, volume.Type)
+	volumeUsedBy, err := storagePoolVolumeUsedByGet(d.State(), projectName, poolName, volume)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -145,40 +145,27 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 
 	resultString := []string{}
 	for _, volume := range volumes {
-		apiEndpoint, err := storagePoolVolumeTypeNameToAPIEndpoint(volume.Type)
-		if err != nil {
-			return response.InternalError(err)
-		}
-
-		if apiEndpoint == storagePoolVolumeAPIEndpointContainers {
-			apiEndpoint = "container"
-		} else if apiEndpoint == storagePoolVolumeAPIEndpointVMs {
-			apiEndpoint = "virtual-machine"
-		} else if apiEndpoint == storagePoolVolumeAPIEndpointImages {
-			apiEndpoint = "image"
-		}
-
 		if !recursion {
 			volName, snapName, ok := shared.InstanceGetParentAndSnapshotName(volume.Name)
 			if ok {
 				if projectName == project.Default {
 					resultString = append(resultString,
 						fmt.Sprintf("/%s/storage-pools/%s/volumes/%s/%s/snapshots/%s",
-							version.APIVersion, poolName, apiEndpoint, volName, snapName))
+							version.APIVersion, poolName, volume.Type, volName, snapName))
 				} else {
 					resultString = append(resultString,
 						fmt.Sprintf("/%s/storage-pools/%s/volumes/%s/%s/snapshots/%s?project=%s",
-							version.APIVersion, poolName, apiEndpoint, volName, snapName, projectName))
+							version.APIVersion, poolName, volume.Type, volName, snapName, projectName))
 				}
 			} else {
 				if projectName == project.Default {
 					resultString = append(resultString,
 						fmt.Sprintf("/%s/storage-pools/%s/volumes/%s/%s",
-							version.APIVersion, poolName, apiEndpoint, volume.Name))
+							version.APIVersion, poolName, volume.Type, volume.Name))
 				} else {
 					resultString = append(resultString,
 						fmt.Sprintf("/%s/storage-pools/%s/volumes/%s/%s?project=%s",
-							version.APIVersion, poolName, apiEndpoint, volume.Name, projectName))
+							version.APIVersion, poolName, volume.Type, volume.Name, projectName))
 				}
 			}
 		} else {
@@ -240,20 +227,7 @@ func storagePoolVolumesTypeGet(d *Daemon, r *http.Request) response.Response {
 	resultMap := []*api.StorageVolume{}
 	for _, volume := range volumes {
 		if !recursion {
-			apiEndpoint, err := storagePoolVolumeTypeToAPIEndpoint(volumeType)
-			if err != nil {
-				return response.InternalError(err)
-			}
-
-			if apiEndpoint == storagePoolVolumeAPIEndpointContainers {
-				apiEndpoint = "container"
-			} else if apiEndpoint == storagePoolVolumeAPIEndpointVMs {
-				apiEndpoint = "virtual-machine"
-			} else if apiEndpoint == storagePoolVolumeAPIEndpointImages {
-				apiEndpoint = "image"
-			}
-
-			resultString = append(resultString, fmt.Sprintf("/%s/storage-pools/%s/volumes/%s/%s", version.APIVersion, poolName, apiEndpoint, volume))
+			resultString = append(resultString, fmt.Sprintf("/%s/storage-pools/%s/volumes/%s/%s", version.APIVersion, poolName, volumeTypeName, volume))
 		} else {
 			_, vol, err := d.cluster.GetLocalStoragePoolVolume(projectName, volume, volumeType, poolID)
 			if err != nil {
@@ -759,7 +733,7 @@ func storagePoolVolumeTypePostRename(d *Daemon, projectName, poolName, volumeNam
 		return response.SmartError(err)
 	}
 
-	return response.SyncResponseLocation(true, nil, fmt.Sprintf("/%s/storage-pools/%s/volumes/%s", version.APIVersion, poolName, storagePoolVolumeAPIEndpointCustom))
+	return response.SyncResponseLocation(true, nil, fmt.Sprintf("/%s/storage-pools/%s/volumes/%s", version.APIVersion, poolName, db.StoragePoolVolumeTypeNameCustom))
 }
 
 // storagePoolVolumeTypePostMove handles volume move type POST requests.

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1198,7 +1198,19 @@ func storagePoolVolumeTypeDelete(d *Daemon, r *http.Request, volumeTypeName stri
 		return response.BadRequest(fmt.Errorf("Storage volumes of type %q cannot be deleted with the storage API", volumeTypeName))
 	}
 
-	volumeUsedBy, err := storagePoolVolumeUsedByGet(d.State(), projectName, poolName, volumeName, volumeTypeName)
+	// Get the storage pool the storage volume is supposed to be attached to.
+	pool, err := storagePools.GetPoolByName(d.State(), poolName)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	// Get the storage volume.
+	_, volume, err := d.cluster.GetLocalStoragePoolVolume(projectName, volumeName, volumeType, pool.ID())
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	volumeUsedBy, err := storagePoolVolumeUsedByGet(d.State(), projectName, poolName, volume)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1207,11 +1219,6 @@ func storagePoolVolumeTypeDelete(d *Daemon, r *http.Request, volumeTypeName stri
 		if len(volumeUsedBy) != 1 || volumeType != db.StoragePoolVolumeTypeImage || volumeUsedBy[0] != fmt.Sprintf("/%s/images/%s", version.APIVersion, volumeName) {
 			return response.BadRequest(fmt.Errorf("The storage volume is still in use"))
 		}
-	}
-
-	pool, err := storagePools.GetPoolByName(d.State(), poolName)
-	if err != nil {
-		return response.SmartError(err)
 	}
 
 	switch volumeType {

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -182,7 +182,7 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 				}
 			}
 		} else {
-			volumeUsedBy, err := storagePoolVolumeUsedByGet(d.State(), projectName, poolName, volume.Name, volume.Type)
+			volumeUsedBy, err := storagePoolVolumeUsedByGet(d.State(), projectName, poolName, volume)
 			if err != nil {
 				return response.InternalError(err)
 			}
@@ -260,7 +260,7 @@ func storagePoolVolumesTypeGet(d *Daemon, r *http.Request) response.Response {
 				continue
 			}
 
-			volumeUsedBy, err := storagePoolVolumeUsedByGet(d.State(), projectName, poolName, vol.Name, vol.Type)
+			volumeUsedBy, err := storagePoolVolumeUsedByGet(d.State(), projectName, poolName, vol)
 			if err != nil {
 				return response.SmartError(err)
 			}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -738,8 +738,6 @@ func storagePoolVolumeTypePostRename(d *Daemon, projectName string, poolName str
 
 // storagePoolVolumeTypePostMove handles volume move type POST requests.
 func storagePoolVolumeTypePostMove(d *Daemon, projectName, poolName, volumeName string, volumeType int, req api.StorageVolumePost) response.Response {
-	var run func(op *operations.Operation) error
-
 	srcPool, err := storagePools.GetPoolByName(d.State(), poolName)
 	if err != nil {
 		return response.SmartError(err)
@@ -750,7 +748,7 @@ func storagePoolVolumeTypePostMove(d *Daemon, projectName, poolName, volumeName 
 		return response.SmartError(err)
 	}
 
-	run = func(op *operations.Operation) error {
+	run := func(op *operations.Operation) error {
 		// Notify users of the volume that it's name is changing.
 		err := storagePoolVolumeUpdateUsers(d, projectName, poolName, volumeName, req.Pool, req.Name)
 		if err != nil {

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -223,7 +223,7 @@ func storagePoolVolumeSnapshotsTypeGet(d *Daemon, r *http.Request) response.Resp
 				continue
 			}
 
-			volumeUsedBy, err := storagePoolVolumeUsedByGet(d.State(), projectName, poolName, vol.Name, vol.Type)
+			volumeUsedBy, err := storagePoolVolumeUsedByGet(d.State(), projectName, poolName, vol)
 			if err != nil {
 				return response.SmartError(err)
 			}

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -212,11 +212,7 @@ func storagePoolVolumeSnapshotsTypeGet(d *Daemon, r *http.Request) response.Resp
 		_, snapshotName, _ := shared.InstanceGetParentAndSnapshotName(volume.Name)
 
 		if !recursion {
-			apiEndpoint, err := storagePoolVolumeTypeToAPIEndpoint(volumeType)
-			if err != nil {
-				return response.InternalError(err)
-			}
-			resultString = append(resultString, fmt.Sprintf("/%s/storage-pools/%s/volumes/%s/%s/snapshots/%s", version.APIVersion, poolName, apiEndpoint, volumeName, snapshotName))
+			resultString = append(resultString, fmt.Sprintf("/%s/storage-pools/%s/volumes/%s/%s/snapshots/%s", version.APIVersion, poolName, volumeTypeName, volumeName, snapshotName))
 		} else {
 			_, vol, err := d.cluster.GetLocalStoragePoolVolume(projectName, volume.Name, volumeType, poolID)
 			if err != nil {
@@ -340,11 +336,6 @@ func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Respo
 	volumeType, err := storagePools.VolumeTypeNameToDBType(volumeTypeName)
 	if err != nil {
 		return response.BadRequest(err)
-	}
-
-	// Check that the storage volume type is valid.
-	if volumeType != db.StoragePoolVolumeTypeCustom {
-		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
 	projectName, err := project.StorageVolumeProject(d.State().Cluster, projectParam(r), volumeType)

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -16,48 +16,8 @@ import (
 	"github.com/lxc/lxd/shared/version"
 )
 
-// Leave the string type in here! This guarantees that go treats this is as a
-// typed string constant. Removing it causes go to treat these as untyped string
-// constants which is not what we want.
-const (
-	storagePoolVolumeAPIEndpointContainers string = "containers"
-	storagePoolVolumeAPIEndpointVMs        string = "virtual-machines"
-	storagePoolVolumeAPIEndpointImages     string = "images"
-	storagePoolVolumeAPIEndpointCustom     string = "custom"
-)
-
 var supportedVolumeTypes = []int{db.StoragePoolVolumeTypeContainer, db.StoragePoolVolumeTypeVM, db.StoragePoolVolumeTypeCustom, db.StoragePoolVolumeTypeImage}
 var supportedVolumeTypesInstances = []int{db.StoragePoolVolumeTypeContainer, db.StoragePoolVolumeTypeVM}
-
-func storagePoolVolumeTypeNameToAPIEndpoint(volumeTypeName string) (string, error) {
-	switch volumeTypeName {
-	case db.StoragePoolVolumeTypeNameContainer:
-		return storagePoolVolumeAPIEndpointContainers, nil
-	case db.StoragePoolVolumeTypeNameVM:
-		return storagePoolVolumeAPIEndpointVMs, nil
-	case db.StoragePoolVolumeTypeNameImage:
-		return storagePoolVolumeAPIEndpointImages, nil
-	case db.StoragePoolVolumeTypeNameCustom:
-		return storagePoolVolumeAPIEndpointCustom, nil
-	}
-
-	return "", fmt.Errorf("Invalid storage volume type name")
-}
-
-func storagePoolVolumeTypeToAPIEndpoint(volumeType int) (string, error) {
-	switch volumeType {
-	case db.StoragePoolVolumeTypeContainer:
-		return storagePoolVolumeAPIEndpointContainers, nil
-	case db.StoragePoolVolumeTypeVM:
-		return storagePoolVolumeAPIEndpointVMs, nil
-	case db.StoragePoolVolumeTypeImage:
-		return storagePoolVolumeAPIEndpointImages, nil
-	case db.StoragePoolVolumeTypeCustom:
-		return storagePoolVolumeAPIEndpointCustom, nil
-	}
-
-	return "", fmt.Errorf("Invalid storage volume type")
-}
 
 func storagePoolVolumeUpdateUsers(d *Daemon, projectName string, oldPoolName string, oldVolumeName string, newPoolName string, newVolumeName string) error {
 	s := d.State()

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -205,10 +205,10 @@ func storagePoolVolumeUpdateUsers(d *Daemon, projectName string, oldPoolName str
 }
 
 // volumeUsedBy = append(volumeUsedBy, fmt.Sprintf("/%s/containers/%s", version.APIVersion, ct))
-func storagePoolVolumeUsedByGet(s *state.State, projectName string, poolName string, volumeName string, volumeTypeName string) ([]string, error) {
+func storagePoolVolumeUsedByGet(s *state.State, projectName string, poolName string, vol *api.StorageVolume) ([]string, error) {
 	// Handle instance volumes.
-	if volumeTypeName == "container" || volumeTypeName == "virtual-machine" {
-		cName, sName, snap := shared.InstanceGetParentAndSnapshotName(volumeName)
+	if vol.Type == db.StoragePoolVolumeTypeNameContainer || vol.Type == db.StoragePoolVolumeTypeNameVM {
+		cName, sName, snap := shared.InstanceGetParentAndSnapshotName(vol.Name)
 		if snap {
 			if projectName == project.Default {
 				return []string{fmt.Sprintf("/%s/instances/%s/snapshots/%s", version.APIVersion, cName, sName)}, nil
@@ -225,16 +225,16 @@ func storagePoolVolumeUsedByGet(s *state.State, projectName string, poolName str
 	}
 
 	// Handle image volumes.
-	if volumeTypeName == "image" {
+	if vol.Type == db.StoragePoolVolumeTypeNameImage {
 		if projectName == project.Default {
-			return []string{fmt.Sprintf("/%s/images/%s", version.APIVersion, volumeName)}, nil
+			return []string{fmt.Sprintf("/%s/images/%s", version.APIVersion, vol.Name)}, nil
 		} else {
-			return []string{fmt.Sprintf("/%s/images/%s?project=%s", version.APIVersion, volumeName, projectName)}, nil
+			return []string{fmt.Sprintf("/%s/images/%s?project=%s", version.APIVersion, vol.Name, projectName)}, nil
 		}
 	}
 
 	// Check if the daemon itself is using it.
-	used, err := storagePools.VolumeUsedByDaemon(s, poolName, volumeName)
+	used, err := storagePools.VolumeUsedByDaemon(s, poolName, vol.Name)
 	if err != nil {
 		return []string{}, err
 	}
@@ -250,7 +250,7 @@ func storagePoolVolumeUsedByGet(s *state.State, projectName string, poolName str
 
 	// Pass false to expandDevices, as we only want to see instances directly using a volume, rather than their
 	// profiles using a volume.
-	err = storagePools.VolumeUsedByInstances(s, poolName, projectName, volumeName, volumeTypeName, false, func(inst db.Instance, project api.Project, profiles []api.Profile) error {
+	err = storagePools.VolumeUsedByInstances(s, poolName, projectName, vol, false, func(inst db.Instance, project api.Project, profiles []api.Profile) error {
 		instancesUsingVolume = append(instancesUsingVolume, &inst)
 		return nil
 	})
@@ -267,7 +267,7 @@ func storagePoolVolumeUsedByGet(s *state.State, projectName string, poolName str
 	}
 
 	// Look for profiles using this volume.
-	profiles, err := profilesUsingPoolVolumeGetNames(s.Cluster, volumeName, volumeTypeName)
+	profiles, err := profilesUsingPoolVolumeGetNames(s.Cluster, vol.Name, vol.Type)
 	if err != nil {
 		return []string{}, err
 	}


### PR DESCRIPTION
Fixes issue with attaching volumes and resource usage when a volume exists on multiple cluster members, described on https://discuss.linuxcontainers.org/t/how-to-attach-a-storage-volume-with-the-same-name-defined-in-multiple-nodes-in-lxd-cluster/9387

It solves this by passing in the `api.StorageVolume` struct into `storagePools.VolumeUsedByInstances` and then modifying `VolumeUsedByInstances` to use the `Location` field in the `StorageVolume` supplied to decide whether the volume is local to the specific cluster member or available on all. If it is only available on the local cluster member then it will filter the instance list to only include instances on that node.

This PR also replaces `GetStorageVolumeNodeAddresses` with `GetStorageVolumeNodes` which returns a list of `db.NodeInfo` and unifies the function so that it works on both current schema (where remote volumes have a null node ID) and the old schema (where remote volumes are created on each node), allowing us to use the same function in both the current and 4.0 LTS branches.

It also fixes some issues with volume types used in URLs generated when not doing recursive volume lists.