### PR TITLE
Smarter handling of `volatile` keys in restricted projects #7896

### DIFF
--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -152,8 +152,32 @@ func checkRestrictionsOnVolatileConfig(project *api.Project, instanceType instan
 		return nil
 	}
 
+	// Checker for safe volatile keys.
+	isSafeKey := func(key string) bool {
+		if strings.StringInSlice(key, []string{"volatile.apply_template", "volatile.base_image", "volatile.last_state.power"}) {
+			return true
+		}
+
+		if strings.HasPrefix(key, shared.ConfigVolatilePrefix) {
+			if strings.HasSuffix(key, ".apply_quota") {
+				return true
+			}
+
+			if strings.HasSuffix(key, ".hwaddr") {
+				return true
+			}
+		}
+
+		return false
+	}
+
 	for key, value := range config {
 		if !strings.HasPrefix(key, shared.ConfigVolatilePrefix) {
+			continue
+		}
+
+		// Allow given safe volatile keys to be set
+		if isSafeKey(key) {
 			continue
 		}
 

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -762,7 +762,7 @@ test_projects_restrictions() {
   # It's not possible to use forbidden low-level options
   ! lxc profile set default "raw.idmap=both 0 0" || false
   ! lxc init testimage c1 -c "raw.idmap=both 0 0" || false
-  ! lxc init testimage c1 -c volatile.apply_template="foo" || false
+  ! lxc init testimage c1 -c volatile.uuid="foo" || false
 
   # It's not possible to create privileged containers.
   ! lxc profile set default security.privileged=true || false
@@ -773,7 +773,7 @@ test_projects_restrictions() {
 
   # It's not possible to change low-level options
   ! lxc config set c1 "raw.idmap=both 0 0" || false
-  ! lxc config set c1 volatile.apply_template="foo" || false
+  ! lxc config set c1 volatile.uuid="foo" || false
 
   # It's not possible to attach character devices.
   ! lxc profile device add default tty unix-char path=/dev/ttyS0 || false


### PR DESCRIPTION
Changes made:
- Created a list of safe volatile keys
- Modified checkRestrictionsOnVolatileConfig function to parse through the list of safe volatile keys and skip any keys that were safe and deleted any unsafe volatile keys from the config file instead of failing the copy

Fixes https://github.com/lxc/lxd/issues/7896