### PR TITLE
Network: Make OVN updates more nuanced and less destructive

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1669,18 +1669,30 @@ func (n *ovn) setup(update bool) error {
 			}
 		}
 
-		// Add default routes.
+		// Add or remove default routes as config dictates.
+		defaultIPv4Route := &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)}
 		if uplinkNet.routerExtGwIPv4 != nil {
-			err = client.LogicalRouterRouteAdd(n.getRouterName(), &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)}, uplinkNet.routerExtGwIPv4, false)
+			err = client.LogicalRouterRouteAdd(n.getRouterName(), defaultIPv4Route, uplinkNet.routerExtGwIPv4, update)
 			if err != nil {
 				return errors.Wrapf(err, "Failed adding IPv4 default route")
 			}
+		} else if update {
+			err = client.LogicalRouterRouteDelete(n.getRouterName(), defaultIPv4Route, nil)
+			if err != nil {
+				return errors.Wrapf(err, "Failed removing IPv4 default route")
+			}
 		}
 
+		defaultIPv6Route := &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)}
 		if uplinkNet.routerExtGwIPv6 != nil {
-			err = client.LogicalRouterRouteAdd(n.getRouterName(), &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)}, uplinkNet.routerExtGwIPv6, false)
+			err = client.LogicalRouterRouteAdd(n.getRouterName(), defaultIPv6Route, uplinkNet.routerExtGwIPv6, update)
 			if err != nil {
 				return errors.Wrapf(err, "Failed adding IPv6 default route")
+			}
+		} else if update {
+			err = client.LogicalRouterRouteDelete(n.getRouterName(), defaultIPv6Route, nil)
+			if err != nil {
+				return errors.Wrapf(err, "Failed removing IPv6 default route")
 			}
 		}
 	}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1658,14 +1658,14 @@ func (n *ovn) setup(update bool) error {
 		if shared.IsTrue(n.config["ipv4.nat"]) && routerIntPortIPv4Net != nil && routerExtPortIPv4 != nil {
 			err = client.LogicalRouterSNATAdd(n.getRouterName(), routerIntPortIPv4Net, routerExtPortIPv4, update)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "Failed adding router IPv4 SNAT rule")
 			}
 		}
 
 		if shared.IsTrue(n.config["ipv6.nat"]) && routerIntPortIPv6Net != nil && routerExtPortIPv6 != nil {
 			err = client.LogicalRouterSNATAdd(n.getRouterName(), routerIntPortIPv6Net, routerExtPortIPv6, update)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "Failed adding router IPv6 SNAT rule")
 			}
 		}
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1824,10 +1824,13 @@ func (n *ovn) setup(update bool) error {
 	}
 
 	// Set IPv6 router advertisement settings.
-	if dhcpV6Subnet != nil {
+	if routerIntPortIPv6Net != nil {
 		adressMode := openvswitch.OVNIPv6AddressModeSLAAC
-		if shared.IsTrue(n.config["ipv6.dhcp.stateful"]) {
-			adressMode = openvswitch.OVNIPv6AddressModeDHCPStateful
+		if dhcpV6Subnet != nil {
+			adressMode = openvswitch.OVNIPv6AddressModeDHCPStateless
+			if shared.IsTrue(n.config["ipv6.dhcp.stateful"]) {
+				adressMode = openvswitch.OVNIPv6AddressModeDHCPStateful
+			}
 		}
 
 		var recursiveDNSServer net.IP
@@ -1849,6 +1852,11 @@ func (n *ovn) setup(update bool) error {
 		})
 		if err != nil {
 			return errors.Wrapf(err, "Failed setting internal router port IPv6 advertisement settings")
+		}
+	} else {
+		err = client.LogicalRouterPortDeleteIPv6Advertisements(n.getRouterIntPortName())
+		if err != nil {
+			return errors.Wrapf(err, "Failed removing internal router port IPv6 advertisement settings")
 		}
 	}
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2585,6 +2585,11 @@ func (n *ovn) DHCPv6Subnet() *net.IPNet {
 		return nil
 	}
 
+	ones, _ := subnet.Mask.Size()
+	if ones < 64 {
+		return nil // OVN only supports DHCPv6 allocated using EUI64 (which requires at least a /64).
+	}
+
 	return subnet
 }
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1645,6 +1645,15 @@ func (n *ovn) setup(update bool) error {
 			return errors.Wrapf(err, "Failed linking external switch provider port to external provider network")
 		}
 
+		// Remove any existing SNAT rules on update. As currently these are only defined from the network
+		// config rather than from any instance NIC config, so we can re-create the active config below.
+		if update {
+			err = client.LogicalRouterSNATDeleteAll(n.getRouterName())
+			if err != nil {
+				return errors.Wrapf(err, "Failed removing existing router SNAT rules")
+			}
+		}
+
 		// Add SNAT rules.
 		if shared.IsTrue(n.config["ipv4.nat"]) && routerIntPortIPv4Net != nil && routerExtPortIPv4 != nil {
 			err = client.LogicalRouterSNATAdd(n.getRouterName(), routerIntPortIPv4Net, routerExtPortIPv4, update)

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -348,6 +348,17 @@ func (o *OVN) LogicalRouterPortSetIPv6Advertisements(portName OVNRouterPort, opt
 	return nil
 }
 
+// LogicalRouterPortDeleteIPv6Advertisements removes the IPv6 RA announcement settings from a router port.
+func (o *OVN) LogicalRouterPortDeleteIPv6Advertisements(portName OVNRouterPort) error {
+	// Delete IPv6 Router Advertisements.
+	_, err := o.nbctl("clear", "logical_router_port", string(portName), "ipv6_ra_configs")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // LogicalRouterPortLinkChassisGroup links a logical router port to a HA chassis group.
 func (o *OVN) LogicalRouterPortLinkChassisGroup(portName OVNRouterPort, haChassisGroupName OVNChassisGroup) error {
 	chassisGroupID, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--colum=_uuid", "find", "ha_chassis_group", fmt.Sprintf("name=%s", haChassisGroupName))

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -204,8 +204,7 @@ func (o *OVN) LogicalRouterRouteAdd(routerName OVNRouter, destination *net.IPNet
 		args = append(args, "--may-exist")
 	}
 
-	args = append(args, "lr-route-add", string(routerName), destination.String(), nextHop.String())
-	_, err := o.nbctl(args...)
+	_, err := o.nbctl(append(args, "lr-route-add", string(routerName), destination.String(), nextHop.String())...)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -125,8 +125,14 @@ func (o *OVN) nbctl(args ...string) (string, error) {
 }
 
 // LogicalRouterAdd adds a named logical router.
-func (o *OVN) LogicalRouterAdd(routerName OVNRouter) error {
-	_, err := o.nbctl("lr-add", string(routerName))
+func (o *OVN) LogicalRouterAdd(routerName OVNRouter, mayExist bool) error {
+	args := []string{}
+
+	if mayExist {
+		args = append(args, "--may-exist")
+	}
+
+	_, err := o.nbctl(append(args, "lr-add", string(routerName))...)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -151,8 +151,14 @@ func (o OVN) LogicalRouterDelete(routerName OVNRouter) error {
 }
 
 // LogicalRouterSNATAdd adds an SNAT rule to a logical router to translate packets from intNet to extIP.
-func (o *OVN) LogicalRouterSNATAdd(routerName OVNRouter, intNet *net.IPNet, extIP net.IP) error {
-	_, err := o.nbctl("lr-nat-add", string(routerName), "snat", extIP.String(), intNet.String())
+func (o *OVN) LogicalRouterSNATAdd(routerName OVNRouter, intNet *net.IPNet, extIP net.IP, mayExist bool) error {
+	args := []string{}
+
+	if mayExist {
+		args = append(args, "--may-exist")
+	}
+
+	_, err := o.nbctl(append(args, "lr-nat-add", string(routerName), "snat", extIP.String(), intNet.String())...)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -166,6 +166,16 @@ func (o *OVN) LogicalRouterSNATAdd(routerName OVNRouter, intNet *net.IPNet, extI
 	return nil
 }
 
+// LogicalRouterSNATDeleteAll deletes all SNAT rules from a logical router.
+func (o *OVN) LogicalRouterSNATDeleteAll(routerName OVNRouter) error {
+	_, err := o.nbctl("--if-exists", "lr-nat-del", string(routerName), "snat")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // LogicalRouterDNATSNATAdd adds a DNAT and SNAT rule to a logical router to translate packets from extIP to intIP.
 func (o *OVN) LogicalRouterDNATSNATAdd(routerName OVNRouter, extIP net.IP, intIP net.IP, stateless bool, mayExist bool) error {
 	args := []string{}


### PR DESCRIPTION
Don't tear down all OVN config and rebuild, instead try and apply only changes, so as to reduce impact on instance port config.