### PR TITLE
Instance: Adds volatile.uuid key for container and VMs, replaces volatile.vm.uuid for VMs

### DIFF
--- a/doc/instances.md
+++ b/doc/instances.md
@@ -110,7 +110,7 @@ volatile.idmap.current                      | string    | -             | The id
 volatile.idmap.next                         | string    | -             | The idmap to use next time the instance starts
 volatile.last\_state.idmap                  | string    | -             | Serialized instance uid/gid map
 volatile.last\_state.power                  | string    | -             | Instance state as of last host shutdown
-volatile.vm.uuid                            | string    | -             | Virtual machine UUID
+volatile.uuid                               | string    | -             | Instance UUID
 volatile.\<name\>.apply\_quota              | string    | -             | Disk quota to be applied on next instance start
 volatile.\<name\>.ceph\_rbd                 | string    | -             | RBD device path for Ceph disk devices
 volatile.\<name\>.host\_name                | string    | -             | Network device name on the host

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/flosch/pongo2"
+	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 	liblxc "gopkg.in/lxc/go-lxc.v2"
@@ -2128,6 +2129,13 @@ func (c *lxc) startCommon() (string, []func() error, error) {
 		return "", nil, err
 	}
 	ourStart = mountInfo.OurMount
+
+	// Generate UUID if not present.
+	instUUID := c.localConfig["volatile.uuid"]
+	if instUUID == "" {
+		instUUID = uuid.New()
+		c.VolatileSet(map[string]string{"volatile.uuid": instUUID})
+	}
 
 	// Create the devices
 	postStartHooks := []func() error{}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -779,10 +779,10 @@ func (vm *qemu) Start(stateful bool) error {
 	}
 
 	// Get a UUID for Qemu.
-	vmUUID := vm.localConfig["volatile.vm.uuid"]
+	vmUUID := vm.localConfig["volatile.uuid"]
 	if vmUUID == "" {
 		vmUUID = uuid.New()
-		vm.VolatileSet(map[string]string{"volatile.vm.uuid": vmUUID})
+		vm.VolatileSet(map[string]string{"volatile.uuid": vmUUID})
 	}
 
 	// Copy OVMF settings firmware to nvram file.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -778,11 +778,11 @@ func (vm *qemu) Start(stateful bool) error {
 		logger.Warn("Unable to use virtio-fs for config drive, using 9p as a fallback: virtiofsd missing")
 	}
 
-	// Get a UUID for Qemu.
-	vmUUID := vm.localConfig["volatile.uuid"]
-	if vmUUID == "" {
-		vmUUID = uuid.New()
-		vm.VolatileSet(map[string]string{"volatile.uuid": vmUUID})
+	// Generate UUID if not present.
+	instUUID := vm.localConfig["volatile.uuid"]
+	if instUUID == "" {
+		instUUID = uuid.New()
+		vm.VolatileSet(map[string]string{"volatile.uuid": instUUID})
 	}
 
 	// Copy OVMF settings firmware to nvram file.
@@ -850,7 +850,7 @@ func (vm *qemu) Start(stateful bool) error {
 		qemuPath,
 		"-S",
 		"-name", vm.Name(),
-		"-uuid", vmUUID,
+		"-uuid", instUUID,
 		"-daemonize",
 		"-cpu", "host",
 		"-nographic",

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -116,6 +116,7 @@ var patches = []patch{
 	{name: "network_ovn_remove_routes", stage: patchPostDaemonStorage, run: patchNetworkOVNRemoveRoutes},
 	{name: "network_fan_enable_nat", stage: patchPostDaemonStorage, run: patchNetworkFANEnableNAT},
 	{name: "thinpool_typo_fix", stage: patchPostDaemonStorage, run: patchThinpoolTypoFix},
+	{name: "vm_rename_uuid_key", stage: patchPostDaemonStorage, run: patchVMRenameUUIDKey},
 }
 
 type patch struct {
@@ -179,6 +180,57 @@ func patchesApply(d *Daemon, stage patchStage) error {
 }
 
 // Patches begin here
+
+// patchVMRenameUUIDKey renames the volatile.vm.uuid key to volatile.uuid in instance and snapshot configs.
+func patchVMRenameUUIDKey(name string, d *Daemon) error {
+	oldUUIDKey := "volatile.vm.uuid"
+	newUUIDKey := "volatile.uuid"
+
+	return d.State().Cluster.InstanceList(func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+		if inst.Type != instancetype.VM {
+			return nil
+		}
+
+		return d.State().Cluster.Transaction(func(tx *db.ClusterTx) error {
+			uuid := inst.Config[oldUUIDKey]
+			if uuid != "" {
+				changes := map[string]string{
+					oldUUIDKey: "",
+					newUUIDKey: uuid,
+				}
+
+				logger.Debugf("Renaming config key %q to %q for VM %q (Project %q)", oldUUIDKey, newUUIDKey, inst.Name, inst.Project)
+				err := tx.UpdateInstanceConfig(inst.ID, changes)
+				if err != nil {
+					return errors.Wrapf(err, "Failed renaming config key %q to %q for VM %q (Project %q)", oldUUIDKey, newUUIDKey, inst.Name, inst.Project)
+				}
+			}
+
+			snaps, err := tx.GetInstanceSnapshotsWithName(inst.Project, inst.Name)
+			if err != nil {
+				return err
+			}
+
+			for _, snap := range snaps {
+				uuid := snap.Config[oldUUIDKey]
+				if uuid != "" {
+					changes := map[string]string{
+						oldUUIDKey: "",
+						newUUIDKey: uuid,
+					}
+
+					logger.Debugf("Renaming config key %q to %q for VM %q (Project %q)", oldUUIDKey, newUUIDKey, snap.Name, snap.Project)
+					err = tx.UpdateInstanceSnapshotConfig(snap.ID, changes)
+					if err != nil {
+						return errors.Wrapf(err, "Failed renaming config key %q to %q for VM %q (Project %q)", oldUUIDKey, newUUIDKey, snap.Name, snap.Project)
+					}
+				}
+			}
+
+			return nil
+		})
+	})
+}
 
 // patchThinpoolTypoFix renames any config incorrectly set config file entries due to the lvm.thinpool_name typo.
 func patchThinpoolTypoFix(name string, d *Daemon) error {

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -255,6 +255,7 @@ var KnownInstanceConfigKeys = map[string]func(value string) error{
 	"volatile.idmap.current":    validate.IsAny,
 	"volatile.idmap.next":       validate.IsAny,
 	"volatile.apply_quota":      validate.IsAny,
+	"volatile.uuid":             validate.Optional(validate.IsUUID),
 }
 
 // ConfigKeyChecker returns a function that will check whether or not

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -306,10 +306,6 @@ func ConfigKeyChecker(key string) (func(value string) error, error) {
 			return validate.IsAny, nil
 		}
 
-		if strings.HasSuffix(key, "vm.uuid") {
-			return validate.IsAny, nil
-		}
-
 		if strings.HasSuffix(key, ".ceph_rbd") {
 			return validate.IsAny, nil
 		}

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pborman/uuid"
+
 	"github.com/lxc/lxd/shared/units"
 )
 
@@ -447,6 +449,15 @@ func IsURLSegmentSafe(value string) error {
 		if strings.Contains(value, char) {
 			return fmt.Errorf("Cannot contain %q", char)
 		}
+	}
+
+	return nil
+}
+
+// IsUUID validates whether a value is a UUID.
+func IsUUID(value string) error {
+	if uuid.Parse(value) == nil {
+		return fmt.Errorf("Invalid UUID")
 	}
 
 	return nil


### PR DESCRIPTION
- Tested patch on running VMs with the `volatile.vm.uuid` key with and without snapshots to check they all get renamed. 