### PR TITLE
Storage: Fix snapshot remove subsequent

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2064,23 +2064,25 @@ func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instanc
 
 			// Go through all the snapshots.
 			for _, snap := range snaps {
-				_, snapName, _ := shared.InstanceGetParentAndSnapshotName(src.Name())
+				_, snapName, _ := shared.InstanceGetParentAndSnapshotName(snap.Name())
 				if !shared.StringInSlice(snapName, snapErr.Snapshots) {
 					continue
 				}
 
-				// Delete if listed.
-				err := b.DeleteInstanceSnapshot(snap, op)
+				// Delete snapshot instance if listed in the error as one that needs removing.
+				err := snap.Delete(true)
 				if err != nil {
 					return err
 				}
 			}
 
-			// Now try again.
+			// Now try restoring again.
 			err = b.driver.RestoreVolume(vol, snapshotName, op)
 			if err != nil {
 				return err
 			}
+
+			return nil
 		}
 
 		return err

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1996,9 +1996,9 @@ func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operatio
 		return err
 	}
 
-	// Remove the snapshot volume record from the database.
+	// Remove the snapshot volume record from the database if exists.
 	err = b.state.Cluster.RemoveStoragePoolVolume(inst.Project(), drivers.GetSnapshotVolumeName(parentName, snapName), volDBType, b.ID())
-	if err != nil {
+	if err != nil && err != db.ErrNoSuchObject {
 		return err
 	}
 

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1788,14 +1788,14 @@ func (d *zfs) RestoreVolume(vol Volume, snapshotName string, op *operations.Oper
 
 		if strings.HasPrefix(entry, "@") {
 			// Located an internal snapshot.
-			return fmt.Errorf("Snapshot '%s' cannot be restored due to subsequent internal snapshot(s) (from a copy)", snapshotName)
+			return fmt.Errorf("Snapshot %q cannot be restored due to subsequent internal snapshot(s) (from a copy)", snapshotName)
 		}
 	}
 
 	// Check if snapshot removal is allowed.
 	if len(snapshots) > 0 {
 		if !shared.IsTrue(vol.ExpandedConfig("zfs.remove_snapshots")) {
-			return fmt.Errorf("Snapshot '%s' cannot be restored due to subsequent snapshot(s). Set zfs.remove_snapshots to override", snapshotName)
+			return fmt.Errorf("Snapshot %q cannot be restored due to subsequent snapshot(s). Set zfs.remove_snapshots to override", snapshotName)
 		}
 
 		// Setup custom error to tell the backend what to delete.


### PR DESCRIPTION
When setting `volume.zfs.remove_snapshots=true` on a ZFS storage pool, this fixes several issues:

- The wrong snapshot was being checked for deletion suitability (resulting in not deleting any snapshots).
- Once that was fixed, there was also an issue with only the storage volume and storage volume DB record of the snapshot being deleted, not the instance snapshot record as well. Leaving orphaned snapshots in `lxc info <instance>` output and preventing deletion of instance (because snapshot volume DB record had been removed).
- Because of the scope of the `err` being returned, it was likely that as a new `err` was created inside the subsequent snapshot deletion block, that the original error would be returned even on successful restore. Added `return nil` after successful restore.
- Modified `DeleteInstanceSnapshot` to not fail if the storage volume DB record has already been removed (as that is the desired result anyway).

Fixes https://discuss.linuxcontainers.org/t/snapshot-c1-20201218-03-cannot-be-restored-due-to-subsequent-snapshot-s-set-zfs-remove-snapshots-to-override/9742
