### PR TITLE
Cluster: Don't apply node changes when network/pool is in pending state

### DIFF
--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1557,8 +1557,10 @@ func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clientType
 		return nil // Nothing changed.
 	}
 
-	if n.LocalStatus() == api.NetworkStatusPending {
-		// Apply DB change to local node only.
+	// If the network as a whole has not had any previous creation attempts, or the node itself is still
+	// pending, then don't apply the new settings to the node, just to the database record (ready for the
+	// actual global create request to be initiated).
+	if n.Status() == api.NetworkStatusPending || n.LocalStatus() == api.NetworkStatusPending {
 		return n.common.update(newNetwork, targetNode, clientType)
 	}
 

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -90,8 +90,10 @@ func (n *macvlan) Update(newNetwork api.NetworkPut, targetNode string, clientTyp
 		return nil // Nothing changed.
 	}
 
-	if n.LocalStatus() == api.NetworkStatusPending {
-		// Apply DB change to local node only.
+	// If the network as a whole has not had any previous creation attempts, or the node itself is still
+	// pending, then don't apply the new settings to the node, just to the database record (ready for the
+	// actual global create request to be initiated).
+	if n.Status() == api.NetworkStatusPending || n.LocalStatus() == api.NetworkStatusPending {
 		return n.common.update(newNetwork, targetNode, clientType)
 	}
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2002,8 +2002,10 @@ func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clientType re
 		return nil // Nothing changed.
 	}
 
-	if n.LocalStatus() == api.NetworkStatusPending {
-		// Apply DB change to local node only.
+	// If the network as a whole has not had any previous creation attempts, or the node itself is still
+	// pending, then don't apply the new settings to the node, just to the database record (ready for the
+	// actual global create request to be initiated).
+	if n.Status() == api.NetworkStatusPending || n.LocalStatus() == api.NetworkStatusPending {
 		return n.common.update(newNetwork, targetNode, clientType)
 	}
 

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -232,8 +232,10 @@ func (n *physical) Update(newNetwork api.NetworkPut, targetNode string, clientTy
 		return nil // Nothing changed.
 	}
 
-	if n.LocalStatus() == api.NetworkStatusPending {
-		// Apply DB change to local node only.
+	// If the network as a whole has not had any previous creation attempts, or the node itself is still
+	// pending, then don't apply the new settings to the node, just to the database record (ready for the
+	// actual global create request to be initiated).
+	if n.Status() == api.NetworkStatusPending || n.LocalStatus() == api.NetworkStatusPending {
 		return n.common.update(newNetwork, targetNode, clientType)
 	}
 

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -90,8 +90,10 @@ func (n *sriov) Update(newNetwork api.NetworkPut, targetNode string, clientType 
 		return nil // Nothing changed.
 	}
 
-	if n.LocalStatus() == api.NetworkStatusPending {
-		// Apply DB change to local node only.
+	// If the network as a whole has not had any previous creation attempts, or the node itself is still
+	// pending, then don't apply the new settings to the node, just to the database record (ready for the
+	// actual global create request to be initiated).
+	if n.Status() == api.NetworkStatusPending || n.LocalStatus() == api.NetworkStatusPending {
 		return n.common.update(newNetwork, targetNode, clientType)
 	}
 


### PR DESCRIPTION
Only apply changes to DB.

These commits are from the stable-4.0 branch ported to the master branch for the bridge network driver and backendLXD storage framework, and then a subsequent commit to align the non-stable-4.0 network drivers with the bridge driver.