### PR TITLE
test/suites/static/analysis: Fixes ineffassign usage due to upstream changes

### DIFF
--- a/test/suites/static_analysis.sh
+++ b/test/suites/static_analysis.sh
@@ -161,7 +161,7 @@ test_static_analysis() {
 
     ## ineffassign
     if which ineffassign >/dev/null 2>&1; then
-      ineffassign ./
+      ineffassign ./...
     fi
 
     # Skip the tests which require git


### PR DESCRIPTION
Caused by https://github.com/gordonklaus/ineffassign/commit/664217a59c00a74b4491898ca757d3f711fff321

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>