### PR TITLE
Instance: Copy snapshot devices reliably during migration

### DIFF
--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -100,12 +100,14 @@ func snapshotToProtobuf(c instance.Instance) *migration.Snapshot {
 	for name, d := range c.LocalDevices() {
 		props := []*migration.Config{}
 		for k, v := range d {
+			// Local loop vars.
 			kCopy := string(k)
 			vCopy := string(v)
 			props = append(props, &migration.Config{Key: &kCopy, Value: &vCopy})
 		}
 
-		devices = append(devices, &migration.Device{Name: &name, Config: props})
+		nameCopy := name // Local loop var.
+		devices = append(devices, &migration.Device{Name: &nameCopy, Config: props})
 	}
 
 	parts := strings.SplitN(c.Name(), shared.SnapshotDelimiter, 2)

--- a/lxd/storage_migration.go
+++ b/lxd/storage_migration.go
@@ -13,14 +13,14 @@ import (
 func snapshotProtobufToInstanceArgs(inst instance.Instance, snap *migration.Snapshot) db.InstanceArgs {
 	config := map[string]string{}
 
-	for _, ent := range snap.LocalConfig {
+	for _, ent := range snap.GetLocalConfig() {
 		config[ent.GetKey()] = ent.GetValue()
 	}
 
 	devices := deviceConfig.Devices{}
-	for _, ent := range snap.LocalDevices {
+	for _, ent := range snap.GetLocalDevices() {
 		props := map[string]string{}
-		for _, prop := range ent.Config {
+		for _, prop := range ent.GetConfig() {
 			props[prop.GetKey()] = prop.GetValue()
 		}
 

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -246,7 +246,8 @@ migration() {
   rm testfile1
   lxc_remote stop -f l2:c2
 
-  # This will create snapshot c1/snap0
+  # This will create snapshot c1/snap0 with expiry
+  lxc_remote config set l1:c1 snapshots.expiry '1d'
   lxc_remote snapshot l1:c1
 
   # Remove the testfile from c1 and refresh again
@@ -261,6 +262,7 @@ migration() {
   lxc_remote copy l1:c1 l2:c2 --refresh
   lxc_remote ls l2:
   lxc_remote config show l2:c2/snap0
+  ! lxc_remote config show l2:c2/snap0 | grep -q 'expires_at: 0001-01-01T00:00:00Z' || false
 
   # This will create snapshot c2/snap1
   lxc_remote snapshot l2:c2

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -246,9 +246,12 @@ migration() {
   rm testfile1
   lxc_remote stop -f l2:c2
 
-  # This will create snapshot c1/snap0 with expiry
+  # This will create snapshot c1/snap0 with test device and expiry date.
+  lxc_remote config device add l1:c1 testsnapdev none
   lxc_remote config set l1:c1 snapshots.expiry '1d'
   lxc_remote snapshot l1:c1
+  lxc_remote config device remove l1:c1 testsnapdev
+  lxc_remote config device add l1:c1 testdev none
 
   # Remove the testfile from c1 and refresh again
   lxc_remote file delete l1:c1/root/testfile1
@@ -257,12 +260,15 @@ migration() {
   ! lxc_remote file pull l2:c2/root/testfile1 . || false
   lxc_remote stop -f l2:c2
 
-  # Check whether snapshot c2/snap0 has been created
+  # Check whether snapshot c2/snap0 has been created with its config intact.
   ! lxc_remote config show l2:c2/snap0 || false
   lxc_remote copy l1:c1 l2:c2 --refresh
   lxc_remote ls l2:
   lxc_remote config show l2:c2/snap0
   ! lxc_remote config show l2:c2/snap0 | grep -q 'expires_at: 0001-01-01T00:00:00Z' || false
+  lxc_remote config device get l2:c2 testdev type | grep -q 'none'
+  lxc_remote restore l2:c2 snap0
+  lxc_remote config device get l2:c2 testsnapdev type | grep -q 'none'
 
   # This will create snapshot c2/snap1
   lxc_remote snapshot l2:c2

--- a/test/suites/snapshots.sh
+++ b/test/suites/snapshots.sh
@@ -235,8 +235,12 @@ test_snap_expiry() {
   lxc snapshot c1
   ! lxc config show c1/snap1 | grep -q 'expires_at: 0001-01-01T00:00:00Z' || false
 
+  lxc copy c1 c2
+  ! lxc config show c2/snap1 | grep -q 'expires_at: 0001-01-01T00:00:00Z' || false
+
   lxc snapshot c1 --no-expiry
   lxc config show c1/snap2 | grep -q 'expires_at: 0001-01-01T00:00:00Z' || false
 
   lxc rm -f c1
+  lxc rm -f c2
 }


### PR DESCRIPTION
Snapshot device names could be mixed up during migration due to use of loop pointer for name.

Fixes https://github.com/lxc/lxd/issues/8283