### PR TITLE
Network: Adds network node state to improve clustered network creation process

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -436,7 +436,7 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) response.Response {
 			}
 
 			for _, name := range networkNames {
-				_, network, err := d.cluster.GetNetworkInAnyState(p.Name, name)
+				_, network, _, err := d.cluster.GetNetworkInAnyState(p.Name, name)
 				if err != nil {
 					return err
 				}
@@ -1628,7 +1628,7 @@ func clusterCheckNetworksMatch(cluster *db.Cluster, reqNetworks []internalCluste
 
 				found = true
 
-				_, network, err := cluster.GetNetworkInAnyState(networkProjectName, networkName)
+				_, network, _, err := cluster.GetNetworkInAnyState(networkProjectName, networkName)
 				if err != nil {
 					return err
 				}

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -624,7 +624,7 @@ func projectValidateRestrictedSubnets(s *state.State, value string) error {
 		}
 
 		// Check uplink exists and load config to compare subnets.
-		_, uplink, err := s.Cluster.GetNetworkInAnyState(project.Default, uplinkName)
+		_, uplink, _, err := s.Cluster.GetNetworkInAnyState(project.Default, uplinkName)
 		if err != nil {
 			return errors.Wrapf(err, "Invalid uplink network %q", uplinkName)
 		}

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -299,6 +299,7 @@ CREATE TABLE "networks_nodes" (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     network_id INTEGER NOT NULL,
     node_id INTEGER NOT NULL,
+    state INTEGER NOT NULL DEFAULT 0,
     UNIQUE (network_id, node_id),
     FOREIGN KEY (network_id) REFERENCES "networks" (id) ON DELETE CASCADE,
     FOREIGN KEY (node_id) REFERENCES nodes (id) ON DELETE CASCADE
@@ -589,5 +590,5 @@ CREATE TABLE storage_volumes_snapshots_config (
     UNIQUE (storage_volume_snapshot_id, key)
 );
 
-INSERT INTO schema (version, updated_at) VALUES (39, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (40, strftime("%s"))
 `

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -76,6 +76,17 @@ var updates = map[int]schema.Update{
 	37: updateFromV36,
 	38: updateFromV37,
 	39: updateFromV38,
+	40: updateFromV39,
+}
+
+// Add state column to networks_nodes tables. Set existing row's state to 1 ("created").
+func updateFromV39(tx *sql.Tx) error {
+	stmt := `
+		ALTER TABLE networks_nodes ADD COLUMN state INTEGER NOT NULL DEFAULT 0;
+		UPDATE networks_nodes SET state = 1;
+	`
+	_, err := tx.Exec(stmt)
+	return err
 }
 
 // Add storage_volumes_backups table.

--- a/lxd/db/migration_test.go
+++ b/lxd/db/migration_test.go
@@ -90,7 +90,7 @@ func TestImportPreClusteringData(t *testing.T) {
 	networks, err := cluster.GetNetworks(project.Default)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"lxcbr0"}, networks)
-	id, network, err := cluster.GetNetworkInAnyState(project.Default, "lxcbr0")
+	id, network, _, err := cluster.GetNetworkInAnyState(project.Default, "lxcbr0")
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), id)
 	assert.Equal(t, "true", network.Config["ipv4.nat"])

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -456,15 +456,12 @@ const (
 	NetworkTypePhysical                    // Network type physical.
 )
 
-// GetNetworkInAnyState returns the network with the given name.
-//
-// The network can be in any state.
+// GetNetworkInAnyState returns the network with the given name. The network can be in any state.
 func (c *Cluster) GetNetworkInAnyState(project string, name string) (int64, *api.Network, error) {
 	return c.getNetwork(project, name, false)
 }
 
-// Get the network with the given name. If onlyCreated is true, only return
-// networks in the created state.
+// Get the network with the given name. If onlyCreated is true, only return networks in the created state.
 func (c *Cluster) getNetwork(project string, name string, onlyCreated bool) (int64, *api.Network, error) {
 	description := sql.NullString{}
 	id := int64(-1)
@@ -562,8 +559,7 @@ func (c *Cluster) networkNodes(networkID int64) ([]string, error) {
 	return nodes, nil
 }
 
-// GetNetworkWithInterface returns the network associated with the interface with
-// the given name.
+// GetNetworkWithInterface returns the network associated with the interface with the given name.
 func (c *Cluster) GetNetworkWithInterface(devName string) (int64, *api.Network, error) {
 	id := int64(-1)
 	name := ""
@@ -656,6 +652,7 @@ func (c *Cluster) getNetworkConfig(id int64) (map[string]string, error) {
 func (c *Cluster) CreateNetwork(projectName string, name string, description string, netType NetworkType, config map[string]string) (int64, error) {
 	var id int64
 	err := c.Transaction(func(tx *ClusterTx) error {
+		// Insert a new network record with state "created".
 		result, err := tx.tx.Exec("INSERT INTO networks (project_id, name, description, state, type) VALUES ((SELECT id FROM projects WHERE name = ?), ?, ?, ?, ?)",
 			projectName, name, description, networkCreated, netType)
 		if err != nil {

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -459,6 +459,13 @@ const (
 	NetworkTypePhysical                    // Network type physical.
 )
 
+// NetworkNode represents a network node.
+type NetworkNode struct {
+	ID    int64
+	Name  string
+	State NetworkState
+}
+
 // GetNetworkInAnyState returns the network with the given name. The network can be in any state.
 func (c *Cluster) GetNetworkInAnyState(project string, name string) (int64, *api.Network, error) {
 	return c.getNetwork(project, name, false)

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -103,7 +103,7 @@ func (c *ClusterTx) GetNonPendingNetworks() (map[string]map[int64]api.Network, e
 		}
 
 		// Populate Status and Type fields by converting from DB values.
-		networkFillStatus(&network, networkState)
+		network.Status = NetworkStateToAPIStatus(networkState)
 		networkFillType(&network, networkType)
 
 		if projectNetworks[projectName] != nil {
@@ -500,7 +500,7 @@ func (c *Cluster) getNetwork(project string, name string, onlyCreated bool) (int
 	network.Config = config
 
 	// Populate Status and Type fields by converting from DB values.
-	networkFillStatus(&network, state)
+	network.Status = NetworkStateToAPIStatus(state)
 	networkFillType(&network, netType)
 
 	nodes, err := c.networkNodes(id)
@@ -512,16 +512,17 @@ func (c *Cluster) getNetwork(project string, name string, onlyCreated bool) (int
 	return id, &network, nil
 }
 
-func networkFillStatus(network *api.Network, state int) {
+// NetworkStateToAPIStatus converts DB NetworkState to API status string.
+func NetworkStateToAPIStatus(state NetworkState) string {
 	switch state {
 	case networkPending:
-		network.Status = api.NetworkStatusPending
+		return api.NetworkStatusPending
 	case networkCreated:
-		network.Status = api.NetworkStatusCreated
+		return api.NetworkStatusCreated
 	case networkErrored:
-		network.Status = api.NetworkStatusErrored
+		return api.NetworkStatusErrored
 	default:
-		network.Status = api.NetworkStatusUnknown
+		return api.NetworkStatusUnknown
 	}
 }
 

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -664,9 +664,9 @@ func (c *Cluster) CreateNetwork(projectName string, name string, description str
 			return err
 		}
 
-		// Insert a node-specific entry pointing to ourselves.
-		columns := []string{"network_id", "node_id"}
-		values := []interface{}{id, c.nodeID}
+		// Insert a node-specific entry pointing to ourselves with state "pending".
+		columns := []string{"network_id", "node_id", "state"}
+		values := []interface{}{id, c.nodeID, networkPending}
 		_, err = query.UpsertObject(tx.tx, "networks_nodes", columns, values)
 		if err != nil {
 			return err

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -572,13 +572,13 @@ func networkFillType(network *api.Network, netType NetworkType) {
 	}
 }
 
-// Return the names of the nodes the given network is defined on.
-func (c *Cluster) networkNodes(networkID int64) ([]string, error) {
-	var nodes []string
+// NetworkNodes returns the nodes keyed by node ID that the given network is defined on.
+func (c *Cluster) NetworkNodes(networkID int64) (map[int64]NetworkNode, error) {
+	var nodes map[int64]NetworkNode
 	var err error
 
 	err = c.Transaction(func(tx *ClusterTx) error {
-		nodes, err = tx.networkNodes(networkID)
+		nodes, err = tx.NetworkNodes(networkID)
 		if err != nil {
 			return err
 		}

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -299,9 +299,9 @@ func (c *ClusterTx) CreatePendingNetwork(node string, projectName string, name s
 		return ErrAlreadyDefined
 	}
 
-	// Insert the node-specific configuration.
-	columns := []string{"network_id", "node_id"}
-	values := []interface{}{networkID, nodeInfo.ID}
+	// Insert the node-specific configuration with state "pending".
+	columns := []string{"network_id", "node_id", "state"}
+	values := []interface{}{networkID, nodeInfo.ID, networkPending}
 	_, err = query.UpsertObject(c.tx, "networks_nodes", columns, values)
 	if err != nil {
 		return err

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -171,8 +171,9 @@ func (c *ClusterTx) CreateNetworkConfig(networkID, nodeID int64, config map[stri
 // assume that the relevant network has already been created on the joining node,
 // and we just need to track it.
 func (c *ClusterTx) NetworkNodeJoin(networkID, nodeID int64) error {
-	columns := []string{"network_id", "node_id"}
-	values := []interface{}{networkID, nodeID}
+	columns := []string{"network_id", "node_id", "state"}
+	// Create network node with "created" state as we expect the network to already be setup.
+	values := []interface{}{networkID, nodeID, networkCreated}
 	_, err := query.UpsertObject(c.tx, "networks_nodes", columns, values)
 	return err
 }

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -720,7 +720,7 @@ func (c *Cluster) CreateNetwork(projectName string, name string, description str
 
 // UpdateNetwork updates the network with the given name.
 func (c *Cluster) UpdateNetwork(project string, name, description string, config map[string]string) error {
-	id, netInfo, err := c.GetNetworkInAnyState(project, name)
+	id, netInfo, _, err := c.GetNetworkInAnyState(project, name)
 	if err != nil {
 		return err
 	}
@@ -794,7 +794,7 @@ func clearNetworkConfig(tx *sql.Tx, networkID, nodeID int64) error {
 
 // DeleteNetwork deletes the network with the given name.
 func (c *Cluster) DeleteNetwork(project string, name string) error {
-	id, _, err := c.GetNetworkInAnyState(project, name)
+	id, _, _, err := c.GetNetworkInAnyState(project, name)
 	if err != nil {
 		return err
 	}
@@ -809,7 +809,7 @@ func (c *Cluster) DeleteNetwork(project string, name string) error {
 
 // RenameNetwork renames a network.
 func (c *Cluster) RenameNetwork(project string, oldName string, newName string) error {
-	id, _, err := c.GetNetworkInAnyState(project, oldName)
+	id, _, _, err := c.GetNetworkInAnyState(project, oldName)
 	if err != nil {
 		return err
 	}

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -130,11 +130,14 @@ func (c *ClusterTx) GetNonPendingNetworks() (map[string]map[int64]api.Network, e
 
 			network.Config = networkConfig
 
-			nodes, err := c.networkNodes(networkID)
+			nodes, err := c.NetworkNodes(networkID)
 			if err != nil {
 				return nil, err
 			}
-			network.Locations = nodes
+
+			for _, node := range nodes {
+				network.Locations = append(network.Locations, node.Name)
+			}
 
 			projectNetworks[projectName][networkID] = network
 		}

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -341,6 +341,29 @@ func (c *ClusterTx) networkState(project string, name string, state int) error {
 	return nil
 }
 
+// NetworkNodeCreated sets the state of the given network for the local member to "Created".
+func (c *ClusterTx) NetworkNodeCreated(networkID int64) error {
+	return c.networkNodeState(networkID, networkCreated)
+}
+
+// networkNodeState updates the network member state for the local member and specified network ID.
+func (c *ClusterTx) networkNodeState(networkID int64, state int) error {
+	stmt := "UPDATE networks_nodes SET state=? WHERE network_id = ? and node_id = ?"
+	result, err := c.tx.Exec(stmt, state, networkID, c.nodeID)
+	if err != nil {
+		return err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return ErrNoSuchObject
+	}
+
+	return nil
+}
+
 // UpdateNetwork updates the network with the given ID.
 func (c *ClusterTx) UpdateNetwork(id int64, description string, config map[string]string) error {
 	err := updateNetworkDescription(c.tx, id, description)

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -493,7 +493,7 @@ func (d *nicBridged) rebuildDnsmasqEntry() error {
 	defer dnsmasq.ConfigMutex.Unlock()
 
 	// Use project.Default here as bridge networks don't support projects.
-	_, dbInfo, err := d.state.Cluster.GetNetworkInAnyState(project.Default, d.config["parent"])
+	_, dbInfo, _, err := d.state.Cluster.GetNetworkInAnyState(project.Default, d.config["parent"])
 	if err != nil {
 		return err
 	}

--- a/lxd/device/nictype/nictype.go
+++ b/lxd/device/nictype/nictype.go
@@ -26,7 +26,7 @@ func NICType(s *state.State, deviceProjectName string, d deviceConfig.Device) (s
 				return "", errors.Wrapf(err, "Failed to translate device project %q into network project", deviceProjectName)
 			}
 
-			_, netInfo, err := s.Cluster.GetNetworkInAnyState(networkProjectName, d["network"])
+			_, netInfo, _, err := s.Cluster.GetNetworkInAnyState(networkProjectName, d["network"])
 			if err != nil {
 				return "", errors.Wrapf(err, "Failed to load network %q for project %q", d["network"], networkProjectName)
 			}

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -487,10 +487,6 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 
 	n.logger.Debug("Setting up network")
 
-	if n.status == api.NetworkStatusPending {
-		return fmt.Errorf("Cannot start pending network")
-	}
-
 	// Create directory.
 	if !shared.PathExists(shared.VarPath("networks", n.name)) {
 		err := os.MkdirAll(shared.VarPath("networks", n.name), 0711)

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1539,6 +1539,11 @@ func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clientType
 		return nil // Nothing changed.
 	}
 
+	if n.LocalStatus() == api.NetworkStatusPending {
+		// Apply DB change to local node only.
+		return n.common.update(newNetwork, targetNode, clientType)
+	}
+
 	revert := revert.New()
 	defer revert.Fail()
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1056,7 +1056,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		underlay := n.config["fan.underlay_subnet"]
 		_, underlaySubnet, err := net.ParseCIDR(underlay)
 		if err != nil {
-			return nil
+			return err
 		}
 
 		// Parse the overlay.

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -414,18 +414,20 @@ func (n *bridge) isRunning() bool {
 func (n *bridge) Delete(clientType cluster.ClientType) error {
 	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
 
-	// Bring the network down.
-	if n.isRunning() {
-		err := n.Stop()
+	// Bring the local network down if created on this node.
+	if n.LocalStatus() == api.NetworkStatusCreated {
+		if n.isRunning() {
+			err := n.Stop()
+			if err != nil {
+				return err
+			}
+		}
+
+		// Delete apparmor profiles.
+		err := apparmor.NetworkDelete(n.state, n)
 		if err != nil {
 			return err
 		}
-	}
-
-	// Delete apparmor profiles.
-	err := apparmor.NetworkDelete(n.state, n)
-	if err != nil {
-		return err
 	}
 
 	return n.common.delete(clientType)

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1542,47 +1542,50 @@ func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clientType
 	revert := revert.New()
 	defer revert.Fail()
 
-	// Define a function which reverts everything.
-	revert.Add(func() {
-		// Reset changes to all nodes and database.
-		n.common.update(oldNetwork, targetNode, clientType)
+	// Perform any pre-update cleanup needed if local node network was already created.
+	if len(changedKeys) > 0 {
+		// Define a function which reverts everything.
+		revert.Add(func() {
+			// Reset changes to all nodes and database.
+			n.common.update(oldNetwork, targetNode, clientType)
 
-		// Reset any change that was made to local bridge.
-		n.setup(newNetwork.Config)
-	})
+			// Reset any change that was made to local bridge.
+			n.setup(newNetwork.Config)
+		})
 
-	// Bring the bridge down entirely if the driver has changed.
-	if shared.StringInSlice("bridge.driver", changedKeys) && n.isRunning() {
-		err = n.Stop()
-		if err != nil {
-			return err
-		}
-	}
-
-	// Detach any external interfaces should no longer be attached.
-	if shared.StringInSlice("bridge.external_interfaces", changedKeys) && n.isRunning() {
-		devices := []string{}
-		for _, dev := range strings.Split(newNetwork.Config["bridge.external_interfaces"], ",") {
-			dev = strings.TrimSpace(dev)
-			devices = append(devices, dev)
+		// Bring the bridge down entirely if the driver has changed.
+		if shared.StringInSlice("bridge.driver", changedKeys) && n.isRunning() {
+			err = n.Stop()
+			if err != nil {
+				return err
+			}
 		}
 
-		for _, dev := range strings.Split(oldNetwork.Config["bridge.external_interfaces"], ",") {
-			dev = strings.TrimSpace(dev)
-			if dev == "" {
-				continue
+		// Detach any external interfaces should no longer be attached.
+		if shared.StringInSlice("bridge.external_interfaces", changedKeys) && n.isRunning() {
+			devices := []string{}
+			for _, dev := range strings.Split(newNetwork.Config["bridge.external_interfaces"], ",") {
+				dev = strings.TrimSpace(dev)
+				devices = append(devices, dev)
 			}
 
-			if !shared.StringInSlice(dev, devices) && InterfaceExists(dev) {
-				err = DetachInterface(n.name, dev)
-				if err != nil {
-					return err
+			for _, dev := range strings.Split(oldNetwork.Config["bridge.external_interfaces"], ",") {
+				dev = strings.TrimSpace(dev)
+				if dev == "" {
+					continue
+				}
+
+				if !shared.StringInSlice(dev, devices) && InterfaceExists(dev) {
+					err = DetachInterface(n.name, dev)
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}
 	}
 
-	// Apply changes to all nodes and databse.
+	// Apply changes to all nodes and database.
 	err = n.common.update(newNetwork, targetNode, clientType)
 	if err != nil {
 		return err

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -36,6 +36,7 @@ type common struct {
 	description string
 	config      map[string]string
 	status      string
+	managed     bool
 	nodes       map[int64]db.NetworkNode
 }
 
@@ -49,6 +50,7 @@ func (n *common) init(state *state.State, id int64, projectName string, netInfo 
 	n.state = state
 	n.description = netInfo.Description
 	n.status = netInfo.Status
+	n.managed = netInfo.Managed
 	n.nodes = netNodes
 }
 
@@ -148,6 +150,10 @@ func (n *common) LocalStatus() string {
 // Config returns the network config.
 func (n *common) Config() map[string]string {
 	return n.config
+}
+
+func (n *common) IsManaged() bool {
+	return n.managed
 }
 
 // Config returns the common network driver info.

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -1,8 +1,6 @@
 package network
 
 import (
-	"fmt"
-
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/revert"
@@ -66,10 +64,6 @@ func (n *macvlan) Rename(newName string) error {
 // Start starts is a no-op.
 func (n *macvlan) Start() error {
 	n.logger.Debug("Start")
-
-	if n.status == api.NetworkStatusPending {
-		return fmt.Errorf("Cannot start pending network")
-	}
 
 	return nil
 }

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -89,6 +89,11 @@ func (n *macvlan) Update(newNetwork api.NetworkPut, targetNode string, clientTyp
 		return nil // Nothing changed.
 	}
 
+	if n.LocalStatus() == api.NetworkStatusPending {
+		// Apply DB change to local node only.
+		return n.common.update(newNetwork, targetNode, clientType)
+	}
+
 	revert := revert.New()
 	defer revert.Fail()
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1758,61 +1758,63 @@ func (n *ovn) deleteChassisGroupEntry() error {
 func (n *ovn) Delete(clientType cluster.ClientType) error {
 	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
 
-	err := n.Stop()
-	if err != nil {
-		return err
-	}
-
-	if clientType == cluster.ClientTypeNormal {
-		client, err := n.getClient()
+	if n.LocalStatus() == api.NetworkStatusCreated {
+		err := n.Stop()
 		if err != nil {
 			return err
 		}
 
-		err = client.LogicalRouterDelete(n.getRouterName())
-		if err != nil {
-			return err
-		}
+		if clientType == cluster.ClientTypeNormal {
+			client, err := n.getClient()
+			if err != nil {
+				return err
+			}
 
-		err = client.LogicalSwitchDelete(n.getExtSwitchName())
-		if err != nil {
-			return err
-		}
+			err = client.LogicalRouterDelete(n.getRouterName())
+			if err != nil {
+				return err
+			}
 
-		err = client.LogicalSwitchDelete(n.getIntSwitchName())
-		if err != nil {
-			return err
-		}
+			err = client.LogicalSwitchDelete(n.getExtSwitchName())
+			if err != nil {
+				return err
+			}
 
-		err = client.LogicalRouterPortDelete(n.getRouterExtPortName())
-		if err != nil {
-			return err
-		}
+			err = client.LogicalSwitchDelete(n.getIntSwitchName())
+			if err != nil {
+				return err
+			}
 
-		err = client.LogicalRouterPortDelete(n.getRouterIntPortName())
-		if err != nil {
-			return err
-		}
+			err = client.LogicalRouterPortDelete(n.getRouterExtPortName())
+			if err != nil {
+				return err
+			}
 
-		err = client.LogicalSwitchPortDelete(n.getExtSwitchRouterPortName())
-		if err != nil {
-			return err
-		}
+			err = client.LogicalRouterPortDelete(n.getRouterIntPortName())
+			if err != nil {
+				return err
+			}
 
-		err = client.LogicalSwitchPortDelete(n.getExtSwitchProviderPortName())
-		if err != nil {
-			return err
-		}
+			err = client.LogicalSwitchPortDelete(n.getExtSwitchRouterPortName())
+			if err != nil {
+				return err
+			}
 
-		err = client.LogicalSwitchPortDelete(n.getIntSwitchRouterPortName())
-		if err != nil {
-			return err
-		}
+			err = client.LogicalSwitchPortDelete(n.getExtSwitchProviderPortName())
+			if err != nil {
+				return err
+			}
 
-		// Must be done after logical router removal.
-		err = client.ChassisGroupDelete(n.getChassisGroupName())
-		if err != nil {
-			return err
+			err = client.LogicalSwitchPortDelete(n.getIntSwitchRouterPortName())
+			if err != nil {
+				return err
+			}
+
+			// Must be done after logical router removal.
+			err = client.ChassisGroupDelete(n.getChassisGroupName())
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1892,6 +1892,11 @@ func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clientType cl
 		return nil // Nothing changed.
 	}
 
+	if n.LocalStatus() == api.NetworkStatusPending {
+		// Apply DB change to local node only.
+		return n.common.update(newNetwork, targetNode, clientType)
+	}
+
 	revert := revert.New()
 	defer revert.Fail()
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1836,10 +1836,6 @@ func (n *ovn) Rename(newName string) error {
 func (n *ovn) Start() error {
 	n.logger.Debug("Start")
 
-	if n.status == api.NetworkStatusPending {
-		return fmt.Errorf("Cannot start pending network")
-	}
-
 	// Add local node's OVS chassis ID to logical chassis group.
 	err := n.addChassisGroupEntry()
 	if err != nil {

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -82,7 +82,7 @@ func (n *ovn) Info() Info {
 
 // uplinkRoutes parses ipv4.routes and ipv6.routes settings for a named uplink network into a slice of *net.IPNet.
 func (n *ovn) uplinkRoutes(uplinkNetworkName string) ([]*net.IPNet, error) {
-	_, uplink, err := n.state.Cluster.GetNetworkInAnyState(project.Default, uplinkNetworkName)
+	_, uplink, _, err := n.state.Cluster.GetNetworkInAnyState(project.Default, uplinkNetworkName)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -118,9 +118,11 @@ func (n *physical) Create(clientType cluster.ClientType) error {
 func (n *physical) Delete(clientType cluster.ClientType) error {
 	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
 
-	err := n.Stop()
-	if err != nil {
-		return err
+	if n.LocalStatus() == api.NetworkStatusCreated {
+		err := n.Stop()
+		if err != nil {
+			return err
+		}
 	}
 
 	return n.common.delete(clientType)

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -143,10 +143,6 @@ func (n *physical) Rename(newName string) error {
 func (n *physical) Start() error {
 	n.logger.Debug("Start")
 
-	if n.status == api.NetworkStatusPending {
-		return fmt.Errorf("Cannot start pending network")
-	}
-
 	revert := revert.New()
 	defer revert.Fail()
 

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -229,6 +229,11 @@ func (n *physical) Update(newNetwork api.NetworkPut, targetNode string, clientTy
 		return nil // Nothing changed.
 	}
 
+	if n.LocalStatus() == api.NetworkStatusPending {
+		// Apply DB change to local node only.
+		return n.common.update(newNetwork, targetNode, clientType)
+	}
+
 	revert := revert.New()
 	defer revert.Fail()
 

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -89,6 +89,11 @@ func (n *sriov) Update(newNetwork api.NetworkPut, targetNode string, clientType 
 		return nil // Nothing changed.
 	}
 
+	if n.LocalStatus() == api.NetworkStatusPending {
+		// Apply DB change to local node only.
+		return n.common.update(newNetwork, targetNode, clientType)
+	}
+
 	revert := revert.New()
 	defer revert.Fail()
 

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -1,8 +1,6 @@
 package network
 
 import (
-	"fmt"
-
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/revert"
@@ -66,10 +64,6 @@ func (n *sriov) Rename(newName string) error {
 // Start starts is a no-op.
 func (n *sriov) Start() error {
 	n.logger.Debug("Start")
-
-	if n.status == api.NetworkStatusPending {
-		return fmt.Errorf("Cannot start pending network")
-	}
 
 	return nil
 }

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -35,6 +35,7 @@ type Network interface {
 	LocalStatus() string
 	Config() map[string]string
 	IsUsed() (bool, error)
+	IsManaged() bool
 	DHCPv4Subnet() *net.IPNet
 	DHCPv6Subnet() *net.IPNet
 	DHCPv4Ranges() []shared.IPRange

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -32,6 +32,7 @@ type Network interface {
 	Name() string
 	Description() string
 	Status() string
+	LocalStatus() string
 	Config() map[string]string
 	IsUsed() (bool, error)
 	DHCPv4Subnet() *net.IPNet

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -24,7 +24,7 @@ type Network interface {
 	Type
 
 	// Load.
-	init(state *state.State, id int64, projectName string, name string, netType string, description string, config map[string]string, status string)
+	init(state *state.State, id int64, projectName string, netInfo *api.Network, netNodes map[int64]db.NetworkNode)
 
 	// Config.
 	Validate(config map[string]string) error

--- a/lxd/network/network_load.go
+++ b/lxd/network/network_load.go
@@ -26,7 +26,7 @@ func LoadByType(driverType string) (Type, error) {
 
 // LoadByName loads an instantiated network from the database by project and name.
 func LoadByName(s *state.State, projectName string, name string) (Network, error) {
-	id, netInfo, err := s.Cluster.GetNetworkInAnyState(projectName, name)
+	id, netInfo, netNodes, err := s.Cluster.GetNetworkInAnyState(projectName, name)
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +37,7 @@ func LoadByName(s *state.State, projectName string, name string) (Network, error
 	}
 
 	n := driverFunc()
-	n.init(s, id, projectName, name, netInfo.Type, netInfo.Description, netInfo.Config, netInfo.Status)
+	n.init(s, id, projectName, netInfo, netNodes)
 
 	return n, nil
 }

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -530,7 +530,7 @@ func doNetworkGet(d *Daemon, projectName string, name string) (api.Network, erro
 	}
 
 	// Get some information.
-	_, dbInfo, _ := d.cluster.GetNetworkInAnyState(projectName, name)
+	_, dbInfo, _, _ := d.cluster.GetNetworkInAnyState(projectName, name)
 
 	// Don't allow retrieving info about the local node interfaces when not using default project.
 	if projectName != project.Default && dbInfo == nil {

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -280,7 +280,6 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Non-clustered network creation.
-
 	networks, err := d.cluster.GetNetworks(projectName)
 	if err != nil {
 		return response.InternalError(err)

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -673,6 +673,10 @@ func networkPost(d *Daemon, r *http.Request) response.Response {
 		return response.InternalError(errors.Wrapf(err, "Failed loading network"))
 	}
 
+	if n.Status() != api.NetworkStatusCreated {
+		return response.BadRequest(fmt.Errorf("Cannot rename network when not in created state"))
+	}
+
 	// Sanity check new name.
 	if req.Name == "" {
 		return response.BadRequest(fmt.Errorf("New network name not provided"))

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -742,6 +742,10 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	if targetNode == "" && n.Status() != api.NetworkStatusCreated {
+		return response.BadRequest(fmt.Errorf("Cannot update network global config when not in created state"))
+	}
+
 	// Duplicate config for etag modification and generation.
 	curConfig := map[string]string{}
 	for k, v := range n.Config() {

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -602,19 +602,6 @@ func networkDelete(d *Daemon, r *http.Request) response.Response {
 	name := mux.Vars(r)["name"]
 	state := d.State()
 
-	// Check if the network is pending, if so we just need to delete it from the database.
-	_, dbNetwork, err := d.cluster.GetNetworkInAnyState(projectName, name)
-	if err != nil {
-		return response.SmartError(err)
-	}
-	if dbNetwork.Status == api.NetworkStatusPending {
-		err := d.cluster.DeleteNetwork(projectName, name)
-		if err != nil {
-			return response.SmartError(err)
-		}
-		return response.EmptySyncResponse
-	}
-
 	// Get the existing network.
 	n, err := network.LoadByName(state, projectName, name)
 	if err != nil {
@@ -636,7 +623,7 @@ func networkDelete(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	// Delete the network.
+	// Delete the network from each member.
 	err = n.Delete(clientType)
 	if err != nil {
 		return response.SmartError(err)

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -731,9 +731,9 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 	name := mux.Vars(r)["name"]
 
 	// Get the existing network.
-	_, dbInfo, _, err := d.cluster.GetNetworkInAnyState(projectName, name)
+	n, err := network.LoadByName(d.State(), projectName, name)
 	if err != nil {
-		return response.SmartError(err)
+		return response.NotFound(err)
 	}
 
 	targetNode := queryParam(r, "target")
@@ -742,17 +742,23 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	// Duplicate config for etag modification and generation.
+	curConfig := map[string]string{}
+	for k, v := range n.Config() {
+		curConfig[k] = v
+	}
+
 	// If no target node is specified and the daemon is clustered, we omit the node-specific fields so that
 	// the e-tag can be generated correctly. This is because the GET request used to populate the request
 	// will also remove node-specific keys when no target is specified.
 	if targetNode == "" && clustered {
 		for _, key := range db.NodeSpecificNetworkConfig {
-			delete(dbInfo.Config, key)
+			delete(curConfig, key)
 		}
 	}
 
 	// Validate the ETag.
-	etag := []interface{}{dbInfo.Name, dbInfo.Managed, dbInfo.Type, dbInfo.Description, dbInfo.Config}
+	etag := []interface{}{n.Name(), n.IsManaged(), n.Type(), n.Description(), curConfig}
 	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return response.PreconditionFailed(err)
@@ -777,7 +783,7 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 		} else {
 			// If a target is specified, then ensure only node-specific config keys are changed.
 			for k, v := range req.Config {
-				if !shared.StringInSlice(k, db.NodeSpecificNetworkConfig) && dbInfo.Config[k] != v {
+				if !shared.StringInSlice(k, db.NodeSpecificNetworkConfig) && curConfig[k] != v {
 					return response.BadRequest(fmt.Errorf("Config key %q may not be used as node-specific key", k))
 				}
 			}
@@ -786,7 +792,7 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 
 	clientType := cluster.UserAgentClientType(r.Header.Get("User-Agent"))
 
-	return doNetworkUpdate(d, projectName, name, req, targetNode, clientType, r.Method, clustered)
+	return doNetworkUpdate(d, projectName, n, req, targetNode, clientType, r.Method, clustered)
 }
 
 func networkPatch(d *Daemon, r *http.Request) response.Response {
@@ -795,13 +801,7 @@ func networkPatch(d *Daemon, r *http.Request) response.Response {
 
 // doNetworkUpdate loads the current local network config, merges with the requested network config, validates
 // and applies the changes. Will also notify other cluster nodes of non-node specific config if needed.
-func doNetworkUpdate(d *Daemon, projectName string, name string, req api.NetworkPut, targetNode string, clientType cluster.ClientType, httpMethod string, clustered bool) response.Response {
-	// Load the local node-specific network.
-	n, err := network.LoadByName(d.State(), projectName, name)
-	if err != nil {
-		return response.NotFound(err)
-	}
-
+func doNetworkUpdate(d *Daemon, projectName string, n network.Network, req api.NetworkPut, targetNode string, clientType cluster.ClientType, httpMethod string, clustered bool) response.Response {
 	if req.Config == nil {
 		req.Config = map[string]string{}
 	}
@@ -829,7 +829,7 @@ func doNetworkUpdate(d *Daemon, projectName string, name string, req api.Network
 	}
 
 	// Validate the merged configuration.
-	err = n.Validate(req.Config)
+	err := n.Validate(req.Config)
 	if err != nil {
 		return response.BadRequest(err)
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -323,7 +323,7 @@ func networksPostCluster(d *Daemon, projectName string, req api.NetworksPost, cl
 
 	// Check that the requested network type matches the type created when adding the local node config.
 	// If network doesn't exist yet, ignore not found error, as this will be checked by NetworkNodeConfigs().
-	_, netInfo, err := d.cluster.GetNetworkInAnyState(projectName, req.Name)
+	_, netInfo, _, err := d.cluster.GetNetworkInAnyState(projectName, req.Name)
 	if err != nil && err != db.ErrNoSuchObject {
 		return err
 	}
@@ -727,7 +727,7 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 	name := mux.Vars(r)["name"]
 
 	// Get the existing network.
-	_, dbInfo, err := d.cluster.GetNetworkInAnyState(projectName, name)
+	_, dbInfo, _, err := d.cluster.GetNetworkInAnyState(projectName, name)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -3787,7 +3787,7 @@ func patchNetworkCearBridgeVolatileHwaddr(name string, d *Daemon) error {
 	}
 
 	for _, networkName := range networks {
-		_, net, err := d.cluster.GetNetworkInAnyState(projectName, networkName)
+		_, net, _, err := d.cluster.GetNetworkInAnyState(projectName, networkName)
 		if err != nil {
 			return errors.Wrapf(err, "Failed loading network %q for network_clear_bridge_volatile_hwaddr patch", networkName)
 		}

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -182,7 +182,7 @@ func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 	// storage config are the ones in StoragePoolNodeConfigKeys.
 	for key := range req.Config {
 		if !shared.StringInSlice(key, db.StoragePoolNodeConfigKeys) {
-			return response.SmartError(fmt.Errorf("Config key '%s' may not be used as node-specific key", key))
+			return response.SmartError(fmt.Errorf("Config key %q may not be used as node-specific key", key))
 		}
 	}
 
@@ -196,7 +196,7 @@ func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 	})
 	if err != nil {
 		if err == db.ErrAlreadyDefined {
-			return response.BadRequest(fmt.Errorf("The storage pool already defined on node %s", targetNode))
+			return response.BadRequest(fmt.Errorf("The storage pool already defined on node %q", targetNode))
 		}
 
 		return response.SmartError(err)
@@ -209,7 +209,7 @@ func storagePoolsPostCluster(d *Daemon, req api.StoragePoolsPost) error {
 	// Check that no node-specific config key has been defined.
 	for key := range req.Config {
 		if shared.StringInSlice(key, db.StoragePoolNodeConfigKeys) {
-			return fmt.Errorf("Config key '%s' is node-specific", key)
+			return fmt.Errorf("Config key %q is node-specific", key)
 		}
 	}
 
@@ -525,7 +525,7 @@ func storagePoolPatch(d *Daemon, r *http.Request) response.Response {
 func storagePoolValidateClusterConfig(reqConfig map[string]string) error {
 	for key := range reqConfig {
 		if shared.StringInSlice(key, db.StoragePoolNodeConfigKeys) {
-			return fmt.Errorf("node-specific config key %s can't be changed", key)
+			return fmt.Errorf("Node-specific config key %q can't be changed", key)
 		}
 	}
 	return nil

--- a/lxd/storage_pools_utils.go
+++ b/lxd/storage_pools_utils.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"github.com/lxc/lxd/lxd/state"
 	storagePools "github.com/lxc/lxd/lxd/storage"
 	"github.com/lxc/lxd/shared"
@@ -95,7 +97,7 @@ func storagePoolCreateGlobal(state *state.State, req api.StoragePoolsPost) error
 	return nil
 }
 
-// This performs all non-db related work needed to create the pool.
+// This performs local pool setup and updates DB record if config was changed during pool setup.
 func storagePoolCreateLocal(state *state.State, id int64, req api.StoragePoolsPost, isNotification bool) (map[string]string, error) {
 	tryUndo := true
 
@@ -145,7 +147,7 @@ func storagePoolCreateLocal(state *state.State, id int64, req api.StoragePoolsPo
 		// Create the database entry for the storage pool.
 		err = state.Cluster.UpdateStoragePool(req.Name, req.Description, updatedConfig)
 		if err != nil {
-			return nil, fmt.Errorf("Error inserting %s into database: %s", req.Name, err)
+			return nil, errors.Wrapf(err, "Error updating storage pool config after local create for %q", req.Name)
 		}
 	}
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -731,6 +731,10 @@ test_clustering_network() {
   # The state of the preseeded network is still CREATED
   LXD_DIR="${LXD_ONE_DIR}" lxc network list| grep "${bridge}" | grep -q CREATED
 
+  # Check both nodes show network created.
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${bridge}' AND nodes.name = 'node1'" | grep "| node1 | 1     |"
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${bridge}' AND nodes.name = 'node2'" | grep "| node2 | 1     |"
+
   # Trying to pass config values other than
   # 'bridge.external_interfaces' results in an error
   ! LXD_DIR="${LXD_ONE_DIR}" lxc network create foo ipv4.address=auto --target node1 || false
@@ -766,6 +770,74 @@ test_clustering_network() {
   # Delete the networks
   LXD_DIR="${LXD_TWO_DIR}" lxc network delete "${net}"
   LXD_DIR="${LXD_TWO_DIR}" lxc network delete "${bridge}"
+
+  LXD_PID1="$(LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0 | jq .environment.server_pid)"
+  LXD_PID2="$(LXD_DIR="${LXD_TWO_DIR}" lxc query /1.0 | jq .environment.server_pid)"
+
+  # Test network create partial failures.
+  nsenter -n -t "${LXD_PID1}" -- ip link add "${net}" type dummy # Create dummy interface to conflict with network.
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net}" --target node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net}" --target node2
+
+  # Run network create on other node1 (expect this to fail early due to existing interface).
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net}" || false
+  LXD_DIR="${LXD_ONE_DIR}" lxc network show "${net}" | grep status: | grep -q Pending # Check is still pending.
+
+  # Check each node status (expect both node1 and node2 to be pending as local node running created failed first).
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node1'" | grep "| node1 | 0     |"
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node2'" | grep "| node2 | 0     |"
+
+  # Run network create on other node2 (still excpect to fail on node1, but expect node2 create to succeed).
+  ! LXD_DIR="${LXD_TWO_DIR}" lxc network create "${net}" || false
+
+  # Check each node status (expect node1 to be pending and node2 to be created).
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node1'" | grep "| node1 | 0     |"
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node2'" | grep "| node2 | 1     |"
+
+  # Check interfaces are expected types (dummy on node1 and bridge on node2).
+  nsenter -n -t "${LXD_PID1}" -- ip -details link show "${net}" | grep dummy
+  nsenter -n -t "${LXD_PID2}" -- ip -details link show "${net}" | grep bridge
+
+  # Check we cannot update network global config while in pending state on either node.
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc network set "${net}" ipv4.dhcp false || false
+  ! LXD_DIR="${LXD_TWO_DIR}" lxc network set "${net}" ipv4.dhcp false || false
+
+  # Check we can update node-specific config on the node that has been created (and that it is applied).
+  nsenter -n -t "${LXD_PID2}" -- ip link add "ext-${net}" type dummy # Create dummy interface to add to bridge.
+  LXD_DIR="${LXD_TWO_DIR}" lxc network set "${net}" bridge.external_interfaces "ext-${net}" --target node2
+  nsenter -n -t "${LXD_PID2}" -- ip link show "ext-${net}" | grep "master ${net}"
+
+  # Check we can update node-specific config on the node that hasn't been created (and that only DB is updated).
+  nsenter -n -t "${LXD_PID1}" -- ip link add "ext-${net}" type dummy # Create dummy interface to add to bridge.
+  nsenter -n -t "${LXD_PID1}" -- ip address add 192.0.2.1/32 dev "ext-${net}" # Add address to prevent attach.
+  LXD_DIR="${LXD_ONE_DIR}" lxc network set "${net}" bridge.external_interfaces "ext-${net}" --target node1
+  ! nsenter -n -t "${LXD_PID1}" -- ip link show "ext-${net}" | grep "master ${net}" || false  # Don't expect to be attached.
+
+  # Delete partially created network and check nodes that were created are cleaned up.
+  LXD_DIR="${LXD_ONE_DIR}" lxc network delete "${net}"
+  ! nsenter -n -t "${LXD_PID2}" -- ip link show "${net}" || false # Check bridge is removed.
+  nsenter -n -t "${LXD_PID2}" -- ip link show "ext-${net}" # Check external interface still exists.
+  nsenter -n -t "${LXD_PID1}" -- ip -details link show "${net}" | grep dummy # Check node1 conflict still exists.
+
+  # Create new partially created network and check we can fix it.
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net}" --target node1
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net}" --target node2
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net}" || false
+  LXD_DIR="${LXD_ONE_DIR}" lxc network show "${net}" | grep status: | grep -q Pending # Check is still pending.
+  nsenter -n -t "${LXD_PID1}" -- ip link delete "${net}" # Remove conflicting interface.
+  LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net}"
+  LXD_DIR="${LXD_ONE_DIR}" lxc network show "${net}" | grep status: | grep -q Created # Check is created after fix.
+  nsenter -n -t "${LXD_PID1}" -- ip -details link show "${net}" | grep bridge # Check bridge exists.
+  nsenter -n -t "${LXD_PID2}" -- ip -details link show "${net}" | grep bridge # Check bridge exists.
+
+  # Check both nodes marked created.
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node1'" | grep "| node1 | 1     |"
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node2'" | grep "| node2 | 1     |"
+
+  # Delete network.
+  LXD_DIR="${LXD_ONE_DIR}" lxc network delete "${net}"
+  ! nsenter -n -t "${LXD_PID1}" -- ip link show "${net}" || false # Check bridge is removed.
+  ! nsenter -n -t "${LXD_PID2}" -- ip link show "${net}" || false # Check bridge is removed.
 
   LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
   LXD_DIR="${LXD_ONE_DIR}" lxd shutdown


### PR DESCRIPTION
- Adds state column to networks_nodes table.
- Modifies network create process to allow per-node state tracking.
- Allows fixing of per-node creation blockers when creating a network in a cluster.

Checks:

- [x] Check partially created network stays in `pending` state, but successful nodes are marked as `created`.
- [x] Allow update of `pending` node specific config when network in `pending` state.
- [x] Block update of non-node-specific config when network in `pending` state.
- [x] Block rename of network in `pending state`.
- [x] Run local delete process for `created` nodes when deleting network in `pending` state.
- [x] Allow subsequent non-targeted network create command and skip any nodes already in `created` state.
- [x] Only mark network as `created` when all nodes successfully created.

Related to https://github.com/lxc/lxd/issues/8111