### PR TITLE
Network: Improvements to clustering node state to better handle failed startup during network create

### DIFF
--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -436,20 +436,17 @@ func (n *bridge) isRunning() bool {
 func (n *bridge) Delete(clientType request.ClientType) error {
 	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
 
-	// Bring the local network down if created on this node.
-	if n.LocalStatus() == api.NetworkStatusCreated || n.LocalStatus() == api.NetworkStatusUnknown {
-		if n.isRunning() {
-			err := n.Stop()
-			if err != nil {
-				return err
-			}
-		}
-
-		// Delete apparmor profiles.
-		err := apparmor.NetworkDelete(n.state, n)
+	if n.isRunning() {
+		err := n.Stop()
 		if err != nil {
 			return err
 		}
+	}
+
+	// Delete apparmor profiles.
+	err := apparmor.NetworkDelete(n.state, n)
+	if err != nil {
+		return err
 	}
 
 	return n.common.delete(clientType)

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -130,6 +130,11 @@ func (n *common) Name() string {
 	return n.name
 }
 
+// Project returns the network project.
+func (n *common) Project() string {
+	return n.project
+}
+
 // Description returns the network description.
 func (n *common) Description() string {
 	return n.description

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -368,32 +368,14 @@ func (n *common) rename(newName string) error {
 
 // delete the network from the database if clusterNotification is false.
 func (n *common) delete(clientType request.ClientType) error {
-	// Only delete database record if not cluster notification.
-	if clientType != request.ClientTypeNotifier {
-		// Notify all other nodes. If any node is down, an error will be returned.
-		notifier, err := cluster.NewNotifier(n.state, n.state.Endpoints.NetworkCert(), cluster.NotifyAll)
-		if err != nil {
-			return err
-		}
-		err = notifier(func(client lxd.InstanceServer) error {
-			return client.UseProject(n.project).DeleteNetwork(n.name)
-		})
-		if err != nil {
-			return err
-		}
-
-		// Remove the network from the database.
-		err = n.state.Cluster.DeleteNetwork(n.project, n.name)
-		if err != nil {
-			return err
-		}
-
-		n.lifecycle("deleted", nil)
-	}
-
 	// Cleanup storage.
 	if shared.PathExists(shared.VarPath("networks", n.name)) {
 		os.RemoveAll(shared.VarPath("networks", n.name))
+	}
+
+	// Generate lifecycle event if not notification.
+	if clientType != request.ClientTypeNotifier {
+		n.lifecycle("deleted", nil)
 	}
 
 	return nil

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -45,6 +45,7 @@ func (n *macvlan) Validate(config map[string]string) error {
 // Delete deletes a network.
 func (n *macvlan) Delete(clientType request.ClientType) error {
 	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
+
 	return n.common.delete(clientType)
 }
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1808,63 +1808,61 @@ func (n *ovn) deleteChassisGroupEntry() error {
 func (n *ovn) Delete(clientType request.ClientType) error {
 	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
 
-	if n.LocalStatus() == api.NetworkStatusCreated || n.LocalStatus() == api.NetworkStatusUnknown {
-		err := n.Stop()
+	err := n.Stop()
+	if err != nil {
+		return err
+	}
+
+	if clientType == request.ClientTypeNormal {
+		client, err := n.getClient()
 		if err != nil {
 			return err
 		}
 
-		if clientType == request.ClientTypeNormal {
-			client, err := n.getClient()
-			if err != nil {
-				return err
-			}
+		err = client.LogicalRouterDelete(n.getRouterName())
+		if err != nil {
+			return err
+		}
 
-			err = client.LogicalRouterDelete(n.getRouterName())
-			if err != nil {
-				return err
-			}
+		err = client.LogicalSwitchDelete(n.getExtSwitchName())
+		if err != nil {
+			return err
+		}
 
-			err = client.LogicalSwitchDelete(n.getExtSwitchName())
-			if err != nil {
-				return err
-			}
+		err = client.LogicalSwitchDelete(n.getIntSwitchName())
+		if err != nil {
+			return err
+		}
 
-			err = client.LogicalSwitchDelete(n.getIntSwitchName())
-			if err != nil {
-				return err
-			}
+		err = client.LogicalRouterPortDelete(n.getRouterExtPortName())
+		if err != nil {
+			return err
+		}
 
-			err = client.LogicalRouterPortDelete(n.getRouterExtPortName())
-			if err != nil {
-				return err
-			}
+		err = client.LogicalRouterPortDelete(n.getRouterIntPortName())
+		if err != nil {
+			return err
+		}
 
-			err = client.LogicalRouterPortDelete(n.getRouterIntPortName())
-			if err != nil {
-				return err
-			}
+		err = client.LogicalSwitchPortDelete(n.getExtSwitchRouterPortName())
+		if err != nil {
+			return err
+		}
 
-			err = client.LogicalSwitchPortDelete(n.getExtSwitchRouterPortName())
-			if err != nil {
-				return err
-			}
+		err = client.LogicalSwitchPortDelete(n.getExtSwitchProviderPortName())
+		if err != nil {
+			return err
+		}
 
-			err = client.LogicalSwitchPortDelete(n.getExtSwitchProviderPortName())
-			if err != nil {
-				return err
-			}
+		err = client.LogicalSwitchPortDelete(n.getIntSwitchRouterPortName())
+		if err != nil {
+			return err
+		}
 
-			err = client.LogicalSwitchPortDelete(n.getIntSwitchRouterPortName())
-			if err != nil {
-				return err
-			}
-
-			// Must be done after logical router removal.
-			err = client.ChassisGroupDelete(n.getChassisGroupName())
-			if err != nil {
-				return err
-			}
+		// Must be done after logical router removal.
+		err = client.ChassisGroupDelete(n.getChassisGroupName())
+		if err != nil {
+			return err
 		}
 	}
 

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -123,11 +123,9 @@ func (n *physical) Create(clientType request.ClientType) error {
 func (n *physical) Delete(clientType request.ClientType) error {
 	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
 
-	if n.LocalStatus() == api.NetworkStatusCreated || n.LocalStatus() == api.NetworkStatusUnknown {
-		err := n.Stop()
-		if err != nil {
-			return err
-		}
+	err := n.Stop()
+	if err != nil {
+		return err
 	}
 
 	return n.common.delete(clientType)

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -45,6 +45,7 @@ func (n *sriov) Validate(config map[string]string) error {
 // Delete deletes a network.
 func (n *sriov) Delete(clientType request.ClientType) error {
 	n.logger.Debug("Delete", log.Ctx{"clientType": clientType})
+
 	return n.common.delete(clientType)
 }
 

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -31,6 +31,7 @@ type Network interface {
 	Validate(config map[string]string) error
 	ID() int64
 	Name() string
+	Project() string
 	Description() string
 	Status() string
 	LocalStatus() string

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -616,8 +616,39 @@ func networkDelete(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	// Delete the network from each member.
-	err = n.Delete(clientType)
+	if n.LocalStatus() != api.NetworkStatusPending {
+		err = n.Delete(clientType)
+		if err != nil {
+			return response.InternalError(err)
+		}
+	}
+
+	// If this is a cluster notification, we're done, any database work will be done by the node that is
+	// originally serving the request.
+	if clusterNotification {
+		return response.EmptySyncResponse
+	}
+
+	// If we are clustered, also notify all other nodes, if any.
+	clustered, err := cluster.Enabled(d.db)
+	if err != nil {
+		return response.SmartError(err)
+	}
+	if clustered {
+		notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), cluster.NotifyAll)
+		if err != nil {
+			return response.SmartError(err)
+		}
+		err = notifier(func(client lxd.InstanceServer) error {
+			return client.UseProject(n.Project()).DeleteNetwork(n.Name())
+		})
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
+
+	// Remove the network from the database.
+	err = d.State().Cluster.DeleteNetwork(n.Project(), n.Name())
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -252,7 +252,7 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 
 				for _, node := range nodes {
 					err = tx.CreatePendingNetwork(node.Name, projectName, req.Name, netType.DBType(), req.Config)
-					if err != nil {
+					if err != nil && errors.Cause(err) != db.ErrAlreadyDefined {
 						return errors.Wrapf(err, "Failed creating pending network for node %q", node.Name)
 					}
 				}


### PR DESCRIPTION
- If a network was successfully "created" (using `n.Create()`) on a local node, but then failed to start (using `n.Start()`) then it was possible for setup done in `n.Create()` to be left behind because although `n.Delete()` was called on failure, the node status was still Pending and so the tear down was not performed.
- To cope with this, and to better align with storage pool state management, I've moved the DB record deletion and cluster notification logic into the API route handler function, leaving the network package's `Delete()` function to always tear down local setup.
- This allows the API route handler functions to decide for themselves (using `n.LocalStatus()`) whether it is appropriate to call `n.Delete()` depending on the scenario.

Example scenario:

1. Create `physical` network with `parent` interface missing on one node.
2. Create `ovn` network using the `physical` network as uplink.
3. Local create and start would succeed for OVN network on first node (where `physical` uplink parent exists), which would also create the OVN logical config in the northbound database.
4. But on notification of network create on 2nd node, the create step succeeds, but the start step fails.