### PR TITLE
Storage: Copy parent volume config into snapshot volume config

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3342,6 +3342,7 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 
 	// Restart the container.
 	if wasRunning {
+		d.logger.Debug("Starting instance after snapshot restore")
 		err = d.Start(false)
 		if err != nil {
 			op.Done(err)

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3241,13 +3241,14 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 		return err
 	}
 
+	d.logger.Debug("Mounting instance to check for CRIU state path existence")
+
 	// Ensure that storage is mounted for state path checks and for backup.yaml updates.
 	_, err = pool.MountInstance(d, nil)
 	if err != nil {
 		op.Done(err)
 		return err
 	}
-	defer pool.UnmountInstance(d, nil)
 
 	// Check for CRIU if necessary, before doing a bunch of filesystem manipulations.
 	// Requires container be mounted to check StatePath exists.
@@ -3258,6 +3259,12 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 			op.Done(err)
 			return err
 		}
+	}
+
+	_, err = pool.UnmountInstance(d, nil)
+	if err != nil {
+		op.Done(err)
+		return err
 	}
 
 	// Restore the rootfs.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3288,15 +3288,8 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 	}
 
 	// Don't pass as user-requested as there's no way to fix a bad config.
+	// This will call d.UpdateBackupFile() to ensure snapshot list is up to date.
 	err = d.Update(args, false)
-	if err != nil {
-		op.Done(err)
-		return err
-	}
-
-	// The old backup file may be out of date (e.g. it doesn't have all the current snapshots of
-	// the container listed); let's write a new one to be safe.
-	err = d.UpdateBackupFile()
 	if err != nil {
 		op.Done(err)
 		return err

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -4286,12 +4286,9 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		return errors.Wrap(err, "Failed to update database")
 	}
 
-	// Only update the backup file if it already exists (indicating the instance is mounted).
-	if shared.PathExists(filepath.Join(d.Path(), "backup.yaml")) {
-		err := d.UpdateBackupFile()
-		if err != nil && !os.IsNotExist(err) {
-			return errors.Wrap(err, "Failed to write backup file")
-		}
+	err = d.UpdateBackupFile()
+	if err != nil && !os.IsNotExist(err) {
+		return errors.Wrap(err, "Failed to write backup file")
 	}
 
 	// Send devlxd notifications

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2779,15 +2779,8 @@ func (d *qemu) Restore(source instance.Instance, stateful bool) error {
 	}
 
 	// Don't pass as user-requested as there's no way to fix a bad config.
+	// This will call d.UpdateBackupFile() to ensure snapshot list is up to date.
 	err = d.Update(args, false)
-	if err != nil {
-		op.Done(err)
-		return err
-	}
-
-	// The old backup file may be out of date (e.g. it doesn't have all the current snapshots of
-	// the instance listed); let's write a new one to be safe.
-	err = d.UpdateBackupFile()
 	if err != nil {
 		op.Done(err)
 		return err

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2788,6 +2788,7 @@ func (d *qemu) Restore(source instance.Instance, stateful bool) error {
 
 	// Restart the insance.
 	if wasRunning {
+		d.logger.Debug("Starting instance after snapshot restore")
 		err := d.Start(false)
 		if err != nil {
 			op.Done(err)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -252,22 +252,31 @@ func qemuCreate(s *state.State, args db.InstanceArgs) (instance.Instance, error)
 		return nil, errors.Wrapf(err, "Failed loading storage pool")
 	}
 
-	// Fill default config.
-	volumeConfig := map[string]string{}
-	err = d.storagePool.FillInstanceConfig(d, volumeConfig)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed filling default config")
-	}
-
 	// Create a new database entry for the instance's storage volume.
 	if d.IsSnapshot() {
-		_, err = s.Cluster.CreateStorageVolumeSnapshot(args.Project, args.Name, "", db.StoragePoolVolumeTypeVM, d.storagePool.ID(), volumeConfig, time.Time{})
+		// Copy volume config from parent.
+		parentName, _, _ := shared.InstanceGetParentAndSnapshotName(args.Name)
+		_, parentVol, err := s.Cluster.GetLocalStoragePoolVolume(args.Project, parentName, db.StoragePoolVolumeTypeVM, d.storagePool.ID())
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed loading source volume for snapshot")
+		}
 
+		_, err = s.Cluster.CreateStorageVolumeSnapshot(args.Project, args.Name, "", db.StoragePoolVolumeTypeVM, d.storagePool.ID(), parentVol.Config, time.Time{})
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed creating storage record for snapshot")
+		}
 	} else {
+		// Fill default config for new instances.
+		volumeConfig := map[string]string{}
+		err = d.storagePool.FillInstanceConfig(d, volumeConfig)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed filling default config")
+		}
+
 		_, err = s.Cluster.CreateStoragePoolVolume(args.Project, args.Name, "", db.StoragePoolVolumeTypeVM, d.storagePool.ID(), volumeConfig, db.StoragePoolVolumeContentTypeBlock)
-	}
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed creating storage record")
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed creating storage record")
+		}
 	}
 
 	if !d.IsSnapshot() {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2758,14 +2758,6 @@ func (d *qemu) Restore(source instance.Instance, stateful bool) error {
 		return err
 	}
 
-	// Ensure that storage is mounted for backup.yaml updates.
-	_, err = pool.MountInstance(d, nil)
-	if err != nil {
-		op.Done(err)
-		return err
-	}
-	defer pool.UnmountInstance(d, nil)
-
 	// Restore the rootfs.
 	err = pool.RestoreInstanceSnapshot(d, source, nil)
 	if err != nil {

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3543,9 +3543,7 @@ func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, op *operat
 
 	// Get the volume name on storage.
 	volStorageName := project.Instance(inst.Project(), inst.Name())
-
-	// We don't need to use the volume's config for mounting so set to nil.
-	vol := b.newVolume(volType, contentType, volStorageName, nil)
+	vol := b.newVolume(volType, contentType, volStorageName, volume.Config)
 
 	// Update pool information in the backup.yaml file.
 	err = vol.MountTask(func(mountPath string, op *operations.Operation) error {

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -165,7 +165,7 @@ func TryMount(src string, dst string, fs string, flags uintptr, options string) 
 	}
 
 	if err != nil {
-		return errors.Wrapf(err, "Failed to mount '%s' on '%s'", src, dst)
+		return errors.Wrapf(err, "Failed to mount %q on %q using %q", src, dst, fs)
 	}
 
 	return nil


### PR DESCRIPTION
- Copy parent volume config into snapshot volume config.
- Respect volume config when mounting in `UpdateInstanceBackupFile`.
- Optimise snapshot restore process.

Fixes #8301