### PR TITLE
lxd/instance/qemu: Use a minimum of 2 network queues

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2380,11 +2380,17 @@ func (d *qemu) addNetDevConfig(sb *strings.Builder, cpuCount int, bus *qemuBus, 
 		// Detect TAP (via TUN driver) device.
 		tplFields["ifName"] = nicName
 
+		// Run with a minimum of two queues.
+		queueCount := cpuCount
+		if queueCount < 2 {
+			queueCount = 2
+		}
+
 		// Number of queues is the same as number of vCPUs.
-		tplFields["queues"] = cpuCount
+		tplFields["queues"] = queueCount
 
 		// Number of vectors is number of vCPUs * 2 (RX/TX) + 2 (config/control MSI-X).
-		tplFields["vectors"] = 2*cpuCount + 2
+		tplFields["vectors"] = 2*queueCount + 2
 
 		tpl = qemuNetDevTapTun
 	} else if pciSlotName != "" {


### PR DESCRIPTION
Otherwise qemu expects a single queue TAP device which isn't what we're
preparing these days :)

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>