### PR TITLE
Network: Use Instance UUID for generating OVN logical switch port names

### DIFF
--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -369,10 +369,8 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 func (d *nicOVN) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 	oldConfig := oldDevices[d.name]
 
-	v := d.volatileGet()
-
 	// Populate device config with volatile fields if needed.
-	networkVethFillFromVolatile(d.config, v)
+	networkVethFillFromVolatile(d.config, d.volatileGet())
 
 	// If instance is running, apply host side limits and filters first before rebuilding
 	// dnsmasq config below so that existing config can be used as part of the filter removal.
@@ -452,9 +450,7 @@ func (d *nicOVN) postStop() error {
 		"host_name": "",
 	})
 
-	v := d.volatileGet()
-
-	networkVethFillFromVolatile(d.config, v)
+	networkVethFillFromVolatile(d.config, d.volatileGet())
 
 	if d.config["host_name"] != "" && shared.PathExists(fmt.Sprintf("/sys/class/net/%s", d.config["host_name"])) {
 		integrationBridge, err := d.getIntegrationBridgeName()
@@ -487,10 +483,8 @@ func (d *nicOVN) Remove() error {
 
 // State gets the state of an OVN NIC by querying the OVN Northbound logical switch port record.
 func (d *nicOVN) State() (*api.InstanceStateNetwork, error) {
-	v := d.volatileGet()
-
 	// Populate device config with volatile fields (hwaddr and host_name) if needed.
-	networkVethFillFromVolatile(d.config, v)
+	networkVethFillFromVolatile(d.config, d.volatileGet())
 
 	addresses := []api.InstanceStateNetworkAddress{}
 	netConfig := d.network.Config()

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -29,9 +29,9 @@ type ovnNet interface {
 	network.Network
 
 	InstanceDevicePortValidateExternalRoutes(deviceInstance instance.Instance, deviceName string, externalRoutes []*net.IPNet) error
-	InstanceDevicePortAdd(instanceID int, instanceName string, deviceName string, mac net.HardwareAddr, ips []net.IP, internalRoutes []*net.IPNet, externalRoutes []*net.IPNet) (openvswitch.OVNSwitchPort, error)
-	InstanceDevicePortDelete(instanceID int, deviceName string, internalRoutes []*net.IPNet, externalRoutes []*net.IPNet) error
-	InstanceDevicePortDynamicIPs(instanceID int, deviceName string) ([]net.IP, error)
+	InstanceDevicePortAdd(instanceUUID string, instanceName string, deviceName string, mac net.HardwareAddr, ips []net.IP, internalRoutes []*net.IPNet, externalRoutes []*net.IPNet) (openvswitch.OVNSwitchPort, error)
+	InstanceDevicePortDelete(instanceUUID string, deviceName string, ovsExternalOVNPort openvswitch.OVNSwitchPort, internalRoutes []*net.IPNet, externalRoutes []*net.IPNet) error
+	InstanceDevicePortDynamicIPs(instanceUUID string, deviceName string) ([]net.IP, error)
 }
 
 type nicOVN struct {

--- a/lxd/network/openvswitch/ovs.go
+++ b/lxd/network/openvswitch/ovs.go
@@ -150,6 +150,16 @@ func (o *OVS) InterfaceAssociateOVNSwitchPort(interfaceName string, ovnSwitchPor
 	return nil
 }
 
+// InterfaceAssociatedOVNSwitchPort returns the OVN switch port associated to the OVS interface.
+func (o *OVS) InterfaceAssociatedOVNSwitchPort(interfaceName string) (OVNSwitchPort, error) {
+	ovnSwitchPort, err := shared.RunCommand("ovs-vsctl", "get", "interface", interfaceName, "external_ids:iface-id")
+	if err != nil {
+		return "", err
+	}
+
+	return OVNSwitchPort(strings.TrimSpace(ovnSwitchPort)), nil
+}
+
 // ChassisID returns the local chassis ID.
 func (o *OVS) ChassisID() (string, error) {
 	// ovs-vsctl's get command doesn't support its --format flag, so we always get the output quoted.


### PR DESCRIPTION
- Switches new OVN instance port names to use the instance's UUID setting rather than the instance's ID property.
- This is because the instance's ID property can change if the instance is recovered using `lxd import` while it is still running.
- This has the knock on effect that when the running instance is eventually stopped, its OVN logical switch port is not cleaned up as the ID has changed (and it is left in the OVN NB database).
- Using the `volatile.uuid` setting ensures that it will remain the same between recoveries.

However this introduces a related problem. What about instances that are already started and have an OVN port name containing the instance ID from the old regime. Once this change is applied, any running instance that is stopped will then also leave its OVN port orphaned (because its port name doesn't match the new regime).

To account for this, we lookup the external OVN port name stored in the local OVS integration bridge (that maintains the link between local veth interface and OVN logical port) at device stop time. If there is a value available we use that over the current naming regime (as it represents the actual logical switch port the device was started with) to clear up the port.

If for some reason the external OVN port name is not available in the local OVS bridge (perhaps it was removed manually before shutdown) then we fallback to using the current naming regime to try and clear up the OVN port.