### PR TITLE
lxd/network/driver/ovn: Detect IPv6 DHCP options correctly

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2163,7 +2163,7 @@ func (n *ovn) InstanceDevicePortAdd(instanceUUID string, instanceName string, de
 			return "", err
 		}
 
-		if dhcpV4ID == "" {
+		if dhcpv6ID == "" {
 			return "", fmt.Errorf("Could not find DHCPv6 options for instance port")
 		}
 


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>