### PR TITLE
Network: Clarify error when changing physical parent interface when in use

### DIFF
--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -247,7 +247,7 @@ func (n *physical) Update(newNetwork api.NetworkPut, targetNode string, clientTy
 		if hostNameChanged {
 			isUsed, err := n.IsUsed()
 			if isUsed || err != nil {
-				return fmt.Errorf("Cannot update network host name when in use")
+				return fmt.Errorf("Cannot update network parent interface when in use")
 			}
 
 			inUse, err := n.checkParentUse(newNetwork.Config)


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>