### PR TITLE
Storage: Fix ceph VM rename and VM block volume deactivation

### DIFF
--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -1063,7 +1063,10 @@ func (d *ceph) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Opera
 		// For VMs, unmount the filesystem volume.
 		if vol.IsVMBlock() {
 			fsVol := vol.NewVMBlockFilesystemVolume()
-			return d.UnmountVolume(fsVol, false, op)
+			_, err := d.UnmountVolume(fsVol, false, op)
+			if err != nil {
+				return false, err
+			}
 		}
 
 		if !keepBlockDev {


### PR DESCRIPTION
Ceph storage driver was not attempting to rename the filesystem volume for VMs, nor was it deactivating block volume for VMs.

Fixes https://github.com/lxc/lxd/issues/8328