### PR TITLE
Network: OVN Ingress mode

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1235,3 +1235,10 @@ Adds the usb\_address field to the network card entries in the resources API.
 
 ## resources\_disk\_address
 Adds the usb\_address and pci\_address fields to the disk entries in the resources API.
+
+## network\_physical\_ovn\_ingress_mode
+Adds `ovn.ingress_mode` setting for `physical` networks.
+
+Sets the method that OVN NIC external IPs will be advertised on uplink network.
+
+Either `l2proxy` (proxy ARP/NDP) or `routed`.

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -323,3 +323,4 @@ ipv6.gateway                    | string    | standard mode         | -         
 ipv6.ovn.ranges                 | string    | -                     | -                         | Comma separate list of IPv6 ranges to use for child OVN network routers (FIRST-LAST format)
 ipv6.routes                     | string    | ipv6 address          | -                         | Comma separated list of additional IPv6 CIDR subnets that can be used with child OVN networks ipv6.routes.external setting
 dns.nameservers                 | string    | standard mode         | -                         | List of DNS server IPs on physical network
+ovn.ingress_mode                | string    | standard mode         | l2proxy                   | Sets the method that OVN NIC external IPs will be advertised on uplink network. Either `l2proxy` (proxy ARP/NDP) or `routed`.

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -171,15 +171,6 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 	}
 
 	if len(externalRoutes) > 0 {
-		for _, externalRoute := range externalRoutes {
-			rOnes, rBits := externalRoute.Mask.Size()
-			if rBits > 32 && rOnes < 122 {
-				return fmt.Errorf("External route %q is too large. Maximum size for IPv6 external route is /122", externalRoute.String())
-			} else if rOnes < 26 {
-				return fmt.Errorf("External route %q is too large. Maximum size for IPv4 external route is /26", externalRoute.String())
-			}
-		}
-
 		err = d.network.InstanceDevicePortValidateExternalRoutes(d.inst, d.name, externalRoutes)
 		if err != nil {
 			return err

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1411,7 +1411,7 @@ func (n *ovn) setup(update bool) error {
 		err := n.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
 			err = tx.UpdateNetwork(n.id, n.description, n.config)
 			if err != nil {
-				return errors.Wrapf(err, "Failed saving optimal bridge MTU")
+				return errors.Wrapf(err, "Failed saving updated network config")
 			}
 
 			return nil

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -216,7 +216,12 @@ func (n *ovn) Validate(config map[string]string) error {
 	}
 
 	// Get uplink routes.
-	uplinkRoutes, err := n.uplinkRoutes(uplinkNetworkName)
+	_, uplink, _, err := n.state.Cluster.GetNetworkInAnyState(project.Default, uplinkNetworkName)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to load uplink network %q", uplinkNetworkName)
+	}
+
+	uplinkRoutes, err := n.uplinkRoutes(uplink)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -81,13 +81,9 @@ func (n *ovn) Info() Info {
 	}
 }
 
-// uplinkRoutes parses ipv4.routes and ipv6.routes settings for a named uplink network into a slice of *net.IPNet.
-func (n *ovn) uplinkRoutes(uplinkNetworkName string) ([]*net.IPNet, error) {
-	_, uplink, _, err := n.state.Cluster.GetNetworkInAnyState(project.Default, uplinkNetworkName)
-	if err != nil {
-		return nil, err
-	}
-
+// uplinkRoutes parses ipv4.routes and ipv6.routes settings for an uplink network into a slice of *net.IPNet.
+func (n *ovn) uplinkRoutes(uplink *api.Network) ([]*net.IPNet, error) {
+	var err error
 	var uplinkRoutes []*net.IPNet
 	for _, k := range []string{"ipv4.routes", "ipv6.routes"} {
 		if uplink.Config[k] == "" {

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -34,18 +34,21 @@ func (n *physical) DBType() db.NetworkType {
 // Validate network config.
 func (n *physical) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
-		"parent":                      validate.Required(validate.IsNotEmpty, validInterfaceName),
-		"mtu":                         validate.Optional(validate.IsNetworkMTU),
-		"vlan":                        validate.Optional(validate.IsNetworkVLAN),
-		"maas.subnet.ipv4":            validate.IsAny,
-		"maas.subnet.ipv6":            validate.IsAny,
-		"ipv4.gateway":                validate.Optional(validate.IsNetworkAddressCIDRV4),
-		"ipv6.gateway":                validate.Optional(validate.IsNetworkAddressCIDRV6),
-		"ipv4.ovn.ranges":             validate.Optional(validate.IsNetworkRangeV4List),
-		"ipv6.ovn.ranges":             validate.Optional(validate.IsNetworkRangeV6List),
-		"ipv4.routes":                 validate.Optional(validate.IsNetworkV4List),
-		"ipv6.routes":                 validate.Optional(validate.IsNetworkV6List),
-		"dns.nameservers":             validate.Optional(validate.IsNetworkAddressList),
+		"parent":           validate.Required(validate.IsNotEmpty, validInterfaceName),
+		"mtu":              validate.Optional(validate.IsNetworkMTU),
+		"vlan":             validate.Optional(validate.IsNetworkVLAN),
+		"maas.subnet.ipv4": validate.IsAny,
+		"maas.subnet.ipv6": validate.IsAny,
+		"ipv4.gateway":     validate.Optional(validate.IsNetworkAddressCIDRV4),
+		"ipv6.gateway":     validate.Optional(validate.IsNetworkAddressCIDRV6),
+		"ipv4.ovn.ranges":  validate.Optional(validate.IsNetworkRangeV4List),
+		"ipv6.ovn.ranges":  validate.Optional(validate.IsNetworkRangeV6List),
+		"ipv4.routes":      validate.Optional(validate.IsNetworkV4List),
+		"ipv6.routes":      validate.Optional(validate.IsNetworkV6List),
+		"dns.nameservers":  validate.Optional(validate.IsNetworkAddressList),
+		"ovn.ingress_mode": validate.Optional(func(value string) error {
+			return validate.IsOneOf(value, []string{"l2proxy", "routed"})
+		}),
 		"volatile.last_state.created": validate.Optional(validate.IsBool),
 	}
 

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -166,6 +166,10 @@ func UsedBy(s *state.State, networkProjectName string, networkName string, first
 
 		for projectName, networks := range projectNetworks {
 			for _, network := range networks {
+				if networkName == network.Name && networkProjectName == projectName {
+					continue // Skip ourselves.
+				}
+
 				// The network's config references the network we are searching for. Either by
 				// directly referencing our network or by referencing our interface as its parent.
 				if network.Config["network"] == networkName || network.Config["parent"] == networkName {

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -239,6 +239,7 @@ var APIExtensions = []string{
 	"resources_pci_iommu",
 	"resources_network_usb",
 	"resources_disk_address",
+	"network_physical_ovn_ingress_mode",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Adds `ovn.ingress_mode` (either `l2proxy` (default) or `routed`) to `physical` networks to allow OVN NICs to change the way they advertise their external IPs on the uplink network.