### PR TITLE
Report `qemu` driver with version in `/1.0`

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"strings"
 
-	liblxc "gopkg.in/lxc/go-lxc.v2"
-
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/config"
@@ -201,8 +199,6 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		Architectures:          architectures,
 		Certificate:            certificate,
 		CertificateFingerprint: certificateFingerprint,
-		Driver:                 "lxc",
-		DriverVersion:          liblxc.Version(),
 		Kernel:                 uname.Sysname,
 		KernelArchitecture:     uname.Machine,
 		KernelVersion:          uname.Release,
@@ -224,6 +220,22 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		"seccomp_listener":          fmt.Sprintf("%v", d.os.SeccompListener),
 		"seccomp_listener_continue": fmt.Sprintf("%v", d.os.SeccompListenerContinue),
 		"shiftfs":                   fmt.Sprintf("%v", d.os.Shiftfs),
+	}
+
+	instanceDrivers := readInstanceDriversCache()
+	for driver, version := range instanceDrivers {
+		if env.Driver != "" {
+			env.Driver = env.Driver + " | " + driver
+		} else {
+			env.Driver = driver
+		}
+
+		// Get the version of the instance drivers in use.
+		if env.DriverVersion != "" {
+			env.DriverVersion = env.DriverVersion + " | " + version
+		} else {
+			env.DriverVersion = version
+		}
 	}
 
 	if d.os.LXCFeatures != nil {

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6720,3 +6720,11 @@ func (d *lxc) SaveConfigFile() error {
 
 	return nil
 }
+
+// Info returns "lxc" and the currently loaded version of LXC
+func (d *lxc) Info() instance.Info {
+	return instance.Info{
+		Name:    "lxc",
+		Version: liblxc.Version(),
+	}
+}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4977,3 +4977,35 @@ func (d *qemu) writeInstanceData() error {
 
 	return nil
 }
+
+// Info returns "qemu" and the currently loaded qemu version.
+func (d *qemu) Info() instance.Info {
+	data := instance.Info{
+		Name: "qemu",
+	}
+
+	hostArch, err := osarch.ArchitectureGetLocalID()
+	if err != nil {
+		return data
+	}
+
+	qemuPath, _, err := d.qemuArchConfig(hostArch)
+	if err != nil {
+		return data
+	}
+
+	out, err := exec.Command(qemuPath, "--version").Output()
+	if err != nil {
+		return data
+	}
+
+	qemuOutput := strings.Fields(string(out))
+	if len(qemuOutput) < 4 {
+		data.Version = "unknown"
+		return data
+	}
+
+	qemuVersion := strings.Fields(string(out))[3]
+	data.Version = qemuVersion
+	return data
+}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -837,8 +837,8 @@ func (d *qemu) Start(stateful bool) error {
 		devConfs = append(devConfs, runConf)
 	}
 
-	// Get qemu configuration.
-	qemuBinary, qemuBus, err := d.qemuArchConfig()
+	// Get qemu configuration and check qemu is installed.
+	qemuPath, qemuBus, err := d.qemuArchConfig(d.architecture)
 	if err != nil {
 		op.Done(err)
 		return err
@@ -848,13 +848,6 @@ func (d *qemu) Start(stateful bool) error {
 	fdFiles := make([]string, 0)
 
 	confFile, err := d.generateQemuConfigFile(mountInfo, qemuBus, devConfs, &fdFiles)
-	if err != nil {
-		op.Done(err)
-		return err
-	}
-
-	// Check qemu is installed.
-	qemuPath, err := exec.LookPath(qemuBinary)
 	if err != nil {
 		op.Done(err)
 		return err
@@ -1179,15 +1172,35 @@ func (d *qemu) setupNvram() error {
 	return nil
 }
 
-func (d *qemu) qemuArchConfig() (string, string, error) {
-	if d.architecture == osarch.ARCH_64BIT_INTEL_X86 {
-		return "qemu-system-x86_64", "pcie", nil
-	} else if d.architecture == osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN {
-		return "qemu-system-aarch64", "pcie", nil
-	} else if d.architecture == osarch.ARCH_64BIT_POWERPC_LITTLE_ENDIAN {
-		return "qemu-system-ppc64", "pci", nil
-	} else if d.architecture == osarch.ARCH_64BIT_S390_BIG_ENDIAN {
-		return "qemu-system-s390x", "ccw", nil
+func (d *qemu) qemuArchConfig(arch int) (string, string, error) {
+	if arch == osarch.ARCH_64BIT_INTEL_X86 {
+		path, err := exec.LookPath("qemu-system-x86_64")
+		if err != nil {
+			return "", "", err
+		}
+
+		return path, "pcie", nil
+	} else if arch == osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN {
+		path, err := exec.LookPath("qemu-system-aarch64")
+		if err != nil {
+			return "", "", err
+		}
+
+		return path, "pcie", nil
+	} else if arch == osarch.ARCH_64BIT_POWERPC_LITTLE_ENDIAN {
+		path, err := exec.LookPath("qemu-system-ppc64")
+		if err != nil {
+			return "", "", err
+		}
+
+		return path, "pci", nil
+	} else if arch == osarch.ARCH_64BIT_S390_BIG_ENDIAN {
+		path, err := exec.LookPath("qemu-system-s390x")
+		if err != nil {
+			return "", "", err
+		}
+
+		return path, "ccw", nil
 	}
 
 	return "", "", fmt.Errorf("Architecture isn't supported for virtual machines")

--- a/lxd/instance/drivers/load.go
+++ b/lxd/instance/drivers/load.go
@@ -15,6 +15,11 @@ import (
 	"github.com/lxc/lxd/shared/api"
 )
 
+var instanceDrivers = map[string]func() instance.Instance{
+	"lxc":  func() instance.Instance { return &lxc{} },
+	"qemu": func() instance.Instance { return &qemu{} },
+}
+
 func init() {
 	// Expose load to the instance package, to avoid circular imports.
 	instance.Load = load
@@ -95,4 +100,16 @@ func create(s *state.State, args db.InstanceArgs) (instance.Instance, error) {
 	}
 
 	return nil, fmt.Errorf("Instance type invalid")
+}
+
+// SupportedInstanceDrivers returns a slice of Info structs for all supported drivers
+func SupportedInstanceDrivers() []instance.Info {
+	supportedDrivers := make([]instance.Info, 0, len(instanceDrivers))
+
+	for _, instanceDriver := range instanceDrivers {
+		driver := instanceDriver()
+		supportedDrivers = append(supportedDrivers, driver.Info())
+	}
+
+	return supportedDrivers
 }

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -57,6 +57,7 @@ type Instance interface {
 	RegisterDevices()
 	SaveConfigFile() error
 
+	Info() Info
 	IsPrivileged() bool
 
 	// Snapshots & migration & backups.
@@ -163,4 +164,10 @@ type CriuMigrationArgs struct {
 	DumpDir      string
 	PreDumpDir   string
 	Features     liblxc.CriuFeatures
+}
+
+// Info represents information about an instance driver.
+type Info struct {
+	Name    string // Name of an instance driver, e.g. "lxc"
+	Version string // Version number of a loaded instance driver
 }


### PR DESCRIPTION
As requested, this is a draft pull request for issue #7869, having implemented most of the things mentioned in the most recent comments.

As noted in the description of commit ead2141 the Info() function in driver_qemu.go isn't quite working yet, there's some runtime bugs that I haven't sorted out relating to finding the path of the qemu binary.

Additionally, there seems to be some kind of race condition in the creation of the driver cache, as either ``lxc`` or ``qemu`` can end up appearing first in the list, though I am unsure where this would be generated so it is not listed in any particular commit.