### PR TITLE
Storage: Reinitialise root disk quota on lxd import

### DIFF
--- a/lxd/storage/drivers/driver_dir_utils.go
+++ b/lxd/storage/drivers/driver_dir_utils.go
@@ -37,17 +37,11 @@ func (d *dir) setupInitialQuota(vol Volume) (func(), error) {
 	revert := revert.New()
 	defer revert.Fail()
 
-	// Initialise the volume's quota using the volume ID.
-	err = d.initQuota(volPath, volID)
-	if err != nil {
-		return nil, err
-	}
-
 	// Define a function to revert the quota being setup.
 	revertFunc := func() { d.deleteQuota(volPath, volID) }
 	revert.Add(revertFunc)
 
-	// Set the quota.
+	// Initialise the volume's project using the volume ID and set the quota.
 	err = d.setQuota(volPath, volID, vol.ConfigSize())
 	if err != nil {
 		return nil, err
@@ -75,31 +69,6 @@ func (d *dir) deleteQuota(path string, volID int64) error {
 	}
 
 	err = quota.DeleteProject(path, d.quotaProjectID(volID))
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// initQuota initialises the project quota on the path. The volID generates a quota project ID.
-func (d *dir) initQuota(path string, volID int64) error {
-	if volID == volIDQuotaSkip {
-		// Disabled on purpose, just ignore
-		return nil
-	}
-
-	if volID == 0 {
-		return fmt.Errorf("Missing volume ID")
-	}
-
-	ok, err := quota.Supported(path)
-	if err != nil || !ok {
-		// Skipping quota as underlying filesystem doesn't suppport project quotas.
-		return nil
-	}
-
-	err = quota.SetProject(path, d.quotaProjectID(volID))
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/drivers/driver_dir_utils.go
+++ b/lxd/storage/drivers/driver_dir_utils.go
@@ -139,8 +139,30 @@ func (d *dir) setQuota(path string, volID int64, size string) error {
 			// Skipping quota as underlying filesystem doesn't suppport project quotas.
 			d.logger.Warn("The backing filesystem doesn't support quotas, skipping set quota", log.Ctx{"path": path, "size": size, "volID": volID})
 		}
+
 		return nil
 	}
 
-	return quota.SetProjectQuota(path, d.quotaProjectID(volID), sizeBytes)
+	projectID := d.quotaProjectID(volID)
+	currentProjectID, err := quota.GetProject(path)
+	if err != nil {
+		return err
+	}
+
+	// Remove current project if desired project ID is different.
+	if currentProjectID != d.quotaProjectID(volID) {
+		err = quota.DeleteProject(path, currentProjectID)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Initialise the project.
+	err = quota.SetProject(path, projectID)
+	if err != nil {
+		return err
+	}
+
+	// Set the project quota size.
+	return quota.SetProjectQuota(path, projectID, sizeBytes)
 }

--- a/lxd/storage/quota/projectquota.go
+++ b/lxd/storage/quota/projectquota.go
@@ -204,7 +204,7 @@ func devForPath(path string) (string, error) {
 	return "", errNoDevice
 }
 
-// Supported check if the given path supports project quotas
+// Supported check if the given path supports project quotas.
 func Supported(path string) (bool, error) {
 	// Get the backing device
 	devPath, err := devForPath(path)
@@ -219,7 +219,7 @@ func Supported(path string) (bool, error) {
 	return C.quota_supported(cDevPath) == 0, nil
 }
 
-// GetProject returns the project quota ID for the given path
+// GetProject returns the project quota ID for the given path.
 func GetProject(path string) (uint32, error) {
 	// Call ioctl through CGo
 	cPath := C.CString(path)
@@ -227,7 +227,7 @@ func GetProject(path string) (uint32, error) {
 
 	id := C.quota_get_path(cPath)
 	if id < 0 {
-		return 0, fmt.Errorf("Failed to get project from '%s'", path)
+		return 0, fmt.Errorf("Failed to get project from %q", path)
 	}
 
 	return uint32(id), nil
@@ -264,15 +264,15 @@ func SetProject(path string, id uint32) error {
 	return err
 }
 
-// DeleteProject unsets the project id from the path and clears the quota for the project id
+// DeleteProject unsets the project id from the path and clears the quota for the project ID.
 func DeleteProject(path string, id uint32) error {
-	// Unset the project from the path
+	// Unset the project from the path.
 	err := SetProject(path, 0)
 	if err != nil {
 		return err
 	}
 
-	// Unset the quota on the project
+	// Unset the quota on the project.
 	err = SetProjectQuota(path, id, 0)
 	if err != nil {
 		return err
@@ -281,27 +281,27 @@ func DeleteProject(path string, id uint32) error {
 	return nil
 }
 
-// GetProjectUsage returns the current consumption
+// GetProjectUsage returns the current consumption.
 func GetProjectUsage(path string, id uint32) (int64, error) {
-	// Get the backing device
+	// Get the backing device.
 	devPath, err := devForPath(path)
 	if err != nil {
 		return -1, err
 	}
 
-	// Call quotactl through CGo
+	// Call quotactl through CGo.
 	cDevPath := C.CString(devPath)
 	defer C.free(unsafe.Pointer(cDevPath))
 
 	size := C.quota_get_usage(cDevPath, C.uint32_t(id))
 	if size < 0 {
-		return -1, fmt.Errorf("Failed to get project consumption for id '%d' on '%s'", id, devPath)
+		return -1, fmt.Errorf(`Failed to get project consumption for ID "%d" on %q`, id, devPath)
 	}
 
 	return int64(size), nil
 }
 
-// SetProjectQuota sets the quota on the project id
+// SetProjectQuota sets the quota on the project ID.
 func SetProjectQuota(path string, id uint32, bytes int64) error {
 	// Get the backing device
 	devPath, err := devForPath(path)
@@ -314,7 +314,7 @@ func SetProjectQuota(path string, id uint32, bytes int64) error {
 	defer C.free(unsafe.Pointer(cDevPath))
 
 	if C.quota_set(cDevPath, C.uint32_t(id), C.uint64_t(bytes/1024)) != 0 {
-		return fmt.Errorf("Failed to set project quota for id '%d' on '%s'", id, devPath)
+		return fmt.Errorf(`Failed to set project quota for ID "%d" on %q`, id, devPath)
 	}
 
 	return nil


### PR DESCRIPTION
Reinitialise root disk quota on `lxd import` so that directory project quota is reinitialised based on the instance's new volume ID.

Fixes https://github.com/lxc/lxd/issues/8280