### PR TITLE
shared/proxy: Support CIDR ranges in `no_proxy`

### DIFF
--- a/doc/environment.md
+++ b/doc/environment.md
@@ -12,7 +12,7 @@ Name                            | Description
 `PATH`                          | List of paths to look into when resolving binaries
 `http_proxy`                    | Proxy server URL for HTTP
 `https_proxy`                   | Proxy server URL for HTTPS
-`no_proxy`                      | List of domains that don't require the use of a proxy
+`no_proxy`                      | List of domains, IP addresses or CIDR ranges that don't require the use of a proxy
 
 ## Client environment variable
 Name                            | Description

--- a/shared/proxy.go
+++ b/shared/proxy.go
@@ -123,7 +123,8 @@ func useProxy(addr string, noProxy string) (bool, error) {
 	if host == "localhost" {
 		return false, nil
 	}
-	if ip := net.ParseIP(host); ip != nil {
+	ip := net.ParseIP(host)
+	if ip != nil {
 		if ip.IsLoopback() {
 			return false, nil
 		}
@@ -148,6 +149,12 @@ func useProxy(addr string, noProxy string) (bool, error) {
 		}
 		if addr == p {
 			return false, nil
+		}
+		if _, pnet, err := net.ParseCIDR(p); err == nil && ip != nil {
+			// IPv4/CIDR, IPv6/CIDR
+			if pnet.Contains(ip) {
+				return false, nil
+			}
 		}
 		if p[0] == '.' && (strings.HasSuffix(addr, p) || addr == p[1:]) {
 			// noProxy ".foo.com" matches "bar.foo.com" or "foo.com"


### PR DESCRIPTION
Sometimes, for example if you need a proxy to access the internet but
not local resources, it can be necessary to bypass the http(s)_proxy for
entire ranges.

Add support for CIDR ranges in no_proxy. This means, for example, that
10.0.0.0/8 will work as expected.

Fixes #8288

Signed-off-by: Iain Lane <iain@orangesquash.org.uk>