### PR TITLE
lxc-to-lxd: Fix handling on snap

### DIFF
--- a/lxc-to-lxd/main.go
+++ b/lxc-to-lxd/main.go
@@ -1,5 +1,47 @@
 package main
 
+/*
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+__attribute__((constructor)) void init(void) {
+	int ret;
+	int mntns_fd;
+
+	if (getenv("SNAP") == NULL)
+		return;
+
+	mntns_fd = open("/proc/1/ns/mnt", O_RDONLY | O_CLOEXEC);
+	if (ret < 0) {
+		fprintf(stderr, "Failed open mntns: %s\n", strerror(errno));
+		_exit(EXIT_FAILURE);
+	}
+
+	ret = setns(mntns_fd, CLONE_NEWNS);
+	close(mntns_fd);
+	if (ret < 0) {
+		fprintf(stderr, "Failed setns to outside mount namespace: %s\n", strerror(errno));
+		_exit(EXIT_FAILURE);
+	}
+
+	ret = chdir("/");
+	if (ret < 0) {
+		fprintf(stderr, "Failed chdir /: %s\n", strerror(errno));
+		_exit(EXIT_FAILURE);
+	}
+
+	// We're done, jump back to Go
+}
+*/
+import "C"
 import (
 	"os"
 

--- a/lxc-to-lxd/main_migrate.go
+++ b/lxc-to-lxd/main_migrate.go
@@ -71,7 +71,7 @@ func (c *cmdMigrate) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	// Retrieve LXC containers
-	for _, container := range liblxc.Containers(shared.HostPathFollow(c.flagLXCPath)) {
+	for _, container := range liblxc.Containers(c.flagLXCPath) {
 		if !c.flagAll && !shared.StringInSlice(container.Name(), c.flagContainers) {
 			continue
 		}


### PR DESCRIPTION
Running lxc-to-lxd from a snap environment is tricky.

We can't just use the previous approach of resolving the main container
dir through HostPath as any included file will cause a config read
failure. We also can't just have the snap run the entire binary on the
host as the linker would fail on liblxc.

Instead, this approach lets the loader take care of the dynamic
libraries and we then attach to the host mount namespace and process the
rest from there.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>