### PR TITLE
lxd/apparmor/qemu: Allow some more files

### DIFF
--- a/lxd/apparmor/instance_qemu.go
+++ b/lxd/apparmor/instance_qemu.go
@@ -40,6 +40,10 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   /usr/share/qemu/**                        kr,
   /usr/share/seabios/**                     kr,
   owner @{PROC}/@{pid}/task/@{tid}/comm     rw,
+  {{ .rootPath }}/etc/nsswitch.conf         r,
+  {{ .rootPath }}/etc/passwd                r,
+  {{ .rootPath }}/etc/group                 r,
+  @{PROC}/version                           r,
 
   # Instance specific paths
   {{ .logPath }}/** rwk,


### PR DESCRIPTION
This allows NSS related files:
 - nsswitch.conf
 - passwd
 - group

As well as /proc/version which QEMU apparently accesses sometimes.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>