### PR TITLE
DB: Adds optional filter argument to InstanceList function

### DIFF
--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -525,16 +525,16 @@ func (c *ClusterTx) UpdateInstanceNode(project, oldName, newName, newNode string
 	return nil
 }
 
-// GetLocalInstancesInProject retuurns all instances of the given type on the
-// local node within the given project.
-func (c *ClusterTx) GetLocalInstancesInProject(project string, instanceType instancetype.Type) ([]Instance, error) {
+// GetLocalInstancesInProject retuurns all instances of the given type on the local node within the given project.
+// If projectName is empty then all instances in all projects are returned.
+func (c *ClusterTx) GetLocalInstancesInProject(projectName string, instanceType instancetype.Type) ([]Instance, error) {
 	node, err := c.GetLocalNodeName()
 	if err != nil {
 		return nil, errors.Wrap(err, "Local node name")
 	}
 
 	filter := InstanceFilter{
-		Project: project,
+		Project: projectName,
 		Node:    node,
 		Type:    instanceType,
 	}

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -198,7 +198,7 @@ func TestInstanceList(t *testing.T) {
 	require.NoError(t, err)
 
 	var instances []db.Instance
-	err = cluster.InstanceList(func(dbInst db.Instance, p api.Project, profiles []api.Profile) error {
+	err = cluster.InstanceList(nil, func(dbInst db.Instance, p api.Project, profiles []api.Profile) error {
 		dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, profiles)
 		dbInst.Devices = db.ExpandInstanceDevices(deviceConfig.NewDevices(dbInst.Devices), profiles).CloneNative()
 		instances = append(instances, dbInst)

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2691,7 +2691,7 @@ func (n *ovn) ovnNICExternalRoutes(ourDeviceInstance instance.Instance, ourDevic
 		return false
 	}
 
-	err := n.state.Cluster.InstanceList(func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+	err := n.state.Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 		devices := db.ExpandInstanceDevices(deviceConfig.NewDevices(inst.Devices), profiles).CloneNative()
@@ -2798,7 +2798,7 @@ func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]
 		if shared.StringInSlice(uplinkConfig["ovn.ingress_mode"], []string{"l2proxy", ""}) {
 			// Find all instance NICs that use this network, and re-add the logical OVN instance port.
 			// This will restore the l2proxy DNAT_AND_SNAT rules.
-			err = n.state.Cluster.InstanceList(func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+			err = n.state.Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
 				// Get the instance's effective network project name.
 				instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -186,7 +186,7 @@ func patchVMRenameUUIDKey(name string, d *Daemon) error {
 	oldUUIDKey := "volatile.vm.uuid"
 	newUUIDKey := "volatile.uuid"
 
-	return d.State().Cluster.InstanceList(func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+	return d.State().Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
 		if inst.Type != instancetype.VM {
 			return nil
 		}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -711,7 +711,7 @@ func VolumeUsedByInstanceDevices(s *state.State, poolName string, projectName st
 		return err
 	}
 
-	return s.Cluster.InstanceList(func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+	return s.Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
 		// If the volume has a specific cluster member which is different than the instance then skip as
 		// instance cannot be using this volume.
 		if vol.Location != "" && inst.Node != vol.Location {

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -786,10 +786,14 @@ func VolumeUsedByExclusiveRemoteInstancesWithProfiles(s *state.State, poolName s
 	var localNode string
 	err = s.Cluster.Transaction(func(tx *db.ClusterTx) error {
 		localNode, err = tx.GetLocalNodeName()
-		return err
+		if err != nil {
+			return errors.Wrapf(err, "Failed to get local node name")
+		}
+
+		return nil
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "Fetch node name")
+		return nil, err
 	}
 
 	// Find if volume is attached to a remote instance.


### PR DESCRIPTION
Allows DB level filtering before running callback function on each returned instance record.

This will be used in forthcoming OVN SR-IOV uplink support.