### PR TITLE
Lifecycle improvements

### DIFF
--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -177,6 +177,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 	}
 
 	revert.Success()
+	backup.Lifecycle(s, sourceInst, args.Name, "created", nil)
 	return nil
 }
 

--- a/lxd/backup/backup_instance.go
+++ b/lxd/backup/backup_instance.go
@@ -89,6 +89,9 @@ func (b *InstanceBackup) Rename(newName string) error {
 		return err
 	}
 
+	oldName := b.name
+	b.name = newName
+	Lifecycle(b.state, b.instance, b.name, "renamed", map[string]interface{}{"old_name": oldName})
 	return nil
 }
 
@@ -120,6 +123,7 @@ func (b *InstanceBackup) Delete() error {
 		return err
 	}
 
+	Lifecycle(b.state, b.instance, b.name, "deleted", nil)
 	return nil
 }
 

--- a/lxd/backup/backup_utils.go
+++ b/lxd/backup/backup_utils.go
@@ -5,7 +5,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 
+	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 )
 
@@ -27,4 +30,16 @@ func TarReader(r io.ReadSeeker) (*tar.Reader, context.CancelFunc, error) {
 	}
 
 	return tr, cancelFunc, nil
+}
+
+// Lifecycle emits a backup-specific lifecycle event.
+func Lifecycle(s *state.State, inst Instance, name string, action string, ctx map[string]interface{}) error {
+	prefix := "instance-backup"
+	u := fmt.Sprintf("/1.0/instances/%s/backups/%s", url.PathEscape(inst.Name()), url.PathEscape(name))
+
+	if inst.Project() != project.Default {
+		u = fmt.Sprintf("%s?project=%s", u, url.QueryEscape(inst.Project()))
+	}
+
+	return s.Events.SendLifecycle(inst.Project(), fmt.Sprintf("%s-%s", prefix, action), u, ctx)
 }

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -454,11 +454,11 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 					return ua, nil
 				}
 
-				if r.Context().Value("protocol") == "cluster" {
+				if protocol == "cluster" {
 					return ua, nil
 				}
 
-				if r.Context().Value("protocol") == "tls" {
+				if protocol == "tls" {
 					return ua, nil
 				}
 

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -417,12 +417,6 @@ func instanceCreateAsSnapshot(s *state.State, args db.InstanceArgs, sourceInstan
 		os.RemoveAll(sourceInstance.StatePath())
 	}
 
-	s.Events.SendLifecycle(sourceInstance.Project(), "container-snapshot-created",
-		fmt.Sprintf("/1.0/containers/%s", sourceInstance.Name()),
-		map[string]interface{}{
-			"snapshot_name": args.Name,
-		})
-
 	revert.Success()
 	return inst, nil
 }

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -291,7 +291,7 @@ func qemuCreate(s *state.State, args db.InstanceArgs) (instance.Instance, error)
 	}
 
 	logger.Info("Created instance", ctxMap)
-	d.state.Events.SendLifecycle(d.project, "virtual-machine-created", fmt.Sprintf("/1.0/virtual-machines/%s", d.name), nil)
+	d.lifecycle("created", nil)
 
 	revert.Success()
 	return d, nil
@@ -482,6 +482,7 @@ func (d *qemu) Freeze() error {
 		return err
 	}
 
+	d.lifecycle("paused", nil)
 	return nil
 }
 
@@ -543,8 +544,7 @@ func (d *qemu) onStop(target string) error {
 			return err
 		}
 
-		d.state.Events.SendLifecycle(d.project, "virtual-machine-restarted",
-			fmt.Sprintf("/1.0/virtual-machines/%s", d.name), nil)
+		d.lifecycle("restarted", nil)
 	} else if d.ephemeral {
 		// Reset timeout to 30s.
 		op.Reset()
@@ -557,9 +557,8 @@ func (d *qemu) onStop(target string) error {
 		}
 	}
 
-	if target != "reboot" {
-		d.state.Events.SendLifecycle(d.project, "virtual-machine-shutdown",
-			fmt.Sprintf("/1.0/virtual-machines/%s", d.name), nil)
+	if op == nil {
+		d.lifecycle("shutdown", nil)
 	}
 
 	op.Done(nil)
@@ -635,7 +634,7 @@ func (d *qemu) Shutdown(timeout time.Duration) error {
 	}
 
 	if op.Action() == "stop" {
-		d.state.Events.SendLifecycle(d.project, "virtual-machine-shutdown", fmt.Sprintf("/1.0/virtual-machines/%s", d.name), nil)
+		d.lifecycle("shutdown", nil)
 	}
 
 	return nil
@@ -648,8 +647,7 @@ func (d *qemu) Restart(timeout time.Duration) error {
 		return err
 	}
 
-	d.state.Events.SendLifecycle(d.project, "virtual-machine-restarted",
-		fmt.Sprintf("/1.0/virtual-machines/%s", d.name), nil)
+	d.lifecycle("restarted", nil)
 
 	return nil
 }
@@ -1120,7 +1118,7 @@ func (d *qemu) Start(stateful bool) error {
 	revert.Success()
 
 	if op.Action() == "start" {
-		d.state.Events.SendLifecycle(d.project, "virtual-machine-started", fmt.Sprintf("/1.0/virtual-machines/%s", d.name), nil)
+		d.lifecycle("started", nil)
 	}
 
 	return nil
@@ -2600,7 +2598,7 @@ func (d *qemu) Stop(stateful bool) error {
 	}
 
 	if op.Action() == "stop" {
-		d.state.Events.SendLifecycle(d.project, "virtual-machine-stopped", fmt.Sprintf("/1.0/virtual-machines/%s", d.name), nil)
+		d.lifecycle("stopped", nil)
 	}
 
 	return nil
@@ -2620,6 +2618,7 @@ func (d *qemu) Unfreeze() error {
 		return err
 	}
 
+	d.lifecycle("resumed", nil)
 	return nil
 }
 
@@ -2731,14 +2730,15 @@ func (d *qemu) Restore(source instance.Instance, stateful bool) error {
 		return err
 	}
 
-	d.state.Events.SendLifecycle(d.project, "virtual-machine-snapshot-restored", fmt.Sprintf("/1.0/virtual-machines/%s", d.name), map[string]interface{}{"snapshot_name": d.name})
-
 	// Restart the insance.
 	if wasRunning {
-		logger.Info("Restored instance", ctxMap)
-		return d.Start(false)
+		err := d.Start(false)
+		if err != nil {
+			return err
+		}
 	}
 
+	d.lifecycle("restored", map[string]interface{}{"snapshot": source.Name()})
 	logger.Info("Restored instance", ctxMap)
 	return nil
 }
@@ -2879,19 +2879,7 @@ func (d *qemu) Rename(newName string) error {
 	}
 
 	logger.Info("Renamed instance", ctxMap)
-
-	if d.IsSnapshot() {
-		d.state.Events.SendLifecycle(d.project, "virtual-machine-snapshot-renamed",
-			fmt.Sprintf("/1.0/virtual-machines/%s", oldName), map[string]interface{}{
-				"new_name":      newName,
-				"snapshot_name": oldName,
-			})
-	} else {
-		d.state.Events.SendLifecycle(d.project, "virtual-machine-renamed",
-			fmt.Sprintf("/1.0/virtual-machines/%s", oldName), map[string]interface{}{
-				"new_name": newName,
-			})
-	}
+	d.lifecycle("renamed", map[string]interface{}{"old_name": oldName})
 
 	revert.Success()
 	return nil
@@ -3220,16 +3208,10 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 	}
 
-	var endpoint string
-
-	if d.IsSnapshot() {
-		parentName, snapName, _ := shared.InstanceGetParentAndSnapshotName(d.name)
-		endpoint = fmt.Sprintf("/1.0/virtual-machines/%s/snapshots/%s", parentName, snapName)
-	} else {
-		endpoint = fmt.Sprintf("/1.0/virtual-machines/%s", d.name)
+	if userRequested {
+		d.lifecycle("updated", nil)
 	}
 
-	d.state.Events.SendLifecycle(d.project, "virtual-machine-updated", endpoint, nil)
 	return nil
 }
 
@@ -3627,16 +3609,7 @@ func (d *qemu) Delete(force bool) error {
 	}
 
 	logger.Info("Deleted instance", ctxMap)
-
-	if d.IsSnapshot() {
-		d.state.Events.SendLifecycle(d.project, "virtual-machine-snapshot-deleted",
-			fmt.Sprintf("/1.0/virtual-machines/%s", d.name), map[string]interface{}{
-				"snapshot_name": d.name,
-			})
-	} else {
-		d.state.Events.SendLifecycle(d.project, "virtual-machine-deleted",
-			fmt.Sprintf("/1.0/virtual-machines/%s", d.name), nil)
-	}
+	d.lifecycle("deleted", nil)
 
 	return nil
 }

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -423,7 +423,7 @@ func (n *bridge) Create(clientType cluster.ClientType) error {
 		return fmt.Errorf("Network interface %q already exists", n.name)
 	}
 
-	return nil
+	return n.common.create(clientType)
 }
 
 // isRunning returns whether the network is up.

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -3,6 +3,7 @@ package network
 import (
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"strings"
 
@@ -11,6 +12,7 @@ import (
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -386,4 +388,16 @@ func (n *common) Create(clientType cluster.ClientType) error {
 // HandleHeartbeat is a no-op.
 func (n *common) HandleHeartbeat(heartbeatData *cluster.APIHeartbeat) error {
 	return nil
+}
+
+// lifecycle sends a lifecycle event for the network.
+func (n *common) lifecycle(action string, ctx map[string]interface{}) error {
+	prefix := "network"
+	u := fmt.Sprintf("/1.0/networks/%s", url.PathEscape(n.name))
+
+	if n.project != project.Default {
+		u = fmt.Sprintf("%s?project=%s", u, url.QueryEscape(n.project))
+	}
+
+	return n.state.Events.SendLifecycle(n.project, fmt.Sprintf("%s-%s", prefix, action), u, ctx)
 }

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -267,6 +267,8 @@ func (n *common) update(applyNetwork api.NetworkPut, targetNode string, clientTy
 		if err != nil {
 			return err
 		}
+
+		n.lifecycle("updated", nil)
 	}
 
 	return nil
@@ -322,6 +324,10 @@ func (n *common) configChanged(newNetwork api.NetworkPut) (bool, []string, api.N
 
 // create just sends the needed lifecycle event.
 func (n *common) create(clientType cluster.ClientType) error {
+	if clientType == cluster.ClientTypeNormal {
+		n.lifecycle("created", nil)
+	}
+
 	return nil
 }
 
@@ -347,8 +353,10 @@ func (n *common) rename(newName string) error {
 	}
 
 	// Reinitialise internal name variable and logger context with new name.
+	oldName := n.name
 	n.name = newName
 
+	n.lifecycle("renamed", map[string]interface{}{"old_name": oldName})
 	return nil
 }
 
@@ -373,6 +381,8 @@ func (n *common) delete(clientType cluster.ClientType) error {
 		if err != nil {
 			return err
 		}
+
+		n.lifecycle("deleted", nil)
 	}
 
 	// Cleanup storage.

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -320,6 +320,11 @@ func (n *common) configChanged(newNetwork api.NetworkPut) (bool, []string, api.N
 	return dbUpdateNeeded, changedKeys, oldNetwork, nil
 }
 
+// create just sends the needed lifecycle event.
+func (n *common) create(clientType cluster.ClientType) error {
+	return nil
+}
+
 // rename the network directory, update database record and update internal variables.
 func (n *common) rename(newName string) error {
 	// Clear new directory if exists.
@@ -382,7 +387,7 @@ func (n *common) delete(clientType cluster.ClientType) error {
 func (n *common) Create(clientType cluster.ClientType) error {
 	n.logger.Debug("Create", log.Ctx{"clientType": clientType, "config": n.config})
 
-	return nil
+	return n.create(clientType)
 }
 
 // HandleHeartbeat is a no-op.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1271,7 +1271,7 @@ func (n *ovn) Create(clientType cluster.ClientType) error {
 		}
 	}
 
-	return nil
+	return n.common.create(clientType)
 }
 
 // allowedUplinkNetworks returns a list of allowed networks to use as uplinks based on project restrictions.

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -111,7 +111,7 @@ func (n *physical) Create(clientType cluster.ClientType) error {
 		}
 	}
 
-	return nil
+	return n.common.create(clientType)
 }
 
 // Delete deletes a network.

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -129,9 +129,11 @@ func genericVFSRenameVolumeSnapshot(d Driver, snapVol Volume, newSnapshotName st
 	oldPath := snapVol.MountPath()
 	newPath := GetVolumeMountPath(d.Name(), snapVol.volType, GetSnapshotVolumeName(parentName, newSnapshotName))
 
-	err := os.Rename(oldPath, newPath)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to rename '%s' to '%s'", oldPath, newPath)
+	if shared.PathExists(oldPath) {
+		err := os.Rename(oldPath, newPath)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to rename '%s' to '%s'", oldPath, newPath)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This implements consistent events for:

 - instance-created
 - instance-renamed
 - instance-deleted
 - instance-updated
 - instance-started
 - instance-stopped
 - instance-shutdown
 - instance-restarted
 - instance-paused
 - instance-resumed
 - instance-snapshot-create
 - instance-snapshot-renamed
 - instance-snapshot-deleted
 - instance-restored
 - instance-backup-created (new)
 - instance-backup-renamed (new)
 - instance-backup-deleted (new)

 - network-created (new)
 - network-updated (new)
 - network-renamed (new)
 - network-deleted (new)

It also fixes the URLs to properly contain the project name when applicable.

The branch also has a couple of unrelated fixes:

 - Fix for RBAC failure on clients that are not using RBAC (due to bad checks in the exception rules)
 - Fix for a failure to rename VM snapshots on ZFS due to ZFS renaming the directory under us