### PR TITLE
lxd/rbac: Fix checks by matching proper name

### DIFF
--- a/lxd/rbac/server.go
+++ b/lxd/rbac/server.go
@@ -332,7 +332,17 @@ func (r *Server) UserAccess(username string) (*UserAccess, error) {
 			continue
 		}
 
-		access.Projects[k] = v
+		// Look for project name.
+		for projectName, resourceID := range r.resources {
+			if k != resourceID {
+				continue
+			}
+
+			access.Projects[projectName] = v
+			break
+		}
+
+		// Ignore unknown projects.
 	}
 
 	return &access, nil


### PR DESCRIPTION
The data from RBAC uses resource IDs not project names, so we need to
map things through r.resources.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>