### PR TITLE
Storage: Fixes 10s delay when using VMs with ZFS in snap

### DIFF
--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1003,7 +1003,7 @@ func (d *zfs) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 // GetVolumeDiskPath returns the location of a root disk block device.
 func (d *zfs) GetVolumeDiskPath(vol Volume) (string, error) {
 	// Shortcut for udev.
-	if tryExists(filepath.Join("/dev/zvol", d.dataset(vol, false))) {
+	if shared.PathExists(filepath.Join("/dev/zvol", d.dataset(vol, false))) {
 		return filepath.Join("/dev/zvol", d.dataset(vol, false)), nil
 	}
 


### PR DESCRIPTION
This is caused because /dev/zvol appears to not be populated when using the snap.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>