### PR TITLE
Storage: Mount reference counting

### DIFF
--- a/lxd/daemon_storage.go
+++ b/lxd/daemon_storage.go
@@ -53,7 +53,7 @@ func daemonStorageMount(s *state.State) error {
 		}
 
 		// Mount volume.
-		_, err = pool.MountCustomVolume(project.Default, volumeName, nil)
+		err = pool.MountCustomVolume(project.Default, volumeName, nil)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to mount storage volume %q", source)
 		}
@@ -119,13 +119,11 @@ func daemonStorageValidate(s *state.State, target string) error {
 	}
 
 	// Mount volume.
-	ourMount, err := pool.MountCustomVolume(project.Default, volumeName, nil)
+	err = pool.MountCustomVolume(project.Default, volumeName, nil)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to mount storage volume %q", target)
 	}
-	if ourMount {
-		defer pool.UnmountCustomVolume(project.Default, volumeName, nil)
-	}
+	defer pool.UnmountCustomVolume(project.Default, volumeName, nil)
 
 	// Validate volume is empty (ignore lost+found).
 	volStorageName := project.StorageVolume(project.Default, volumeName)
@@ -249,7 +247,7 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 	}
 
 	// Mount volume.
-	_, err = pool.MountCustomVolume(project.Default, volumeName, nil)
+	err = pool.MountCustomVolume(project.Default, volumeName, nil)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to mount storage volume %q", target)
 	}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -883,14 +883,11 @@ func (d *disk) mountPoolVolume(reverter *revert.Reverter) (string, error) {
 		return "", err
 	}
 
-	ourMount, err := pool.MountCustomVolume(storageProjectName, volumeName, nil)
+	err = pool.MountCustomVolume(storageProjectName, volumeName, nil)
 	if err != nil {
 		return "", errors.Wrapf(err, "Failed mounting storage volume %q of type %q on storage pool %q", volumeName, volumeTypeName, pool.Name())
 	}
-
-	if ourMount {
-		reverter.Add(func() { pool.UnmountCustomVolume(storageProjectName, volumeName, nil) })
-	}
+	reverter.Add(func() { pool.UnmountCustomVolume(storageProjectName, volumeName, nil) })
 
 	_, vol, err := d.state.Cluster.GetLocalStoragePoolVolume(storageProjectName, volumeName, db.StoragePoolVolumeTypeCustom, pool.ID())
 	if err != nil {

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -245,6 +245,8 @@ func (d *disk) CanHotPlug() (bool, []string) {
 	return true, []string{"limits.max", "limits.read", "limits.write", "size"}
 }
 
+// Register calls mount for the disk volume (which should already be mounted) to reinitialise the reference counter
+// for volumes attached to running instances on LXD restart.
 func (d *disk) Register() error {
 	d.logger.Debug("Initialising mounted disk ref counter")
 
@@ -254,6 +256,7 @@ func (d *disk) Register() error {
 			return err
 		}
 
+		// Try to mount the volume that should already be mounted to reinitialise the ref counter.
 		_, err = pool.MountInstance(d.inst, nil)
 		if err != nil {
 			return err
@@ -269,6 +272,7 @@ func (d *disk) Register() error {
 			return err
 		}
 
+		// Try to mount the volume that should already be mounted to reinitialise the ref counter.
 		err = pool.MountCustomVolume(storageProjectName, d.config["source"], nil)
 		if err != nil {
 			return err

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -245,6 +245,39 @@ func (d *disk) CanHotPlug() (bool, []string) {
 	return true, []string{"limits.max", "limits.read", "limits.write", "size"}
 }
 
+func (d *disk) Register() error {
+	d.logger.Debug("Initialising mounted disk ref counter")
+
+	if d.config["path"] == "/" {
+		pool, err := storagePools.GetPoolByInstance(d.state, d.inst)
+		if err != nil {
+			return err
+		}
+
+		_, err = pool.MountInstance(d.inst, nil)
+		if err != nil {
+			return err
+		}
+	} else if d.config["path"] != "/" && d.config["source"] != "" && d.config["pool"] != "" {
+		pool, err := storagePools.GetPoolByName(d.state, d.config["pool"])
+		if err != nil {
+			return err
+		}
+
+		storageProjectName, err := project.StorageVolumeProject(d.state.Cluster, d.inst.Project(), db.StoragePoolVolumeTypeCustom)
+		if err != nil {
+			return err
+		}
+
+		err = pool.MountCustomVolume(storageProjectName, d.config["source"], nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // Start is run when the device is added to the instance.
 func (d *disk) Start() (*deviceConfig.RunConfig, error) {
 	err := d.validateEnvironment()

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -583,7 +583,7 @@ func deviceEventListener(s *state.State) {
 
 // devicesRegister calls the Register() function on all supported devices so they receive events.
 func devicesRegister(s *state.State) {
-	instances, err := instance.LoadNodeAll(s, instancetype.Container)
+	instances, err := instance.LoadNodeAll(s, instancetype.Any)
 	if err != nil {
 		logger.Error("Problem loading instances list", log.Ctx{"err": err})
 		return

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -402,13 +402,11 @@ func instanceCreateAsSnapshot(s *state.State, args db.InstanceArgs, sourceInstan
 	}
 
 	// Mount volume for backup.yaml writing.
-	mountInfo, err := pool.MountInstance(sourceInstance, op)
+	_, err = pool.MountInstance(sourceInstance, op)
 	if err != nil {
 		return nil, errors.Wrap(err, "Create instance snapshot (mount source)")
 	}
-	if mountInfo.OurMount {
-		defer pool.UnmountInstance(sourceInstance, op)
-	}
+	defer pool.UnmountInstance(sourceInstance, op)
 
 	// Attempt to update backup.yaml for instance.
 	err = sourceInstance.UpdateBackupFile()

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -2,13 +2,14 @@ package drivers
 
 import (
 	"errors"
+	"time"
+
 	"github.com/lxc/lxd/lxd/db"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared/api"
-	"time"
 )
 
 // common provides structure common to all instance types.

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -96,8 +96,8 @@ func (c *common) DevPaths() []string {
 	return c.devPaths
 }
 
-// Restart handles instance restarts.
-func (c *common) Restart(inst instance.Instance, timeout time.Duration) error {
+// restart handles instance restarts.
+func (c *common) restart(inst instance.Instance, timeout time.Duration) error {
 	if timeout == 0 {
 		err := inst.Stop(false)
 		if err != nil {

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1988,6 +1988,16 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 		}
 	}
 
+	// Rotate the log file.
+	logfile := c.LogFilePath()
+	if shared.PathExists(logfile) {
+		os.Remove(logfile + ".old")
+		err := os.Rename(logfile, logfile+".old")
+		if err != nil {
+			return "", nil, err
+		}
+	}
+
 	// Mount instance root volume.
 	_, err = c.mount()
 	if err != nil {
@@ -2103,16 +2113,6 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 	err = os.MkdirAll(c.ShmountsPath(), 0711)
 	if err != nil {
 		return "", nil, err
-	}
-
-	// Rotate the log file.
-	logfile := c.LogFilePath()
-	if shared.PathExists(logfile) {
-		os.Remove(logfile + ".old")
-		err := os.Rename(logfile, logfile+".old")
-		if err != nil {
-			return "", nil, err
-		}
 	}
 
 	// Generate UUID if not present.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1988,6 +1988,13 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 		}
 	}
 
+	// Mount instance root volume.
+	_, err = c.mount()
+	if err != nil {
+		return "", nil, err
+	}
+	revert.Add(func() { c.unmount() })
+
 	/* Deal with idmap changes */
 	nextIdmap, err := c.NextIdmap()
 	if err != nil {
@@ -1998,13 +2005,6 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 	if err != nil {
 		return "", nil, errors.Wrap(err, "Set last ID map")
 	}
-
-	// Mount instance root volume.
-	_, err = c.mount()
-	if err != nil {
-		return "", nil, err
-	}
-	revert.Add(func() { c.unmount() })
 
 	// Once mounted, check if filesystem needs shifting.
 	if !nextIdmap.Equals(diskIdmap) && !(diskIdmap == nil && c.state.OS.Shiftfs) {

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2831,7 +2831,7 @@ func (c *lxc) Shutdown(timeout time.Duration) error {
 
 // Restart restart the instance.
 func (c *lxc) Restart(timeout time.Duration) error {
-	return c.common.Restart(c, timeout)
+	return c.common.restart(c, timeout)
 }
 
 // onStopNS is triggered by LXC's stop hook once a container is shutdown but before the container's

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5965,16 +5965,6 @@ func (c *lxc) getStorageType() (string, error) {
 	return pool.Driver().Info().Name, nil
 }
 
-// StorageStart mounts the instance's rootfs volume. Deprecated.
-func (c *lxc) StorageStart() (bool, error) {
-	mountInfo, err := c.mount()
-	if err != nil {
-		return false, err
-	}
-
-	return mountInfo.OurMount, nil
-}
-
 // mount the instance's rootfs volume if needed.
 func (c *lxc) mount() (*storagePools.MountInfo, error) {
 	pool, err := c.getStoragePool()
@@ -5997,11 +5987,6 @@ func (c *lxc) mount() (*storagePools.MountInfo, error) {
 	}
 
 	return mountInfo, nil
-}
-
-// StorageStop unmounts the instance's rootfs volume. Deprecated.
-func (c *lxc) StorageStop() (bool, error) {
-	return c.unmount()
 }
 
 // unmount the instance's rootfs volume if needed.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4705,16 +4705,6 @@ func (vm *qemu) SetOperation(op *operations.Operation) {
 	vm.op = op
 }
 
-// StorageStart deprecated.
-func (vm *qemu) StorageStart() (bool, error) {
-	return false, storagePools.ErrNotImplemented
-}
-
-// StorageStop deprecated.
-func (vm *qemu) StorageStop() (bool, error) {
-	return false, storagePools.ErrNotImplemented
-}
-
 // DeferTemplateApply not used currently.
 func (vm *qemu) DeferTemplateApply(trigger string) error {
 	err := vm.VolatileSet(map[string]string{"volatile.apply_template": trigger})

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -376,7 +376,8 @@ func (vm *qemu) getStoragePool() (storagePools.Pool, error) {
 }
 
 func (vm *qemu) getMonitorEventHandler() func(event string, data map[string]interface{}) {
-	id := vm.id
+	projectName := vm.Project()
+	instanceName := vm.Name()
 	state := vm.state
 
 	return func(event string, data map[string]interface{}) {
@@ -384,9 +385,9 @@ func (vm *qemu) getMonitorEventHandler() func(event string, data map[string]inte
 			return
 		}
 
-		inst, err := instance.LoadByID(state, id)
+		inst, err := instance.LoadByProjectAndName(state, projectName, instanceName)
 		if err != nil {
-			logger.Errorf("Failed to load instance with id=%d", id)
+			logger.Error("Failed to load instance", "project", projectName, "instance", instanceName, "err", err)
 			return
 		}
 
@@ -399,7 +400,7 @@ func (vm *qemu) getMonitorEventHandler() func(event string, data map[string]inte
 
 			err = inst.(*qemu).onStop(target)
 			if err != nil {
-				logger.Errorf("Failed to cleanly stop instance '%s': %v", project.Instance(inst.Project(), inst.Name()), err)
+				logger.Error("Failed to cleanly stop instance", "project", projectName, "instance", instanceName, "err", err)
 				return
 			}
 		}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -648,7 +648,7 @@ func (vm *qemu) Shutdown(timeout time.Duration) error {
 
 // Restart restart the instance.
 func (vm *qemu) Restart(timeout time.Duration) error {
-	return vm.common.Restart(vm, timeout)
+	return vm.common.restart(vm, timeout)
 }
 
 func (vm *qemu) ovmfPath() string {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1342,19 +1342,13 @@ func (vm *qemu) spicePath() string {
 // generateConfigShare generates the config share directory that will be exported to the VM via
 // a 9P share. Due to the unknown size of templates inside the images this directory is created
 // inside the VM's config volume so that it can be restricted by quota.
+// Requires the instance be mounted before calling this function.
 func (vm *qemu) generateConfigShare() error {
-	// Mount the instance's config volume if needed.
-	_, err := vm.mount()
-	if err != nil {
-		return err
-	}
-	defer vm.unmount()
-
 	configDrivePath := filepath.Join(vm.Path(), "config")
 
 	// Create config drive dir.
 	os.RemoveAll(configDrivePath)
-	err = os.MkdirAll(configDrivePath, 0500)
+	err := os.MkdirAll(configDrivePath, 0500)
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -138,8 +138,6 @@ type Instance interface {
 
 	// FIXME: Those should be internal functions.
 	// Needed for migration for now.
-	StorageStart() (bool, error)
-	StorageStop() (bool, error)
 	DeferTemplateApply(trigger string) error
 }
 

--- a/lxd/instance_metadata.go
+++ b/lxd/instance_metadata.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/response"
+	storagePools "github.com/lxc/lxd/lxd/storage"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -42,18 +43,21 @@ func containerMetadataGet(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.SmartError(err)
 	}
-	metadataPath := filepath.Join(c.Path(), "metadata.yaml")
 
 	// Start the storage if needed
-	ourStart, err := c.StorageStart()
+	pool, err := storagePools.GetPoolByInstance(d.State(), c)
 	if err != nil {
 		return response.SmartError(err)
 	}
-	if ourStart {
-		defer c.StorageStop()
+
+	_, err = storagePools.InstanceMount(pool, c, nil)
+	if err != nil {
+		return response.SmartError(err)
 	}
+	defer storagePools.InstanceUnmount(pool, c, nil)
 
 	// If missing, just return empty result
+	metadataPath := filepath.Join(c.Path(), "metadata.yaml")
 	if !shared.PathExists(metadataPath) {
 		return response.SyncResponse(true, api.ImageMetadata{})
 	}
@@ -103,16 +107,18 @@ func containerMetadataPut(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.SmartError(err)
 	}
-	metadataPath := filepath.Join(c.Path(), "metadata.yaml")
 
 	// Start the storage if needed
-	ourStart, err := c.StorageStart()
+	pool, err := storagePools.GetPoolByInstance(d.State(), c)
 	if err != nil {
 		return response.SmartError(err)
 	}
-	if ourStart {
-		defer c.StorageStop()
+
+	_, err = storagePools.InstanceMount(pool, c, nil)
+	if err != nil {
+		return response.SmartError(err)
 	}
+	defer storagePools.InstanceUnmount(pool, c, nil)
 
 	// Read the new metadata
 	metadata := api.ImageMetadata{}
@@ -126,6 +132,7 @@ func containerMetadataPut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
+	metadataPath := filepath.Join(c.Path(), "metadata.yaml")
 	if err := ioutil.WriteFile(metadataPath, data, 0644); err != nil {
 		return response.InternalError(err)
 	}
@@ -159,13 +166,16 @@ func containerMetadataTemplatesGet(d *Daemon, r *http.Request) response.Response
 	}
 
 	// Start the storage if needed
-	ourStart, err := c.StorageStart()
+	pool, err := storagePools.GetPoolByInstance(d.State(), c)
 	if err != nil {
 		return response.SmartError(err)
 	}
-	if ourStart {
-		defer c.StorageStop()
+
+	_, err = storagePools.InstanceMount(pool, c, nil)
+	if err != nil {
+		return response.SmartError(err)
 	}
+	defer storagePools.InstanceUnmount(pool, c, nil)
 
 	// Look at the request
 	templateName := r.FormValue("path")
@@ -253,13 +263,16 @@ func containerMetadataTemplatesPostPut(d *Daemon, r *http.Request) response.Resp
 	}
 
 	// Start the storage if needed
-	ourStart, err := c.StorageStart()
+	pool, err := storagePools.GetPoolByInstance(d.State(), c)
 	if err != nil {
 		return response.SmartError(err)
 	}
-	if ourStart {
-		defer c.StorageStop()
+
+	_, err = storagePools.InstanceMount(pool, c, nil)
+	if err != nil {
+		return response.SmartError(err)
 	}
+	defer storagePools.InstanceUnmount(pool, c, nil)
 
 	// Look at the request
 	templateName := r.FormValue("path")
@@ -326,13 +339,16 @@ func containerMetadataTemplatesDelete(d *Daemon, r *http.Request) response.Respo
 	}
 
 	// Start the storage if needed
-	ourStart, err := c.StorageStart()
+	pool, err := storagePools.GetPoolByInstance(d.State(), c)
 	if err != nil {
 		return response.SmartError(err)
 	}
-	if ourStart {
-		defer c.StorageStop()
+
+	_, err = storagePools.InstanceMount(pool, c, nil)
+	if err != nil {
+		return response.SmartError(err)
 	}
+	defer storagePools.InstanceUnmount(pool, c, nil)
 
 	// Look at the request
 	templateName := r.FormValue("path")

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -146,7 +146,9 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 	c2, err := instance.LoadByProjectAndName(state, "default", "testFoo")
 	c2.IsRunning()
 	suite.Req.Nil(err)
-	_, err = c2.StorageStart()
+
+	// This causes the mock storage pool to be loaded internally, allowing it to match the created container.
+	err = c2.UpdateBackupFile()
 	suite.Req.Nil(err)
 
 	instanceDrivers.PrepareEqualTest(c, c2)

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -1575,15 +1575,12 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 				err = func() error {
 					// In case the new LVM logical volume for the container is not mounted mount it.
 					if !shared.IsMountPoint(newContainerMntPoint) {
-						mountInfo, err := pool.MountInstance(ctStruct, nil)
+						_, err = pool.MountInstance(ctStruct, nil)
 						if err != nil {
 							logger.Errorf("Failed to mount new empty LVM logical volume for container %s: %s", ct, err)
 							return err
 						}
-
-						if mountInfo.OurMount {
-							defer pool.UnmountInstance(ctStruct, nil)
-						}
+						defer pool.UnmountInstance(ctStruct, nil)
 					}
 
 					// Use rsync to fill the empty volume.
@@ -1741,15 +1738,12 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 					err = func() error {
 						// In case the new LVM logical volume for the snapshot is not mounted mount it.
 						if !shared.IsMountPoint(newSnapshotMntPoint) {
-							mountInfo, err := pool.MountInstanceSnapshot(csStruct, nil)
+							_, err = pool.MountInstanceSnapshot(csStruct, nil)
 							if err != nil {
 								logger.Errorf("Failed to mount new empty LVM logical volume for container %s: %s", cs, err)
 								return err
 							}
-
-							if mountInfo.OurMount {
-								defer pool.UnmountInstanceSnapshot(csStruct, nil)
-							}
+							defer pool.UnmountInstanceSnapshot(csStruct, nil)
 						}
 
 						// Use rsync to fill the snapshot volume.
@@ -3377,14 +3371,11 @@ func patchStorageApiPermissions(name string, d *Daemon) error {
 
 			// Run task in anonymous function so as not to stack up defers.
 			err = func() error {
-				ourMount, err := pool.MountCustomVolume(project.Default, vol, nil)
+				err = pool.MountCustomVolume(project.Default, vol, nil)
 				if err != nil {
 					return err
 				}
-
-				if ourMount {
-					defer pool.UnmountCustomVolume(project.Default, vol, nil)
-				}
+				defer pool.UnmountCustomVolume(project.Default, vol, nil)
 
 				cuMntPoint := storageDrivers.GetVolumeMountPath(poolName, storageDrivers.VolumeTypeCustom, vol)
 				err = os.Chmod(cuMntPoint, 0711)
@@ -3407,25 +3398,29 @@ func patchStorageApiPermissions(name string, d *Daemon) error {
 
 	for _, ct := range cRegular {
 		// load the container from the database
-		ctStruct, err := instance.LoadByProjectAndName(d.State(), "default", ct)
+		inst, err := instance.LoadByProjectAndName(d.State(), project.Default, ct)
 		if err != nil {
 			return err
 		}
 
-		ourMount, err := ctStruct.StorageStart()
+		// Start the storage if needed
+		pool, err := storagePools.GetPoolByInstance(d.State(), inst)
 		if err != nil {
 			return err
 		}
 
-		if ctStruct.IsPrivileged() {
-			err = os.Chmod(ctStruct.Path(), 0700)
+		_, err = storagePools.InstanceMount(pool, inst, nil)
+		if err != nil {
+			return err
+		}
+
+		if inst.IsPrivileged() {
+			err = os.Chmod(inst.Path(), 0700)
 		} else {
-			err = os.Chmod(ctStruct.Path(), 0711)
+			err = os.Chmod(inst.Path(), 0711)
 		}
 
-		if ourMount {
-			ctStruct.StorageStop()
-		}
+		storagePools.InstanceUnmount(pool, inst, nil)
 
 		if err != nil && !os.IsNotExist(err) {
 			return err

--- a/lxd/refcount/refcount.go
+++ b/lxd/refcount/refcount.go
@@ -1,0 +1,52 @@
+package refcount
+
+import (
+	"fmt"
+	"sync"
+)
+
+var refCounters = map[string]uint{}
+
+// refCounterMutex is used to access refCounters safely.
+var refCounterMutex sync.Mutex
+
+// Increment increases a refCounter by the value. If the ref counter doesn't exist, a new one is created.
+// The counter's new value is returned.
+func Increment(refCounter string, value uint) uint {
+	refCounterMutex.Lock()
+	defer refCounterMutex.Unlock()
+
+	v := refCounters[refCounter]
+	oldValue := v
+	v = v + value
+
+	if v < oldValue {
+		panic(fmt.Sprintf("Ref counter %q overflowed from %d to %d", refCounter, oldValue, v))
+	}
+
+	refCounters[refCounter] = v
+
+	return v
+}
+
+// Decrement decreases a refCounter by the value. If the ref counter doesn't exist, a new one is created.
+// The counter's new value is returned. A counter cannot be decreased below zero.
+func Decrement(refCounter string, value uint) uint {
+	refCounterMutex.Lock()
+	defer refCounterMutex.Unlock()
+
+	v := refCounters[refCounter]
+	if v < value {
+		v = 0
+	} else {
+		v = v - value
+	}
+
+	if v == 0 {
+		delete(refCounters, refCounter)
+	} else {
+		refCounters[refCounter] = v
+	}
+
+	return v
+}

--- a/lxd/refcount/refcount_test.go
+++ b/lxd/refcount/refcount_test.go
@@ -1,0 +1,53 @@
+package refcount
+
+import (
+	"fmt"
+)
+
+func ExampleIncrement() {
+	refCounter1 := "testinc1"
+	fmt.Println(Increment(refCounter1, 1))
+	fmt.Println(Increment(refCounter1, 1))
+	fmt.Println(Increment(refCounter1, 2))
+
+	refCounter2 := "testinc2"
+	fmt.Println(Increment(refCounter2, 1))
+	fmt.Println(Increment(refCounter2, 10))
+
+	// Test overflow panic.
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Printf("Recovered: %v\n", r)
+		}
+	}()
+	var maxUint uint = ^uint(0)
+	fmt.Println(Increment(refCounter2, maxUint))
+
+	// Output: 1
+	// 2
+	// 4
+	// 1
+	// 11
+	// Recovered: Ref counter "testinc2" overflowed from 11 to 10
+}
+
+func ExampleDecrement() {
+	refCounter1 := "testdec1"
+	fmt.Println(Increment(refCounter1, 10))
+	fmt.Println(Decrement(refCounter1, 1))
+	fmt.Println(Decrement(refCounter1, 2))
+
+	refCounter2 := "testdec2"
+	fmt.Println(Decrement(refCounter2, 1))
+	fmt.Println(Increment(refCounter2, 1))
+	fmt.Println(Decrement(refCounter2, 1))
+	fmt.Println(Decrement(refCounter2, 1))
+
+	// Output: 10
+	// 9
+	// 7
+	// 0
+	// 1
+	// 0
+	// 0
+}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -626,6 +626,10 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		return fmt.Errorf("Instance types must match")
 	}
 
+	if src.Type() == instancetype.VM && src.IsRunning() {
+		return errors.Wrap(ErrNotImplemented, "Unable to perform VM live migration")
+	}
+
 	volType, err := InstanceTypeToVolumeType(inst.Type())
 	if err != nil {
 		return err

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1643,7 +1643,7 @@ func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operat
 	// Get the volume.
 	vol := b.newVolume(volType, contentType, volStorageName, rootDiskConf)
 
-	ourMount, err := b.driver.MountVolume(vol, op)
+	err = b.driver.MountVolume(vol, op)
 	if err != nil {
 		return nil, err
 	}
@@ -1654,7 +1654,6 @@ func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operat
 	}
 
 	mountInfo := &MountInfo{
-		OurMount: ourMount,
 		DiskPath: diskPath,
 	}
 
@@ -2022,7 +2021,7 @@ func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, op *operation
 	// Get the volume.
 	vol := b.newVolume(volType, contentType, volStorageName, rootDiskConf)
 
-	ourMount, err := b.driver.MountVolumeSnapshot(vol, op)
+	_, err = b.driver.MountVolumeSnapshot(vol, op)
 	if err != nil {
 		return nil, err
 	}
@@ -2033,7 +2032,6 @@ func (b *lxdBackend) MountInstanceSnapshot(inst instance.Instance, op *operation
 	}
 
 	mountInfo := &MountInfo{
-		OurMount: ourMount,
 		DiskPath: diskPath,
 	}
 
@@ -3050,14 +3048,14 @@ func (b *lxdBackend) GetCustomVolumeUsage(projectName, volName string) (int64, e
 }
 
 // MountCustomVolume mounts a custom volume.
-func (b *lxdBackend) MountCustomVolume(projectName, volName string, op *operations.Operation) (bool, error) {
+func (b *lxdBackend) MountCustomVolume(projectName, volName string, op *operations.Operation) error {
 	logger := logging.AddContext(b.logger, log.Ctx{"project": projectName, "volName": volName})
 	logger.Debug("MountCustomVolume started")
 	defer logger.Debug("MountCustomVolume finished")
 
 	_, volume, err := b.state.Cluster.GetLocalStoragePoolVolume(projectName, volName, db.StoragePoolVolumeTypeCustom, b.id)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	// Get the volume name on storage.

--- a/lxd/storage/backend_lxd_patches.go
+++ b/lxd/storage/backend_lxd_patches.go
@@ -129,7 +129,7 @@ func lxdPatchStorageRenameCustomVolumeAddProject(b *lxdBackend) error {
 
 			if ourUnmount {
 				logger.Infof("Mount custom volume %q in pool %q", newVolStorageName, b.Name())
-				_, err = b.driver.MountVolume(newVol, nil)
+				err = b.driver.MountVolume(newVol, nil)
 				if err != nil {
 					return err
 				}

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -211,8 +211,8 @@ func (b *mockBackend) GetCustomVolumeUsage(projectName string, volName string) (
 	return 0, nil
 }
 
-func (b *mockBackend) MountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error) {
-	return true, nil
+func (b *mockBackend) MountCustomVolume(projectName string, volName string, op *operations.Operation) error {
+	return nil
 }
 
 func (b *mockBackend) UnmountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error) {

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -128,7 +128,7 @@ func (b *mockBackend) SetInstanceQuota(inst instance.Instance, size string, op *
 }
 
 func (b *mockBackend) MountInstance(inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
-	return &MountInfo{OurMount: true}, nil
+	return &MountInfo{}, nil
 }
 
 func (b *mockBackend) UnmountInstance(inst instance.Instance, op *operations.Operation) (bool, error) {
@@ -152,7 +152,7 @@ func (b *mockBackend) RestoreInstanceSnapshot(inst instance.Instance, src instan
 }
 
 func (b *mockBackend) MountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
-	return &MountInfo{OurMount: true}, nil
+	return &MountInfo{}, nil
 }
 
 func (b *mockBackend) UnmountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (bool, error) {

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -755,9 +755,8 @@ func (d *btrfs) GetVolumeDiskPath(vol Volume) (string, error) {
 	return genericVFSGetVolumeDiskPath(vol)
 }
 
-// MountVolume simulates mounting a volume. As the driver doesn't have volumes to mount it returns
-// false indicating that there is no need to issue an unmount.
-func (d *btrfs) MountVolume(vol Volume, op *operations.Operation) (bool, error) {
+// MountVolume simulates mounting a volume.
+func (d *btrfs) MountVolume(vol Volume, op *operations.Operation) error {
 	unlock := vol.MountLock()
 	defer unlock()
 
@@ -766,11 +765,11 @@ func (d *btrfs) MountVolume(vol Volume, op *operations.Operation) (bool, error) 
 	if !shared.PathExists(vol.MountPath()) || vol.volType != VolumeTypeCustom {
 		err := vol.EnsureMountPath()
 		if err != nil {
-			return false, err
+			return err
 		}
 	}
 
-	return false, nil
+	return nil
 }
 
 // UnmountVolume simulates unmounting a volume.

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -923,43 +923,47 @@ func (d *ceph) GetVolumeDiskPath(vol Volume) (string, error) {
 	return "", ErrNotSupported
 }
 
-// MountVolume simulates mounting a volume.
-func (d *ceph) MountVolume(vol Volume, op *operations.Operation) (bool, error) {
+// MountVolume mounts a volume and increments ref counter. Please call UnmountVolume() when done with the volume.
+func (d *ceph) MountVolume(vol Volume, op *operations.Operation) error {
 	unlock := vol.MountLock()
 	defer unlock()
 
-	mountPath := vol.MountPath()
-
 	// Activate RBD volume if needed.
-	ourMount, devPath, err := d.getRBDMappedDevPath(vol, true)
+	_, devPath, err := d.getRBDMappedDevPath(vol, true)
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	if vol.contentType == ContentTypeFS && !shared.IsMountPoint(mountPath) {
-		err := vol.EnsureMountPath()
-		if err != nil {
-			return false, err
+	if vol.contentType == ContentTypeFS {
+		mountPath := vol.MountPath()
+		if !shared.IsMountPoint(mountPath) {
+			err := vol.EnsureMountPath()
+			if err != nil {
+				return err
+			}
+
+			RBDFilesystem := vol.ConfigBlockFilesystem()
+			mountFlags, mountOptions := resolveMountOptions(vol.ConfigBlockMountOptions())
+			err = TryMount(devPath, mountPath, RBDFilesystem, mountFlags, mountOptions)
+			if err != nil {
+				return err
+			}
+
+			d.logger.Debug("Mounted RBD volume", log.Ctx{"dev": devPath, "path": mountPath, "options": mountOptions})
 		}
-
-		RBDFilesystem := vol.ConfigBlockFilesystem()
-		mountFlags, mountOptions := resolveMountOptions(vol.ConfigBlockMountOptions())
-		err = TryMount(devPath, mountPath, RBDFilesystem, mountFlags, mountOptions)
-		if err != nil {
-			return false, err
+	} else if vol.contentType == ContentTypeBlock {
+		// For VMs, mount the filesystem volume.
+		if vol.IsVMBlock() {
+			fsVol := vol.NewVMBlockFilesystemVolume()
+			err = d.MountVolume(fsVol, op)
+			if err != nil {
+				return err
+			}
 		}
-		d.logger.Debug("Mounted RBD volume", log.Ctx{"dev": devPath, "path": mountPath, "options": mountOptions})
-
-		return true, nil
 	}
 
-	// For VMs, mount the filesystem volume.
-	if vol.IsVMBlock() {
-		fsVol := vol.NewVMBlockFilesystemVolume()
-		return d.MountVolume(fsVol, op)
-	}
-
-	return ourMount, nil
+	vol.MountRefCountIncrement() // From here on it is up to caller to call UnmountVolume() when done.
+	return nil
 }
 
 // UnmountVolume simulates unmounting a volume.
@@ -968,41 +972,62 @@ func (d *ceph) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Opera
 	unlock := vol.MountLock()
 	defer unlock()
 
-	// Attempt to unmount the volume.
-	mountPath := vol.MountPath()
-	if vol.contentType == ContentTypeFS && shared.IsMountPoint(mountPath) {
-		err := TryUnmount(mountPath, unix.MNT_DETACH)
-		if err != nil {
-			return false, err
-		}
-		d.logger.Debug("Unmounted RBD volume", log.Ctx{"path": mountPath, "keepBlockDev": keepBlockDev})
+	ourUnmount := false
+	refCount := vol.MountRefCountDecrement()
 
-		// Attempt to unmap.
-		if !keepBlockDev {
-			err = d.rbdUnmapVolume(vol, true)
+	// Attempt to unmount the volume.
+	if vol.contentType == ContentTypeFS {
+		mountPath := vol.MountPath()
+		if shared.IsMountPoint(mountPath) {
+			if refCount > 0 {
+				d.logger.Debug("Skipping unmount as in use", "refCount", refCount)
+				return false, ErrInUse
+			}
+
+			err := TryUnmount(mountPath, unix.MNT_DETACH)
 			if err != nil {
 				return false, err
 			}
+			d.logger.Debug("Unmounted RBD volume", log.Ctx{"path": mountPath, "keepBlockDev": keepBlockDev})
+
+			// Attempt to unmap.
+			if !keepBlockDev {
+				err = d.rbdUnmapVolume(vol, true)
+				if err != nil {
+					return false, err
+				}
+			}
+
+			ourUnmount = true
+		}
+	} else if vol.contentType == ContentTypeBlock {
+		// For VMs, unmount the filesystem volume.
+		if vol.IsVMBlock() {
+			fsVol := vol.NewVMBlockFilesystemVolume()
+			return d.UnmountVolume(fsVol, false, op)
 		}
 
-		return true, nil
-	}
+		if !keepBlockDev {
+			// Check if device is currently mapped (but don't map if not).
+			_, devPath, _ := d.getRBDMappedDevPath(vol, false)
+			if devPath != "" && shared.PathExists(devPath) {
+				if refCount > 0 {
+					d.logger.Debug("Skipping unmount as in use", "refCount", refCount)
+					return false, ErrInUse
+				}
 
-	if vol.contentType == ContentTypeBlock && !keepBlockDev {
-		// Attempt to unmap.
-		err := d.rbdUnmapVolume(vol, true)
-		if err != nil {
-			return false, err
+				// Attempt to unmap.
+				err := d.rbdUnmapVolume(vol, true)
+				if err != nil {
+					return false, err
+				}
+
+				ourUnmount = true
+			}
 		}
 	}
 
-	// For VMs, unmount the filesystem volume.
-	if vol.IsVMBlock() {
-		fsVol := vol.NewVMBlockFilesystemVolume()
-		return d.UnmountVolume(fsVol, false, op)
-	}
-
-	return false, nil
+	return ourUnmount, nil
 }
 
 // RenameVolume renames a volume and its snapshots.
@@ -1059,13 +1084,11 @@ func (d *ceph) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mi
 		// activated to avoid issues activating the snapshot volume device.
 		parent, _, _ := shared.InstanceGetParentAndSnapshotName(vol.Name())
 		parentVol := NewVolume(d, d.Name(), vol.volType, vol.contentType, parent, vol.config, vol.poolConfig)
-		ourMount, err := d.MountVolume(parentVol, op)
+		err := d.MountVolume(parentVol, op)
 		if err != nil {
 			return err
 		}
-		if ourMount {
-			defer d.UnmountVolume(parentVol, false, op)
-		}
+		defer d.UnmountVolume(parentVol, false, op)
 
 		return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
 	} else if volSrcArgs.MigrationType.FSType != migration.MigrationFSType_RBD {

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -338,11 +338,11 @@ func (d *cephfs) GetVolumeDiskPath(vol Volume) (string, error) {
 }
 
 // MountVolume sets up the volume for use.
-func (d *cephfs) MountVolume(vol Volume, op *operations.Operation) (bool, error) {
+func (d *cephfs) MountVolume(vol Volume, op *operations.Operation) error {
 	unlock := vol.MountLock()
 	defer unlock()
 
-	return false, nil
+	return nil
 }
 
 // UnmountVolume clears any runtime state for the volume.

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -307,9 +307,8 @@ func (d *dir) GetVolumeDiskPath(vol Volume) (string, error) {
 	return genericVFSGetVolumeDiskPath(vol)
 }
 
-// MountVolume simulates mounting a volume. As the driver doesn't have volumes to mount it returns
-// false indicating that there is no need to issue an unmount.
-func (d *dir) MountVolume(vol Volume, op *operations.Operation) (bool, error) {
+// MountVolume simulates mounting a volume.
+func (d *dir) MountVolume(vol Volume, op *operations.Operation) error {
 	unlock := vol.MountLock()
 	defer unlock()
 
@@ -318,11 +317,11 @@ func (d *dir) MountVolume(vol Volume, op *operations.Operation) (bool, error) {
 	if !shared.PathExists(vol.MountPath()) || vol.volType != VolumeTypeCustom {
 		err := vol.EnsureMountPath()
 		if err != nil {
-			return false, err
+			return err
 		}
 	}
 
-	return false, nil
+	return nil
 }
 
 // UnmountVolume simulates unmounting a volume.

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -431,90 +431,112 @@ func (d *lvm) GetVolumeDiskPath(vol Volume) (string, error) {
 	return "", ErrNotSupported
 }
 
-// MountVolume mounts a volume. Returns true if this volume was our mount.
-func (d *lvm) MountVolume(vol Volume, op *operations.Operation) (bool, error) {
+// MountVolume mounts a volume and increments ref counter. Please call UnmountVolume() when done with the volume.
+func (d *lvm) MountVolume(vol Volume, op *operations.Operation) error {
 	unlock := vol.MountLock()
 	defer unlock()
 
 	// Activate LVM volume if needed.
 	volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, vol.name)
-	activated, err := d.activateVolume(volDevPath)
+	_, err := d.activateVolume(volDevPath)
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	// Check if already mounted.
-	mountPath := vol.MountPath()
-	if vol.contentType == ContentTypeFS && !shared.IsMountPoint(mountPath) {
-		err = vol.EnsureMountPath()
-		if err != nil {
-			return false, err
+	if vol.contentType == ContentTypeFS {
+		// Check if already mounted.
+		mountPath := vol.MountPath()
+		if !shared.IsMountPoint(mountPath) {
+			err = vol.EnsureMountPath()
+			if err != nil {
+				return err
+			}
+
+			mountFlags, mountOptions := resolveMountOptions(vol.ConfigBlockMountOptions())
+			err = TryMount(volDevPath, mountPath, vol.ConfigBlockFilesystem(), mountFlags, mountOptions)
+			if err != nil {
+				return errors.Wrapf(err, "Failed to mount LVM logical volume")
+			}
+			d.logger.Debug("Mounted logical volume", log.Ctx{"dev": volDevPath, "path": mountPath, "options": mountOptions})
 		}
-
-		mountFlags, mountOptions := resolveMountOptions(vol.ConfigBlockMountOptions())
-		err = TryMount(volDevPath, mountPath, vol.ConfigBlockFilesystem(), mountFlags, mountOptions)
-		if err != nil {
-			return false, errors.Wrapf(err, "Failed to mount LVM logical volume")
+	} else if vol.contentType == ContentTypeBlock {
+		// For VMs, mount the filesystem volume.
+		if vol.IsVMBlock() {
+			fsVol := vol.NewVMBlockFilesystemVolume()
+			err = d.MountVolume(fsVol, op)
+			if err != nil {
+				return err
+			}
 		}
-		d.logger.Debug("Mounted logical volume", log.Ctx{"dev": volDevPath, "path": mountPath, "options": mountOptions})
-
-		return true, nil
 	}
 
-	// For VMs, mount the filesystem volume.
-	if vol.IsVMBlock() {
-		fsVol := vol.NewVMBlockFilesystemVolume()
-		return d.MountVolume(fsVol, op)
-	}
-
-	return activated, nil
+	vol.MountRefCountIncrement() // From here on it is up to caller to call UnmountVolume() when done.
+	return nil
 }
 
-// UnmountVolume unmounts a volume. Returns true if we unmounted.
-// keepBlockDev indicates if backing block device should be not be deactivated if volume is unmounted.
+// UnmountVolume unmounts volume if mounted and not in use. Returns true if this unmounted the volume.
+// keepBlockDev indicates if backing block device should be not be deactivated when volume is unmounted.
 func (d *lvm) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
 	unlock := vol.MountLock()
 	defer unlock()
 
 	var err error
+	ourUnmount := false
 	volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, vol.name)
-	mountPath := vol.MountPath()
+	refCount := vol.MountRefCountDecrement()
 
 	// Check if already mounted.
-	if vol.contentType == ContentTypeFS && shared.IsMountPoint(mountPath) {
-		err = TryUnmount(mountPath, 0)
-		if err != nil {
-			return false, errors.Wrapf(err, "Failed to unmount LVM logical volume")
-		}
-		d.logger.Debug("Unmounted logical volume", log.Ctx{"path": mountPath, "keepBlockDev": keepBlockDev})
+	if vol.contentType == ContentTypeFS {
+		mountPath := vol.MountPath()
+		if shared.IsMountPoint(mountPath) {
+			if refCount > 0 {
+				d.logger.Debug("Skipping unmount as in use", "refCount", refCount)
+				return false, ErrInUse
+			}
 
-		// We only deactivate filesystem volumes if an unmount was needed to better align with our
-		// unmount return value indicator.
-		if !keepBlockDev {
-			_, err = d.deactivateVolume(volDevPath)
+			err = TryUnmount(mountPath, 0)
+			if err != nil {
+				return false, errors.Wrapf(err, "Failed to unmount LVM logical volume")
+			}
+			d.logger.Debug("Unmounted logical volume", log.Ctx{"path": mountPath, "keepBlockDev": keepBlockDev})
+
+			// We only deactivate filesystem volumes if an unmount was needed to better align with our
+			// unmount return value indicator.
+			if !keepBlockDev {
+				_, err = d.deactivateVolume(volDevPath)
+				if err != nil {
+					return false, err
+				}
+			}
+
+			ourUnmount = true
+		}
+	} else if vol.contentType == ContentTypeBlock {
+		// For VMs, unmount the filesystem volume.
+		if vol.IsVMBlock() {
+			fsVol := vol.NewVMBlockFilesystemVolume()
+			_, err = d.UnmountVolume(fsVol, false, op)
 			if err != nil {
 				return false, err
 			}
 		}
 
-		return true, nil
-	}
+		if !keepBlockDev && shared.PathExists(volDevPath) {
+			if refCount > 0 {
+				d.logger.Debug("Skipping unmount as in use", "refCount", refCount)
+				return false, ErrInUse
+			}
 
-	deactivated := false
-	if vol.contentType == ContentTypeBlock && !keepBlockDev {
-		deactivated, err = d.deactivateVolume(volDevPath)
-		if err != nil {
-			return false, err
+			_, err = d.deactivateVolume(volDevPath)
+			if err != nil {
+				return false, err
+			}
+
+			ourUnmount = true
 		}
 	}
 
-	// For VMs, unmount the filesystem volume.
-	if vol.IsVMBlock() {
-		fsVol := vol.NewVMBlockFilesystemVolume()
-		return d.UnmountVolume(fsVol, false, op)
-	}
-
-	return deactivated, nil
+	return ourUnmount, nil
 }
 
 // RenameVolume renames a volume and its snapshots.

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -415,6 +415,7 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 		if err != nil {
 			return nil, nil, err
 		}
+		revert.Add(func() { d.UnmountVolume(vol, false, op) })
 
 		postHook = func(vol Volume) error {
 			_, err := d.UnmountVolume(vol, false, op)

--- a/lxd/storage/drivers/drivers_mock.go
+++ b/lxd/storage/drivers/drivers_mock.go
@@ -141,10 +141,9 @@ func (d *mock) GetVolumeDiskPath(vol Volume) (string, error) {
 	return "", nil
 }
 
-// MountVolume simulates mounting a volume. As dir driver doesn't have volumes to mount it returns
-// false indicating that there is no need to issue an unmount.
-func (d *mock) MountVolume(vol Volume, op *operations.Operation) (bool, error) {
-	return false, nil
+// MountVolume simulates mounting a volume.
+func (d *mock) MountVolume(vol Volume, op *operations.Operation) error {
+	return nil
 }
 
 // UnmountVolume simulates unmounting a volume. As dir driver doesn't have volumes to unmount it

--- a/lxd/storage/drivers/errors.go
+++ b/lxd/storage/drivers/errors.go
@@ -16,6 +16,9 @@ var ErrNotSupported = fmt.Errorf("Not supported")
 // ErrCannotBeShrunk is the "Cannot be shrunk" error
 var ErrCannotBeShrunk = fmt.Errorf("Cannot be shrunk")
 
+// ErrInUse indicates operation cannot proceed as resource is in use.
+var ErrInUse = fmt.Errorf("In use")
+
 // ErrDeleteSnapshots is a special error used to tell the backend to delete more recent snapshots
 type ErrDeleteSnapshots struct {
 	Snapshots []string

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -775,6 +775,7 @@ func genericVFSBackupUnpack(d Driver, vol Volume, snapshots []string, srcData io
 	if err != nil {
 		return nil, nil, err
 	}
+	revert.Add(func() { d.UnmountVolume(vol, false, op) })
 
 	backupPrefix := "backup/container"
 	if vol.IsVMBlock() {

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -771,7 +771,7 @@ func genericVFSBackupUnpack(d Driver, vol Volume, snapshots []string, srcData io
 		revert.Add(func() { d.DeleteVolumeSnapshot(snapVol, op) })
 	}
 
-	ourMount, err := d.MountVolume(vol, op)
+	err = d.MountVolume(vol, op)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -805,17 +805,12 @@ func genericVFSBackupUnpack(d Driver, vol Volume, snapshots []string, srcData io
 		// backup restoration process). Create a post hook function that will be called at the end of the
 		// backup restore process to unmount the volume if needed.
 		postHook = func(vol Volume) error {
-			if ourMount {
-				d.UnmountVolume(vol, false, op)
-			}
-
+			d.UnmountVolume(vol, false, op)
 			return nil
 		}
 	} else {
 		// For custom volumes unmount now, there is no post hook as there is no backup.yaml to generate.
-		if ourMount {
-			d.UnmountVolume(vol, false, op)
-		}
+		d.UnmountVolume(vol, false, op)
 	}
 
 	return postHook, revertExternal.Fail, nil

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -57,9 +57,8 @@ type Driver interface {
 	SetVolumeQuota(vol Volume, size string, op *operations.Operation) error
 	GetVolumeDiskPath(vol Volume) (string, error)
 
-	// MountVolume mounts a storage volume, returns true if we caused a new mount, false if
-	// already mounted.
-	MountVolume(vol Volume, op *operations.Operation) (bool, error)
+	// MountVolume mounts a storage volume (if not mounted) and increments reference counter.
+	MountVolume(vol Volume, op *operations.Operation) error
 
 	// MountVolumeSnapshot mounts a storage volume snapshot as readonly, returns true if we
 	// caused a new mount, false if already mounted.

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -475,7 +475,7 @@ func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64)
 	case "": // if not specified, default to ext4.
 		fallthrough
 	case "xfs":
-		return errors.Wrapf(ErrCannotBeShrunk, `Shrinking not supported for filesystem type "%s". A dump, mkfs, and restore are required`, fsType)
+		return errors.Wrapf(ErrCannotBeShrunk, "Shrinking not supported for filesystem type %q. A dump, mkfs, and restore are required", fsType)
 	case "ext4":
 		return vol.UnmountTask(func(op *operations.Operation) error {
 			output, err := shared.RunCommand("e2fsck", "-f", "-y", devPath)
@@ -516,7 +516,7 @@ func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64)
 			return nil
 		}, nil)
 	default:
-		return errors.Wrapf(ErrCannotBeShrunk, `Shrinking not supported for filesystem type "%s"`, fsType)
+		return errors.Wrapf(ErrCannotBeShrunk, "Shrinking not supported for filesystem type %q", fsType)
 	}
 }
 

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -217,14 +217,11 @@ func (v Volume) MountTask(task func(mountPath string, op *operations.Operation) 
 			defer v.driver.UnmountVolumeSnapshot(v, op)
 		}
 	} else {
-		ourMount, err := v.driver.MountVolume(v, op)
+		err := v.driver.MountVolume(v, op)
 		if err != nil {
 			return err
 		}
-
-		if ourMount {
-			defer v.driver.UnmountVolume(v, false, op)
-		}
+		defer v.driver.UnmountVolume(v, false, op)
 	}
 
 	return task(v.MountPath(), op)

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -15,7 +15,6 @@ import (
 
 // MountInfo represents info about the result of a mount operation.
 type MountInfo struct {
-	OurMount bool   // Whether a mount was needed.
 	DiskPath string // The location of the block disk (if supported).
 }
 

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -78,7 +78,7 @@ type Pool interface {
 	DeleteCustomVolume(projectName string, volName string, op *operations.Operation) error
 	GetCustomVolumeDisk(projectName string, volName string) (string, error)
 	GetCustomVolumeUsage(projectName string, volName string) (int64, error)
-	MountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error)
+	MountCustomVolume(projectName string, volName string, op *operations.Operation) error
 	UnmountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error)
 
 	// Custom volume snapshots.

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -944,31 +944,49 @@ func RenderSnapshotUsage(s *state.State, snapInst instance.Instance) func(respon
 	}
 }
 
-// InstanceDiskBlockSize returns the block device size for the instance's disk.
-// This will mount the instance if not already mounted and will unmount at the end if needed.
-func InstanceDiskBlockSize(pool Pool, inst instance.Instance, op *operations.Operation) (int64, error) {
+// InstanceMount mounts an instance's storage volume (if not already mounted).
+// Please call InstanceUnmount when finished.
+func InstanceMount(pool Pool, inst instance.Instance, op *operations.Operation) (*MountInfo, error) {
 	var err error
 	var mountInfo *MountInfo
 
 	if inst.IsSnapshot() {
 		mountInfo, err = pool.MountInstanceSnapshot(inst, op)
 		if err != nil {
-			return -1, err
-		}
-
-		if mountInfo.OurMount {
-			defer pool.UnmountInstanceSnapshot(inst, op)
+			return nil, err
 		}
 	} else {
 		mountInfo, err = pool.MountInstance(inst, op)
 		if err != nil {
-			return -1, err
-		}
-
-		if mountInfo.OurMount {
-			defer pool.UnmountInstance(inst, op)
+			return nil, err
 		}
 	}
+
+	return mountInfo, nil
+}
+
+// InstanceUnmount unmounts an instance's storage volume (if not in use). Returns if we unmounted the volume.
+func InstanceUnmount(pool Pool, inst instance.Instance, op *operations.Operation) (bool, error) {
+	var err error
+	var ourUnmount bool
+
+	if inst.IsSnapshot() {
+		ourUnmount, err = pool.UnmountInstanceSnapshot(inst, op)
+	} else {
+		ourUnmount, err = pool.UnmountInstance(inst, op)
+	}
+
+	return ourUnmount, err
+}
+
+// InstanceDiskBlockSize returns the block device size for the instance's disk.
+// This will mount the instance if not already mounted and will unmount at the end if needed.
+func InstanceDiskBlockSize(pool Pool, inst instance.Instance, op *operations.Operation) (int64, error) {
+	mountInfo, err := InstanceMount(pool, inst, op)
+	if err != nil {
+		return -1, err
+	}
+	defer InstanceUnmount(pool, inst, op)
 
 	if mountInfo.DiskPath == "" {
 		return -1, fmt.Errorf("No disk path available from mount")

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -40,9 +40,7 @@ test_container_import() {
     pid=$(lxc info ctImport | grep ^Pid | awk '{print $2}')
     ! lxd import ctImport || false
     lxd import ctImport --force
-    kill_lxc "${pid}"
     lxc info ctImport | grep snap0
-    lxc start ctImport
     lxc delete --force ctImport
 
     lxc init testimage ctImport

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -25,6 +25,7 @@ test_container_import() {
     lxc start ctImport
     pid=$(lxc info ctImport | grep ^Pid | awk '{print $2}')
     ! lxd import ctImport || false
+    # Import without killing the running instance to test restoring control plane after DB corruption.
     lxd import ctImport --force
     kill_lxc "${pid}"
     lxd sql global "PRAGMA foreign_keys=ON; DELETE FROM instances WHERE name='ctImport'"
@@ -88,6 +89,9 @@ test_container_import() {
     lxd sql global "PRAGMA foreign_keys=ON; DELETE FROM instances WHERE name='ctImport'"
     lxd sql global "PRAGMA foreign_keys=ON; DELETE FROM storage_volumes WHERE name='ctImport'"
     lxd import ctImport
+    lxc start ctImport
+    pid=$(lxc info ctImport | grep ^Pid | awk '{print $2}')
+    kill_lxc "${pid}"
     lxd import ctImport --force
     lxc info ctImport | grep snap0
     lxc start ctImport


### PR DESCRIPTION
Includes https://github.com/lxc/lxd/pull/8157

Introduces the concept of storage volume mount/unmount reference counting.

When a storage volume is mounted for the first time, a global reference counter is created and incremented to 1.
If other operations on the storage volume also need it while it is already mounted, then subsequent requests to mount the volume will just increment the reference counter again.

Then once each operation has finished with the volume they unmount the volume, and the reference counter is decremented.
If the reference counter is not yet at zero, then other operations are still using the volume and an `ErrInUse` error is returned.
The last unmount request that detects the reference counter is at zero will actually perform the unmount of the volume.

This work was done primarily to address the following group of issues related to copying ZFS VM snapshot as another instance:

- Fixes https://github.com/lxc/lxd/issues/8113
- https://discuss.linuxcontainers.org/t/copying-vm-snapshot-to-other-host-not-working-attempts-to-create-a-container/9363
- https://discuss.linuxcontainers.org/t/lxc-copy-container-ok-lxc-copy-vm-fails-with-failed-to-mount-permission-denied/9237

Reference counting is required to solve these problems because in order to activate a ZFS block volume snapshot, the parent volume also needs to be activated. However the current storage interface didn't provide a clean way for the parent volume to be unmounted (if needed) once the snapshot volume was unmounted.

By introducing reference counters we can just request that the parent volume always be unmounted when unmounting a snapshot, and if others are using it, the unmount request will fail.

However reference counting also helps with several other classes of problems:

- Long running Instance file operations (push/pull/delete etc) when the instance is running and stopped while file operation is ongoing.
- Detecting when a custom volume is mounted in multiple running instances and deciding whether to unmount when one instance is stopped (which was causing shutdown delays and errors).

In order to support reference counting, everywhere that mounts a volume needed to be reviewed to ensure that where appropriate the equivalent unmount request was made when the operation completed, otherwise the reference counter would not be decremented and the volume would be left mounted.
