### PR TITLE
lxd/instance/lxc: Add extra check for devpts_fd

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6631,6 +6631,10 @@ func (c *lxc) DevptsFd() (*os.File, error) {
 		return nil, err
 	}
 
+	if !liblxc.HasApiExtension("devpts_fd") {
+		return nil, fmt.Errorf("Missing devpts_fd extension")
+	}
+
 	return c.c.DevptsFd()
 }
 


### PR DESCRIPTION
Don't attempt to call the function if we don't have the runtime extension.

Closes #8159

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>