### PR TITLE
Network: Adds ipv4.routes.anycast and ipv6.routes.anycast settings to physical networks

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1247,3 +1247,9 @@ Either `l2proxy` (proxy ARP/NDP) or `routed`.
 Adds `ipv4.dhcp` and `ipv6.dhcp` settings for `ovn` networks.
 
 Allows DHCP (and RA for IPv6) to be disabled. Defaults to on.
+
+## network\_physical\_routes\_anycast
+Adds `ipv4.routes.anycast` and `ipv6.routes.anycast` boolean settings for `physical` networks. Defaults to false.
+
+Allows OVN networks using physical network as uplink to relax external subnet/route overlap detection when used
+with `ovn.ingress_mode=routed`.

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -324,8 +324,10 @@ vlan                            | integer   | -                     | -         
 ipv4.gateway                    | string    | standard mode         | -                         | IPv4 address for the gateway and network (CIDR notation)
 ipv4.ovn.ranges                 | string    | -                     | -                         | Comma separate list of IPv4 ranges to use for child OVN network routers (FIRST-LAST format)
 ipv4.routes                     | string    | ipv4 address          | -                         | Comma separated list of additional IPv4 CIDR subnets that can be used with child OVN networks ipv4.routes.external setting
+ipv4.routes.anycast             | boolean   | ipv4 address          | false                     | Allow the overlapping routes to be used on multiple networks/NIC at the same time.
 ipv6.gateway                    | string    | standard mode         | -                         | IPv6 address for the gateway and network  (CIDR notation)
 ipv6.ovn.ranges                 | string    | -                     | -                         | Comma separate list of IPv6 ranges to use for child OVN network routers (FIRST-LAST format)
 ipv6.routes                     | string    | ipv6 address          | -                         | Comma separated list of additional IPv6 CIDR subnets that can be used with child OVN networks ipv6.routes.external setting
+ipv6.routes.anycast             | boolean   | ipv6 address          | false                     | Allow the overlapping routes to be used on multiple networks/NIC at the same time.
 dns.nameservers                 | string    | standard mode         | -                         | List of DNS server IPs on physical network
 ovn.ingress_mode                | string    | standard mode         | l2proxy                   | Sets the method that OVN NIC external IPs will be advertised on uplink network. Either `l2proxy` (proxy ARP/NDP) or `routed`.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2079,12 +2079,25 @@ func (n *ovn) InstanceDevicePortValidateExternalRoutes(deviceInstance instance.I
 		}
 	}
 
+	// Check if uplink has routed ingress anycast mode enabled, as this relaxes the overlap checks.
+	ipv4UplinkAnycast := n.uplinkHasIngressRoutedAnycastIPv4(uplink)
+	ipv6UplinkAnycast := n.uplinkHasIngressRoutedAnycastIPv6(uplink)
+
 	for _, portExternalRoute := range portExternalRoutes {
 		// Check the external port route is allowed within both the uplink's external routes and any
 		// project restricted subnets.
 		err = n.validateExternalSubnet(uplinkRoutes, projectRestrictedSubnets, portExternalRoute)
 		if err != nil {
 			return err
+		}
+
+		// Skip overlap checks if the external route's protocol has anycast mode enabled on the uplink.
+		if portExternalRoute.IP.To4() == nil {
+			if ipv6UplinkAnycast == true {
+				continue
+			}
+		} else if ipv4UplinkAnycast == true {
+			continue
 		}
 
 		// Check the external port route doesn't fall within any existing OVN network external subnets.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2557,3 +2557,13 @@ func (n *ovn) ovnProjectNetworksWithUplink(uplink string, projectNetworks map[st
 
 	return ovnProjectNetworksWithOurUplink
 }
+
+// uplinkHasIngressRoutedAnycastIPv4 returns true if the uplink network has IPv4 routed ingress anycast enabled.
+func (n *ovn) uplinkHasIngressRoutedAnycastIPv4(uplink *api.Network) bool {
+	return shared.IsTrue(uplink.Config["ipv4.routes.anycast"]) && uplink.Config["ovn.ingress_mode"] == "routed"
+}
+
+// uplinkHasIngressRoutedAnycastIPv6 returns true if the uplink network has routed IPv6 ingress anycast enabled.
+func (n *ovn) uplinkHasIngressRoutedAnycastIPv6(uplink *api.Network) bool {
+	return shared.IsTrue(uplink.Config["ipv6.routes.anycast"]) && uplink.Config["ovn.ingress_mode"] == "routed"
+}

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -34,18 +34,20 @@ func (n *physical) DBType() db.NetworkType {
 // Validate network config.
 func (n *physical) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
-		"parent":           validate.Required(validate.IsNotEmpty, validInterfaceName),
-		"mtu":              validate.Optional(validate.IsNetworkMTU),
-		"vlan":             validate.Optional(validate.IsNetworkVLAN),
-		"maas.subnet.ipv4": validate.IsAny,
-		"maas.subnet.ipv6": validate.IsAny,
-		"ipv4.gateway":     validate.Optional(validate.IsNetworkAddressCIDRV4),
-		"ipv6.gateway":     validate.Optional(validate.IsNetworkAddressCIDRV6),
-		"ipv4.ovn.ranges":  validate.Optional(validate.IsNetworkRangeV4List),
-		"ipv6.ovn.ranges":  validate.Optional(validate.IsNetworkRangeV6List),
-		"ipv4.routes":      validate.Optional(validate.IsNetworkV4List),
-		"ipv6.routes":      validate.Optional(validate.IsNetworkV6List),
-		"dns.nameservers":  validate.Optional(validate.IsNetworkAddressList),
+		"parent":              validate.Required(validate.IsNotEmpty, validInterfaceName),
+		"mtu":                 validate.Optional(validate.IsNetworkMTU),
+		"vlan":                validate.Optional(validate.IsNetworkVLAN),
+		"maas.subnet.ipv4":    validate.IsAny,
+		"maas.subnet.ipv6":    validate.IsAny,
+		"ipv4.gateway":        validate.Optional(validate.IsNetworkAddressCIDRV4),
+		"ipv6.gateway":        validate.Optional(validate.IsNetworkAddressCIDRV6),
+		"ipv4.ovn.ranges":     validate.Optional(validate.IsNetworkRangeV4List),
+		"ipv6.ovn.ranges":     validate.Optional(validate.IsNetworkRangeV6List),
+		"ipv4.routes":         validate.Optional(validate.IsNetworkV4List),
+		"ipv4.routes.anycast": validate.Optional(validate.IsBool),
+		"ipv6.routes":         validate.Optional(validate.IsNetworkV6List),
+		"ipv6.routes.anycast": validate.Optional(validate.IsBool),
+		"dns.nameservers":     validate.Optional(validate.IsNetworkAddressList),
 		"ovn.ingress_mode": validate.Optional(func(value string) error {
 			return validate.IsOneOf(value, []string{"l2proxy", "routed"})
 		}),

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -241,6 +241,7 @@ var APIExtensions = []string{
 	"resources_disk_address",
 	"network_physical_ovn_ingress_mode",
 	"network_ovn_dhcp",
+	"network_physical_routes_anycast",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Adds `ipv4.routes.anycast` and `ipv6.routes.anycast` boolean settings for `physical` networks. Defaults to false.

Allows OVN networks using physical network as uplink to relax external subnet/route overlap detection when used
with `ovn.ingress_mode=routed`.
