### PR TITLE
Storage: Remove instance configure internal function

### DIFF
--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -61,8 +61,7 @@ func instanceCreateAsEmpty(d *Daemon, args db.InstanceArgs) (instance.Instance, 
 		return nil, errors.Wrap(err, "Create instance")
 	}
 
-	// Apply any post-storage configuration.
-	err = instanceConfigureInternal(d.State(), inst)
+	err = inst.UpdateBackupFile()
 	if err != nil {
 		return nil, err
 	}
@@ -174,10 +173,9 @@ func instanceCreateFromImage(d *Daemon, args db.InstanceArgs, hash string, op *o
 		return nil, errors.Wrap(err, "Create instance from image")
 	}
 
-	// Apply any post-storage configuration.
-	err = instanceConfigureInternal(d.State(), inst)
+	err = inst.UpdateBackupFile()
 	if err != nil {
-		return nil, errors.Wrap(err, "Configure instance")
+		return nil, err
 	}
 
 	revert = false
@@ -325,20 +323,9 @@ func instanceCreateAsCopy(s *state.State, args db.InstanceArgs, sourceInst insta
 		}
 	}
 
-	// Apply any post-storage configuration.
-	err = instanceConfigureInternal(s, inst)
+	err = inst.UpdateBackupFile()
 	if err != nil {
 		return nil, err
-	}
-
-	if !instanceOnly {
-		for _, snap := range snapList {
-			// Apply any post-storage configuration.
-			err = instanceConfigureInternal(s, *snap)
-			if err != nil {
-				return nil, err
-			}
-		}
 	}
 
 	revertInst = nil

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1104,6 +1104,8 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 	if args.VolumeSize > 0 && contentType == drivers.ContentTypeBlock {
 		b.logger.Debug("Setting volume size from offer header", log.Ctx{"size": args.VolumeSize})
 		args.Config["size"] = fmt.Sprintf("%d", args.VolumeSize)
+	} else if args.Config["size"] != "" {
+		b.logger.Debug("Using volume size from root disk config", log.Ctx{"size": args.Config["size"]})
 	}
 
 	// Get the volume name on storage.


### PR DESCRIPTION
Don't post-set volume size after volume creation, rely on correct device size being available at volume creation time.

Avoids subtle differences in sizes between the actual block volume size sent in migration header and size in instance disk config.

Fixes https://github.com/lxc/lxd/issues/8112