### PR TITLE
Device: Allow bridged NIC removal even when parent bridge interface is missing

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -1199,7 +1199,7 @@ func (d *nicBridged) State() (*api.InstanceStateNetwork, error) {
 	// Get MTU.
 	iface, err := net.InterfaceByName(d.config["host_name"])
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed getting host interface state")
+		return nil, errors.Wrapf(err, "Failed getting host interface state for %q", d.config["host_name"])
 	}
 
 	// Retrieve the host counters, as we report the values from the instance's point of view,

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -801,13 +801,13 @@ func (d *nicBridged) networkClearLease(name string, network string, hwaddr strin
 				srcIP := net.ParseIP(fields[2])
 
 				if dstIPv4 == nil {
-					logger.Warnf("Failed to release DHCPv4 lease for instance \"%s\", IP \"%s\", MAC \"%s\", %v", name, srcIP, srcMAC, "No server address found")
+					logger.Warnf("Failed to release DHCPv4 lease for instance %q, IP %q, MAC %q, %v", name, srcIP, srcMAC, "No server address found")
 					continue // Cant send release packet if no dstIP found.
 				}
 
 				err = d.networkDHCPv4Release(srcMAC, srcIP, dstIPv4)
 				if err != nil {
-					errs = append(errs, fmt.Errorf("Failed to release DHCPv4 lease for instance \"%s\", IP \"%s\", MAC \"%s\", %v", name, srcIP, srcMAC, err))
+					errs = append(errs, fmt.Errorf("Failed to release DHCPv4 lease for instance %q, IP %q, MAC %q, %v", name, srcIP, srcMAC, err))
 				}
 			} else if (mode == clearLeaseAll || mode == clearLeaseIPv6Only) && name == fields[3] { // Handle IPv6 addresses by matching hostname to lease.
 				IAID := fields[1]
@@ -820,18 +820,18 @@ func (d *nicBridged) networkClearLease(name string, network string, hwaddr strin
 				}
 
 				if dstIPv6 == nil {
-					logger.Warn("Failed to release DHCPv6 lease for instance \"%s\", IP \"%s\", DUID \"%s\", IAID \"%s\": %s", name, srcIP, DUID, IAID, "No server address found")
+					logger.Warn("Failed to release DHCPv6 lease for instance %q, IP %q, DUID %q, IAID %q: %q", name, srcIP, DUID, IAID, "No server address found")
 					continue // Cant send release packet if no dstIP found.
 				}
 
 				if dstDUID == "" {
-					errs = append(errs, fmt.Errorf("Failed to release DHCPv6 lease for instance \"%s\", IP \"%s\", DUID \"%s\", IAID \"%s\": %s", name, srcIP, DUID, IAID, "No server DUID found"))
+					errs = append(errs, fmt.Errorf("Failed to release DHCPv6 lease for instance %q, IP %q, DUID %q, IAID %q: %s", name, srcIP, DUID, IAID, "No server DUID found"))
 					continue // Cant send release packet if no dstDUID found.
 				}
 
 				err = d.networkDHCPv6Release(DUID, IAID, srcIP, dstIPv6, dstDUID)
 				if err != nil {
-					errs = append(errs, fmt.Errorf("Failed to release DHCPv6 lease for instance \"%s\", IP \"%s\", DUID \"%s\", IAID \"%s\": %v", name, srcIP, DUID, IAID, err))
+					errs = append(errs, fmt.Errorf("Failed to release DHCPv6 lease for instance %q, IP %q, DUID %q, IAID %q: %v", name, srcIP, DUID, IAID, err))
 				}
 			}
 		} else if fieldsLen == 2 && fields[0] == "duid" {

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -756,13 +756,13 @@ func (d *nicBridged) networkClearLease(name string, network string, hwaddr strin
 
 	iface, err := net.InterfaceByName(network)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "Failed getting bridge interface state for %q", network)
 	}
 
 	// Get IPv4 and IPv6 address of interface running dnsmasq on host.
 	addrs, err := iface.Addrs()
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "Failed getting bridge interface addresses for %q", network)
 	}
 
 	var dstIPv4, dstIPv6 net.IP

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -464,14 +464,16 @@ func (d *nicBridged) postStop() error {
 
 // Remove is run when the device is removed from the instance or the instance is deleted.
 func (d *nicBridged) Remove() error {
-	err := d.networkClearLease(d.inst.Name(), d.config["parent"], d.config["hwaddr"], clearLeaseAll)
-	if err != nil {
-		return err
-	}
-
 	if d.config["parent"] != "" {
 		dnsmasq.ConfigMutex.Lock()
 		defer dnsmasq.ConfigMutex.Unlock()
+
+		if network.InterfaceExists(d.config["parent"]) {
+			err := d.networkClearLease(d.inst.Name(), d.config["parent"], d.config["hwaddr"], clearLeaseAll)
+			if err != nil {
+				return errors.Wrapf(err, "Failed clearing leases")
+			}
+		}
 
 		// Remove dnsmasq config if it exists (doesn't return error if file is missing).
 		err := dnsmasq.RemoveStaticEntry(d.config["parent"], d.inst.Project(), d.inst.Name())


### PR DESCRIPTION
Fixes #8337