### PR TITLE
Network: Clustering state avoid duplicate global config when doing re-create

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -793,7 +793,7 @@ func clusterInitMember(d lxd.InstanceServer, client lxd.InstanceServer, memberCo
 		// Merge the returned networks configs with the node-specific configs provided by the user.
 		for _, network := range networks {
 			// Skip unmanaged or pending networks.
-			if !network.Managed || network.Status == api.NetworkStatusPending {
+			if !network.Managed || network.Status != api.NetworkStatusCreated {
 				continue
 			}
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1568,7 +1568,7 @@ func clusterCheckNetworksMatch(cluster *db.Cluster, reqNetworks []internalCluste
 	}
 
 	for _, networkProjectName := range networkProjectNames {
-		networkNames, err := cluster.GetNonPendingNetworks(networkProjectName)
+		networkNames, err := cluster.GetCreatedNetworks(networkProjectName)
 		if err != nil && err != db.ErrNoSuchObject {
 			return err
 		}

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -591,5 +591,5 @@ CREATE TABLE storage_volumes_snapshots_config (
     UNIQUE (storage_volume_snapshot_id, key)
 );
 
-INSERT INTO schema (version, updated_at) VALUES (41, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (42, strftime("%s"))
 `

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -725,7 +725,7 @@ func (c *Cluster) CreateNetwork(projectName string, name string, description str
 
 // UpdateNetwork updates the network with the given name.
 func (c *Cluster) UpdateNetwork(project string, name, description string, config map[string]string) error {
-	id, netInfo, _, err := c.GetNetworkInAnyState(project, name)
+	id, _, _, err := c.GetNetworkInAnyState(project, name)
 	if err != nil {
 		return err
 	}
@@ -734,14 +734,6 @@ func (c *Cluster) UpdateNetwork(project string, name, description string, config
 		err = tx.UpdateNetwork(id, description, config)
 		if err != nil {
 			return err
-		}
-
-		// Update network status if change applied successfully.
-		if netInfo.Status == api.NetworkStatusErrored {
-			err = tx.NetworkCreated(project, name)
-			if err != nil {
-				return err
-			}
 		}
 
 		return nil

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -422,9 +422,9 @@ func (c *Cluster) GetNetworks(project string) ([]string, error) {
 	return c.networks(project, "")
 }
 
-// GetNonPendingNetworks returns the names of all networks that are not in state networkPending.
-func (c *Cluster) GetNonPendingNetworks(project string) ([]string, error) {
-	return c.networks(project, "NOT state=?", networkPending)
+// GetCreatedNetworks returns the names of all networks that are not in state networkCreated.
+func (c *Cluster) GetCreatedNetworks(project string) ([]string, error) {
+	return c.networks(project, "state=?", networkCreated)
 }
 
 // Get all networks matching the given WHERE filter (if given).

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -68,21 +68,20 @@ func (c *ClusterTx) GetNonPendingNetworkIDs() (map[string]int64, error) {
 	return ids, nil
 }
 
-// GetNonPendingNetworks returns a map of api.Network associated to project and network ID.
-//
-// Pending networks are skipped.
-func (c *ClusterTx) GetNonPendingNetworks() (map[string]map[int64]api.Network, error) {
+// GetCreatedNetworks returns a map of api.Network associated to project and network ID.
+// Only networks that have are in state networkCreated are returned.
+func (c *ClusterTx) GetCreatedNetworks() (map[string]map[int64]api.Network, error) {
 	stmt, err := c.tx.Prepare(`SELECT projects.name, networks.id, networks.name, coalesce(networks.description, ''), networks.type, networks.state
 		FROM networks
 		JOIN projects on projects.id = networks.project_id
-		WHERE networks.state != ?
+		WHERE networks.state = ?
 	`)
 	if err != nil {
 		return nil, err
 	}
 	defer stmt.Close()
 
-	rows, err := stmt.Query(networkPending)
+	rows, err := stmt.Query(networkCreated)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -670,6 +670,11 @@ func (c *Cluster) getNetworkConfig(id int64) (map[string]string, error) {
 		key = r[0].(string)
 		value = r[1].(string)
 
+		_, found := config[key]
+		if found {
+			return nil, fmt.Errorf("Duplicate config row found for key %q for network ID %d", key, id)
+		}
+
 		config[key] = value
 	}
 

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -323,6 +323,11 @@ func (c *ClusterTx) NetworkCreated(project string, name string) error {
 	return c.networkState(project, name, networkCreated)
 }
 
+// NetworkErrored sets the state of the given network to networkErrored.
+func (c *ClusterTx) NetworkErrored(project string, name string) error {
+	return c.networkState(project, name, networkErrored)
+}
+
 func (c *ClusterTx) networkState(project string, name string, state NetworkState) error {
 	stmt := "UPDATE networks SET state=? WHERE project_id = (SELECT id FROM projects WHERE name = ?) AND name=?"
 	result, err := c.tx.Exec(stmt, state, project, name)

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -275,9 +275,9 @@ func (c *ClusterTx) CreatePendingNetwork(node string, projectName string, name s
 			return err
 		}
 	} else {
-		// Check that the existing network is in the networkPending or networkErrored state.
-		if network.state != networkPending && network.state != networkErrored {
-			return fmt.Errorf("Network is not in pending or errored state")
+		// Check that the existing network is in the networkPending state.
+		if network.state != networkPending {
+			return fmt.Errorf("Network is not in pending state")
 		}
 
 		// Check that the existing network type matches the requested type.

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -88,7 +88,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 			return errors.Wrapf(err, "Error loading network config for %q", d.config["network"])
 		}
 
-		if n.Status() == api.NetworkStatusPending {
+		if n.Status() != api.NetworkStatusCreated {
 			return fmt.Errorf("Specified network is not fully created")
 		}
 

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -56,7 +56,7 @@ func (d *nicMACVLAN) validateConfig(instConf instance.ConfigReader) error {
 			return errors.Wrapf(err, "Error loading network config for %q", d.config["network"])
 		}
 
-		if n.Status() == api.NetworkStatusPending {
+		if n.Status() != api.NetworkStatusCreated {
 			return fmt.Errorf("Specified network is not fully created")
 		}
 

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -87,7 +87,7 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 		return errors.Wrapf(err, "Error loading network config for %q", d.config["network"])
 	}
 
-	if n.Status() == api.NetworkStatusPending {
+	if n.Status() != api.NetworkStatusCreated {
 		return fmt.Errorf("Specified network is not fully created")
 	}
 

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -66,7 +66,7 @@ func (d *nicSRIOV) validateConfig(instConf instance.ConfigReader) error {
 			return errors.Wrapf(err, "Error loading network config for %q", d.config["network"])
 		}
 
-		if n.Status() == api.NetworkStatusPending {
+		if n.Status() != api.NetworkStatusCreated {
 			return fmt.Errorf("Specified network is not fully created")
 		}
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -252,7 +252,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		var projectNetworks map[string]map[int64]api.Network
 		err = n.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
 			// Get all managed networks across all projects.
-			projectNetworks, err = tx.GetNonPendingNetworks()
+			projectNetworks, err = tx.GetCreatedNetworks()
 			if err != nil {
 				return errors.Wrapf(err, "Failed to load all networks")
 			}
@@ -753,7 +753,7 @@ func (n *ovn) allocateUplinkPortIPs(uplinkNet Network, routerMAC net.HardwareAdd
 // uplinkAllAllocatedIPs gets a list of all IPv4 and IPv6 addresses allocated to OVN networks connected to uplink.
 func (n *ovn) uplinkAllAllocatedIPs(tx *db.ClusterTx, uplinkNetName string) ([]net.IP, []net.IP, error) {
 	// Get all managed networks across all projects.
-	projectNetworks, err := tx.GetNonPendingNetworks()
+	projectNetworks, err := tx.GetCreatedNetworks()
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "Failed to load all networks")
 	}
@@ -1051,7 +1051,7 @@ func (n *ovn) checkUplinkUse() (bool, error) {
 	var projectNetworks map[string]map[int64]api.Network
 
 	err = n.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
-		projectNetworks, err = tx.GetNonPendingNetworks()
+		projectNetworks, err = tx.GetCreatedNetworks()
 		return err
 	})
 	if err != nil {
@@ -2040,7 +2040,7 @@ func (n *ovn) InstanceDevicePortValidateExternalRoutes(deviceInstance instance.I
 		}
 
 		// Get all managed networks across all projects.
-		projectNetworks, err = tx.GetNonPendingNetworks()
+		projectNetworks, err = tx.GetCreatedNetworks()
 		if err != nil {
 			return errors.Wrapf(err, "Failed to load all networks")
 		}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2151,12 +2151,20 @@ func (n *ovn) InstanceDevicePortAdd(instanceUUID string, instanceName string, de
 		if err != nil {
 			return "", err
 		}
+
+		if dhcpV4ID == "" {
+			return "", fmt.Errorf("Could not find DHCPv4 options for instance port")
+		}
 	}
 
 	if dhcpv6Subnet != nil {
 		dhcpv6ID, err = client.LogicalSwitchDHCPOptionsGetID(n.getIntSwitchName(), dhcpv6Subnet)
 		if err != nil {
 			return "", err
+		}
+
+		if dhcpV4ID == "" {
+			return "", fmt.Errorf("Could not find DHCPv6 options for instance port")
 		}
 
 		// If port isn't going to have fully dynamic IPs allocated by OVN, and instead only static IPv4

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -69,7 +69,7 @@ func (n *physical) checkParentUse(ourConfig map[string]string) (bool, error) {
 	var projectNetworks map[string]map[int64]api.Network
 
 	err = n.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
-		projectNetworks, err = tx.GetNonPendingNetworks()
+		projectNetworks, err = tx.GetCreatedNetworks()
 		return err
 	})
 	if err != nil {

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -157,7 +157,7 @@ func UsedBy(s *state.State, networkProjectName string, networkName string, first
 		var projectNetworks map[string]map[int64]api.Network
 
 		err = s.Cluster.Transaction(func(tx *db.ClusterTx) error {
-			projectNetworks, err = tx.GetNonPendingNetworks()
+			projectNetworks, err = tx.GetCreatedNetworks()
 			return err
 		})
 		if err != nil {

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -256,7 +256,9 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 				}
 
 				for _, node := range nodes {
-					err = tx.CreatePendingNetwork(node.Name, projectName, req.Name, netType.DBType(), req.Config)
+					// Don't pass in any config, as these nodes don't have any node-specific
+					// config and we don't want to create duplicate global config.
+					err = tx.CreatePendingNetwork(node.Name, projectName, req.Name, netType.DBType(), nil)
 					if err != nil && errors.Cause(err) != db.ErrAlreadyDefined {
 						return errors.Wrapf(err, "Failed creating pending network for node %q", node.Name)
 					}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -198,9 +198,14 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	clientType := request.UserAgentClientType(r.Header.Get("User-Agent"))
 
 	if isClusterNotification(r) {
+		n, err := network.LoadByName(d.State(), projectName, req.Name)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
 		// This is an internal request which triggers the actual creation of the network across all nodes
 		// after they have been previously defined.
-		err = doNetworksCreate(d, projectName, req, clientType)
+		err = doNetworksCreate(d, n, clientType)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -298,7 +303,12 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	}
 	revert.Add(func() { d.cluster.DeleteNetwork(projectName, req.Name) })
 
-	err = doNetworksCreate(d, projectName, req, clientType)
+	n, err := network.LoadByName(d.State(), projectName, req.Name)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	err = doNetworksCreate(d, n, clientType)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -439,7 +439,7 @@ func doNetworksCreate(d *Daemon, n network.Network, clientType request.ClientTyp
 	}
 
 	if n.LocalStatus() == api.NetworkStatusCreated {
-		logger.Debug("Skipping network create as already created locally", log.Ctx{"project": n.Project(), "network": n.Name()})
+		logger.Debug("Skipping local network create as already created", log.Ctx{"project": n.Project(), "network": n.Name()})
 		return nil
 	}
 

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1122,7 +1122,7 @@ func networkStartup(s *state.State) error {
 		deferredNetworks[projectName] = make([]network.Network, 0)
 
 		// Get a list of managed networks.
-		networks, err := s.Cluster.GetNonPendingNetworks(projectName)
+		networks, err := s.Cluster.GetCreatedNetworks(projectName)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to load networks for project %q", projectName)
 		}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -319,6 +319,26 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 	return resp
 }
 
+// networkPartiallyCreated returns true of supplied network has properties that indicate it has had previous
+// create attempts run on it but failed on one or more nodes.
+func networkPartiallyCreated(netInfo *api.Network) bool {
+	// If the network status is NetworkStatusErrored, this means create has been run in the past and has
+	// failed on one or more nodes. Hence it is partially created.
+	if netInfo.Status == api.NetworkStatusErrored {
+		return true
+	}
+
+	// If the network has global config keys, then it has previously been created by having its global config
+	// inserted, and this means it is partialled created.
+	for key := range netInfo.Config {
+		if !shared.StringInSlice(key, db.NodeSpecificNetworkConfig) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // networksPostCluster checks that there is a pending network in the database and then attempts to setup the
 // network on each node. If all nodes are successfully setup then the network's state is set to created.
 func networksPostCluster(d *Daemon, projectName string, req api.NetworksPost, clientType request.ClientType, netType network.Type) error {

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -25,7 +25,7 @@ func networkUpdateForkdnsServersTask(s *state.State, heartbeatData *cluster.APIH
 	projectName := project.Default
 
 	// Get a list of managed networks
-	networks, err := s.Cluster.GetNonPendingNetworks(projectName)
+	networks, err := s.Cluster.GetCreatedNetworks(projectName)
 	if err != nil {
 		return err
 	}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -304,7 +304,7 @@ INSERT INTO storage_pools_config(storage_pool_id, node_id, key, value)
 // having "ipv4.nat" set is to disable NAT (bringing in line with the non-fan bridge behavior and docs).
 func patchNetworkFANEnableNAT(name string, d *Daemon) error {
 	err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
-		projectNetworks, err := tx.GetNonPendingNetworks()
+		projectNetworks, err := tx.GetCreatedNetworks()
 		if err != nil {
 			return err
 		}
@@ -351,7 +351,7 @@ func patchNetworkFANEnableNAT(name string, d *Daemon) error {
 // networks. It was decided that the OVN NIC level equivalent settings were sufficient.
 func patchNetworkOVNRemoveRoutes(name string, d *Daemon) error {
 	err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
-		projectNetworks, err := tx.GetNonPendingNetworks()
+		projectNetworks, err := tx.GetCreatedNetworks()
 		if err != nil {
 			return err
 		}
@@ -401,7 +401,7 @@ func patchNetworkOVNRemoveRoutes(name string, d *Daemon) error {
 // patchNetworkCearBridgeVolatileHwaddr removes the unsupported `volatile.bridge.hwaddr` config key from networks.
 func patchNetworkOVNEnableNAT(name string, d *Daemon) error {
 	err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
-		projectNetworks, err := tx.GetNonPendingNetworks()
+		projectNetworks, err := tx.GetCreatedNetworks()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When doing a `lxc network create` for subsequent attempts after failed initial attempt, avoid creating duplicate global config by ignoring global config supplied on subsequent attempts.

- Reintroduces the `Errored` status for a network when initial create attempt fails - so we can identify a partially created network both from global config existing and from its status (in cases where no global config is supplied).
- Blocks global config being supplied on subsequent re-create attempts when network is partially created.
- Skips global config insert on subsequent re-creates to avoid duplicate config (even if no config is supplied, could be default values generated and duplicated).
- Blocks re-create attempts once the network is successfully created.
- Makes looking for created networks explicit, rather than looking for "non-pending" networks (which would then erroneously return networks in the errored state too).
- Adds a patch to remove identical duplicated network config (primarily created by OVN networks).
- Adds checks for any future duplicated config in DB load function.
- Adds ability to single node cluster network create using two-step process (same as storage pools).