### PR TITLE
Storage: ZFS rounding up and Ceph image deletion improvements

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1471,7 +1471,7 @@ func (b *lxdBackend) DeleteInstance(inst instance.Instance, op *operations.Opera
 
 	// Remove the volume record from the database.
 	err = b.state.Cluster.RemoveStoragePoolVolume(inst.Project(), inst.Name(), volDBType, b.ID())
-	if err != nil {
+	if err != nil && errors.Cause(err) != db.ErrNoSuchObject {
 		return errors.Wrapf(err, "Error deleting storage volume from database")
 	}
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2283,7 +2283,10 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 		} else {
 			// We somehow have an unrecorded on-disk volume, assume it's a partial unpack and delete it.
 			logger.Warn("Deleting leftover/partially unpacked image volume")
-			b.driver.DeleteVolume(imgVol, op)
+			err = b.driver.DeleteVolume(imgVol, op)
+			if err != nil {
+				return errors.Wrapf(err, "Failed deleting leftover/partially unpacked image volume")
+			}
 		}
 	}
 

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -610,21 +610,41 @@ func (d *ceph) DeleteVolume(vol Volume, op *operations.Operation) error {
 		// Try to umount but don't fail.
 		d.UnmountVolume(vol, false, op)
 
-		// Check if image has dependant snapshots.
-		_, err := d.rbdListSnapshotClones(vol, "readonly")
-		if err != nil {
-			if err != db.ErrNoSuchObject {
+		hasReadonlySnapshot := d.hasVolume(d.getRBDVolumeName(vol, "readonly", false, false))
+		hasDependendantSnapshots := false
+
+		if hasReadonlySnapshot {
+			dependantSnapshots, err := d.rbdListSnapshotClones(vol, "readonly")
+			if err != nil && err != db.ErrNoSuchObject {
 				return err
 			}
 
-			// Unprotect snapshot.
-			err = d.rbdUnprotectVolumeSnapshot(vol, "readonly")
+			hasDependendantSnapshots = len(dependantSnapshots) > 0
+		}
+
+		if hasDependendantSnapshots {
+			// If the image has dependant snapshots, then we just mark it as deleted, but don't
+			// actually remove it yet.
+			err := d.rbdUnmapVolume(vol, true)
 			if err != nil {
 				return err
 			}
 
+			err = d.rbdMarkVolumeDeleted(vol, vol.name)
+			if err != nil {
+				return err
+			}
+		} else {
+			if hasReadonlySnapshot {
+				// Unprotect snapshot.
+				err := d.rbdUnprotectVolumeSnapshot(vol, "readonly")
+				if err != nil {
+					return err
+				}
+			}
+
 			// Delete snapshots.
-			_, err = shared.RunCommand(
+			_, err := shared.RunCommand(
 				"rbd",
 				"--id", d.config["ceph.user.name"],
 				"--cluster", d.config["ceph.cluster_name"],
@@ -644,16 +664,9 @@ func (d *ceph) DeleteVolume(vol Volume, op *operations.Operation) error {
 
 			// Delete image.
 			err = d.rbdDeleteVolume(vol)
-		} else {
-			err = d.rbdUnmapVolume(vol, true)
 			if err != nil {
 				return err
 			}
-
-			err = d.rbdMarkVolumeDeleted(vol, vol.name)
-		}
-		if err != nil {
-			return err
 		}
 	} else {
 		_, err := d.UnmountVolume(vol, false, op)

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -204,7 +204,6 @@ func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 	}, op)
 	if err != nil {
 		return err
-
 	}
 
 	// Create a readonly snapshot of the image volume which will be used a the

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -693,18 +693,23 @@ func (d *ceph) DeleteVolume(vol Volume, op *operations.Operation) error {
 	return nil
 }
 
-// HasVolume indicates whether a specific volume exists on the storage pool.
-func (d *ceph) HasVolume(vol Volume) bool {
+// hasVolume indicates whether a specific RBD volume exists on the storage pool.
+func (d *ceph) hasVolume(rbdVolumeName string) bool {
 	_, err := shared.RunCommand(
 		"rbd",
 		"--id", d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
 		"--pool", d.config["ceph.osd.pool_name"],
 		"info",
-		d.getRBDVolumeName(vol, "", false, false),
+		rbdVolumeName,
 	)
 
 	return err == nil
+}
+
+// HasVolume indicates whether a specific volume exists on the storage pool.
+func (d *ceph) HasVolume(vol Volume) bool {
+	return d.hasVolume(d.getRBDVolumeName(vol, "", false, false))
 }
 
 // FillVolumeConfig populate volume with default config.

--- a/lxd/storage/drivers/driver_zfs_utils.go
+++ b/lxd/storage/drivers/driver_zfs_utils.go
@@ -55,7 +55,7 @@ func (d *zfs) createDataset(dataset string, options ...string) error {
 }
 
 func (d *zfs) createVolume(dataset string, size int64, options ...string) error {
-	size = (size / MinBlockBoundary) * MinBlockBoundary
+	size = roundVolumeBlockFileSizeBytes(size)
 
 	args := []string{"create", "-s", "-V", fmt.Sprintf("%d", size)}
 	for _, option := range options {

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -921,7 +921,7 @@ func (d *zfs) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 			return nil
 		}
 
-		sizeBytes = (sizeBytes / MinBlockBoundary) * MinBlockBoundary
+		sizeBytes = roundVolumeBlockFileSizeBytes(sizeBytes)
 
 		oldSizeBytesStr, err := d.getDatasetProperty(d.dataset(vol, false), "volsize")
 		if err != nil {

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -73,7 +73,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 			}
 
 			// Round to block boundary.
-			poolVolSizeBytes = (poolVolSizeBytes / MinBlockBoundary) * MinBlockBoundary
+			poolVolSizeBytes = roundVolumeBlockFileSizeBytes(poolVolSizeBytes)
 
 			// If the cached volume size is different than the pool volume size, then we can't use the
 			// deleted cached image volume and instead we will rename it to a random UUID so it can't

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -339,10 +339,7 @@ func ensureVolumeBlockFile(vol Volume, path string, sizeBytes int64) (bool, erro
 	}
 
 	// Get rounded block size to avoid qemu boundary issues.
-	sizeBytes, err := roundVolumeBlockFileSizeBytes(sizeBytes)
-	if err != nil {
-		return false, err
-	}
+	sizeBytes = roundVolumeBlockFileSizeBytes(sizeBytes)
 
 	if shared.PathExists(path) {
 		fi, err := os.Stat(path)
@@ -384,7 +381,7 @@ func ensureVolumeBlockFile(vol Volume, path string, sizeBytes int64) (bool, erro
 
 	// If path doesn't exist, then there has been no filler function supplied to create it from another source.
 	// So instead create an empty volume (use for PXE booting a VM).
-	err = ensureSparseFile(path, sizeBytes)
+	err := ensureSparseFile(path, sizeBytes)
 	if err != nil {
 		return false, errors.Wrapf(err, "Failed creating disk image %q as size %d", path, sizeBytes)
 	}


### PR DESCRIPTION
Fixes issue when copying from ceph to zfs pools, the zfs volumes were being rounded to the nearest 8192 bytes, which sometimes meant the volume size created was just too small to accommodate the source ceph volume (which doesn't round to nearest 8192 bytes).

This modifies the ZFS volumes to round up to nearest 8192 bytes.

Also fixes a revert cleanup issue that prevented removing the errored instance record if the storage volume record was already gone.

Also fixes an issue in the Ceph driver that prevented deleting an image volume if the readonly snapshot didn't exist.
