### PR TITLE
rbac/server.go: Sleep for seconds instead of nanoseconds

### DIFF
--- a/lxd/rbac/server.go
+++ b/lxd/rbac/server.go
@@ -173,7 +173,7 @@ func (r *Server) StartStatusCheck() {
 				// For other errors we assume a server restart and give it a few seconds.
 				resp.Body.Close()
 				logger.Debugf("RBAC server disconnected, re-connecting. (code=%v)", resp.StatusCode)
-				time.Sleep(10)
+				time.Sleep(5 * time.Second)
 				continue
 			}
 
@@ -181,7 +181,7 @@ func (r *Server) StartStatusCheck() {
 			resp.Body.Close()
 			if err != nil {
 				logger.Errorf("Failed to parse RBAC response, re-trying: %v", err)
-				time.Sleep(10)
+				time.Sleep(5 * time.Second)
 				continue
 			}
 


### PR DESCRIPTION
Fix ``time.Sleep()`` in ``StartStatusCheck()`` method to use seconds instead of nanoseconds

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>