### PR TITLE
NIC: Remove host-side veth interface if exists on routed device stop

### DIFF
--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -81,8 +81,8 @@ func (d *nicRouted) validateEnvironment() error {
 		return fmt.Errorf("Requires liblxc has following API extensions: network_veth_router, network_l2proxy")
 	}
 
-	if d.config["parent"] != "" && !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", d.config["parent"])) {
-		return fmt.Errorf("Parent device '%s' doesn't exist", d.config["parent"])
+	if d.config["parent"] != "" && !network.InterfaceExists(d.config["parent"]) {
+		return fmt.Errorf("Parent device %q doesn't exist", d.config["parent"])
 	}
 
 	if d.config["parent"] == "" && d.config["vlan"] != "" {
@@ -119,7 +119,7 @@ func (d *nicRouted) validateEnvironment() error {
 
 	// If the effective parent doesn't exist and the vlan option is specified, it means we are going to create
 	// the VLAN parent at start, and we will configure the needed sysctls so don't need to check them yet.
-	if d.config["vlan"] != "" && !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", effectiveParentName)) {
+	if d.config["vlan"] != "" && network.InterfaceExists(effectiveParentName) {
 		return nil
 	}
 

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -414,7 +414,17 @@ func (d *nicRouted) postStop() error {
 
 	v := d.volatileGet()
 
+	networkVethFillFromVolatile(d.config, v)
+
 	errs := []error{}
+
+	if network.InterfaceExists(d.config["host_name"]) {
+		// Removing host-side end of veth pair will delete the peer end too.
+		err := network.InterfaceRemove(d.config["host_name"])
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "Failed to remove interface %q", d.config["host_name"]))
+		}
+	}
 
 	// This will delete the parent interface if we created it for VLAN parent.
 	if shared.IsTrue(v["last_state.created"]) {


### PR DESCRIPTION
Although liblxc should remove the interface, if it still exists for some reason we should try again to remove it.

Addresses https://discuss.linuxcontainers.org/t/unknown-error-17-failed-to-setup-ipv4-address-route-for-network-device/9718