### PR TITLE
Network: Adds state column to networks_nodes table

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -436,7 +436,7 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) response.Response {
 			}
 
 			for _, name := range networkNames {
-				_, network, err := d.cluster.GetNetworkInAnyState(p.Name, name)
+				_, network, _, err := d.cluster.GetNetworkInAnyState(p.Name, name)
 				if err != nil {
 					return err
 				}
@@ -1628,7 +1628,7 @@ func clusterCheckNetworksMatch(cluster *db.Cluster, reqNetworks []internalCluste
 
 				found = true
 
-				_, network, err := cluster.GetNetworkInAnyState(networkProjectName, networkName)
+				_, network, _, err := cluster.GetNetworkInAnyState(networkProjectName, networkName)
 				if err != nil {
 					return err
 				}

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -624,7 +624,7 @@ func projectValidateRestrictedSubnets(s *state.State, value string) error {
 		}
 
 		// Check uplink exists and load config to compare subnets.
-		_, uplink, err := s.Cluster.GetNetworkInAnyState(project.Default, uplinkName)
+		_, uplink, _, err := s.Cluster.GetNetworkInAnyState(project.Default, uplinkName)
 		if err != nil {
 			return errors.Wrapf(err, "Invalid uplink network %q", uplinkName)
 		}

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -299,6 +299,7 @@ CREATE TABLE "networks_nodes" (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     network_id INTEGER NOT NULL,
     node_id INTEGER NOT NULL,
+    state INTEGER NOT NULL DEFAULT 0,
     UNIQUE (network_id, node_id),
     FOREIGN KEY (network_id) REFERENCES "networks" (id) ON DELETE CASCADE,
     FOREIGN KEY (node_id) REFERENCES nodes (id) ON DELETE CASCADE
@@ -489,6 +490,7 @@ CREATE TABLE storage_pools_nodes (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     storage_pool_id INTEGER NOT NULL,
     node_id INTEGER NOT NULL,
+    state INTEGER NOT NULL DEFAULT 0,
     UNIQUE (storage_pool_id, node_id),
     FOREIGN KEY (storage_pool_id) REFERENCES storage_pools (id) ON DELETE CASCADE,
     FOREIGN KEY (node_id) REFERENCES nodes (id) ON DELETE CASCADE
@@ -589,5 +591,5 @@ CREATE TABLE storage_volumes_snapshots_config (
     UNIQUE (storage_volume_snapshot_id, key)
 );
 
-INSERT INTO schema (version, updated_at) VALUES (39, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (40, strftime("%s"))
 `

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -76,6 +76,19 @@ var updates = map[int]schema.Update{
 	37: updateFromV36,
 	38: updateFromV37,
 	39: updateFromV38,
+	40: updateFromV39,
+}
+
+// Add state column to storage_pools_nodes and networks_nodes tables. Set existing row's state to 1 ("created").
+func updateFromV39(tx *sql.Tx) error {
+	stmt := `
+		ALTER TABLE storage_pools_nodes ADD COLUMN state INTEGER NOT NULL DEFAULT 0;
+		UPDATE storage_pools_nodes SET state = 1;
+		ALTER TABLE networks_nodes ADD COLUMN state INTEGER NOT NULL DEFAULT 0;
+		UPDATE networks_nodes SET state = 1;
+	`
+	_, err := tx.Exec(stmt)
+	return err
 }
 
 // Add storage_volumes_backups table.

--- a/lxd/db/migration_test.go
+++ b/lxd/db/migration_test.go
@@ -90,7 +90,7 @@ func TestImportPreClusteringData(t *testing.T) {
 	networks, err := cluster.GetNetworks(project.Default)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"lxcbr0"}, networks)
-	id, network, err := cluster.GetNetworkInAnyState(project.Default, "lxcbr0")
+	id, network, _, err := cluster.GetNetworkInAnyState(project.Default, "lxcbr0")
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), id)
 	assert.Equal(t, "true", network.Config["ipv4.nat"])

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -456,15 +456,12 @@ const (
 	NetworkTypePhysical                    // Network type physical.
 )
 
-// GetNetworkInAnyState returns the network with the given name.
-//
-// The network can be in any state.
+// GetNetworkInAnyState returns the network with the given name. The network can be in any state.
 func (c *Cluster) GetNetworkInAnyState(project string, name string) (int64, *api.Network, error) {
 	return c.getNetwork(project, name, false)
 }
 
-// Get the network with the given name. If onlyCreated is true, only return
-// networks in the created state.
+// Get the network with the given name. If onlyCreated is true, only return networks in the created state.
 func (c *Cluster) getNetwork(project string, name string, onlyCreated bool) (int64, *api.Network, error) {
 	description := sql.NullString{}
 	id := int64(-1)
@@ -562,8 +559,7 @@ func (c *Cluster) networkNodes(networkID int64) ([]string, error) {
 	return nodes, nil
 }
 
-// GetNetworkWithInterface returns the network associated with the interface with
-// the given name.
+// GetNetworkWithInterface returns the network associated with the interface with the given name.
 func (c *Cluster) GetNetworkWithInterface(devName string) (int64, *api.Network, error) {
 	id := int64(-1)
 	name := ""
@@ -656,6 +652,7 @@ func (c *Cluster) getNetworkConfig(id int64) (map[string]string, error) {
 func (c *Cluster) CreateNetwork(projectName string, name string, description string, netType NetworkType, config map[string]string) (int64, error) {
 	var id int64
 	err := c.Transaction(func(tx *ClusterTx) error {
+		// Insert a new network record with state "created".
 		result, err := tx.tx.Exec("INSERT INTO networks (project_id, name, description, state, type) VALUES ((SELECT id FROM projects WHERE name = ?), ?, ?, ?, ?)",
 			projectName, name, description, networkCreated, netType)
 		if err != nil {

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -459,6 +459,13 @@ const (
 	NetworkTypePhysical                    // Network type physical.
 )
 
+// NetworkNode represents a network node.
+type NetworkNode struct {
+	ID    int64
+	Name  string
+	State NetworkState
+}
+
 // GetNetworkInAnyState returns the network with the given name. The network can be in any state.
 func (c *Cluster) GetNetworkInAnyState(project string, name string) (int64, *api.Network, error) {
 	return c.getNetwork(project, name, false)

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -103,7 +103,7 @@ func (c *ClusterTx) GetNonPendingNetworks() (map[string]map[int64]api.Network, e
 		}
 
 		// Populate Status and Type fields by converting from DB values.
-		networkFillStatus(&network, networkState)
+		network.Status = NetworkStateToAPIStatus(networkState)
 		networkFillType(&network, networkType)
 
 		if projectNetworks[projectName] != nil {
@@ -500,7 +500,7 @@ func (c *Cluster) getNetwork(project string, name string, onlyCreated bool) (int
 	network.Config = config
 
 	// Populate Status and Type fields by converting from DB values.
-	networkFillStatus(&network, state)
+	network.Status = NetworkStateToAPIStatus(state)
 	networkFillType(&network, netType)
 
 	nodes, err := c.networkNodes(id)
@@ -512,16 +512,17 @@ func (c *Cluster) getNetwork(project string, name string, onlyCreated bool) (int
 	return id, &network, nil
 }
 
-func networkFillStatus(network *api.Network, state int) {
+// NetworkStateToAPIStatus converts DB NetworkState to API status string.
+func NetworkStateToAPIStatus(state NetworkState) string {
 	switch state {
 	case networkPending:
-		network.Status = api.NetworkStatusPending
+		return api.NetworkStatusPending
 	case networkCreated:
-		network.Status = api.NetworkStatusCreated
+		return api.NetworkStatusCreated
 	case networkErrored:
-		network.Status = api.NetworkStatusErrored
+		return api.NetworkStatusErrored
 	default:
-		network.Status = api.NetworkStatusUnknown
+		return api.NetworkStatusUnknown
 	}
 }
 

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -664,9 +664,9 @@ func (c *Cluster) CreateNetwork(projectName string, name string, description str
 			return err
 		}
 
-		// Insert a node-specific entry pointing to ourselves.
-		columns := []string{"network_id", "node_id"}
-		values := []interface{}{id, c.nodeID}
+		// Insert a node-specific entry pointing to ourselves with state "pending".
+		columns := []string{"network_id", "node_id", "state"}
+		values := []interface{}{id, c.nodeID, networkPending}
 		_, err = query.UpsertObject(tx.tx, "networks_nodes", columns, values)
 		if err != nil {
 			return err

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -572,13 +572,13 @@ func networkFillType(network *api.Network, netType NetworkType) {
 	}
 }
 
-// Return the names of the nodes the given network is defined on.
-func (c *Cluster) networkNodes(networkID int64) ([]string, error) {
-	var nodes []string
+// NetworkNodes returns the nodes keyed by node ID that the given network is defined on.
+func (c *Cluster) NetworkNodes(networkID int64) (map[int64]NetworkNode, error) {
+	var nodes map[int64]NetworkNode
 	var err error
 
 	err = c.Transaction(func(tx *ClusterTx) error {
-		nodes, err = tx.networkNodes(networkID)
+		nodes, err = tx.NetworkNodes(networkID)
 		if err != nil {
 			return err
 		}

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -299,9 +299,9 @@ func (c *ClusterTx) CreatePendingNetwork(node string, projectName string, name s
 		return ErrAlreadyDefined
 	}
 
-	// Insert the node-specific configuration.
-	columns := []string{"network_id", "node_id"}
-	values := []interface{}{networkID, nodeInfo.ID}
+	// Insert the node-specific configuration with state "pending".
+	columns := []string{"network_id", "node_id", "state"}
+	values := []interface{}{networkID, nodeInfo.ID, networkPending}
 	_, err = query.UpsertObject(c.tx, "networks_nodes", columns, values)
 	if err != nil {
 		return err

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -171,8 +171,9 @@ func (c *ClusterTx) CreateNetworkConfig(networkID, nodeID int64, config map[stri
 // assume that the relevant network has already been created on the joining node,
 // and we just need to track it.
 func (c *ClusterTx) NetworkNodeJoin(networkID, nodeID int64) error {
-	columns := []string{"network_id", "node_id"}
-	values := []interface{}{networkID, nodeID}
+	columns := []string{"network_id", "node_id", "state"}
+	// Create network node with "created" state as we expect the network to already be setup.
+	values := []interface{}{networkID, nodeID, networkCreated}
 	_, err := query.UpsertObject(c.tx, "networks_nodes", columns, values)
 	return err
 }

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -720,7 +720,7 @@ func (c *Cluster) CreateNetwork(projectName string, name string, description str
 
 // UpdateNetwork updates the network with the given name.
 func (c *Cluster) UpdateNetwork(project string, name, description string, config map[string]string) error {
-	id, netInfo, err := c.GetNetworkInAnyState(project, name)
+	id, netInfo, _, err := c.GetNetworkInAnyState(project, name)
 	if err != nil {
 		return err
 	}
@@ -794,7 +794,7 @@ func clearNetworkConfig(tx *sql.Tx, networkID, nodeID int64) error {
 
 // DeleteNetwork deletes the network with the given name.
 func (c *Cluster) DeleteNetwork(project string, name string) error {
-	id, _, err := c.GetNetworkInAnyState(project, name)
+	id, _, _, err := c.GetNetworkInAnyState(project, name)
 	if err != nil {
 		return err
 	}
@@ -809,7 +809,7 @@ func (c *Cluster) DeleteNetwork(project string, name string) error {
 
 // RenameNetwork renames a network.
 func (c *Cluster) RenameNetwork(project string, oldName string, newName string) error {
-	id, _, err := c.GetNetworkInAnyState(project, oldName)
+	id, _, _, err := c.GetNetworkInAnyState(project, oldName)
 	if err != nil {
 		return err
 	}

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -130,11 +130,14 @@ func (c *ClusterTx) GetNonPendingNetworks() (map[string]map[int64]api.Network, e
 
 			network.Config = networkConfig
 
-			nodes, err := c.networkNodes(networkID)
+			nodes, err := c.NetworkNodes(networkID)
 			if err != nil {
 				return nil, err
 			}
-			network.Locations = nodes
+
+			for _, node := range nodes {
+				network.Locations = append(network.Locations, node.Name)
+			}
 
 			projectNetworks[projectName][networkID] = network
 		}

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -341,6 +341,29 @@ func (c *ClusterTx) networkState(project string, name string, state int) error {
 	return nil
 }
 
+// NetworkNodeCreated sets the state of the given network for the local member to "Created".
+func (c *ClusterTx) NetworkNodeCreated(networkID int64) error {
+	return c.networkNodeState(networkID, networkCreated)
+}
+
+// networkNodeState updates the network member state for the local member and specified network ID.
+func (c *ClusterTx) networkNodeState(networkID int64, state int) error {
+	stmt := "UPDATE networks_nodes SET state=? WHERE network_id = ? and node_id = ?"
+	result, err := c.tx.Exec(stmt, state, networkID, c.nodeID)
+	if err != nil {
+		return err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return ErrNoSuchObject
+	}
+
+	return nil
+}
+
 // UpdateNetwork updates the network with the given ID.
 func (c *ClusterTx) UpdateNetwork(id int64, description string, config map[string]string) error {
 	err := updateNetworkDescription(c.tx, id, description)

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -492,7 +492,7 @@ func (d *nicBridged) rebuildDnsmasqEntry() error {
 	defer dnsmasq.ConfigMutex.Unlock()
 
 	// Use project.Default here as bridge networks don't support projects.
-	_, dbInfo, err := d.state.Cluster.GetNetworkInAnyState(project.Default, d.config["parent"])
+	_, dbInfo, _, err := d.state.Cluster.GetNetworkInAnyState(project.Default, d.config["parent"])
 	if err != nil {
 		return err
 	}

--- a/lxd/device/nictype/nictype.go
+++ b/lxd/device/nictype/nictype.go
@@ -26,7 +26,7 @@ func NICType(s *state.State, deviceProjectName string, d deviceConfig.Device) (s
 				return "", errors.Wrapf(err, "Failed to translate device project %q into network project", deviceProjectName)
 			}
 
-			_, netInfo, err := s.Cluster.GetNetworkInAnyState(networkProjectName, d["network"])
+			_, netInfo, _, err := s.Cluster.GetNetworkInAnyState(networkProjectName, d["network"])
 			if err != nil {
 				return "", errors.Wrapf(err, "Failed to load network %q for project %q", d["network"], networkProjectName)
 			}

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -487,10 +487,6 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 
 	n.logger.Debug("Setting up network")
 
-	if n.status == api.NetworkStatusPending {
-		return fmt.Errorf("Cannot start pending network")
-	}
-
 	// Create directory.
 	if !shared.PathExists(shared.VarPath("networks", n.name)) {
 		err := os.MkdirAll(shared.VarPath("networks", n.name), 0711)

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -414,18 +414,20 @@ func (n *bridge) isRunning() bool {
 func (n *bridge) Delete(clientType cluster.ClientType) error {
 	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
 
-	// Bring the network down.
-	if n.isRunning() {
-		err := n.Stop()
+	// Bring the local network down if created on this node.
+	if n.LocalStatus() == api.NetworkStatusCreated {
+		if n.isRunning() {
+			err := n.Stop()
+			if err != nil {
+				return err
+			}
+		}
+
+		// Delete apparmor profiles.
+		err := apparmor.NetworkDelete(n.state, n)
 		if err != nil {
 			return err
 		}
-	}
-
-	// Delete apparmor profiles.
-	err := apparmor.NetworkDelete(n.state, n)
-	if err != nil {
-		return err
 	}
 
 	return n.common.delete(clientType)

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -1,8 +1,6 @@
 package network
 
 import (
-	"fmt"
-
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/revert"
@@ -66,10 +64,6 @@ func (n *macvlan) Rename(newName string) error {
 // Start starts is a no-op.
 func (n *macvlan) Start() error {
 	n.logger.Debug("Start")
-
-	if n.status == api.NetworkStatusPending {
-		return fmt.Errorf("Cannot start pending network")
-	}
 
 	return nil
 }

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1758,61 +1758,63 @@ func (n *ovn) deleteChassisGroupEntry() error {
 func (n *ovn) Delete(clientType cluster.ClientType) error {
 	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
 
-	err := n.Stop()
-	if err != nil {
-		return err
-	}
-
-	if clientType == cluster.ClientTypeNormal {
-		client, err := n.getClient()
+	if n.LocalStatus() == api.NetworkStatusCreated {
+		err := n.Stop()
 		if err != nil {
 			return err
 		}
 
-		err = client.LogicalRouterDelete(n.getRouterName())
-		if err != nil {
-			return err
-		}
+		if clientType == cluster.ClientTypeNormal {
+			client, err := n.getClient()
+			if err != nil {
+				return err
+			}
 
-		err = client.LogicalSwitchDelete(n.getExtSwitchName())
-		if err != nil {
-			return err
-		}
+			err = client.LogicalRouterDelete(n.getRouterName())
+			if err != nil {
+				return err
+			}
 
-		err = client.LogicalSwitchDelete(n.getIntSwitchName())
-		if err != nil {
-			return err
-		}
+			err = client.LogicalSwitchDelete(n.getExtSwitchName())
+			if err != nil {
+				return err
+			}
 
-		err = client.LogicalRouterPortDelete(n.getRouterExtPortName())
-		if err != nil {
-			return err
-		}
+			err = client.LogicalSwitchDelete(n.getIntSwitchName())
+			if err != nil {
+				return err
+			}
 
-		err = client.LogicalRouterPortDelete(n.getRouterIntPortName())
-		if err != nil {
-			return err
-		}
+			err = client.LogicalRouterPortDelete(n.getRouterExtPortName())
+			if err != nil {
+				return err
+			}
 
-		err = client.LogicalSwitchPortDelete(n.getExtSwitchRouterPortName())
-		if err != nil {
-			return err
-		}
+			err = client.LogicalRouterPortDelete(n.getRouterIntPortName())
+			if err != nil {
+				return err
+			}
 
-		err = client.LogicalSwitchPortDelete(n.getExtSwitchProviderPortName())
-		if err != nil {
-			return err
-		}
+			err = client.LogicalSwitchPortDelete(n.getExtSwitchRouterPortName())
+			if err != nil {
+				return err
+			}
 
-		err = client.LogicalSwitchPortDelete(n.getIntSwitchRouterPortName())
-		if err != nil {
-			return err
-		}
+			err = client.LogicalSwitchPortDelete(n.getExtSwitchProviderPortName())
+			if err != nil {
+				return err
+			}
 
-		// Must be done after logical router removal.
-		err = client.ChassisGroupDelete(n.getChassisGroupName())
-		if err != nil {
-			return err
+			err = client.LogicalSwitchPortDelete(n.getIntSwitchRouterPortName())
+			if err != nil {
+				return err
+			}
+
+			// Must be done after logical router removal.
+			err = client.ChassisGroupDelete(n.getChassisGroupName())
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1836,10 +1836,6 @@ func (n *ovn) Rename(newName string) error {
 func (n *ovn) Start() error {
 	n.logger.Debug("Start")
 
-	if n.status == api.NetworkStatusPending {
-		return fmt.Errorf("Cannot start pending network")
-	}
-
 	// Add local node's OVS chassis ID to logical chassis group.
 	err := n.addChassisGroupEntry()
 	if err != nil {

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -82,7 +82,7 @@ func (n *ovn) Info() Info {
 
 // uplinkRoutes parses ipv4.routes and ipv6.routes settings for a named uplink network into a slice of *net.IPNet.
 func (n *ovn) uplinkRoutes(uplinkNetworkName string) ([]*net.IPNet, error) {
-	_, uplink, err := n.state.Cluster.GetNetworkInAnyState(project.Default, uplinkNetworkName)
+	_, uplink, _, err := n.state.Cluster.GetNetworkInAnyState(project.Default, uplinkNetworkName)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -118,9 +118,11 @@ func (n *physical) Create(clientType cluster.ClientType) error {
 func (n *physical) Delete(clientType cluster.ClientType) error {
 	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
 
-	err := n.Stop()
-	if err != nil {
-		return err
+	if n.LocalStatus() == api.NetworkStatusCreated {
+		err := n.Stop()
+		if err != nil {
+			return err
+		}
 	}
 
 	return n.common.delete(clientType)

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -143,10 +143,6 @@ func (n *physical) Rename(newName string) error {
 func (n *physical) Start() error {
 	n.logger.Debug("Start")
 
-	if n.status == api.NetworkStatusPending {
-		return fmt.Errorf("Cannot start pending network")
-	}
-
 	revert := revert.New()
 	defer revert.Fail()
 

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -1,8 +1,6 @@
 package network
 
 import (
-	"fmt"
-
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/revert"
@@ -66,10 +64,6 @@ func (n *sriov) Rename(newName string) error {
 // Start starts is a no-op.
 func (n *sriov) Start() error {
 	n.logger.Debug("Start")
-
-	if n.status == api.NetworkStatusPending {
-		return fmt.Errorf("Cannot start pending network")
-	}
 
 	return nil
 }

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -32,6 +32,7 @@ type Network interface {
 	Name() string
 	Description() string
 	Status() string
+	LocalStatus() string
 	Config() map[string]string
 	IsUsed() (bool, error)
 	DHCPv4Subnet() *net.IPNet

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -24,7 +24,7 @@ type Network interface {
 	Type
 
 	// Load.
-	init(state *state.State, id int64, projectName string, name string, netType string, description string, config map[string]string, status string)
+	init(state *state.State, id int64, projectName string, netInfo *api.Network, netNodes map[int64]db.NetworkNode)
 
 	// Config.
 	Validate(config map[string]string) error

--- a/lxd/network/network_load.go
+++ b/lxd/network/network_load.go
@@ -26,7 +26,7 @@ func LoadByType(driverType string) (Type, error) {
 
 // LoadByName loads an instantiated network from the database by project and name.
 func LoadByName(s *state.State, projectName string, name string) (Network, error) {
-	id, netInfo, err := s.Cluster.GetNetworkInAnyState(projectName, name)
+	id, netInfo, netNodes, err := s.Cluster.GetNetworkInAnyState(projectName, name)
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +37,7 @@ func LoadByName(s *state.State, projectName string, name string) (Network, error
 	}
 
 	n := driverFunc()
-	n.init(s, id, projectName, name, netInfo.Type, netInfo.Description, netInfo.Config, netInfo.Status)
+	n.init(s, id, projectName, netInfo, netNodes)
 
 	return n, nil
 }

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -529,7 +529,7 @@ func doNetworkGet(d *Daemon, projectName string, name string) (api.Network, erro
 	}
 
 	// Get some information.
-	_, dbInfo, _ := d.cluster.GetNetworkInAnyState(projectName, name)
+	_, dbInfo, _, _ := d.cluster.GetNetworkInAnyState(projectName, name)
 
 	// Don't allow retrieving info about the local node interfaces when not using default project.
 	if projectName != project.Default && dbInfo == nil {

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -444,6 +444,11 @@ func doNetworksCreate(d *Daemon, projectName string, req api.NetworksPost, clien
 		return err
 	}
 
+	if n.LocalStatus() == api.NetworkStatusCreated {
+		logger.Debug("Skipping network create as already created locally", log.Ctx{"project": projectName, "network": n.Name()})
+		return nil
+	}
+
 	// Run initial creation setup for the network driver.
 	err = n.Create(clientType)
 	if err != nil {
@@ -457,12 +462,25 @@ func doNetworksCreate(d *Daemon, projectName string, req api.NetworksPost, clien
 		if err != nil {
 			delErr := n.Delete(clientType)
 			if delErr != nil {
-				logger.Errorf("Failed clearing up network %q after failed create: %v", n.Name(), delErr)
+				logger.Error("Failed clearing up network after failed create", log.Ctx{"project": projectName, "network": n.Name(), "err": delErr})
 			}
 
 			return err
 		}
 	}
+
+	// Mark local as status as networkCreated.
+	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
+		return tx.NetworkNodeCreated(n.ID())
+	})
+	if err != nil {
+		delErr := n.Delete(clientType)
+		if delErr != nil {
+			logger.Error("Failed clearing up network after failed local status update", log.Ctx{"project": projectName, "network": n.Name(), "err": delErr})
+		}
+		return err
+	}
+	logger.Debug("Marked network local status as created", log.Ctx{"project": projectName, "network": req.Name})
 
 	return nil
 }

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -279,7 +279,6 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Non-clustered network creation.
-
 	networks, err := d.cluster.GetNetworks(projectName)
 	if err != nil {
 		return response.InternalError(err)

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -312,6 +312,8 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	return resp
 }
 
+// networksPostCluster checks that there is a pending network in the database and then attempts to setup the
+// network on each node. If all nodes are successfully setup then the network's state is set to created.
 func networksPostCluster(d *Daemon, projectName string, req api.NetworksPost, clientType cluster.ClientType, netType network.Type) error {
 	// Check that no node-specific config key has been supplied in request.
 	for key := range req.Config {
@@ -371,6 +373,12 @@ func networksPostCluster(d *Daemon, projectName string, req api.NetworksPost, cl
 		return err
 	}
 
+	// Create notifier for other nodes to create the network.
+	notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), cluster.NotifyAll)
+	if err != nil {
+		return err
+	}
+
 	// Create the network on this node.
 	nodeReq := req
 
@@ -379,35 +387,13 @@ func networksPostCluster(d *Daemon, projectName string, req api.NetworksPost, cl
 		nodeReq.Config[key] = value
 	}
 
-	// Notify all other nodes to create the network.
-	notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), cluster.NotifyAll)
-	if err != nil {
-		return err
-	}
-
-	revert := revert.New()
-	defer revert.Fail()
-
-	revert.Add(func() {
-		d.cluster.Transaction(func(tx *db.ClusterTx) error {
-			return tx.NetworkErrored(projectName, req.Name)
-		})
-	})
-
-	// We need to mark the network as created now, because the network.LoadByName call invoked by
-	// doNetworksCreate would fail with not-found otherwise.
-	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
-		return tx.NetworkCreated(projectName, req.Name)
-	})
-	if err != nil {
-		return err
-	}
-
 	err = doNetworksCreate(d, projectName, nodeReq, clientType)
 	if err != nil {
 		return err
 	}
+	logger.Error("Created network on local cluster member", log.Ctx{"project": projectName, "network": req.Name})
 
+	// Notify other nodes to create the network.
 	err = notifier(func(client lxd.InstanceServer) error {
 		server, _, err := client.GetServer()
 		if err != nil {
@@ -419,13 +405,27 @@ func networksPostCluster(d *Daemon, projectName string, req api.NetworksPost, cl
 			nodeReq.Config[key] = value
 		}
 
-		return client.UseProject(projectName).CreateNetwork(nodeReq)
+		err = client.UseProject(projectName).CreateNetwork(nodeReq)
+		if err != nil {
+			return err
+		}
+		logger.Error("Created network on cluster member", log.Ctx{"project": projectName, "network": req.Name, "member": server.Environment.ServerName})
+
+		return nil
 	})
 	if err != nil {
 		return err
 	}
 
-	revert.Success()
+	// Mark network global status as networkCreated now that all nodes have succeeded.
+	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
+		return tx.NetworkCreated(projectName, req.Name)
+	})
+	if err != nil {
+		return err
+	}
+	logger.Debug("Marked network global status as created", log.Ctx{"project": projectName, "network": req.Name})
+
 	return nil
 }
 

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -601,19 +601,6 @@ func networkDelete(d *Daemon, r *http.Request) response.Response {
 	name := mux.Vars(r)["name"]
 	state := d.State()
 
-	// Check if the network is pending, if so we just need to delete it from the database.
-	_, dbNetwork, err := d.cluster.GetNetworkInAnyState(projectName, name)
-	if err != nil {
-		return response.SmartError(err)
-	}
-	if dbNetwork.Status == api.NetworkStatusPending {
-		err := d.cluster.DeleteNetwork(projectName, name)
-		if err != nil {
-			return response.SmartError(err)
-		}
-		return response.EmptySyncResponse
-	}
-
 	// Get the existing network.
 	n, err := network.LoadByName(state, projectName, name)
 	if err != nil {
@@ -635,7 +622,7 @@ func networkDelete(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	// Delete the network.
+	// Delete the network from each member.
 	err = n.Delete(clientType)
 	if err != nil {
 		return response.SmartError(err)

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -322,7 +322,7 @@ func networksPostCluster(d *Daemon, projectName string, req api.NetworksPost, cl
 
 	// Check that the requested network type matches the type created when adding the local node config.
 	// If network doesn't exist yet, ignore not found error, as this will be checked by NetworkNodeConfigs().
-	_, netInfo, err := d.cluster.GetNetworkInAnyState(projectName, req.Name)
+	_, netInfo, _, err := d.cluster.GetNetworkInAnyState(projectName, req.Name)
 	if err != nil && err != db.ErrNoSuchObject {
 		return err
 	}
@@ -726,7 +726,7 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 	name := mux.Vars(r)["name"]
 
 	// Get the existing network.
-	_, dbInfo, err := d.cluster.GetNetworkInAnyState(projectName, name)
+	_, dbInfo, _, err := d.cluster.GetNetworkInAnyState(projectName, name)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -3787,7 +3787,7 @@ func patchNetworkCearBridgeVolatileHwaddr(name string, d *Daemon) error {
 	}
 
 	for _, networkName := range networks {
-		_, net, err := d.cluster.GetNetworkInAnyState(projectName, networkName)
+		_, net, _, err := d.cluster.GetNetworkInAnyState(projectName, networkName)
 		if err != nil {
 			return errors.Wrapf(err, "Failed loading network %q for network_clear_bridge_volatile_hwaddr patch", networkName)
 		}

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -182,7 +182,7 @@ func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 	// storage config are the ones in StoragePoolNodeConfigKeys.
 	for key := range req.Config {
 		if !shared.StringInSlice(key, db.StoragePoolNodeConfigKeys) {
-			return response.SmartError(fmt.Errorf("Config key '%s' may not be used as node-specific key", key))
+			return response.SmartError(fmt.Errorf("Config key %q may not be used as node-specific key", key))
 		}
 	}
 
@@ -196,7 +196,7 @@ func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 	})
 	if err != nil {
 		if err == db.ErrAlreadyDefined {
-			return response.BadRequest(fmt.Errorf("The storage pool already defined on node %s", targetNode))
+			return response.BadRequest(fmt.Errorf("The storage pool already defined on node %q", targetNode))
 		}
 
 		return response.SmartError(err)
@@ -209,7 +209,7 @@ func storagePoolsPostCluster(d *Daemon, req api.StoragePoolsPost) error {
 	// Check that no node-specific config key has been defined.
 	for key := range req.Config {
 		if shared.StringInSlice(key, db.StoragePoolNodeConfigKeys) {
-			return fmt.Errorf("Config key '%s' is node-specific", key)
+			return fmt.Errorf("Config key %q is node-specific", key)
 		}
 	}
 
@@ -525,7 +525,7 @@ func storagePoolPatch(d *Daemon, r *http.Request) response.Response {
 func storagePoolValidateClusterConfig(reqConfig map[string]string) error {
 	for key := range reqConfig {
 		if shared.StringInSlice(key, db.StoragePoolNodeConfigKeys) {
-			return fmt.Errorf("node-specific config key %s can't be changed", key)
+			return fmt.Errorf("Node-specific config key %q can't be changed", key)
 		}
 	}
 	return nil

--- a/lxd/storage_pools_utils.go
+++ b/lxd/storage_pools_utils.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"github.com/lxc/lxd/lxd/state"
 	storagePools "github.com/lxc/lxd/lxd/storage"
 	"github.com/lxc/lxd/shared"
@@ -95,7 +97,7 @@ func storagePoolCreateGlobal(state *state.State, req api.StoragePoolsPost) error
 	return nil
 }
 
-// This performs all non-db related work needed to create the pool.
+// This performs local pool setup and updates DB record if config was changed during pool setup.
 func storagePoolCreateLocal(state *state.State, id int64, req api.StoragePoolsPost, isNotification bool) (map[string]string, error) {
 	tryUndo := true
 
@@ -145,7 +147,7 @@ func storagePoolCreateLocal(state *state.State, id int64, req api.StoragePoolsPo
 		// Create the database entry for the storage pool.
 		err = state.Cluster.UpdateStoragePool(req.Name, req.Description, updatedConfig)
 		if err != nil {
-			return nil, fmt.Errorf("Error inserting %s into database: %s", req.Name, err)
+			return nil, errors.Wrapf(err, "Error updating storage pool config after local create for %q", req.Name)
 		}
 	}
 


### PR DESCRIPTION
-  Adds state column to networks_nodes table.
- Modifies network create process to allow per-node state tracking.
- Allows fixing of per-node creation blockers when creating a network in a cluster.

Related to https://github.com/lxc/lxd/issues/8111