### PR TITLE
Instance: Regenerate container config file during lxd import recovery

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1255,9 +1255,10 @@ func (d *qemu) RegisterDevices() {
 	}
 }
 
-// SaveConfigFile is not used by VMs.
+// SaveConfigFile is not used by VMs because the Qemu config file is generated at start up and is not needed
+// after that, so doesn't need to support being regenerated.
 func (d *qemu) SaveConfigFile() error {
-	return instance.ErrNotImplemented
+	return nil
 }
 
 // OnHook is the top-level hook handler.

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -27,6 +27,9 @@ test_container_import() {
     ! lxd import ctImport || false
     # Import without killing the running instance to test restoring control plane after DB corruption.
     lxd import ctImport --force
+
+    # Check exec works after forced import while running (to check config file is regenerated).
+    lxc exec ctImport -- date
     kill_lxc "${pid}"
     lxd sql global "PRAGMA foreign_keys=ON; DELETE FROM instances WHERE name='ctImport'"
     lxd sql global "PRAGMA foreign_keys=ON; DELETE FROM storage_volumes WHERE name='ctImport'"


### PR DESCRIPTION
To allow exec to work when running container is recovered.

Fixes https://github.com/lxc/lxd/issues/8320