### PR TITLE
Storage: Allow unsafe resize when filling initial image volume

### DIFF
--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -149,14 +149,9 @@ func instanceCreateFromImage(d *Daemon, args db.InstanceArgs, hash string, op *o
 		return nil, errors.Wrap(err, "Failed creating instance record")
 	}
 
-	revert := true
-	defer func() {
-		if !revert {
-			return
-		}
-
-		inst.Delete()
-	}()
+	revert := revert.New()
+	defer revert.Fail()
+	revert.Add(func() { inst.Delete() })
 
 	err = s.Cluster.UpdateImageLastUseDate(hash, time.Now().UTC())
 	if err != nil {
@@ -178,7 +173,7 @@ func instanceCreateFromImage(d *Daemon, args db.InstanceArgs, hash string, op *o
 		return nil, err
 	}
 
-	revert = false
+	revert.Success()
 	return inst, nil
 }
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1069,6 +1069,7 @@ func (b *lxdBackend) CreateInstanceFromImage(inst instance.Instance, fingerprint
 
 		// Set the derived size directly as the "size" property on the new volume so that it is applied.
 		vol.SetConfigSize(newVolSize)
+		logger.Debug("Set new volume size", log.Ctx{"size": newVolSize})
 
 		// Proceed to create a new volume by copying the optimized image volume.
 		err = b.driver.CreateVolumeFromCopy(vol, imgVol, false, op)

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -872,7 +872,8 @@ func (d *ceph) SetVolumeQuota(vol Volume, size string, op *operations.Operation)
 
 	// Block image volumes cannot be resized because they have a readonly snapshot that doesn't get
 	// updated when the volume's size is changed, and this is what instances are created from.
-	if vol.volType == VolumeTypeImage {
+	// During initial volume fill allowUnsafeResize is enabled because snapshot hasn't been taken yet.
+	if !vol.allowUnsafeResize && vol.volType == VolumeTypeImage {
 		return ErrNotSupported
 	}
 

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -940,7 +940,8 @@ func (d *zfs) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 
 		// Block image volumes cannot be resized because they have a readonly snapshot that doesn't get
 		// updated when the volume's size is changed, and this is what instances are created from.
-		if vol.volType == VolumeTypeImage {
+		// During initial volume fill allowUnsafeResize is enabled because snapshot hasn't been taken yet.
+		if !vol.allowUnsafeResize && vol.volType == VolumeTypeImage {
 			return ErrNotSupported
 		}
 


### PR DESCRIPTION
Allows unpacking of images larger than default volume size (while filler function itself still checks the storage pool's `volume.size` setting to ensure no additional restrictions set) into new image volumes (before potential read-only snapshot is taken).

Fixes https://discuss.linuxcontainers.org/t/widnows-vm-creation-from-image-error-increasing-volume-size/9552