### PR TITLE
API to move instances between pools

### DIFF
--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -695,6 +695,10 @@ func (r *ProtocolLXD) MigrateInstance(name string, instance api.InstancePost) (O
 		}
 	}
 
+	if instance.Pool != "" && !r.HasExtension("instance_pool_move") {
+		return nil, fmt.Errorf("The server is missing the required \"instance_pool_move\" API extension")
+	}
+
 	// Sanity check
 	if !instance.Migration {
 		return nil, fmt.Errorf("Can't ask for a rename through MigrateInstance")

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1272,3 +1272,7 @@ This adds the `security.port_isolation` field for bridged NIC instances.
 Adds the following endpoint for bulk state change (see [RESTful API](rest-api.md) for details):
 
 * `PUT /1.0/instances`
+
+## instance\_pool\_move
+This adds a `pool` field to the `POST /1.0/instances/NAME` API,
+allowing for easy move of an instance root disk between pools.

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -172,6 +172,23 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if req.Migration {
+		// Server-side pool migration.
+		if req.Pool != "" {
+			// Setup the instance move operation.
+			run := func(op *operations.Operation) error {
+				return instancePostPoolMigration(d, inst, project, name, req.Name, req.Pool, op)
+			}
+
+			resources := map[string][]string{}
+			resources["instances"] = []string{name}
+			op, err := operations.OperationCreate(d.State(), project, operations.OperationClassTask, db.OperationInstanceMigrate, resources, nil, run, nil, nil)
+			if err != nil {
+				return response.InternalError(err)
+			}
+
+			return operations.OperationResponse(op)
+		}
+
 		if targetNode != "" {
 			// Check if instance has backups.
 			backups, err := d.cluster.GetInstanceBackups(project, name)
@@ -278,6 +295,31 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	return operations.OperationResponse(op)
+}
+
+// Move an instance to another pool.
+func instancePostPoolMigration(d *Daemon, inst instance.Instance, project string, oldName string, newName string, newPool string, op *operations.Operation) error {
+	// Load target pool.
+	pool, err := driver.GetPoolByName(d.State(), newPool)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get source instance's storage pool")
+	}
+
+	// Perform the migration.
+	err = pool.MoveInstance(inst, op)
+	if err != nil {
+		return err
+	}
+
+	// Perform a rename if needed.
+	if oldName != newName {
+		err = inst.Rename(newName)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Move a non-ceph container to another cluster node.

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -132,6 +132,10 @@ func (b *mockBackend) CheckInstanceBackupFileSnapshots(backupConf *backup.Config
 	return nil, nil
 }
 
+func (b *mockBackend) MoveInstance(inst instance.Instance, op *operations.Operation) error {
+	return nil
+}
+
 func (b *mockBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error {
 	return nil
 }

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -53,6 +53,7 @@ type Pool interface {
 	UpdateInstanceBackupFile(inst instance.Instance, op *operations.Operation) error
 	CheckInstanceBackupFileSnapshots(backupConf *backup.Config, projectName string, deleteMissing bool, op *operations.Operation) ([]*api.InstanceSnapshot, error)
 
+	MoveInstance(inst instance.Instance, op *operations.Operation) error
 	MigrateInstance(inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error
 	RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, op *operations.Operation) error
 	BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error

--- a/shared/api/instance.go
+++ b/shared/api/instance.go
@@ -45,6 +45,9 @@ type InstancePost struct {
 	InstanceOnly  bool                `json:"instance_only" yaml:"instance_only"`
 	ContainerOnly bool                `json:"container_only" yaml:"container_only"` // Deprecated, use InstanceOnly.
 	Target        *InstancePostTarget `json:"target" yaml:"target"`
+
+	// API extension: instance_pool_move
+	Pool string `json:"pool" yaml:"pool"`
 }
 
 // InstancePostTarget represents the migration target host and operation.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -246,6 +246,7 @@ var APIExtensions = []string{
 	"network_state_vlan",
 	"instance_nic_bridged_port_isolation",
 	"instance_bulk_state_change",
+	"instance_pool_move",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Modified the following four files: 
lxd/storage/backend_lxd.go
/shared/api/instance.go
/lxc/move.go
/lxd/instance_post.go

Attempted to address the below specifications:

Have MoveInstance function use MigrateInstance and CreateInstanceFromMigration to move the data across, update the DB record as needed and finally delete the source from its storage pool.

Extend api.InstancePost to add a Pool string entry that the client would use to trigger such a server-side move

Update lxc/move.go to use MigrateContainer in the client codebase combined with that new Pool field to trigger it

Update lxd/instance_post.go on the server side to detect that Pool field and trigger the new MoveInstance logic.

Fixes https://github.com/lxc/lxd/issues/7274