### PR TITLE
Network: Don't fill default config when doing an update

### DIFF
--- a/doc/networks.md
+++ b/doc/networks.md
@@ -84,7 +84,7 @@ ipv4.firewall                   | boolean   | ipv4 address          | true      
 ipv4.nat.address                | string    | ipv4 address          | -                         | The source address used for outbound traffic from the bridge
 ipv4.nat                        | boolean   | ipv4 address          | false                     | Whether to NAT (defaults to true for regular bridges where ipv4.address is generated and always defaults to true for fan bridges)
 ipv4.nat.order                  | string    | ipv4 address          | before                    | Whether to add the required NAT rules before or after any pre-existing rules
-ipv4.ovn.ranges                 | string    | -                     | none                      | Comma separate list of IPv4 ranges to use for child OVN network routers (FIRST-LAST format)
+ipv4.ovn.ranges                 | string    | -                     | -                         | Comma separate list of IPv4 ranges to use for child OVN network routers (FIRST-LAST format)
 ipv4.routes                     | string    | ipv4 address          | -                         | Comma separated list of additional IPv4 CIDR subnets to route to the bridge
 ipv4.routing                    | boolean   | ipv4 address          | true                      | Whether to route traffic in and out of the bridge
 ipv6.address                    | string    | standard mode         | auto (on create only)     | IPv6 address for the bridge (CIDR notation). Use "none" to turn off IPv6 or "auto" to generate a new random unused subnet
@@ -96,7 +96,7 @@ ipv6.firewall                   | boolean   | ipv6 address          | true      
 ipv6.nat.address                | string    | ipv6 address          | -                         | The source address used for outbound traffic from the bridge
 ipv6.nat                        | boolean   | ipv6 address          | false                     | Whether to NAT (will default to true if unset and a random ipv6.address is generated)
 ipv6.nat.order                  | string    | ipv6 address          | before                    | Whether to add the required NAT rules before or after any pre-existing rules
-ipv6.ovn.ranges                 | string    | -                     | none                      | Comma separate list of IPv6 ranges to use for child OVN network routers (FIRST-LAST format)
+ipv6.ovn.ranges                 | string    | -                     | -                         | Comma separate list of IPv6 ranges to use for child OVN network routers (FIRST-LAST format)
 ipv6.routes                     | string    | ipv6 address          | -                         | Comma separated list of additional IPv6 CIDR subnets to route to the bridge
 ipv6.routing                    | boolean   | ipv6 address          | true                      | Whether to route traffic in and out of the bridge
 maas.subnet.ipv4                | string    | ipv4 address          | -                         | MAAS IPv4 subnet to register instances in (when using `network` property on nic)
@@ -317,9 +317,9 @@ mtu                             | integer   | -                     | -         
 parent                          | string    | -                     | -                         | Parent interface to create sriov NICs on
 vlan                            | integer   | -                     | -                         | The VLAN ID to attach to
 ipv4.gateway                    | string    | standard mode         | -                         | IPv4 address for the gateway and network (CIDR notation)
-ipv4.ovn.ranges                 | string    | -                     | none                      | Comma separate list of IPv4 ranges to use for child OVN network routers (FIRST-LAST format)
+ipv4.ovn.ranges                 | string    | -                     | -                         | Comma separate list of IPv4 ranges to use for child OVN network routers (FIRST-LAST format)
 ipv4.routes                     | string    | ipv4 address          | -                         | Comma separated list of additional IPv4 CIDR subnets that can be used with child OVN networks ipv4.routes.external setting
 ipv6.gateway                    | string    | standard mode         | -                         | IPv6 address for the gateway and network  (CIDR notation)
-ipv6.ovn.ranges                 | string    | -                     | none                      | Comma separate list of IPv6 ranges to use for child OVN network routers (FIRST-LAST format)
+ipv6.ovn.ranges                 | string    | -                     | -                         | Comma separate list of IPv6 ranges to use for child OVN network routers (FIRST-LAST format)
 ipv6.routes                     | string    | ipv6 address          | -                         | Comma separated list of additional IPv6 CIDR subnets that can be used with child OVN networks ipv6.routes.external setting
 dns.nameservers                 | string    | standard mode         | -                         | List of DNS server IPs on physical network

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -74,8 +74,8 @@ dns.mode                        | string    | -                     | managed   
 dns.search                      | string    | -                     | -                         | Full comma separated domain search list, defaulting to `dns.domain` value
 fan.overlay\_subnet             | string    | fan mode              | 240.0.0.0/8               | Subnet to use as the overlay for the FAN (CIDR notation)
 fan.type                        | string    | fan mode              | vxlan                     | The tunneling type for the FAN ("vxlan" or "ipip")
-fan.underlay\_subnet            | string    | fan mode              | default gateway subnet    | Subnet to use as the underlay for the FAN (CIDR notation)
-ipv4.address                    | string    | standard mode         | random unused subnet      | IPv4 address for the bridge (CIDR notation). Use "none" to turn off IPv4 or "auto" to generate a new one
+fan.underlay\_subnet            | string    | fan mode              | auto (on create only)     | Subnet to use as the underlay for the FAN (CIDR notation). Use "auto" to use default gateway subnet
+ipv4.address                    | string    | standard mode         | auto (on create only)     | IPv4 address for the bridge (CIDR notation). Use "none" to turn off IPv4 or "auto" to generate a new random unused subnet
 ipv4.dhcp                       | boolean   | ipv4 address          | true                      | Whether to allocate addresses using DHCP
 ipv4.dhcp.expiry                | string    | ipv4 dhcp             | 1h                        | When to expire DHCP leases
 ipv4.dhcp.gateway               | string    | ipv4 dhcp             | ipv4.address              | Address of the gateway for the subnet
@@ -87,7 +87,7 @@ ipv4.nat.order                  | string    | ipv4 address          | before    
 ipv4.ovn.ranges                 | string    | -                     | none                      | Comma separate list of IPv4 ranges to use for child OVN network routers (FIRST-LAST format)
 ipv4.routes                     | string    | ipv4 address          | -                         | Comma separated list of additional IPv4 CIDR subnets to route to the bridge
 ipv4.routing                    | boolean   | ipv4 address          | true                      | Whether to route traffic in and out of the bridge
-ipv6.address                    | string    | standard mode         | random unused subnet      | IPv6 address for the bridge (CIDR notation). Use "none" to turn off IPv6 or "auto" to generate a new one
+ipv6.address                    | string    | standard mode         | auto (on create only)     | IPv6 address for the bridge (CIDR notation). Use "none" to turn off IPv6 or "auto" to generate a new random unused subnet
 ipv6.dhcp                       | boolean   | ipv6 address          | true                      | Whether to provide additional network configuration over DHCP
 ipv6.dhcp.expiry                | string    | ipv6 dhcp             | 1h                        | When to expire DHCP leases
 ipv6.dhcp.ranges                | string    | ipv6 stateful dhcp    | all addresses             | Comma separated list of IPv6 ranges to use for DHCP (FIRST-LAST format)

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -296,9 +296,9 @@ bridge.hwaddr                   | string    | -                     | -         
 bridge.mtu                      | integer   | -                     | 1442                      | Bridge MTU (default allows host to host geneve tunnels)
 dns.domain                      | string    | -                     | lxd                       | Domain to advertise to DHCP clients and use for DNS resolution
 dns.search                      | string    | -                     | -                         | Full comma separated domain search list, defaulting to `dns.domain` value
-ipv4.address                    | string    | standard mode         | random unused subnet      | IPv4 address for the bridge (CIDR notation). Use "none" to turn off IPv4 or "auto" to generate a new one
+ipv4.address                    | string    | standard mode         | auto (on create only)     | IPv4 address for the bridge (CIDR notation). Use "none" to turn off IPv4 or "auto" to generate a new random unused subnet
 ipv4.nat                        | boolean   | ipv4 address          | false                     | Whether to NAT (will default to true if unset and a random ipv4.address is generated)
-ipv6.address                    | string    | standard mode         | random unused subnet      | IPv6 address for the bridge (CIDR notation). Use "none" to turn off IPv6 or "auto" to generate a new one
+ipv6.address                    | string    | standard mode         | auto (on create only)     | IPv6 address for the bridge (CIDR notation). Use "none" to turn off IPv6 or "auto" to generate a new random unused subnet
 ipv6.dhcp.stateful              | boolean   | ipv6 dhcp             | false                     | Whether to allocate addresses using DHCP
 ipv6.nat                        | boolean   | ipv6 address          | false                     | Whether to NAT (will default to true if unset and a random ipv6.address is generated)
 network                         | string    | -                     | -                         | Uplink network to use for external network access

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1524,12 +1524,6 @@ func (n *bridge) Stop() error {
 func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clientType cluster.ClientType) error {
 	n.logger.Debug("Update", log.Ctx{"clientType": clientType, "newNetwork": newNetwork})
 
-	// Populate default values if they are missing.
-	err := n.FillConfig(newNetwork.Config)
-	if err != nil {
-		return err
-	}
-
 	dbUpdateNeeeded, changedKeys, oldNetwork, err := n.common.configChanged(newNetwork)
 	if err != nil {
 		return err

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -368,7 +368,7 @@ func (n *bridge) Validate(config map[string]string) error {
 
 		_, err := parseIPRanges(config["ipv4.ovn.ranges"], allowedNets...)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "Failed parsing ipv4.ovn.ranges")
 		}
 	}
 
@@ -387,7 +387,7 @@ func (n *bridge) Validate(config map[string]string) error {
 
 		_, err := parseIPRanges(config["ipv6.ovn.ranges"], allowedNets...)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "Failed parsing ipv6.ovn.ranges")
 		}
 	}
 
@@ -798,7 +798,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		// Parse the subnet.
 		ip, subnet, err := net.ParseCIDR(n.config["ipv4.address"])
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "Failed parsing ipv4.address")
 		}
 
 		// Update the dnsmasq config.
@@ -915,7 +915,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		// Parse the subnet.
 		ip, subnet, err := net.ParseCIDR(n.config["ipv6.address"])
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "Failed parsing ipv6.address")
 		}
 		subnetSize, _ := subnet.Mask.Size()
 
@@ -1056,7 +1056,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		underlay := n.config["fan.underlay_subnet"]
 		_, underlaySubnet, err := net.ParseCIDR(underlay)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "Failed parsing fan.underlay_subnet")
 		}
 
 		// Parse the overlay.
@@ -1067,7 +1067,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 
 		_, overlaySubnet, err = net.ParseCIDR(overlay)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "Failed parsing fan.overlay_subnet")
 		}
 
 		// Get the address.
@@ -1112,7 +1112,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		// Parse the host subnet.
 		_, hostSubnet, err := net.ParseCIDR(fmt.Sprintf("%s/24", addr[0]))
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "Failed parsing fan address")
 		}
 
 		// Add the address.

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -115,6 +115,19 @@ func (n *bridge) FillConfig(config map[string]string) error {
 		}
 	}
 
+	// Now replace any "auto" keys with generated values.
+	err := n.populateAutoConfig(config)
+	if err != nil {
+		return errors.Wrapf(err, "Failed generating auto config")
+	}
+
+	return nil
+}
+
+// populateAutoConfig replaces "auto" in config with generated values.
+func (n *bridge) populateAutoConfig(config map[string]string) error {
+	changedConfig := false
+
 	// Now populate "auto" values where needed.
 	if config["ipv4.address"] == "auto" {
 		subnet, err := randomSubnetV4()
@@ -123,6 +136,7 @@ func (n *bridge) FillConfig(config map[string]string) error {
 		}
 
 		config["ipv4.address"] = subnet
+		changedConfig = true
 	}
 
 	if config["ipv6.address"] == "auto" {
@@ -132,6 +146,7 @@ func (n *bridge) FillConfig(config map[string]string) error {
 		}
 
 		config["ipv6.address"] = subnet
+		changedConfig = true
 	}
 
 	if config["fan.underlay_subnet"] == "auto" {
@@ -141,6 +156,12 @@ func (n *bridge) FillConfig(config map[string]string) error {
 		}
 
 		config["fan.underlay_subnet"] = subnet.String()
+		changedConfig = true
+	}
+
+	// Re-validate config if changed.
+	if changedConfig && n.state != nil {
+		return n.Validate(config)
 	}
 
 	return nil
@@ -1523,6 +1544,11 @@ func (n *bridge) Stop() error {
 // cluster notification, in which case do not update the database, just apply local changes needed.
 func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clientType cluster.ClientType) error {
 	n.logger.Debug("Update", log.Ctx{"clientType": clientType, "newNetwork": newNetwork})
+
+	err := n.populateAutoConfig(newNetwork.Config)
+	if err != nil {
+		return errors.Wrapf(err, "Failed generating auto config")
+	}
 
 	dbUpdateNeeeded, changedKeys, oldNetwork, err := n.common.configChanged(newNetwork)
 	if err != nil {

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1878,12 +1878,6 @@ func (n *ovn) Stop() error {
 func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clientType cluster.ClientType) error {
 	n.logger.Debug("Update", log.Ctx{"clientType": clientType, "newNetwork": newNetwork})
 
-	// Populate default values if they are missing.
-	err := n.FillConfig(newNetwork.Config)
-	if err != nil {
-		return err
-	}
-
 	dbUpdateNeeeded, changedKeys, oldNetwork, err := n.common.configChanged(newNetwork)
 	if err != nil {
 		return err

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -233,10 +233,11 @@ func (n *ovn) Validate(config map[string]string) error {
 	// If NAT disabled, parse the external subnets that are being requested.
 	var externalSubnets []*net.IPNet
 	for _, keyPrefix := range []string{"ipv4", "ipv6"} {
-		if !shared.IsTrue(config[fmt.Sprintf("%s.nat", keyPrefix)]) && validate.IsOneOf(config[fmt.Sprintf("%s.address", keyPrefix)], []string{"", "none", "auto"}) != nil {
-			_, ipNet, err := net.ParseCIDR(config[fmt.Sprintf("%s.address", keyPrefix)])
+		addressKey := fmt.Sprintf("%s.address", keyPrefix)
+		if !shared.IsTrue(config[fmt.Sprintf("%s.nat", keyPrefix)]) && validate.IsOneOf(config[addressKey], []string{"", "none", "auto"}) != nil {
+			_, ipNet, err := net.ParseCIDR(config[addressKey])
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "Failed parsing %s", addressKey)
 			}
 
 			externalSubnets = append(externalSubnets, ipNet)

--- a/test/suites/network.sh
+++ b/test/suites/network.sh
@@ -27,6 +27,12 @@ test_network() {
   lxc network unset lxdt$$ ipv6.address
   ! lxc network show lxdt$$ | grep ipv6.address || false
 
+  # check ipv4.address and ipv6.address can be regenerated on update using "auto" value.
+  lxc network set lxdt$$ ipv4.address auto
+  lxc network show lxdt$$ | grep ipv4.address
+  lxc network set lxdt$$ ipv6.address auto
+  lxc network show lxdt$$ | grep ipv6.address
+
   # delete the network
   lxc network delete lxdt$$
 

--- a/test/suites/network.sh
+++ b/test/suites/network.sh
@@ -21,6 +21,12 @@ test_network() {
   lxc query -X PATCH -d "{\\\"config\\\": {\\\"ipv6.dhcp.stateful\\\": \\\"true\\\"}}" /1.0/networks/lxdt$$
   [ "$(lxc network get lxdt$$ ipv6.dhcp.stateful)" = "true" ]
 
+  # check ipv4.address and ipv6.address can be unset without triggering random subnet generation.
+  lxc network unset lxdt$$ ipv4.address
+  ! lxc network show lxdt$$ | grep ipv4.address || false
+  lxc network unset lxdt$$ ipv6.address
+  ! lxc network show lxdt$$ | grep ipv6.address || false
+
   # delete the network
   lxc network delete lxdt$$
 


### PR DESCRIPTION
This allows for `ipv4.address`, `ipv6.address` and `fan.underlay_subnet` settings to be removed and have the effect of "none" rather than "auto".

- [x] Don't fill default config on update.
- [x] Accept "auto" on update.
- [x] Update docs to clarify default behaviour.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>