### PR TITLE
simplestreams: Drop duplicated slash

### DIFF
--- a/shared/simplestreams/simplestreams.go
+++ b/shared/simplestreams/simplestreams.go
@@ -98,7 +98,7 @@ func (s *SimpleStreams) cachedDownload(path string) ([]byte, error) {
 	}
 
 	// Download from the source
-	uri := fmt.Sprintf("%s/%s", s.url, path)
+	uri := fmt.Sprintf("%s/%s", strings.TrimRight(s.url, "/"), strings.TrimLeft(path, "/"))
 	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Could be better in the near future to use url.Parse but i will review the code with the integration of the RFC changes.