### PR TITLE
lxc list, two new usage columns

### DIFF
--- a/lxc/list_test.go
+++ b/lxc/list_test.go
@@ -52,7 +52,7 @@ func TestShouldShow(t *testing.T) {
 }
 
 // Used by TestColumns and TestInvalidColumns
-const shorthand = "46abcdDfFlmnNpPsStL"
+const shorthand = "46abcdDfFlmMnNpPsStuL"
 const alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 func TestColumns(t *testing.T) {

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -437,7 +437,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
@@ -605,7 +605,7 @@ msgstr "automatisches Update: %s"
 msgid "Available projects:"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -679,6 +679,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr " Prozessorauslastung:"
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -698,7 +702,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "ERSTELLT AM"
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr "ERSTELLT AM"
 
@@ -746,7 +750,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -754,7 +758,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -818,7 +822,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr "Spalten"
 
@@ -1049,12 +1053,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1279,7 +1283,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1342,7 +1346,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1495,7 +1499,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1558,7 +1562,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1665,11 +1669,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1810,12 +1814,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1830,17 +1834,17 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1888,11 +1892,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -2011,7 +2015,7 @@ msgid "List instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
 #: lxc/list.go:45
-#, fuzzy
+#, fuzzy, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -2058,6 +2062,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -2065,6 +2070,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -2150,8 +2156,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2443,7 +2454,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2616,15 +2627,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -3054,7 +3065,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3066,7 +3077,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -3078,7 +3089,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3488,7 +3499,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3691,7 +3702,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4739,7 +4750,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -296,7 +296,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -453,7 +453,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -526,6 +526,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "  Χρήση CPU:"
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -544,7 +548,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -583,7 +587,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -591,7 +595,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -650,7 +654,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -861,12 +865,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1078,7 +1082,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1278,7 +1282,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1337,7 +1341,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1440,11 +1444,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1580,12 +1584,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1600,17 +1604,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1653,11 +1657,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1772,6 +1776,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1818,6 +1823,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1825,6 +1831,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1891,8 +1898,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2162,7 +2174,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2332,15 +2344,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2748,7 +2760,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2760,7 +2772,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2772,7 +2784,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3160,7 +3172,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3356,7 +3368,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4007,7 +4019,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -421,7 +421,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
@@ -579,7 +579,7 @@ msgstr "Auto actualización: %s"
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -653,6 +653,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "Uso de CPU:"
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr "Uso de CPU (en segundos)"
@@ -670,7 +674,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "CREADO"
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr "CREADO EN"
 
@@ -710,7 +714,7 @@ msgstr "No se peude leer desde stdin: %s"
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -719,7 +723,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -779,7 +783,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr "Columnas"
 
@@ -998,12 +1002,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1215,7 +1219,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1273,7 +1277,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1418,7 +1422,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1477,7 +1481,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1580,11 +1584,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1722,12 +1726,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1742,17 +1746,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1795,11 +1799,11 @@ msgstr "Cacheado: %s"
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1916,6 +1920,7 @@ msgid "List instances"
 msgstr "Aliases:"
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1962,6 +1967,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1969,6 +1975,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -2035,8 +2042,13 @@ msgstr "Cacheado: %s"
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2308,7 +2320,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2476,15 +2488,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2898,7 +2910,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2922,7 +2934,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3310,7 +3322,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3506,7 +3518,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4243,7 +4255,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -435,7 +435,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -602,7 +602,7 @@ msgstr "Mise à jour auto. : %s"
 msgid "Available projects:"
 msgstr "Rendre l'image publique"
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -676,6 +676,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "CPU utilisé :"
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr "CPU utilisé (en secondes)"
@@ -694,7 +698,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "CRÉÉ À"
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr "CRÉÉ À"
 
@@ -736,7 +740,7 @@ msgstr "Impossible de lire depuis stdin : %s"
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -744,7 +748,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr "Colonnes"
 
@@ -1060,12 +1064,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1287,7 +1291,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr "ÉPHÉMÈRE"
 
@@ -1351,7 +1355,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1511,7 +1515,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 #, fuzzy
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Mode rapide (identique à --columns=nsacPt"
@@ -1573,7 +1577,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1683,11 +1687,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr "IPv4"
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr "IPv6"
 
@@ -1834,12 +1838,12 @@ msgstr "Schème d'URL invalide \"%s\" in \"%s\""
 msgid "Invalid certificate"
 msgstr "Certificat invalide"
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, fuzzy, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr "Clé de configuration invalide"
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1854,17 +1858,17 @@ msgstr "Cible invalide %s"
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1908,11 +1912,11 @@ msgstr "Créé : %s"
 msgid "Keep the image up to date after initial copy"
 msgstr "Garder l'image à jour après la copie initiale"
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -2031,7 +2035,7 @@ msgid "List instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
 #: lxc/list.go:45
-#, fuzzy
+#, fuzzy, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -2078,6 +2082,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -2085,6 +2090,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -2211,8 +2217,13 @@ msgstr "Créé : %s"
 msgid "MANAGED"
 msgstr "GÉRÉ"
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2507,7 +2518,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2689,15 +2700,15 @@ msgstr "Surcharger le mode terminal (auto, interactif ou non-interactif)"
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr "PID"
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr "PROFILS"
 
@@ -3129,7 +3140,7 @@ msgstr ""
 msgid "SIZE"
 msgstr "TAILLE"
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr "INSTANTANÉS"
 
@@ -3141,7 +3152,7 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr "ÉTAT"
 
@@ -3154,7 +3165,7 @@ msgstr "STATIQUE"
 msgid "STATUS"
 msgstr "ÉTAT"
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
@@ -3575,7 +3586,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr "TYPE"
@@ -3784,7 +3795,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4933,7 +4944,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -412,7 +412,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
@@ -570,7 +570,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -643,6 +643,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "Utilizzo CPU:"
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr "Utilizzo CPU (in secondi)"
@@ -661,7 +665,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "CREATO IL"
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr "CREATO IL"
 
@@ -700,7 +704,7 @@ msgstr "Impossible leggere da stdin: %s"
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -708,7 +712,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr "Colonne"
 
@@ -986,12 +990,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1204,7 +1208,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1263,7 +1267,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1407,7 +1411,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1467,7 +1471,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1570,11 +1574,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1712,12 +1716,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1732,17 +1736,17 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1786,11 +1790,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1908,6 +1912,7 @@ msgid "List instances"
 msgstr "Creazione del container in corso"
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1954,6 +1959,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1961,6 +1967,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -2027,8 +2034,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2302,7 +2314,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2470,15 +2482,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2893,7 +2905,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2905,7 +2917,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2917,7 +2929,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3307,7 +3319,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3504,7 +3516,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4244,7 +4256,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: 2020-09-25 15:37+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -413,7 +413,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -581,7 +581,7 @@ msgstr "自動更新: %s"
 msgid "Available projects:"
 msgstr "利用可能なプロジェクト:"
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr "BASE IMAGE"
 
@@ -655,6 +655,11 @@ msgstr "CONTENT TYPE"
 msgid "CPU (%s):"
 msgstr "CPU (%s):"
 
+#: lxc/list.go:445
+#, fuzzy
+msgid "CPU USAGE"
+msgstr "DISK USAGE"
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr "CPU使用量（秒）"
@@ -672,7 +677,7 @@ msgstr "CPUs (%s):"
 msgid "CREATED"
 msgstr "CREATED"
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr "CREATED AT"
 
@@ -712,7 +717,7 @@ msgstr "標準入力から読み込めません: %s"
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr "--fast と --columns は同時に指定できません"
 
@@ -720,7 +725,7 @@ msgstr "--fast と --columns は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
@@ -779,7 +784,7 @@ msgstr "クラスタメンバ名"
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr "カラムレイアウト"
 
@@ -1002,12 +1007,12 @@ msgstr "現在の VF 数: %d"
 msgid "DATABASE"
 msgstr "DATABASE"
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr "DISK USAGE"
 
@@ -1218,7 +1223,7 @@ msgstr "進捗情報を表示しません"
 msgid "Driver: %v (%v)"
 msgstr "ドライバ: %v (%v)"
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr "EPHEMERAL"
 
@@ -1278,7 +1283,7 @@ msgstr "ストレージプールの設定をYAMLで編集します"
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1447,7 +1452,7 @@ msgstr "エイリアス %s の削除に失敗しました"
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Fast モード (--columns=nsacPt と同じ)"
 
@@ -1521,7 +1526,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1624,11 +1629,11 @@ msgstr "IMAGES"
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr "IPV6"
 
@@ -1772,12 +1777,12 @@ msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
 msgid "Invalid certificate"
 msgstr "不正な証明書です"
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr "'%s' は正しくない設定項目 (key) です (%s 中の)"
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1793,19 +1798,19 @@ msgstr "不正なフォーマット %q"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 "'%s' は最大幅の値として不正です (-1 もしくは 0 もしくは正の整数でなくてはなり"
 "ません) ('%s' 中の)"
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr "'%s' は最大幅の値として不正です (整数でなくてはなりません) ('%s' 中の)"
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1849,11 +1854,11 @@ msgstr "IsSM: %s (%s)"
 msgid "Keep the image up to date after initial copy"
 msgstr "最初にコピーした後も常にイメージを最新の状態に保つ"
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr "LAST USED AT"
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr "LOCATION"
@@ -1998,6 +2003,7 @@ msgid "List instances"
 msgstr "インスタンスを一覧表示します"
 
 #: lxc/list.go:45
+#, fuzzy, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -2044,6 +2050,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -2051,6 +2058,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -2180,8 +2188,13 @@ msgstr "MAD: %s (%s)"
 msgid "MANAGED"
 msgstr "MANAGED"
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr "MEMORY USAGE"
+
+#: lxc/list.go:437
+#, fuzzy, c-format
+msgid "MEMORY USAGE%"
 msgstr "MEMORY USAGE"
 
 #: lxc/cluster.go:136
@@ -2471,7 +2484,7 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2640,15 +2653,15 @@ msgstr "ターミナルモードを上書きします (auto, interactive, non-in
 msgid "PCI address: %v"
 msgstr "PCI アドレス: %v"
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr "PID"
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr "PROCESSES"
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr "PROFILES"
 
@@ -3063,7 +3076,7 @@ msgstr "すべてのインスタンスに対してコマンドを実行します
 msgid "SIZE"
 msgstr "SIZE"
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr "SNAPSHOTS"
 
@@ -3075,7 +3088,7 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr "STATE"
 
@@ -3087,7 +3100,7 @@ msgstr "STATIC"
 msgid "STATUS"
 msgstr "STATUS"
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr "STORAGE POOL"
 
@@ -3507,7 +3520,7 @@ msgstr "デフォルトのリモートを切り替えます"
 msgid "TARGET"
 msgstr "TARGET"
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr "TYPE"
@@ -3728,7 +3741,7 @@ msgstr "UUID: %v"
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
@@ -4443,7 +4456,7 @@ msgstr ""
 "lxc launch ubuntu:18.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成し、起動します"
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 #, fuzzy
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2020-11-13 15:44-0500\n"
+        "POT-Creation-Date: 2020-11-13 16:42-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -281,7 +281,7 @@ msgstr  ""
 msgid   "ALIASES"
 msgstr  ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid   "ARCHITECTURE"
 msgstr  ""
 
@@ -434,7 +434,7 @@ msgstr  ""
 msgid   "Available projects:"
 msgstr  ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid   "BASE IMAGE"
 msgstr  ""
 
@@ -506,6 +506,10 @@ msgstr  ""
 msgid   "CPU (%s):"
 msgstr  ""
 
+#: lxc/list.go:445
+msgid   "CPU USAGE"
+msgstr  ""
+
 #: lxc/info.go:509
 msgid   "CPU usage (in seconds)"
 msgstr  ""
@@ -523,7 +527,7 @@ msgstr  ""
 msgid   "CREATED"
 msgstr  ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid   "CREATED AT"
 msgstr  ""
 
@@ -562,7 +566,7 @@ msgstr  ""
 msgid   "Can't remove the default remote"
 msgstr  ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid   "Can't specify --fast with --columns"
 msgstr  ""
 
@@ -570,7 +574,7 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
@@ -619,7 +623,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid   "Columns"
 msgstr  ""
 
@@ -824,11 +828,11 @@ msgstr  ""
 msgid   "DATABASE"
 msgstr  ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883 lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883 lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid   "DESCRIPTION"
 msgstr  ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid   "DISK USAGE"
 msgstr  ""
 
@@ -987,7 +991,7 @@ msgstr  ""
 msgid   "Driver: %v (%v)"
 msgstr  ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid   "EPHEMERAL"
 msgstr  ""
 
@@ -1043,7 +1047,7 @@ msgstr  ""
 msgid   "Edit storage volume configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1177,7 +1181,7 @@ msgstr  ""
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid   "Fast mode (same as --columns=nsacPt)"
 msgstr  ""
 
@@ -1229,7 +1233,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238 lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155 lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510 lxc/storage_volume.go:1085
+#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238 lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155 lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510 lxc/storage_volume.go:1085
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
@@ -1330,11 +1334,11 @@ msgstr  ""
 msgid   "IP ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid   "IPV4"
 msgstr  ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid   "IPV6"
 msgstr  ""
 
@@ -1467,12 +1471,12 @@ msgstr  ""
 msgid   "Invalid certificate"
 msgstr  ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid   "Invalid config key '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid   "Invalid config key column format (too many fields): '%s'"
 msgstr  ""
@@ -1487,17 +1491,17 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid   "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid   "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
@@ -1539,11 +1543,11 @@ msgstr  ""
 msgid   "Keep the image up to date after initial copy"
 msgstr  ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid   "LAST USED AT"
 msgstr  ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165 lxc/storage_volume.go:1144
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165 lxc/storage_volume.go:1144
 msgid   "LOCATION"
 msgstr  ""
 
@@ -1655,6 +1659,7 @@ msgid   "List instances"
 msgstr  ""
 
 #: lxc/list.go:45
+#, c-format
 msgid   "List instances\n"
         "\n"
         "Default column layout: ns46tS\n"
@@ -1697,6 +1702,7 @@ msgid   "List instances\n"
         "  D - disk usage\n"
         "  l - Last used date\n"
         "  m - Memory usage\n"
+        "  M - Memory usage (%)\n"
         "  n - Name\n"
         "  N - Number of Processes\n"
         "  p - PID of the instance's init process\n"
@@ -1704,6 +1710,7 @@ msgid   "List instances\n"
         "  s - State\n"
         "  S - Number of snapshots\n"
         "  t - Type (persistent or ephemeral)\n"
+        "  u - CPU usage (in seconds)\n"
         "  L - Location of the instance (e.g. its cluster member)\n"
         "  f - Base Image Fingerprint (short)\n"
         "  F - Base Image Fingerprint (long)\n"
@@ -1768,8 +1775,13 @@ msgstr  ""
 msgid   "MANAGED"
 msgstr  ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid   "MEMORY USAGE"
+msgstr  ""
+
+#: lxc/list.go:437
+#, c-format
+msgid   "MEMORY USAGE%"
 msgstr  ""
 
 #: lxc/cluster.go:136
@@ -2013,7 +2025,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558 lxc/storage_volume.go:1138
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558 lxc/storage_volume.go:1138
 msgid   "NAME"
 msgstr  ""
 
@@ -2177,15 +2189,15 @@ msgstr  ""
 msgid   "PCI address: %v"
 msgstr  ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid   "PID"
 msgstr  ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid   "PROCESSES"
 msgstr  ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid   "PROFILES"
 msgstr  ""
 
@@ -2587,7 +2599,7 @@ msgstr  ""
 msgid   "SIZE"
 msgstr  ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid   "SNAPSHOTS"
 msgstr  ""
 
@@ -2599,7 +2611,7 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid   "STATE"
 msgstr  ""
 
@@ -2611,7 +2623,7 @@ msgstr  ""
 msgid   "STATUS"
 msgstr  ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid   "STORAGE POOL"
 msgstr  ""
 
@@ -2983,7 +2995,7 @@ msgstr  ""
 msgid   "TARGET"
 msgstr  ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879 lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879 lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid   "TYPE"
 msgstr  ""
 
@@ -3166,7 +3178,7 @@ msgstr  ""
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -3781,7 +3793,7 @@ msgid   "lxc launch ubuntu:18.04 u1\n"
         "    Create and start the instance with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid   "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
         "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", \"IPV6\" and \"MAC\" columns.\n"
         "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from instance configuration keys.\n"

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -410,7 +410,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
@@ -567,7 +567,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -640,6 +640,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -657,7 +661,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -696,7 +700,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -704,7 +708,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -763,7 +767,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -974,12 +978,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1188,7 +1192,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1246,7 +1250,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1388,7 +1392,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1447,7 +1451,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1550,11 +1554,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1690,12 +1694,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1710,17 +1714,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1763,11 +1767,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1882,6 +1886,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1928,6 +1933,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1935,6 +1941,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -2001,8 +2008,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2270,7 +2282,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2438,15 +2450,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2854,7 +2866,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2866,7 +2878,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2878,7 +2890,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3266,7 +3278,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3462,7 +3474,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4113,7 +4125,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -577,7 +577,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -650,6 +650,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -667,7 +671,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -706,7 +710,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -714,7 +718,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -773,7 +777,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -984,12 +988,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1198,7 +1202,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1256,7 +1260,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1398,7 +1402,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1457,7 +1461,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1560,11 +1564,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1700,12 +1704,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1720,17 +1724,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1773,11 +1777,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1892,6 +1896,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1938,6 +1943,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1945,6 +1951,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -2011,8 +2018,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2280,7 +2292,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2448,15 +2460,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2864,7 +2876,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2876,7 +2888,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2888,7 +2900,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3276,7 +3288,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3472,7 +3484,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4123,7 +4135,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -426,7 +426,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
@@ -592,7 +592,7 @@ msgstr "Atualização automática: %s"
 msgid "Available projects:"
 msgstr "Criar projetos"
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr "IMAGEM BASE"
 
@@ -665,6 +665,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "Utilização do CPU:"
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr "Utilização do CPU (em segundos)"
@@ -682,7 +686,7 @@ msgstr "CPUs:"
 msgid "CREATED"
 msgstr "CRIADO"
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr "CRIADO EM"
 
@@ -722,7 +726,7 @@ msgstr "Não é possível ler stdin: %s"
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr "Não é possível especificar --fast com --columns"
 
@@ -730,7 +734,7 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
@@ -790,7 +794,7 @@ msgstr "Nome de membro do cluster"
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr "Colunas"
 
@@ -1018,12 +1022,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1240,7 +1244,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr "EFÊMERO"
 
@@ -1304,7 +1308,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1446,7 +1450,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1505,7 +1509,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1611,11 +1615,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr "IPV6"
 
@@ -1753,12 +1757,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1826,11 +1830,11 @@ msgstr "Em cache: %s"
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1946,6 +1950,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1992,6 +1997,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1999,6 +2005,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -2065,8 +2072,13 @@ msgstr "Em cache: %s"
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2340,7 +2352,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2508,15 +2520,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2931,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2943,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2955,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3352,7 +3364,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3548,7 +3560,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4210,7 +4222,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: 2020-10-08 08:16+0000\n"
 "Last-Translator: Artem <KovalevArtem.ru@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -435,7 +435,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
@@ -596,7 +596,7 @@ msgstr "Авто-обновление: %s"
 msgid "Available projects:"
 msgstr "Доступные команды:"
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -669,6 +669,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr " Использование ЦП:"
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr "Использование ЦП (в секундах)"
@@ -688,7 +692,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "СОЗДАН"
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr "СОЗДАН"
 
@@ -727,7 +731,7 @@ msgstr "Невозможно прочитать из стандартного в
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -735,7 +739,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -795,7 +799,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr "Столбцы"
 
@@ -1017,12 +1021,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1239,7 +1243,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1299,7 +1303,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1446,7 +1450,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1505,7 +1509,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1608,11 +1612,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1753,12 +1757,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1773,17 +1777,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1826,11 +1830,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1949,6 +1953,7 @@ msgid "List instances"
 msgstr "Псевдонимы:"
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1995,6 +2000,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -2002,6 +2008,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -2069,8 +2076,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2350,7 +2362,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2521,15 +2533,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2945,7 +2957,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2957,7 +2969,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2969,7 +2981,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3363,7 +3375,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3559,7 +3571,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4558,7 +4570,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -293,7 +293,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -523,6 +523,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -540,7 +544,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -579,7 +583,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -587,7 +591,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -646,7 +650,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -857,12 +861,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1071,7 +1075,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1129,7 +1133,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1330,7 +1334,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1433,11 +1437,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1573,12 +1577,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1593,17 +1597,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1646,11 +1650,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1765,6 +1769,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1811,6 +1816,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1818,6 +1824,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1884,8 +1891,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2153,7 +2165,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2321,15 +2333,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2737,7 +2749,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2749,7 +2761,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2761,7 +2773,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3149,7 +3161,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3345,7 +3357,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3996,7 +4008,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2020-11-13 15:44-0500\n"
+"POT-Creation-Date: 2020-11-13 16:42-0500\n"
 "PO-Revision-Date: 2020-11-05 02:45+0000\n"
 "Last-Translator: wdggg <wdggg7@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -336,7 +336,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:426
+#: lxc/cluster.go:137 lxc/image.go:1013 lxc/list.go:428
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -493,7 +493,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:431 lxc/list.go:432
+#: lxc/list.go:433 lxc/list.go:434
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -566,6 +566,10 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
+#: lxc/list.go:445
+msgid "CPU USAGE"
+msgstr ""
+
 #: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
@@ -583,7 +587,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:430
 msgid "CREATED AT"
 msgstr ""
 
@@ -622,7 +626,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:447
+#: lxc/list.go:451
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -630,7 +634,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:463
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:998 lxc/list.go:117
+#: lxc/image.go:998 lxc/list.go:119
 msgid "Columns"
 msgstr ""
 
@@ -900,12 +904,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:429 lxc/network.go:883
+#: lxc/image.go:1012 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
 #: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:432
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1114,7 +1118,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:682
+#: lxc/list.go:713
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1172,7 +1176,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/list.go:471
+#: lxc/image.go:1024 lxc/list.go:475
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1314,7 +1318,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:119
+#: lxc/list.go:121
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1373,7 +1377,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:999 lxc/image_alias.go:155
-#: lxc/list.go:118 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:510
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1476,11 +1480,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:424 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:881
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:425 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:882
 msgid "IPV6"
 msgstr ""
 
@@ -1616,12 +1620,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:503
+#: lxc/list.go:507
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:501
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1636,17 +1640,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:522
+#: lxc/list.go:526
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:519
+#: lxc/list.go:523
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:514
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1689,11 +1693,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:435
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:455 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1808,6 +1812,7 @@ msgid "List instances"
 msgstr ""
 
 #: lxc/list.go:45
+#, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -1854,6 +1859,7 @@ msgid ""
 "  D - disk usage\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
+"  M - Memory usage (%)\n"
 "  n - Name\n"
 "  N - Number of Processes\n"
 "  p - PID of the instance's init process\n"
@@ -1861,6 +1867,7 @@ msgid ""
 "  s - State\n"
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
+"  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
@@ -1927,8 +1934,13 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:434
+#: lxc/list.go:436
 msgid "MEMORY USAGE"
+msgstr ""
+
+#: lxc/list.go:437
+#, c-format
+msgid "MEMORY USAGE%"
 msgstr ""
 
 #: lxc/cluster.go:136
@@ -2196,7 +2208,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:435 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:558
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2364,15 +2376,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:437
+#: lxc/list.go:440
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:436
+#: lxc/list.go:439
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:438 lxc/project.go:462
+#: lxc/list.go:441 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2780,7 +2792,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:439
+#: lxc/list.go:442
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2792,7 +2804,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:440 lxc/network.go:887 lxc/storage.go:563
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
@@ -2804,7 +2816,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:429
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3192,7 +3204,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:441 lxc/network.go:879
+#: lxc/image.go:1016 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
 #: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
@@ -3388,7 +3400,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1031 lxc/list.go:485
+#: lxc/image.go:1031 lxc/list.go:489
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4039,7 +4051,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:107
+#: lxc/list.go:109
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"


### PR DESCRIPTION
I want a more detailed view of resource consumption. 
I've added memory in percent (consumed memory/ limits.memory) and CPU.Usage in seconds.

Example below:

```
lxc list -c nsm,limits.memory,MU

+------------------+---------+--------------+---------------+---------------+-----------+
|       NAME       |  STATE  | MEMORY USAGE | LIMITS MEMORY | MEMORY USAGE% | CPU USAGE |
+------------------+---------+--------------+---------------+---------------+-----------+
| c1               | RUNNING | 63.44MB      | 512MB         | 12.4%         | 51s       |
+------------------+---------+--------------+---------------+---------------+-----------+
| c2               | RUNNING | 113.46MB     | 1024MB        | 11.1%         | 101s      |
+------------------+---------+--------------+---------------+---------------+-----------+
| stopped          | STOPPED |              | 1024MB        |               |           |
+------------------+---------+--------------+---------------+---------------+-----------+
| no_memory_limits | RUNNING | 461.75MB     |               |               | 1057s     |
+------------------+---------+--------------+---------------+---------------+-----------+

```