### PR TITLE
lxd/apparmor: Workaround socket handling

### DIFF
--- a/lxd/apparmor/instance_forkproxy.go
+++ b/lxd/apparmor/instance_forkproxy.go
@@ -77,7 +77,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   /snap/lxd/*/lib/**.so*              mr,
 {{- end }}
 
-{{if .libraryPath -}}
+{{if .libraryPath }}
   # Entries from LD_LIBRARY_PATH
 {{range $index, $element := .libraryPath}}
   {{$element}}/** mr,
@@ -138,7 +138,9 @@ func forkproxyProfile(state *state.State, inst instance, dev device) (string, er
 			return "", err
 		}
 
-		sockets[k] = v
+		if !shared.StringInSlice(v, sockets) {
+			sockets = append(sockets, v)
+		}
 	}
 
 	// Render the profile.


### PR DESCRIPTION
It appears that on some kernel at least, the connect operation is
evaluated against the non-dereference path when dealing with a symlink.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>