### PR TITLE
Cluster: Don't allow re-create attempts on errored networks and storage pools

### DIFF
--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1497,8 +1497,10 @@ func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clientType
 		return nil // Nothing changed.
 	}
 
-	if n.LocalStatus() == api.NetworkStatusPending {
-		// Apply DB change to local node only.
+	// If the network as a whole has not had any previous creation attempts, or the node itself is still
+	// pending, then don't apply the new settings to the node, just to the database record (ready for the
+	// actual global create request to be initiated).
+	if n.Status() == api.NetworkStatusPending || n.LocalStatus() == api.NetworkStatusPending {
 		return n.common.update(newNetwork, targetNode, clientType)
 	}
 

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -203,6 +203,12 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
+	// If the network has previously had a create attempt that failed, then because we cannot track per-node
+	// status, we need to prevent any further create attempts and require the user to delete and re-create.
+	if netInfo != nil && netInfo.Status == api.NetworkStatusErrored {
+		return response.BadRequest(fmt.Errorf("Network is in errored state, please delete and re-create"))
+	}
+
 	// Check if we're clustered.
 	count, err := cluster.Count(d.State())
 	if err != nil {

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -749,6 +749,11 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	// Prevent config changes on errored networks.
+	if n.Status() == api.NetworkStatusErrored {
+		return response.BadRequest(fmt.Errorf("Network config cannot be changed when pool is in errored state"))
+	}
+
 	targetNode := queryParam(r, "target")
 	clustered, err := cluster.Enabled(d.db)
 	if err != nil {

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -223,9 +223,9 @@ func (b *lxdBackend) Update(clientType request.ClientType, newDesc string, newCo
 	// Diff the configurations.
 	changedConfig, userOnly := b.detectChangedConfig(b.db.Config, newConfig)
 
-	// Check if the pool source is being changed that the local state is still pending, otherwise prevent it.
+	// Check if the pool source is being changed that the pool state is still pending, otherwise prevent it.
 	_, sourceChanged := changedConfig["source"]
-	if sourceChanged && b.LocalStatus() != api.StoragePoolStatusPending {
+	if sourceChanged && b.Status() != api.StoragePoolStatusPending {
 		return fmt.Errorf("Pool source cannot be changed when not in pending state")
 	}
 

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -436,6 +436,11 @@ func storagePoolPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	// Prevent config changes on errored pools.
+	if pool.Status() == api.StoragePoolStatusErrored {
+		return response.BadRequest(fmt.Errorf("Pool config cannot be changed when pool is in errored state"))
+	}
+
 	targetNode := queryParam(r, "target")
 	clustered, err := cluster.Enabled(d.db)
 	if err != nil {

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -176,6 +176,12 @@ func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
+	// If the pool has previously had a create attempt that failed, then because we cannot track per-node
+	// status, we need to prevent any further create attempts and require the user to delete and re-create.
+	if pool != nil && pool.Status == api.StoragePoolStatusErrored {
+		return response.BadRequest(fmt.Errorf("Storage pool is in errored state, please delete and re-create"))
+	}
+
 	// Check if we're clustered.
 	count, err := cluster.Count(d.State())
 	if err != nil {


### PR DESCRIPTION
Don't apply node changes when network or storage pool is in pending state.

We can't allow re-create attempts on errored networks/pools, as we don't track per-node state and so cannot tell which nodes have successfully been setup and which ones haven't. So the only valid approach is to require the user to delete and start again.