### PR TITLE
Instance: Fix deadlock in instance operationlock package

### DIFF
--- a/lxd/instance/operationlock/operationlock.go
+++ b/lxd/instance/operationlock/operationlock.go
@@ -37,7 +37,8 @@ func Create(instanceID int, action string, reusable bool, reuse bool) (*Instance
 	op := instanceOperations[instanceID]
 	if op != nil {
 		if op.reusable && reuse {
-			op.Reset()
+			// Reset operation timeout without releasing lock or deadlocking using Reset() function.
+			op.chanReset <- true
 			return op, nil
 		}
 

--- a/lxd/instance/operationlock/operationlock.go
+++ b/lxd/instance/operationlock/operationlock.go
@@ -52,6 +52,8 @@ func Create(instanceID int, action string, reusable bool, reuse bool) (*Instance
 	op.chanDone = make(chan error, 0)
 	op.chanReset = make(chan bool, 0)
 
+	instanceOperations[instanceID] = op
+
 	go func(op *InstanceOperation) {
 		for {
 			select {
@@ -63,8 +65,6 @@ func Create(instanceID int, action string, reusable bool, reuse bool) (*Instance
 			}
 		}
 	}(op)
-
-	instanceOperations[instanceID] = op
 
 	return op, nil
 }

--- a/lxd/instance/operationlock/operationlock.go
+++ b/lxd/instance/operationlock/operationlock.go
@@ -57,6 +57,8 @@ func Create(instanceID int, action string, reusable bool, reuse bool) (*Instance
 	go func(op *InstanceOperation) {
 		for {
 			select {
+			case <-op.chanDone:
+				return
 			case <-op.chanReset:
 				continue
 			case <-time.After(time.Second * 30):


### PR DESCRIPTION
Calling `Reset()` from `Create()` was causing a deadlock causing `lxc stop -f` requests to hang if initiated while an `lxc stop` was in progress.