### PR TITLE
Network: Adds support for notifying dependent networks when their uplink networks change config

### DIFF
--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -404,3 +404,55 @@ func (n *common) lifecycle(action string, ctx map[string]interface{}) error {
 
 	return n.state.Events.SendLifecycle(n.project, fmt.Sprintf("%s-%s", prefix, action), u, ctx)
 }
+
+// notifyDependentNetworks allows any dependent networks to apply changes to themselves when this network changes.
+func (n *common) notifyDependentNetworks(changedKeys []string) {
+	if n.Project() != project.Default {
+		return // Only networks in the default project can be used as dependent networks.
+	}
+
+	// Get a list of projects.
+	var err error
+	var projectNames []string
+
+	err = n.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
+		projectNames, err = tx.GetProjectNames()
+		return err
+	})
+	if err != nil {
+		n.logger.Error("Failed to load projects", log.Ctx{"err": err})
+		return
+	}
+
+	for _, projectName := range projectNames {
+		// Get a list of managed networks in project.
+		depNets, err := n.state.Cluster.GetCreatedNetworks(projectName)
+		if err != nil {
+			n.logger.Error("Failed to load networks in project", log.Ctx{"project": projectName, "err": err})
+			continue // Continue to next project.
+		}
+
+		for _, depName := range depNets {
+			depNet, err := LoadByName(n.state, projectName, depName)
+			if err != nil {
+				n.logger.Error("Failed to load dependent network", log.Ctx{"project": projectName, "dependentNetwork": depName, "err": err})
+				continue // Continue to next network.
+			}
+
+			if depNet.Config()["network"] != n.Name() {
+				continue // Skip network, as does not depend on our network.
+			}
+
+			err = depNet.handleDependencyChange(n.Name(), n.Config(), changedKeys)
+			if err != nil {
+				n.logger.Error("Failed notifying dependent network", log.Ctx{"project": projectName, "dependentNetwork": depName, "err": err})
+				continue // Continue to next network.
+			}
+		}
+	}
+}
+
+// handleDependencyChange is a placeholder for networks that don't need to handle changes from dependent networks.
+func (n *common) handleDependencyChange(netName string, netConfig map[string]string, changedKeys []string) error {
+	return nil
+}

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -290,6 +290,14 @@ func (n *physical) Update(newNetwork api.NetworkPut, targetNode string, clientTy
 	}
 
 	revert.Success()
+
+	// Notify dependent networks (those using this network as their uplink) of the changes.
+	// Do this after the network has been successfully updated so that a failure to notify a dependent network
+	// doesn't prevent the network itself from being updated.
+	if clientType == request.ClientTypeNormal && len(changedKeys) > 0 {
+		n.common.notifyDependentNetworks(changedKeys)
+	}
+
 	return nil
 }
 

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -51,4 +51,5 @@ type Network interface {
 	Update(newNetwork api.NetworkPut, targetNode string, clientType request.ClientType) error
 	HandleHeartbeat(heartbeatData *cluster.APIHeartbeat) error
 	Delete(clientType request.ClientType) error
+	handleDependencyChange(netName string, netConfig map[string]string, changedKeys []string) error
 }


### PR DESCRIPTION
This allows changes to a physical uplink network's `dns.nameservers` setting to be applied to dependent OVN networks that use it.