### PR TITLE
Cluster: Moves ClientType, its constants and helper into own package

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/response"
@@ -118,7 +119,7 @@ func setCORSHeaders(rw http.ResponseWriter, req *http.Request, config *cluster.C
 // notifying us of some user-initiated API request that needs some action to be
 // taken on this node as well.
 func isClusterNotification(r *http.Request) bool {
-	return r.Header.Get("User-Agent") == cluster.UserAgentNotifier
+	return r.Header.Get("User-Agent") == request.UserAgentNotifier
 }
 
 // projectParam returns the project query parameter from the given request or "default" if parameter is not set.

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -16,6 +16,7 @@ import (
 
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/operations"
@@ -388,7 +389,7 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) response.Response {
 		// As ServerAddress field is required to be set it means that we're using the new join API
 		// introduced with the 'clustering_join' extension.
 		// Connect to ourselves to initialize storage pools and networks using the API.
-		localClient, err := lxd.ConnectLXDUnix(d.UnixSocket(), &lxd.ConnectionArgs{UserAgent: cluster.UserAgentJoiner})
+		localClient, err := lxd.ConnectLXDUnix(d.UnixSocket(), &lxd.ConnectionArgs{UserAgent: request.UserAgentJoiner})
 		if err != nil {
 			return errors.Wrap(err, "Failed to connect to local LXD")
 		}

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	lxd "github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/state"
@@ -56,7 +57,7 @@ func Connect(address string, cert *shared.CertInfo, notify bool) (lxd.InstanceSe
 		UserAgent:     version.UserAgent,
 	}
 	if notify {
-		args.UserAgent = UserAgentNotifier
+		args.UserAgent = request.UserAgentNotifier
 	}
 
 	url := fmt.Sprintf("https://%s", address)

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -20,38 +20,6 @@ import (
 	"github.com/lxc/lxd/shared/version"
 )
 
-// UserAgentNotifier used to distinguish between a regular client request and an internal cluster request when
-// notifying other nodes of a cluster change.
-const UserAgentNotifier = "lxd-cluster-notifier"
-
-// UserAgentJoiner used to distinguish between a regular client request and an internal cluster request when
-// joining a node to a cluster.
-const UserAgentJoiner = "lxd-cluster-joiner"
-
-// ClientType indicates which sort of client type is being used.
-type ClientType string
-
-// ClientTypeNotifier cluster notification client.
-const ClientTypeNotifier ClientType = "notifier"
-
-// ClientTypeJoiner cluster joiner client.
-const ClientTypeJoiner ClientType = "joiner"
-
-// ClientTypeNormal normal client.
-const ClientTypeNormal ClientType = "normal"
-
-// UserAgentClientType converts user agent to client type.
-func UserAgentClientType(userAgent string) ClientType {
-	switch userAgent {
-	case UserAgentNotifier:
-		return ClientTypeNotifier
-	case UserAgentJoiner:
-		return ClientTypeJoiner
-	}
-
-	return ClientTypeNormal
-}
-
 // Connect is a convenience around lxd.ConnectLXD that configures the client
 // with the correct parameters for node-to-node communication.
 //

--- a/lxd/cluster/request/clienttype.go
+++ b/lxd/cluster/request/clienttype.go
@@ -1,0 +1,33 @@
+package request
+
+// UserAgentNotifier used to distinguish between a regular client request and an internal cluster request when
+// notifying other nodes of a cluster change.
+const UserAgentNotifier = "lxd-cluster-notifier"
+
+// UserAgentJoiner used to distinguish between a regular client request and an internal cluster request when
+// joining a node to a cluster.
+const UserAgentJoiner = "lxd-cluster-joiner"
+
+// ClientType indicates which sort of client type is being used.
+type ClientType string
+
+// ClientTypeNotifier cluster notification client.
+const ClientTypeNotifier ClientType = "notifier"
+
+// ClientTypeJoiner cluster joiner client.
+const ClientTypeJoiner ClientType = "joiner"
+
+// ClientTypeNormal normal client.
+const ClientTypeNormal ClientType = "normal"
+
+// UserAgentClientType converts user agent to client type.
+func UserAgentClientType(userAgent string) ClientType {
+	switch userAgent {
+	case UserAgentNotifier:
+		return ClientTypeNotifier
+	case UserAgentJoiner:
+		return ClientTypeJoiner
+	}
+
+	return ClientTypeNormal
+}

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/apparmor"
 	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/daemon"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/dnsmasq"
@@ -416,7 +417,7 @@ func (n *bridge) Validate(config map[string]string) error {
 }
 
 // Create checks whether the bridge interface name is used already.
-func (n *bridge) Create(clientType cluster.ClientType) error {
+func (n *bridge) Create(clientType request.ClientType) error {
 	n.logger.Debug("Create", log.Ctx{"clientType": clientType, "config": n.config})
 
 	if InterfaceExists(n.name) {
@@ -432,7 +433,7 @@ func (n *bridge) isRunning() bool {
 }
 
 // Delete deletes a network.
-func (n *bridge) Delete(clientType cluster.ClientType) error {
+func (n *bridge) Delete(clientType request.ClientType) error {
 	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
 
 	// Bring the local network down if created on this node.
@@ -1542,7 +1543,7 @@ func (n *bridge) Stop() error {
 
 // Update updates the network. Accepts notification boolean indicating if this update request is coming from a
 // cluster notification, in which case do not update the database, just apply local changes needed.
-func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clientType cluster.ClientType) error {
+func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clientType request.ClientType) error {
 	n.logger.Debug("Update", log.Ctx{"clientType": clientType, "newNetwork": newNetwork})
 
 	err := n.populateAutoConfig(newNetwork.Config)

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -1,7 +1,7 @@
 package network
 
 import (
-	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/shared/api"
@@ -43,7 +43,7 @@ func (n *macvlan) Validate(config map[string]string) error {
 }
 
 // Delete deletes a network.
-func (n *macvlan) Delete(clientType cluster.ClientType) error {
+func (n *macvlan) Delete(clientType request.ClientType) error {
 	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
 	return n.common.delete(clientType)
 }
@@ -77,7 +77,7 @@ func (n *macvlan) Stop() error {
 
 // Update updates the network. Accepts notification boolean indicating if this update request is coming from a
 // cluster notification, in which case do not update the database, just apply local changes needed.
-func (n *macvlan) Update(newNetwork api.NetworkPut, targetNode string, clientType cluster.ClientType) error {
+func (n *macvlan) Update(newNetwork api.NetworkPut, targetNode string, clientType request.ClientType) error {
 	n.logger.Debug("Update", log.Ctx{"clientType": clientType, "newNetwork": newNetwork})
 
 	dbUpdateNeeeded, _, oldNetwork, err := n.common.configChanged(newNetwork)

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/revert"
@@ -97,11 +97,11 @@ func (n *physical) checkParentUse(ourConfig map[string]string) (bool, error) {
 
 // Create checks whether the referenced parent interface is used by other networks or instance devices, as we
 // need to have exclusive access to the interface.
-func (n *physical) Create(clientType cluster.ClientType) error {
+func (n *physical) Create(clientType request.ClientType) error {
 	n.logger.Debug("Create", log.Ctx{"clientType": clientType, "config": n.config})
 
 	// We only need to check in the database once, not on every clustered node.
-	if clientType == cluster.ClientTypeNormal {
+	if clientType == request.ClientTypeNormal {
 		inUse, err := n.checkParentUse(n.config)
 		if err != nil {
 			return err
@@ -115,7 +115,7 @@ func (n *physical) Create(clientType cluster.ClientType) error {
 }
 
 // Delete deletes a network.
-func (n *physical) Delete(clientType cluster.ClientType) error {
+func (n *physical) Delete(clientType request.ClientType) error {
 	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
 
 	if n.LocalStatus() == api.NetworkStatusCreated {
@@ -217,7 +217,7 @@ func (n *physical) Stop() error {
 
 // Update updates the network. Accepts notification boolean indicating if this update request is coming from a
 // cluster notification, in which case do not update the database, just apply local changes needed.
-func (n *physical) Update(newNetwork api.NetworkPut, targetNode string, clientType cluster.ClientType) error {
+func (n *physical) Update(newNetwork api.NetworkPut, targetNode string, clientType request.ClientType) error {
 	n.logger.Debug("Update", log.Ctx{"clientType": clientType, "newNetwork": newNetwork})
 
 	dbUpdateNeeeded, changedKeys, oldNetwork, err := n.common.configChanged(newNetwork)
@@ -240,7 +240,7 @@ func (n *physical) Update(newNetwork api.NetworkPut, targetNode string, clientTy
 	hostNameChanged := shared.StringInSlice("vlan", changedKeys) || shared.StringInSlice("parent", changedKeys)
 
 	// We only need to check in the database once, not on every clustered node.
-	if clientType == cluster.ClientTypeNormal {
+	if clientType == request.ClientTypeNormal {
 		if hostNameChanged {
 			isUsed, err := n.IsUsed()
 			if isUsed || err != nil {

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -1,7 +1,7 @@
 package network
 
 import (
-	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/shared/api"
@@ -43,7 +43,7 @@ func (n *sriov) Validate(config map[string]string) error {
 }
 
 // Delete deletes a network.
-func (n *sriov) Delete(clientType cluster.ClientType) error {
+func (n *sriov) Delete(clientType request.ClientType) error {
 	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
 	return n.common.delete(clientType)
 }
@@ -77,7 +77,7 @@ func (n *sriov) Stop() error {
 
 // Update updates the network. Accepts notification boolean indicating if this update request is coming from a
 // cluster notification, in which case do not update the database, just apply local changes needed.
-func (n *sriov) Update(newNetwork api.NetworkPut, targetNode string, clientType cluster.ClientType) error {
+func (n *sriov) Update(newNetwork api.NetworkPut, targetNode string, clientType request.ClientType) error {
 	n.logger.Debug("Update", log.Ctx{"clientType": clientType, "newNetwork": newNetwork})
 
 	dbUpdateNeeeded, _, oldNetwork, err := n.common.configChanged(newNetwork)

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -4,6 +4,7 @@ import (
 	"net"
 
 	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
@@ -42,11 +43,11 @@ type Network interface {
 	DHCPv6Ranges() []shared.IPRange
 
 	// Actions.
-	Create(clientType cluster.ClientType) error
+	Create(clientType request.ClientType) error
 	Start() error
 	Stop() error
 	Rename(name string) error
-	Update(newNetwork api.NetworkPut, targetNode string, clientType cluster.ClientType) error
+	Update(newNetwork api.NetworkPut, targetNode string, clientType request.ClientType) error
 	HandleHeartbeat(heartbeatData *cluster.APIHeartbeat) error
-	Delete(clientType cluster.ClientType) error
+	Delete(clientType request.ClientType) error
 }

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -17,6 +17,7 @@ import (
 
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/device/nictype"
 	"github.com/lxc/lxd/lxd/instance"
@@ -194,7 +195,7 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	url := fmt.Sprintf("/%s/networks/%s", version.APIVersion, req.Name)
 	resp := response.SyncResponseLocation(true, nil, url)
 
-	clientType := cluster.UserAgentClientType(r.Header.Get("User-Agent"))
+	clientType := request.UserAgentClientType(r.Header.Get("User-Agent"))
 
 	if isClusterNotification(r) {
 		// This is an internal request which triggers the actual creation of the network across all nodes
@@ -244,7 +245,7 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 
 	if count > 1 {
 		// Simulate adding pending node network config when the driver doesn't support per-node config.
-		if !netTypeInfo.NodeSpecificConfig && clientType != cluster.ClientTypeJoiner {
+		if !netTypeInfo.NodeSpecificConfig && clientType != request.ClientTypeJoiner {
 			revert.Add(func() {
 				d.cluster.DeleteNetwork(projectName, req.Name)
 			})
@@ -315,7 +316,7 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 
 // networksPostCluster checks that there is a pending network in the database and then attempts to setup the
 // network on each node. If all nodes are successfully setup then the network's state is set to created.
-func networksPostCluster(d *Daemon, projectName string, req api.NetworksPost, clientType cluster.ClientType, netType network.Type) error {
+func networksPostCluster(d *Daemon, projectName string, req api.NetworksPost, clientType request.ClientType, netType network.Type) error {
 	// Check that no node-specific config key has been supplied in request.
 	for key := range req.Config {
 		if shared.StringInSlice(key, db.NodeSpecificNetworkConfig) {
@@ -432,7 +433,7 @@ func networksPostCluster(d *Daemon, projectName string, req api.NetworksPost, cl
 
 // Create the network on the system. The clusterNotification flag is used to indicate whether creation request
 // is coming from a cluster notification (and if so we should not delete the database record on error).
-func doNetworksCreate(d *Daemon, projectName string, req api.NetworksPost, clientType cluster.ClientType) error {
+func doNetworksCreate(d *Daemon, projectName string, req api.NetworksPost, clientType request.ClientType) error {
 	// Start the network.
 	n, err := network.LoadByName(d.State(), projectName, req.Name)
 	if err != nil {
@@ -458,7 +459,7 @@ func doNetworksCreate(d *Daemon, projectName string, req api.NetworksPost, clien
 
 	// Only start networks when not doing a cluster pre-join phase (this ensures that networks are only started
 	// once the node has fully joined the clustered database and has consistent config with rest of the nodes).
-	if clientType != cluster.ClientTypeJoiner {
+	if clientType != request.ClientTypeJoiner {
 		err = n.Start()
 		if err != nil {
 			delErr := n.Delete(clientType)
@@ -608,7 +609,7 @@ func networkDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	clientType := cluster.UserAgentClientType(r.Header.Get("User-Agent"))
+	clientType := request.UserAgentClientType(r.Header.Get("User-Agent"))
 
 	clusterNotification := isClusterNotification(r)
 	if !clusterNotification {
@@ -790,7 +791,7 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	clientType := cluster.UserAgentClientType(r.Header.Get("User-Agent"))
+	clientType := request.UserAgentClientType(r.Header.Get("User-Agent"))
 
 	return doNetworkUpdate(d, projectName, n, req, targetNode, clientType, r.Method, clustered)
 }
@@ -801,7 +802,7 @@ func networkPatch(d *Daemon, r *http.Request) response.Response {
 
 // doNetworkUpdate loads the current local network config, merges with the requested network config, validates
 // and applies the changes. Will also notify other cluster nodes of non-node specific config if needed.
-func doNetworkUpdate(d *Daemon, projectName string, n network.Network, req api.NetworkPut, targetNode string, clientType cluster.ClientType, httpMethod string, clustered bool) response.Response {
+func doNetworkUpdate(d *Daemon, projectName string, n network.Network, req api.NetworkPut, targetNode string, clientType request.ClientType, httpMethod string, clustered bool) response.Response {
 	if req.Config == nil {
 		req.Config = map[string]string{}
 	}


### PR DESCRIPTION
To avoid circular imports conflicts with storage package.

Related to https://github.com/lxc/lxd/pull/8205