### PR TITLE
Storage: Clustering state avoid duplicate global config when doing re-create

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1520,7 +1520,7 @@ type internalClusterPostHandoverRequest struct {
 }
 
 func clusterCheckStoragePoolsMatch(cluster *db.Cluster, reqPools []api.StoragePool) error {
-	poolNames, err := cluster.GetNonPendingStoragePoolNames()
+	poolNames, err := cluster.GetCreatedStoragePoolNames()
 	if err != nil && err != db.ErrNoSuchObject {
 		return err
 	}

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -591,5 +591,5 @@ CREATE TABLE storage_volumes_snapshots_config (
     UNIQUE (storage_volume_snapshot_id, key)
 );
 
-INSERT INTO schema (version, updated_at) VALUES (42, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (43, strftime("%s"))
 `

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -81,6 +81,76 @@ var updates = map[int]schema.Update{
 	40: updateFromV39,
 	41: updateFromV40,
 	42: updateFromV41,
+	43: updateFromV42,
+}
+
+// updateFromV42 removes any duplicated storage pool config rows that have the same value.
+// This can occur when multiple create requests have been issued when setting up a clustered storage pool.
+func updateFromV42(tx *sql.Tx) error {
+	// Find all duplicated config rows and return comma delimited list of affected row IDs for each dupe set.
+	stmt, err := tx.Prepare(`SELECT storage_pool_id, COALESCE(node_id,0), key, value, COUNT(*) AS rowCount, GROUP_CONCAT(id, ",") AS dupeRowIDs
+			FROM storage_pools_config
+			GROUP BY storage_pool_id, node_id, key, value
+			HAVING rowCount > 1
+		`)
+	if err != nil {
+		return errors.Wrapf(err, "Failed preparing query")
+	}
+	defer stmt.Close()
+
+	rows, err := stmt.Query()
+	if err != nil {
+		return errors.Wrapf(err, "Failed running query")
+	}
+	defer rows.Close()
+
+	type dupeRow struct {
+		storagePoolID int64
+		nodeID        int64
+		key           string
+		value         string
+		rowCount      int64
+		dupeRowIDs    string
+	}
+
+	var dupeRows []dupeRow
+
+	for rows.Next() {
+		r := dupeRow{}
+		err = rows.Scan(&r.storagePoolID, &r.nodeID, &r.key, &r.value, &r.rowCount, &r.dupeRowIDs)
+		if err != nil {
+			return errors.Wrapf(err, "Failed scanning rows")
+		}
+
+		dupeRows = append(dupeRows, r)
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return errors.Wrap(err, "Got a row error")
+	}
+
+	for _, r := range dupeRows {
+		logger.Warn("Found duplicated storage pool config rows", log.Ctx{"storagePoolID": r.storagePoolID, "nodeID": r.nodeID, "key": r.key, "value": r.value, "rowCount": r.rowCount, "dupeRowIDs": r.dupeRowIDs})
+
+		rowIDs := strings.Split(r.dupeRowIDs, ",")
+
+		// Iterate and delete all but 1 of the rowIDs so we leave just one left.
+		for i := 0; i < len(rowIDs)-1; i++ {
+			rowID, err := strconv.Atoi(rowIDs[i])
+			if err != nil {
+				return errors.Wrapf(err, "Failed converting row ID")
+			}
+
+			_, err = tx.Exec("DELETE FROM storage_pools_config WHERE id = ?", rowID)
+			if err != nil {
+				return errors.Wrapf(err, "Failed deleting storage pool config row with ID %d", rowID)
+			}
+			logger.Warn("Deleted duplicated storage pool config row", log.Ctx{"storagePoolID": r.storagePoolID, "nodeID": r.nodeID, "key": r.key, "value": r.value, "rowCount": r.rowCount, "rowID": rowID})
+		}
+	}
+
+	return nil
 }
 
 // updateFromV41 removes any duplicated network config rows that have the same value.

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -434,10 +434,10 @@ func (c *ClusterTx) CreatePendingStoragePool(node, name, driver string, conf map
 		// Check that the existing pools matches the given driver and
 		// is in the pending state.
 		if pool.driver != driver {
-			return fmt.Errorf("pool already exists with a different driver")
+			return fmt.Errorf("Storage pool already exists with a different driver")
 		}
 		if pool.state != storagePoolPending {
-			return fmt.Errorf("pool is not in pending state")
+			return fmt.Errorf("Storage pool is not in pending state")
 		}
 	}
 

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -793,6 +793,11 @@ func (c *Cluster) getStoragePoolConfig(poolID int64) (map[string]string, error) 
 		key = r[0].(string)
 		value = r[1].(string)
 
+		_, found := config[key]
+		if found {
+			return nil, fmt.Errorf("Duplicate config row found for key %q for storage pool ID %d", key, poolID)
+		}
+
 		config[key] = value
 	}
 

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -477,6 +477,11 @@ func (c *ClusterTx) StoragePoolCreated(name string) error {
 	return c.storagePoolState(name, storagePoolCreated)
 }
 
+// StoragePoolErrored sets the state of the given pool to storagePoolErrored.
+func (c *ClusterTx) StoragePoolErrored(name string) error {
+	return c.storagePoolState(name, storagePoolErrored)
+}
+
 func (c *ClusterTx) storagePoolState(name string, state StoragePoolState) error {
 	stmt := "UPDATE storage_pools SET state=? WHERE name=?"
 	result, err := c.tx.Exec(stmt, state, name)

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -605,10 +605,9 @@ func (c *Cluster) GetStoragePoolNames() ([]string, error) {
 	return c.storagePools("")
 }
 
-// GetNonPendingStoragePoolNames returns the names of all storage pools that are not
-// pending.
-func (c *Cluster) GetNonPendingStoragePoolNames() ([]string, error) {
-	return c.storagePools("NOT state=?", storagePoolPending)
+// GetCreatedStoragePoolNames returns the names of all storage pools that are created.
+func (c *Cluster) GetCreatedStoragePoolNames() ([]string, error) {
+	return c.storagePools("state=?", storagePoolCreated)
 }
 
 // Get all storage pools matching the given WHERE filter (if given).

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -67,7 +67,7 @@ func resetContainerDiskIdmap(container instance.Container, srcIdmap *idmap.Idmap
 }
 
 func setupStorageDriver(s *state.State, forceCheck bool) error {
-	pools, err := s.Cluster.GetNonPendingStoragePoolNames()
+	pools, err := s.Cluster.GetCreatedStoragePoolNames()
 	if err != nil {
 		if err == db.ErrNoSuchObject {
 			logger.Debugf("No existing storage pools detected")

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -149,11 +149,9 @@ func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		if count == 1 {
-			// No targetNode was specified and we're either a
-			// single-node cluster or not clustered at all, so
-			// create the storage pool immediately, unless there's
-			// a pending storage pool (in that case we follow the
-			// regular two-stage process).
+			// No targetNode was specified and we're either a single-node cluster or not clustered at
+			// all, so create the storage pool immediately, unless there's a pending storage pool
+			// (in that case we follow the regular two-stage process).
 			_, pool, _, err := d.cluster.GetStoragePoolInAnyState(req.Name)
 			if err != nil {
 				if err != db.ErrNoSuchObject {

--- a/lxd/storage_pools_utils.go
+++ b/lxd/storage_pools_utils.go
@@ -126,7 +126,7 @@ func storagePoolCreateLocal(state *state.State, id int64, req api.StoragePoolsPo
 	}
 
 	if pool.LocalStatus() == api.NetworkStatusCreated {
-		logger.Debug("Skipping storage pool create as already created locally", log.Ctx{"pool": pool.Name()})
+		logger.Debug("Skipping local storage pool create as already created", log.Ctx{"pool": pool.Name()})
 
 		return pool.Driver().Config(), nil
 	}

--- a/lxd/storage_pools_utils.go
+++ b/lxd/storage_pools_utils.go
@@ -95,7 +95,7 @@ func storagePoolCreateGlobal(state *state.State, req api.StoragePoolsPost, clien
 
 // This performs local pool setup and updates DB record if config was changed during pool setup.
 // Returns resulting config.
-func storagePoolCreateLocal(state *state.State, id int64, req api.StoragePoolsPost, clientType request.ClientType) (map[string]string, error) {
+func storagePoolCreateLocal(state *state.State, poolID int64, req api.StoragePoolsPost, clientType request.ClientType) (map[string]string, error) {
 	// Setup revert.
 	revert := revert.New()
 	defer revert.Fail()
@@ -160,7 +160,7 @@ func storagePoolCreateLocal(state *state.State, id int64, req api.StoragePoolsPo
 
 	// Set storage pool node to storagePoolCreated.
 	err = state.Cluster.Transaction(func(tx *db.ClusterTx) error {
-		return tx.StoragePoolNodeCreated(id)
+		return tx.StoragePoolNodeCreated(poolID)
 	})
 	if err != nil {
 		return nil, err

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -406,7 +406,7 @@ test_clustering_storage() {
     LXD_DIR="${LXD_ONE_DIR}" lxc storage create pool1 "${driver}" source=/tmp/not/exist --target node1
     LXD_DIR="${LXD_TWO_DIR}" lxc storage create pool1 "${driver}" --target node2
     ! LXD_DIR="${LXD_TWO_DIR}" lxc storage create pool1 "${driver}" || false
-    LXD_DIR="${LXD_ONE_DIR}" lxc storage show pool1 | grep status: | grep -q Pending
+    LXD_DIR="${LXD_ONE_DIR}" lxc storage show pool1 | grep status: | grep -q Errored
     LXD_DIR="${LXD_ONE_DIR}" lxc storage unset pool1 source --target node1
     LXD_DIR="${LXD_TWO_DIR}" lxc storage create pool1 "${driver}"
     LXD_ONE_SOURCE="$(LXD_DIR="${LXD_ONE_DIR}" lxc storage get pool1 source --target=node1)"

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -405,10 +405,13 @@ test_clustering_storage() {
     # Create new partially created pool and check we can fix it.
     LXD_DIR="${LXD_ONE_DIR}" lxc storage create pool1 "${driver}" source=/tmp/not/exist --target node1
     LXD_DIR="${LXD_TWO_DIR}" lxc storage create pool1 "${driver}" --target node2
+    LXD_DIR="${LXD_ONE_DIR}" lxc storage show pool1 | grep status: | grep -q Pending
     ! LXD_DIR="${LXD_TWO_DIR}" lxc storage create pool1 "${driver}" || false
     LXD_DIR="${LXD_ONE_DIR}" lxc storage show pool1 | grep status: | grep -q Errored
     LXD_DIR="${LXD_ONE_DIR}" lxc storage unset pool1 source --target node1
+    ! LXD_DIR="${LXD_TWO_DIR}" lxc storage create pool1 "${driver}" rsync.bwlimit=1000 || false # Check global config is rejected on re-create.
     LXD_DIR="${LXD_TWO_DIR}" lxc storage create pool1 "${driver}"
+    ! LXD_DIR="${LXD_TWO_DIR}" lxc storage create pool1 "${driver}" || false # Check re-create after successful create is rejected.
     LXD_ONE_SOURCE="$(LXD_DIR="${LXD_ONE_DIR}" lxc storage get pool1 source --target=node1)"
     LXD_TWO_SOURCE="$(LXD_DIR="${LXD_TWO_DIR}" lxc storage get pool1 source --target=node2)"
     stat "${LXD_ONE_SOURCE}/containers"


### PR DESCRIPTION
- Restructures storage pool creation to align with network creation process.
- Adds checks for any future duplicated config in DB load function.
- Adds rejection of global config when performing a storage pool re-create attempt.
- Skips global config insert on subsequent re-creates to avoid duplicate config (even if no config is supplied, could be default values generated and duplicated).
- Reinstates the Errored storage pool status so that we can detect re-create attempts even when no global config supplied.
- Blocks re-create attempts once the storage pool is successfully created.

Includes https://github.com/lxc/lxd/pull/8244