### PR TITLE
Network: Handle changes to OVN uplink ovn.ingress_mode setting

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2770,10 +2770,11 @@ func (n *ovn) uplinkHasIngressRoutedAnycastIPv6(uplink *api.Network) bool {
 }
 
 // handleDependencyChange applies changes from uplink network if specific watched keys have changed.
-func (n *ovn) handleDependencyChange(netName string, netConfig map[string]string, changedKeys []string) error {
+func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]string, changedKeys []string) error {
+	// Detect changes that need to be applied to the network.
 	for _, k := range []string{"dns.nameservers"} {
 		if shared.StringInSlice(k, changedKeys) {
-			n.logger.Debug("Applying changes from uplink network", log.Ctx{"uplink": netName})
+			n.logger.Debug("Applying changes from uplink network", log.Ctx{"uplink": uplinkName})
 
 			// Re-setup logical network in order to apply uplink changes.
 			err := n.setup(true)

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -186,7 +186,7 @@ func (o *OVN) LogicalRouterSNATDeleteAll(routerName OVNRouter) error {
 	return nil
 }
 
-// LogicalRouterDNATSNATAdd adds a DNAT and SNAT rule to a logical router to translate packets from extIP to intIP.
+// LogicalRouterDNATSNATAdd adds a DNAT_AND_SNAT rule to a logical router to translate packets from extIP to intIP.
 func (o *OVN) LogicalRouterDNATSNATAdd(routerName OVNRouter, extIP net.IP, intIP net.IP, stateless bool, mayExist bool) error {
 	args := []string{}
 
@@ -206,7 +206,7 @@ func (o *OVN) LogicalRouterDNATSNATAdd(routerName OVNRouter, extIP net.IP, intIP
 	return nil
 }
 
-// LogicalRouterDNATSNATDelete deletes a DNAT and SNAT rule from a logical router.
+// LogicalRouterDNATSNATDelete deletes a DNAT_AND_SNAT rule from a logical router.
 func (o *OVN) LogicalRouterDNATSNATDelete(routerName OVNRouter, extIP net.IP) error {
 	_, err := o.nbctl("--if-exists", "lr-nat-del", string(routerName), "dnat_and_snat", extIP.String())
 	if err != nil {

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -716,6 +716,23 @@ func (o *OVN) logicalSwitchDNSRecordsDelete(switchName OVNSwitch) error {
 	return nil
 }
 
+// LogicalSwitchPortExists returns whether the logical switch port exists.
+func (o *OVN) LogicalSwitchPortExists(portName OVNSwitchPort) (bool, error) {
+	foundPort, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--colum=name", "find", "logical_switch_port",
+		fmt.Sprintf("name=%s", string(portName)),
+	)
+	if err != nil {
+		return false, err
+	}
+
+	foundPort = strings.TrimSpace(foundPort)
+	if foundPort == string(portName) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
 // LogicalSwitchPortAdd adds a named logical switch port to a logical switch.
 // If mayExist is true, then an existing resource of the same name is not treated as an error.
 func (o *OVN) LogicalSwitchPortAdd(switchName OVNSwitch, portName OVNSwitchPort, mayExist bool) error {

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -166,6 +166,16 @@ func (o *OVN) LogicalRouterSNATAdd(routerName OVNRouter, intNet *net.IPNet, extI
 	return nil
 }
 
+// LogicalRouterDNATSNATDeleteAll deletes all DNAT_AND_SNAT rules from a logical router.
+func (o *OVN) LogicalRouterDNATSNATDeleteAll(routerName OVNRouter) error {
+	_, err := o.nbctl("--if-exists", "lr-nat-del", string(routerName), "dnat_and_snat")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // LogicalRouterSNATDeleteAll deletes all SNAT rules from a logical router.
 func (o *OVN) LogicalRouterSNATDeleteAll(routerName OVNRouter) error {
 	_, err := o.nbctl("--if-exists", "lr-nat-del", string(routerName), "snat")


### PR DESCRIPTION
- When an OVN network's uplink's `ovn.ingress_mode` is set to `l2proxy` or empty, will find all instance NICs using the network and reinstate the l2proxy DNAT_AND_SNAT rules for any active switch port.
- When it is set to `routed` it will remove all DNAT_AND_SNAT rules for the network.