### PR TITLE
lxc: Adds support for attaching instance to a managed network

### DIFF
--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -346,7 +346,7 @@ test_container_devices_nic_bridged() {
   fi
 
   if [ "$busyboxUdhcpc6" = "1" ]; then
-        lxc exec "${ctName}" -- udhcpc6 -i eth0 -n -q
+        lxc exec "${ctName}" -- udhcpc6 -i eth0 -n -q 2>&1 | grep 'IPv6 obtained'
   fi
 
   # Delete container, check LXD releases lease.

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -348,7 +348,7 @@ test_container_devices_nic_bridged_filtering() {
   fi
 
   if [ "$busyboxUdhcpc6" = "1" ]; then
-      lxc exec "${ctPrefix}A" -- udhcpc6 -i eth0 -n -q
+      lxc exec "${ctPrefix}A" -- udhcpc6 -i eth0 -n -q 2>&1 | grep 'IPv6 obtained'
   fi
 
   lxc exec "${ctPrefix}A" -- ip -6 a flush dev eth0

--- a/test/suites/container_devices_proxy.sh
+++ b/test/suites/container_devices_proxy.sh
@@ -151,7 +151,7 @@ container_devices_proxy_tcp() {
   # Try NAT
   lxc init testimage nattest
 
-  lxc network create lxdt$$ dns.domain=test dns.mode=managed
+  lxc network create lxdt$$ dns.domain=test dns.mode=managed ipv6.dhcp.stateful=true
   lxc network attach lxdt$$ nattest eth0
   v4_addr="$(lxc network get lxdt$$ ipv4.address | cut -d/ -f1)0"
   v6_addr="$(lxc network get lxdt$$ ipv6.address | cut -d/ -f1)00"


### PR DESCRIPTION
Updates `lxc network attach` to detect the use of a managed network and rather than adding a NIC with a `nictype` property, instead adds a NIC with a `network` property. This enables support for attaching all types of managed networks (bridge, macvlan, physical, sriov and ovn).

If the network is unmanaged, falls back to old behaviour of defaulting to `macvlan` NIC type unless the network interface is a bridge in which case it uses `bridged` NIC type.

This also has the side effect that attaching to a managed bridge (i.e `lxc network attach lxdbr0 ...`) will now create a NIC with a `network` property rather than a `nictype` property.

Reported from https://discuss.linuxcontainers.org/t/confusion-about-hosting-dhcp-server-inside-linux-container/9929/6

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>