### PR TITLE
#7868: `proxy` device support for VMs (NAT-only)

### DIFF
--- a/doc/instances.md
+++ b/doc/instances.md
@@ -791,7 +791,7 @@ mdev        | string    | -                 | no        | The mdev profile to us
 
 ### Type: proxy
 
-Supported instance types: container
+Supported instance types: container (`nat` and non-`nat` modes), VM (`nat` mode only)
 
 Proxy devices allow forwarding network connections between host and instance.
 This makes it possible to forward traffic hitting one of the host's

--- a/lxd/device/proxy.go
+++ b/lxd/device/proxy.go
@@ -48,7 +48,7 @@ type proxyProcInfo struct {
 
 // validateConfig checks the supplied config for correctness.
 func (d *proxy) validateConfig(instConf instance.ConfigReader) error {
-	if !instanceSupported(instConf.Type(), instancetype.Container) {
+	if !instanceSupported(instConf.Type(), instancetype.Container, instancetype.VM) {
 		return ErrUnsupportedDevType
 	}
 
@@ -83,6 +83,10 @@ func (d *proxy) validateConfig(instConf instance.ConfigReader) error {
 	err := d.config.Validate(rules)
 	if err != nil {
 		return err
+	}
+
+	if instConf.Type() == instancetype.VM && !shared.IsTrue(d.config["nat"]) {
+		return fmt.Errorf("Only NAT mode is supported for proxies on VM instances")
 	}
 
 	listenAddr, err := ProxyParseAddr(d.config["listen"])

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -812,6 +812,7 @@ func (d *qemu) Start(stateful bool) error {
 	}
 
 	devConfs := make([]*deviceConfig.RunConfig, 0, len(d.expandedDevices))
+	postStartHooks := []func() error{}
 
 	// Setup devices in sorted order, this ensures that device mounts are added in path order.
 	for _, entry := range d.expandedDevices.Sorted() {
@@ -834,6 +835,11 @@ func (d *qemu) Start(stateful bool) error {
 				d.logger.Error("Failed to cleanup device", log.Ctx{"devName": dev.Name, "err": err})
 			}
 		})
+
+		// Add post-start hooks
+		if len(runConf.PostHooks) > 0 {
+			postStartHooks = append(postStartHooks, runConf.PostHooks...)
+		}
 
 		devConfs = append(devConfs, runConf)
 	}
@@ -1119,6 +1125,15 @@ func (d *qemu) Start(stateful bool) error {
 	}
 
 	revert.Success()
+
+	// Run any post-start hooks.
+	err = d.runHooks(postStartHooks)
+	if err != nil {
+		op.Done(err)
+		// Shut down the VM if hooks fail.
+		d.Stop(false)
+		return err
+	}
 
 	if op.Action() == "start" {
 		d.lifecycle("started", nil)


### PR DESCRIPTION
Allows `proxy` devices to attach to VMs, and runs the necessary startup hooks for the proxy device to work.
CC: @grant-he @benhartcheatham