### PR TITLE
Network: Don't fail when resetting SRIOV VF MAC to 00:00:00:00:00:00

### DIFF
--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -461,11 +461,10 @@ func (d *nicSRIOV) setupSriovParent(vfDevice string, vfID int, volatile map[stri
 			return vfPCIDev, err
 		}
 	} else {
-		// Reset VF to ensure no previous MAC restriction exists.
-		_, err := shared.TryRunCommand("ip", "link", "set", "dev", d.config["parent"], "vf", volatile["last_state.vf.id"], "mac", "00:00:00:00:00:00")
-		if err != nil {
-			return vfPCIDev, err
-		}
+		// Try to reset VF to ensure no previous MAC restriction exists, as some devices require this
+		// before being able to set a new VF MAC or disable spoofchecking. However some devices don't
+		// allow it so ignore failures.
+		shared.TryRunCommand("ip", "link", "set", "dev", d.config["parent"], "vf", volatile["last_state.vf.id"], "mac", "00:00:00:00:00:00")
 
 		// Ensure spoof checking is disabled if not enabled in instance.
 		_, err = shared.TryRunCommand("ip", "link", "set", "dev", d.config["parent"], "vf", volatile["last_state.vf.id"], "spoofchk", "off")


### PR DESCRIPTION
Apparently the bnx2x devices don't allow this.

Fixes #8162

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>