### PR TITLE
DB: Adds updateFromV43 patch that adds unique index to storage_pools_config and networks_config table

### DIFF
--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -304,6 +304,7 @@ CREATE TABLE "networks_nodes" (
     FOREIGN KEY (network_id) REFERENCES "networks" (id) ON DELETE CASCADE,
     FOREIGN KEY (node_id) REFERENCES nodes (id) ON DELETE CASCADE
 );
+CREATE UNIQUE INDEX networks_unique_network_id_node_id_key ON networks_config (network_id, IFNULL(node_id, -1), key);
 CREATE TABLE nodes (
     id INTEGER PRIMARY KEY,
     name TEXT NOT NULL,
@@ -495,6 +496,7 @@ CREATE TABLE storage_pools_nodes (
     FOREIGN KEY (storage_pool_id) REFERENCES storage_pools (id) ON DELETE CASCADE,
     FOREIGN KEY (node_id) REFERENCES nodes (id) ON DELETE CASCADE
 );
+CREATE UNIQUE INDEX storage_pools_unique_storage_pool_id_node_id_key ON storage_pools_config (storage_pool_id, IFNULL(node_id, -1), key);
 CREATE TABLE "storage_volumes" (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     name TEXT NOT NULL,
@@ -591,5 +593,5 @@ CREATE TABLE storage_volumes_snapshots_config (
     UNIQUE (storage_volume_snapshot_id, key)
 );
 
-INSERT INTO schema (version, updated_at) VALUES (43, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (44, strftime("%s"))
 `

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -82,6 +82,19 @@ var updates = map[int]schema.Update{
 	41: updateFromV40,
 	42: updateFromV41,
 	43: updateFromV42,
+	44: updateFromV43,
+}
+
+// updateFromV43 adds a unique index to the storage_pools_config and networks_config tables.
+func updateFromV43(tx *sql.Tx) error {
+	_, err := tx.Exec(`CREATE UNIQUE INDEX storage_pools_unique_storage_pool_id_node_id_key ON storage_pools_config (storage_pool_id, IFNULL(node_id, -1), key);
+		CREATE UNIQUE INDEX networks_unique_network_id_node_id_key ON networks_config (network_id, IFNULL(node_id, -1), key);
+	`)
+	if err != nil {
+		return errors.Wrapf(err, "Failed adding unique index to storage_pools_config and networks_config tables")
+	}
+
+	return nil
 }
 
 // updateFromV42 removes any duplicated storage pool config rows that have the same value.

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -88,7 +88,7 @@ var updates = map[int]schema.Update{
 // This can occur when multiple create requests have been issued when setting up a clustered storage pool.
 func updateFromV42(tx *sql.Tx) error {
 	// Find all duplicated config rows and return comma delimited list of affected row IDs for each dupe set.
-	stmt, err := tx.Prepare(`SELECT storage_pool_id, COALESCE(node_id,0), key, value, COUNT(*) AS rowCount, GROUP_CONCAT(id, ",") AS dupeRowIDs
+	stmt, err := tx.Prepare(`SELECT storage_pool_id, IFNULL(node_id, -1), key, value, COUNT(*) AS rowCount, GROUP_CONCAT(id, ",") AS dupeRowIDs
 			FROM storage_pools_config
 			GROUP BY storage_pool_id, node_id, key, value
 			HAVING rowCount > 1
@@ -157,7 +157,7 @@ func updateFromV42(tx *sql.Tx) error {
 // This can occur when multiple create requests have been issued when setting up a clustered network.
 func updateFromV41(tx *sql.Tx) error {
 	// Find all duplicated config rows and return comma delimited list of affected row IDs for each dupe set.
-	stmt, err := tx.Prepare(`SELECT network_id, COALESCE(node_id,0), key, value, COUNT(*) AS rowCount, GROUP_CONCAT(id, ",") AS dupeRowIDs
+	stmt, err := tx.Prepare(`SELECT network_id, IFNULL(node_id, -1), key, value, COUNT(*) AS rowCount, GROUP_CONCAT(id, ",") AS dupeRowIDs
 			FROM networks_config
 			GROUP BY network_id, node_id, key, value
 			HAVING rowCount > 1


### PR DESCRIPTION
Prevents duplicate config rows for the same node and key being inserted.

Uses `IFNULL(node_id, -1)`  to ensure unique index is still enforced for non-node specific config keys where node_id is NULL, and uses `-1` as the pseudo value in order to avoid issues where the node ID is genuinely `0` which @stgraber advises is potentially possible on DBs from older installations.

I tried creating a new table with an updated `UNIQUE` constraint, but sqlite doesn't support the `IFNULL` expression in the `CREATE TABLE` statement.

Also updates previous duplicate row detection patch to use `IFNULL(node_id, -1)` too.

Fixes #8260

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>