### PR TITLE
Device: Validate disk size field properly

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -104,7 +104,7 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 		"limits.read":       validate.IsAny,
 		"limits.write":      validate.IsAny,
 		"limits.max":        validate.IsAny,
-		"size":              validate.IsAny,
+		"size":              validate.Optional(validate.IsSize),
 		"pool":              validate.IsAny,
 		"propagation":       validatePropagation,
 		"raw.mount.options": validate.IsAny,


### PR DESCRIPTION
Reported from https://discuss.linuxcontainers.org/t/fat-fingered-disk-override-container-can-no-longer-start/9962

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>