### PR TITLE
Project: Reject quotes in project names

### DIFF
--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -587,6 +587,10 @@ func projectValidateName(name string) error {
 		return fmt.Errorf("Project names may not contain spaces")
 	}
 
+	if strings.Contains(name, "'") || strings.Contains(name, `"`) {
+		return fmt.Errorf("Project names may not contain quotes")
+	}
+
 	if name == "*" {
 		return fmt.Errorf("Reserved project name")
 	}


### PR DESCRIPTION
This is because some storage drivers cannot support quotes in the volume name.

Also AppArmor policies do not support double quotes in their names.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>