### PR TITLE
Storage: Allow BTRFS to detect volume.size pool changes and regeneration image volumes

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2201,8 +2201,8 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 
 			imgVol.SetConfigSize(newVolSize)
 
-			// Try applying the current size policy to the existin volume. If it is the same the driver
-			// should make no changes, and if not then attempt to resize it to the new policy.
+			// Try applying the current size policy to the existing volume. If it is the same the
+			// driver should make no changes, and if not then attempt to resize it to the new policy.
 			logger.Debug("Setting image volume size", "size", imgVol.ConfigSize())
 			err = b.driver.SetVolumeQuota(imgVol, imgVol.ConfigSize(), op)
 			if errors.Cause(err) == drivers.ErrCannotBeShrunk || errors.Cause(err) == drivers.ErrNotSupported {

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -68,6 +68,13 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 			return err
 		}
 
+		// Allow unsafe resize of image volumes as filler won't have been able to resize the volume to the
+		// target size as volume file didn't exist then (and we can't create in advance because qemu-img
+		// truncates the file to image size).
+		if vol.volType == VolumeTypeImage {
+			vol.allowUnsafeResize = true
+		}
+
 		_, err = ensureVolumeBlockFile(vol, rootBlockPath, sizeBytes)
 
 		// Ignore ErrCannotBeShrunk as this just means the filler has needed to increase the volume size.

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -347,6 +347,13 @@ func ensureVolumeBlockFile(vol Volume, path string, sizeBytes int64) (bool, erro
 			return false, nil
 		}
 
+		// Block image volumes cannot be resized because they can have a readonly snapshot that doesn't get
+		// updated when the volume's size is changed, and this is what instances are created from.
+		// During initial volume fill allowUnsafeResize is enabled because snapshot hasn't been taken yet.
+		if !vol.allowUnsafeResize && vol.volType == VolumeTypeImage {
+			return false, ErrNotSupported
+		}
+
 		// Only perform pre-resize sanity checks if we are not in "unsafe" mode.
 		// In unsafe mode we expect the caller to know what they are doing and understand the risks.
 		if !vol.allowUnsafeResize {

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -512,28 +512,28 @@ func ImageUnpack(imageFile string, vol drivers.Volume, destBlockFile string, blo
 			return -1, fmt.Errorf("Unexpected image format %q", imgInfo.Format)
 		}
 
+		// Check whether image is allowed to be unpacked into pool volume. Create a partial image volume
+		// struct and then use it to check that target volume size can be set as needed.
+		imgVolConfig := map[string]string{
+			"volatile.rootfs.size": fmt.Sprintf("%d", imgInfo.VirtualSize),
+		}
+		imgVol := drivers.NewVolume(nil, "", drivers.VolumeTypeImage, drivers.ContentTypeBlock, "", imgVolConfig, nil)
+
+		logger.Debug("Checking image unpack size")
+		newVolSize, err := vol.ConfigSizeFromSource(imgVol)
+		if err != nil {
+			return -1, err
+		}
+
 		if shared.PathExists(dstPath) {
 			volSizeBytes, err := drivers.BlockDiskSizeBytes(dstPath)
 			if err != nil {
 				return -1, errors.Wrapf(err, "Error getting current size of %q", dstPath)
 			}
 
+			// If the target volume's size is smaller than the image unpack size, then we need to
+			// increase the target volume's size.
 			if volSizeBytes < imgInfo.VirtualSize {
-				// If the target volume's size is smaller than the image unpack size, then we need
-				// to check whether it is inline with the pool's settings to allow us to increase
-				// the target volume's size. Create a partial image volume struct and then use it
-				// to check that target volume size can be set as needed.
-				imgVolConfig := map[string]string{
-					"volatile.rootfs.size": fmt.Sprintf("%d", imgInfo.VirtualSize),
-				}
-				imgVol := drivers.NewVolume(nil, "", drivers.VolumeTypeImage, drivers.ContentTypeBlock, "", imgVolConfig, nil)
-
-				logger.Debug("Checking image unpack size")
-				newVolSize, err := vol.ConfigSizeFromSource(imgVol)
-				if err != nil {
-					return -1, err
-				}
-
 				logger.Debug("Increasing volume size", log.Ctx{"imgPath": imgPath, "dstPath": dstPath, "oldSize": volSizeBytes, "newSize": newVolSize})
 				err = vol.SetQuota(newVolSize, nil)
 				if err != nil {


### PR DESCRIPTION
Fixes image block volume resize errors.