### PR TITLE
Storage: Add support for moving instance to a different pool

### DIFF
--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -695,6 +695,10 @@ func (r *ProtocolLXD) MigrateInstance(name string, instance api.InstancePost) (O
 		}
 	}
 
+	if instance.Pool != "" && !r.HasExtension("instance_pool_move") {
+		return nil, fmt.Errorf("The server is missing the required \"instance_pool_move\" API extension")
+	}
+
 	// Sanity check
 	if !instance.Migration {
 		return nil, fmt.Errorf("Can't ask for a rename through MigrateInstance")

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1279,3 +1279,7 @@ and to `ipvlan`, `macvlan`, `routed` and `physical` NIC devices.
 
 When set, this specifies whether the VLAN should be registered using GARP VLAN
 Registration Protocol. Defaults to false.
+
+## instance\_pool\_move
+This adds a `pool` field to the `POST /1.0/instances/NAME` API,
+allowing for easy move of an instance root disk between pools.

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -64,7 +64,7 @@ func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 	conf := c.global.conf
 
 	// Sanity checks
-	if c.flagTarget == "" && c.flagTargetProject == "" {
+	if c.flagTarget == "" && c.flagTargetProject == "" && c.flagStorage == "" {
 		exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 		if exit {
 			return err
@@ -160,6 +160,10 @@ func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf(i18n.G("The --instance-only flag can't be used with --target"))
 			}
 
+			if c.flagStorage != "" {
+				return fmt.Errorf(i18n.G("The --storage flag can't be used with --target"))
+			}
+
 			if c.flagMode != moveDefaultMode {
 				return fmt.Errorf(i18n.G("The --mode flag can't be used with --target"))
 			}
@@ -174,6 +178,26 @@ func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 
 		if !dest.IsClustered() {
 			return fmt.Errorf(i18n.G("The destination LXD server is not clustered"))
+		}
+	}
+
+	// Support for server-side pool move.
+	if c.flagStorage != "" && sourceRemote == destRemote {
+		source, err := conf.GetInstanceServer(sourceRemote)
+		if err != nil {
+			return err
+		}
+
+		if source.HasExtension("instance_pool_move") {
+			if c.flagStateless {
+				return fmt.Errorf(i18n.G("The --stateless flag can't be used with --storage"))
+			}
+
+			if c.flagMode != moveDefaultMode {
+				return fmt.Errorf(i18n.G("The --mode flag can't be used with --storage"))
+			}
+
+			return moveInstancePool(conf, sourceResource, destResource, c.flagInstanceOnly, c.flagStorage)
 		}
 	}
 
@@ -208,7 +232,7 @@ func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 }
 
 // Move an instance using special POST /instances/<name>?target=<member> API.
-func moveClusterInstance(conf *config.Config, sourceResource, destResource, target string) error {
+func moveClusterInstance(conf *config.Config, sourceResource string, destResource string, target string) error {
 	// Parse the source.
 	sourceRemote, sourceName, err := conf.ParseRemote(sourceResource)
 	if err != nil {
@@ -244,7 +268,62 @@ func moveClusterInstance(conf *config.Config, sourceResource, destResource, targ
 
 	// The migrate API will do the right thing when passed a target.
 	source = source.UseTarget(target)
-	req := api.InstancePost{Name: destName, Migration: true}
+	req := api.InstancePost{
+		Name:      destName,
+		Migration: true,
+	}
+
+	op, err := source.MigrateInstance(sourceName, req)
+	if err != nil {
+		return errors.Wrap(err, i18n.G("Migration API failure"))
+	}
+
+	err = op.Wait()
+	if err != nil {
+		return errors.Wrap(err, i18n.G("Migration operation failure"))
+	}
+
+	return nil
+}
+
+// Move an instance between pools using special POST /instances/<name> API.
+func moveInstancePool(conf *config.Config, sourceResource string, destResource string, instanceOnly bool, storage string) error {
+	// Parse the source.
+	sourceRemote, sourceName, err := conf.ParseRemote(sourceResource)
+	if err != nil {
+		return err
+	}
+
+	// Parse the destination.
+	_, destName, err := conf.ParseRemote(destResource)
+	if err != nil {
+		return err
+	}
+
+	// Make sure we have an instance or snapshot name.
+	if sourceName == "" {
+		return fmt.Errorf(i18n.G("You must specify a source instance name"))
+	}
+
+	// The destination name is optional.
+	if destName == "" {
+		destName = sourceName
+	}
+
+	// Connect to the source host
+	source, err := conf.GetInstanceServer(sourceRemote)
+	if err != nil {
+		return errors.Wrap(err, i18n.G("Failed to connect to cluster member"))
+	}
+
+	// Pass the new pool to the migration API.
+	req := api.InstancePost{
+		Name:         destName,
+		Migration:    true,
+		Pool:         storage,
+		InstanceOnly: instanceOnly,
+	}
+
 	op, err := source.MigrateInstance(sourceName, req)
 	if err != nil {
 		return errors.Wrap(err, i18n.G("Migration API failure"))

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -340,12 +340,12 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 #, fuzzy
 msgid "--console can't be used with --all"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -560,7 +560,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Attach network interfaces to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr "Ungültige Abbild Eigenschaft: %s\n"
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -664,11 +664,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Erstellt: %s"
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
@@ -816,8 +816,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -868,7 +868,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, fuzzy, c-format
@@ -1019,7 +1019,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -1067,7 +1067,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
@@ -1115,7 +1115,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Delete instances and snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -1162,10 +1162,10 @@ msgstr "Kein Zertifikat für diese Verbindung"
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -1192,12 +1192,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 #, fuzzy
 msgid "Detach network interfaces from instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1337,7 +1337,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Edit instance or server configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 #, fuzzy
 msgid "Failed to connect to cluster member"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1514,7 +1514,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 #, fuzzy
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -1573,7 +1573,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1615,7 +1615,7 @@ msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1629,7 +1629,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for instance or server configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1654,7 +1654,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1680,15 +1680,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1890,7 +1890,7 @@ msgstr "Ungültige Quelle %s"
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1911,7 +1911,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1947,7 +1947,7 @@ msgstr "Architektur: %s\n"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1960,7 +1960,7 @@ msgstr "Aliasse:\n"
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -2149,11 +2149,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -2167,7 +2167,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -2184,7 +2184,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2337,11 +2337,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2370,10 +2370,10 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Missing name"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2435,7 +2435,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2469,12 +2469,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 #, fuzzy
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2492,7 +2492,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2520,7 +2520,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2530,22 +2530,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, fuzzy, c-format
 msgid "Network %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, fuzzy, c-format
 msgid "Network %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, fuzzy, c-format
 msgid "Network %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Profil %s erstellt\n"
@@ -2554,12 +2554,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 #, fuzzy
 msgid "Network type"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
@@ -2577,7 +2577,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 #, fuzzy
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2625,7 +2625,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2667,11 +2667,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2707,7 +2707,7 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -3101,7 +3101,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -3189,11 +3189,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -3326,7 +3326,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3404,7 +3404,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3423,7 +3423,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Erstellt: %s"
@@ -3527,8 +3527,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3536,15 +3536,30 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+#, fuzzy
+msgid "The --mode flag can't be used with --storage"
+msgstr "--refresh kann nur mit Containern verwendet werden"
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
 msgstr ""
+
+#: lxc/move.go:193
+#, fuzzy
+msgid "The --stateless flag can't be used with --storage"
+msgstr "--refresh kann nur mit Containern verwendet werden"
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+#, fuzzy
+msgid "The --storage flag can't be used with --target"
+msgstr "--refresh kann nur mit Containern verwendet werden"
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3588,17 +3603,17 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 #, fuzzy
 msgid "The specified device doesn't match the network"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -3650,7 +3665,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3686,7 +3701,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3715,7 +3730,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3759,7 +3774,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3866,7 +3881,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3886,7 +3901,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "You must specify a destination instance name when using --target"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3908,7 +3923,7 @@ msgstr ""
 "lxd %s <Name>\n"
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 #, fuzzy
 msgid "[<remote>:]"
@@ -4273,8 +4288,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -4282,7 +4297,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -4298,7 +4313,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -4306,7 +4321,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -4314,7 +4329,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -4322,7 +4337,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -4330,7 +4345,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
@@ -4338,7 +4353,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -4677,7 +4692,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, fuzzy, c-format
 msgid "error: %v"
 msgstr "Fehler: %v\n"
@@ -4984,6 +4999,10 @@ msgstr ""
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""
+
+#, fuzzy
+#~ msgid "The --instance-only flag can't be used with --storage"
+#~ msgstr "--refresh kann nur mit Containern verwendet werden"
 
 #, fuzzy
 #~ msgid "console [<remote>:]<instance>"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -105,7 +105,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -218,11 +218,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -411,7 +411,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -480,7 +480,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -501,7 +501,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -510,11 +510,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -647,8 +647,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -696,7 +696,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -835,7 +835,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -878,7 +878,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -923,7 +923,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -968,10 +968,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -998,11 +998,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1130,7 +1130,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1269,7 +1269,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1296,7 +1296,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1351,7 +1351,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1392,7 +1392,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1404,7 +1404,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1428,7 +1428,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1454,15 +1454,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1658,7 +1658,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1675,7 +1675,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1711,7 +1711,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1723,7 +1723,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1894,11 +1894,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1925,7 +1925,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2066,11 +2066,11 @@ msgstr "  Χρήση μνήμης:"
 msgid "Memory:"
 msgstr "  Χρήση μνήμης:"
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2096,10 +2096,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2158,7 +2158,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2188,11 +2188,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2210,7 +2210,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2248,22 +2248,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2272,12 +2272,12 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 #, fuzzy
 msgid "Network type"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Χρήση δικτύου:"
@@ -2294,7 +2294,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2340,7 +2340,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2382,11 +2382,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2697,7 +2697,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2794,7 +2794,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2878,11 +2878,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -3007,7 +3007,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3082,7 +3082,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3100,7 +3100,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3198,8 +3198,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3207,15 +3207,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3256,16 +3268,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3314,7 +3326,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3350,7 +3362,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3379,7 +3391,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3420,7 +3432,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3516,7 +3528,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3534,7 +3546,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3547,7 +3559,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3720,12 +3732,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3733,27 +3745,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3935,7 +3947,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -181,7 +181,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -339,11 +339,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -537,7 +537,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -606,7 +606,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -627,7 +627,7 @@ msgstr "Propiedad mala: %s"
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 #, fuzzy
 msgid "Both --all and instance name given"
 msgstr "Ambas: todas y el nombre del contenedor dado"
@@ -637,11 +637,11 @@ msgstr "Ambas: todas y el nombre del contenedor dado"
 msgid "Brand: %v"
 msgstr "Creado: %s"
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
@@ -776,8 +776,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -827,7 +827,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
@@ -1061,7 +1061,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -1106,10 +1106,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -1136,11 +1136,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1267,7 +1267,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1408,7 +1408,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
 
@@ -1491,7 +1491,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1568,7 +1568,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1594,15 +1594,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1800,7 +1800,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1853,7 +1853,7 @@ msgstr "Arquitectura: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1866,7 +1866,7 @@ msgstr "Aliases:"
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -2038,11 +2038,11 @@ msgstr ""
 msgid "Log:"
 msgstr "Registro:"
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -2052,7 +2052,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -2069,7 +2069,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2209,11 +2209,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2241,10 +2241,10 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2305,7 +2305,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2335,11 +2335,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2385,7 +2385,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2395,22 +2395,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2419,11 +2419,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2439,7 +2439,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2527,11 +2527,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2566,7 +2566,7 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2846,7 +2846,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -3029,11 +3029,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -3158,7 +3158,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3233,7 +3233,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s añadido a %s"
@@ -3251,7 +3251,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Auto actualización: %s"
@@ -3349,8 +3349,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3358,15 +3358,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3407,16 +3419,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3465,7 +3477,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3501,7 +3513,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3530,7 +3542,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3571,7 +3583,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3667,7 +3679,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3685,7 +3697,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3700,7 +3712,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 #, fuzzy
 msgid "[<remote>:]"
@@ -3914,13 +3926,13 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<member> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3930,32 +3942,32 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4174,7 +4186,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -4476,6 +4488,11 @@ msgstr ""
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""
+
+#, fuzzy
+#~ msgid "The --instance-only flag can't be used with --storage"
+#~ msgstr ""
+#~ "--container-only no se puede pasar cuando la fuente es una instantánea"
 
 #, fuzzy
 #~ msgid "create [<remote>:]<instance> <template>"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -174,7 +174,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -339,11 +339,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -557,7 +557,7 @@ msgstr "Création du conteneur"
 msgid "Attach network interfaces to instances"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -630,7 +630,7 @@ msgstr "Copie de l'image : %s"
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -651,7 +651,7 @@ msgstr "Mauvaise propriété : %s"
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -660,11 +660,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Créé : %s"
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr "Octets émis"
 
@@ -803,8 +803,8 @@ msgstr "Afficher la version du client"
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -862,7 +862,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -1030,7 +1030,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create new instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
@@ -1128,7 +1128,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Delete instances and snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -1175,10 +1175,10 @@ msgstr "Copie de l'image : %s"
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -1205,11 +1205,11 @@ msgstr "Copie de l'image : %s"
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1345,7 +1345,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Edit instance or server configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1501,7 +1501,7 @@ msgstr "NOM"
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 #, fuzzy
 msgid "Failed to connect to cluster member"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -1531,7 +1531,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Mode rapide (identique à --columns=nsacPt"
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1588,7 +1588,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1629,7 +1629,7 @@ msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1643,7 +1643,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 #, fuzzy
 msgid "Get values for network configuration keys"
 msgstr "Clé de configuration invalide"
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 #, fuzzy
 msgid "HOSTNAME"
 msgstr "NOM"
@@ -1698,15 +1698,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr "IPv4"
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr "IPv6"
 
@@ -1914,7 +1914,7 @@ msgstr "Source invalide %s"
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr "IPs :"
 
@@ -1931,7 +1931,7 @@ msgstr "Garder l'image à jour après la copie initiale"
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1967,7 +1967,7 @@ msgstr "Architecture : %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1980,7 +1980,7 @@ msgstr "Alias :"
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -2214,11 +2214,11 @@ msgstr ""
 msgid "Log:"
 msgstr "Journal : "
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -2228,7 +2228,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr "GÉRÉ"
 
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2397,12 +2397,12 @@ msgstr "  Mémoire utilisée :"
 msgid "Memory:"
 msgstr "  Mémoire utilisée :"
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 #, fuzzy
 msgid "Migration API failure"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2431,10 +2431,10 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Missing name"
 msgstr "Résumé manquant."
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 #, fuzzy
 msgid "Missing network name"
 msgstr "Nom du réseau"
@@ -2498,7 +2498,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 #, fuzzy
 msgid "More than one device matches, specify the device name"
@@ -2533,12 +2533,12 @@ msgstr "Copie de l'image : %s"
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 #, fuzzy
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2556,7 +2556,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2584,7 +2584,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
@@ -2594,22 +2594,22 @@ msgstr "Nom : %s"
 msgid "Name: %v"
 msgstr "Nom : %s"
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, fuzzy, c-format
 msgid "Network %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Le réseau %s a été créé"
@@ -2618,12 +2618,12 @@ msgstr "Le réseau %s a été créé"
 msgid "Network name"
 msgstr "Nom du réseau"
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 #, fuzzy
 msgid "Network type"
 msgstr "Nom du réseau"
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Réseau utilisé :"
@@ -2642,7 +2642,7 @@ msgstr "Nouvel alias à définir sur la cible"
 msgid "New key/value to apply to a specific device"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
@@ -2696,7 +2696,7 @@ msgstr "Seules les URLs https sont supportées par simplestreams"
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 #, fuzzy
 msgid "Only managed networks can be modified"
 msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
@@ -2740,11 +2740,11 @@ msgstr "PROTOCOLE"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr "Paquets émis"
 
@@ -2781,7 +2781,7 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -3192,7 +3192,7 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr "ÉTAT"
 
@@ -3282,12 +3282,12 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 #, fuzzy
 msgid "Set network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -3423,7 +3423,7 @@ msgstr "Afficher les commandes moins communes"
 msgid "Show local and remote versions"
 msgstr "Afficher la version du client"
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 #, fuzzy
 msgid "Show network configurations"
 msgstr "Afficher la configuration étendue"
@@ -3505,7 +3505,7 @@ msgstr "Instantanés :"
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -3524,7 +3524,7 @@ msgstr "Création du conteneur"
 msgid "Starting %s"
 msgstr "Démarrage de %s"
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "État : %s"
@@ -3630,8 +3630,8 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr "TYPE"
 
@@ -3639,15 +3639,27 @@ msgstr "TYPE"
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3697,16 +3709,16 @@ msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 msgid "The profile device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr "le périphérique indiqué ne correspond pas au réseau"
 
@@ -3759,7 +3771,7 @@ msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3795,7 +3807,7 @@ msgstr "Transfert de l'image : %s"
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
@@ -3824,7 +3836,7 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
@@ -3868,7 +3880,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 #, fuzzy
 msgid "Unset network configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3975,7 +3987,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3995,7 +4007,7 @@ msgstr "impossible de copier vers le même nom de conteneur"
 msgid "You must specify a destination instance name when using --target"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
@@ -4017,7 +4029,7 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 #, fuzzy
 msgid "[<remote>:]"
@@ -4448,8 +4460,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -4457,7 +4469,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -4473,7 +4485,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -4481,7 +4493,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -4489,7 +4501,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -4497,7 +4509,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -4505,7 +4517,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
@@ -4513,7 +4525,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -4880,7 +4892,7 @@ msgstr ""
 msgid "enabled"
 msgstr "activé"
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr "erreur : %v"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -331,11 +331,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr "Creazione del container in corso"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -618,7 +618,7 @@ msgstr "Proprietà errata: %s"
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -627,11 +627,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
@@ -765,8 +765,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -814,7 +814,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -959,7 +959,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -1003,7 +1003,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
@@ -1050,7 +1050,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -1095,10 +1095,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -1125,11 +1125,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1257,7 +1257,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1398,7 +1398,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 #, fuzzy
 msgid "Filtering isn't supported yet"
 msgstr "'%s' non è un tipo di file supportato."
@@ -1481,7 +1481,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1534,7 +1534,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1584,15 +1584,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1791,7 +1791,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1808,7 +1808,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1844,7 +1844,7 @@ msgstr "Architettura: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1857,7 +1857,7 @@ msgstr "Alias:"
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -2030,11 +2030,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -2044,7 +2044,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -2061,7 +2061,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2203,11 +2203,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2235,10 +2235,10 @@ msgstr "Il nome del container è: %s"
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2298,7 +2298,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2328,11 +2328,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2350,7 +2350,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2378,7 +2378,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2388,22 +2388,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2412,11 +2412,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2432,7 +2432,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2478,7 +2478,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2520,11 +2520,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2560,7 +2560,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2840,7 +2840,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2939,7 +2939,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -3023,11 +3023,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -3152,7 +3152,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3227,7 +3227,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "errore di processamento degli alias %s\n"
@@ -3246,7 +3246,7 @@ msgstr "Creazione del container in corso"
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -3345,8 +3345,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3354,15 +3354,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3404,16 +3416,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3462,7 +3474,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3498,7 +3510,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3527,7 +3539,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3569,7 +3581,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3665,7 +3677,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3684,7 +3696,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"
@@ -3700,7 +3712,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr "Creazione del container in corso"
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 #, fuzzy
 msgid "[<remote>:]"
@@ -3914,13 +3926,13 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<member> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "Creazione del container in corso"
@@ -3930,32 +3942,32 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -4174,7 +4186,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: 2020-11-22 10:56+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -171,7 +171,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -333,11 +333,11 @@ msgstr "- パーティション %d"
 msgid "- Port %d (%s)"
 msgstr "- ポート %d (%s)"
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr "--console と --all は同時に指定できません"
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr "--console は単一のインスタンスのときのみ指定できます"
 
@@ -536,7 +536,7 @@ msgstr "インスタンスにプロファイルを割り当てます"
 msgid "Attach network interfaces to instances"
 msgstr "インスタンスにネットワークインターフェースを追加します"
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr "プロファイルにネットワークインターフェースを追加します"
 
@@ -609,7 +609,7 @@ msgstr "ストレージボリュームのバックアップ中: %s"
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
@@ -631,7 +631,7 @@ msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 "書式が不適切です。次のような形式で指定してください <device>,<key>=<value>: %s"
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr "--all とインスタンス名を両方同時に指定することはできません"
 
@@ -640,11 +640,11 @@ msgstr "--all とインスタンス名を両方同時に指定することはで
 msgid "Brand: %v"
 msgstr "ブランド: %v"
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
@@ -777,8 +777,8 @@ msgstr "クライアントバージョン: %s\n"
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -831,7 +831,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -978,7 +978,7 @@ msgstr "新たにカスタムストレージボリュームを作成します"
 msgid "Create new instance file templates"
 msgstr "新たにインスタンスのファイルテンプレートを作成します"
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr "新たにネットワークを作成します"
 
@@ -1021,7 +1021,7 @@ msgstr "現在の VF 数: %d"
 msgid "DATABASE"
 msgstr "DATABASE"
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
@@ -1066,7 +1066,7 @@ msgstr "インスタンスのファイルテンプレートを削除します"
 msgid "Delete instances and snapshots"
 msgstr "インスタンスとスナップショットを削除します"
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr "ネットワークを削除します"
 
@@ -1111,10 +1111,10 @@ msgstr "ストレージボリュームを削除します"
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -1141,11 +1141,11 @@ msgstr "ストレージボリュームを削除します"
 msgid "Description"
 msgstr "説明"
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr "インスタンスからネットワークインターフェースを取り外します"
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr "プロファイルからネットワークインターフェースを取り外します"
 
@@ -1275,7 +1275,7 @@ msgstr "インスタンスのメタデータファイルを編集します"
 msgid "Edit instance or server configurations as YAML"
 msgstr "インスタンスもしくはサーバの設定をYAMLファイルで編集します"
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr "ネットワーク設定をYAMLで編集します"
 
@@ -1440,7 +1440,7 @@ msgstr "FILENAME"
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr "クラスタメンバへの接続に失敗しました"
 
@@ -1467,7 +1467,7 @@ msgstr "パス %s にアクセスできませんでした: %s"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Fast モード (--columns=nsacPt と同じ)"
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
 
@@ -1537,7 +1537,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1579,7 +1579,7 @@ msgstr "クライアント証明書を生成します。1分ぐらいかかり�
 msgid "Get image properties"
 msgstr "イメージのプロパティを編集します"
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr "ネットワークのランタイム情報を取得します"
 
@@ -1591,7 +1591,7 @@ msgstr "デバイスの設定値を取得します"
 msgid "Get values for instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定値を取得します"
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr "ネットワークの設定値を取得します"
 
@@ -1615,7 +1615,7 @@ msgstr "ストレージボリュームの設定値を取得します"
 msgid "Group ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のグループ ID (GID) (デフォルト 0)"
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
@@ -1641,15 +1641,15 @@ msgstr "ID: %s"
 msgid "IMAGES"
 msgstr "IMAGES"
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr "IPV6"
 
@@ -1858,7 +1858,7 @@ msgstr "不正なソース %s"
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr "IPアドレス:"
 
@@ -1875,7 +1875,7 @@ msgstr "最初にコピーした後も常にイメージを最新の状態に保
 msgid "LAST USED AT"
 msgstr "LAST USED AT"
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr "LOCATION"
@@ -1913,7 +1913,7 @@ msgstr "リンクを検出: %v"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr "リンクスピード: %dMbit/s (%s duplex)"
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr "DHCP のリースを一覧表示します"
 
@@ -1925,7 +1925,7 @@ msgstr "エイリアスを一覧表示します"
 msgid "List all the cluster members"
 msgstr "クラスタのメンバをすべて一覧表示します"
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr "利用可能なネットワークを一覧表示します"
 
@@ -2187,11 +2187,11 @@ msgstr "ロケーション: %s"
 msgid "Log:"
 msgstr "ログ:"
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr "MAC アドレス: %s"
@@ -2201,7 +2201,7 @@ msgstr "MAC アドレス: %s"
 msgid "MAD: %s (%s)"
 msgstr "MAD: %s (%s)"
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr "MANAGED"
 
@@ -2218,7 +2218,7 @@ msgstr "MEMORY USAGE%"
 msgid "MESSAGE"
 msgstr "MESSAGE"
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr "MTU: %d"
@@ -2374,11 +2374,11 @@ msgstr "メモリ消費量:"
 msgid "Memory:"
 msgstr "メモリ:"
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr "マイグレーション API が失敗しました"
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr "マイグレーションが失敗しました"
 
@@ -2404,10 +2404,10 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Missing name"
 msgstr "名前を指定する必要があります"
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr "ネットワーク名を指定する必要があります"
 
@@ -2469,7 +2469,7 @@ msgstr ""
 "\n"
 "デフォルトではすべてのタイプのメッセージをモニタリングします。"
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
@@ -2501,11 +2501,11 @@ msgstr "ストレージボリュームの移動中: %s"
 msgid "Must run as root to import from directory"
 msgstr "ディレクトリからのインポートは root で実行する必要があります"
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2523,7 +2523,7 @@ msgstr "NIC:"
 msgid "NICs:"
 msgstr "NICs:"
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2551,7 +2551,7 @@ msgstr "NVRM バージョン: %v"
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
@@ -2561,22 +2561,22 @@ msgstr "名前: %s"
 msgid "Name: %v"
 msgstr "名前: %v"
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr "ネットワーク %s を作成しました"
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr "ネットワーク %s を削除しました"
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr "ネットワーク %s はメンバ %s 上でペンディング状態です"
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr "ネットワーク名 %s を %s に変更しました"
@@ -2585,11 +2585,11 @@ msgstr "ネットワーク名 %s を %s に変更しました"
 msgid "Network name"
 msgstr "ネットワーク名:"
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr "ネットワークタイプ:"
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
@@ -2605,7 +2605,7 @@ msgstr "イメージに新しいエイリアスを追加します"
 msgid "New key/value to apply to a specific device"
 msgstr "指定するデバイスに適用する新しいキー/値"
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
@@ -2651,7 +2651,7 @@ msgstr "simplestreams は https の URL のみサポートします"
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr "管理対象のネットワークのみ変更できます"
 
@@ -2693,11 +2693,11 @@ msgstr "PROTOCOL"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr "送信パケット"
 
@@ -2732,7 +2732,7 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr "再度エディタを開くためには Enter キーを押します"
@@ -3008,7 +3008,7 @@ msgstr "エイリアスの名前を変更します"
 msgid "Rename instances and snapshots"
 msgstr "インスタンスまたはインスタンスのスナップショットの名前を変更します"
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr "ネットワーク名を変更します"
 
@@ -3113,7 +3113,7 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr "STATE"
 
@@ -3210,11 +3210,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr "ネットワークの設定項目を設定します"
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -3359,7 +3359,7 @@ msgstr "全てのコマンドを表示します (主なコマンドだけでは�
 msgid "Show local and remote versions"
 msgstr "ローカルとリモートのバージョンを表示します"
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr "ネットワークの設定を表示します"
 
@@ -3434,7 +3434,7 @@ msgstr "スナップショット:"
 msgid "Socket %d:"
 msgstr "ソケット %d:"
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr "一部のインスタンスで %s が失敗しました"
@@ -3452,7 +3452,7 @@ msgstr "インスタンスを起動します"
 msgid "Starting %s"
 msgstr "%s を起動中"
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr "状態: %s"
@@ -3550,8 +3550,8 @@ msgstr "デフォルトのリモートを切り替えます"
 msgid "TARGET"
 msgstr "TARGET"
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr "TYPE"
 
@@ -3559,15 +3559,30 @@ msgstr "TYPE"
 msgid "The --instance-only flag can't be used with --target"
 msgstr "--instance-only と --target は同時に指定できません"
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+#, fuzzy
+msgid "The --mode flag can't be used with --storage"
+msgstr "--mode と --target は同時に指定できません"
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
 msgstr "--mode と --target は同時に指定できません"
+
+#: lxc/move.go:193
+#, fuzzy
+msgid "The --stateless flag can't be used with --storage"
+msgstr "--stateless と --target は同時に指定できません"
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr "--stateless と --target は同時に指定できません"
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+#, fuzzy
+msgid "The --storage flag can't be used with --target"
+msgstr "--mode と --target は同時に指定できません"
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr "移動先の LXD サーバはクラスタに属していません"
 
@@ -3613,16 +3628,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "プロファイルのデバイスが存在しません"
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr "移動元の LXD サーバはクラスタに属していません"
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr "指定したデバイスはネットワークとマッチしません"
 
@@ -3687,7 +3702,7 @@ msgstr ""
 "ください"
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
@@ -3725,7 +3740,7 @@ msgstr "イメージを転送中: %s"
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
@@ -3756,7 +3771,7 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr "USED BY"
@@ -3798,7 +3813,7 @@ msgstr "イメージのプロパティを編集します"
 msgid "Unset instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定を削除します"
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr "ネットワークの設定を削除します"
 
@@ -3900,7 +3915,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr "インスタンスの稼動状態のスナップショットを取得するかどうか"
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3919,7 +3934,7 @@ msgid "You must specify a destination instance name when using --target"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
@@ -3932,7 +3947,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
@@ -4110,12 +4125,12 @@ msgstr "[<remote>:]<member>"
 msgid "[<remote>:]<member> <new-name>"
 msgstr "[<remote>:]<member> <new-name>"
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr "[<remote>:]<network>"
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr "[<remote>:]<network> <instance> [<device name>]"
 
@@ -4123,27 +4138,27 @@ msgstr "[<remote>:]<network> <instance> [<device name>]"
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr "[<remote>:]<network> <key>"
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "[<remote>:]<network> <key>=<value>..."
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr "[<remote>:]<network> <new-name>"
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr "[<remote>:]<network> <profile> [<device name>]"
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "[<remote>:]<network> [key=value...]"
 
@@ -4327,7 +4342,7 @@ msgstr "ドライバ"
 msgid "enabled"
 msgstr "有効"
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr "エラー: %v"
@@ -4747,6 +4762,10 @@ msgstr "y"
 #: lxc/image.go:1079
 msgid "yes"
 msgstr "yes"
+
+#, fuzzy
+#~ msgid "The --instance-only flag can't be used with --storage"
+#~ msgstr "--instance-only と --target は同時に指定できません"
 
 #~ msgid "assign [<remote>:]<instance> <profiles>"
 #~ msgstr "assign [<remote>:]<instance> <profiles>"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2021-01-15 09:53-0500\n"
+        "POT-Creation-Date: 2021-01-22 15:03+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -97,7 +97,7 @@ msgid   "### This is a YAML representation of the instance metadata.\n"
         "###     properties: {}"
 msgstr  ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid   "### This is a YAML representation of the network.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -206,11 +206,11 @@ msgstr  ""
 msgid   "- Port %d (%s)"
 msgstr  ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid   "--console can't be used with --all"
 msgstr  ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid   "--console only works with a single instance"
 msgstr  ""
 
@@ -393,7 +393,7 @@ msgstr  ""
 msgid   "Attach network interfaces to instances"
 msgstr  ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid   "Attach network interfaces to profiles"
 msgstr  ""
 
@@ -461,7 +461,7 @@ msgstr  ""
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
@@ -481,7 +481,7 @@ msgstr  ""
 msgid   "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid   "Both --all and instance name given"
 msgstr  ""
 
@@ -490,11 +490,11 @@ msgstr  ""
 msgid   "Brand: %v"
 msgstr  ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid   "Bytes received"
 msgstr  ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid   "Bytes sent"
 msgstr  ""
 
@@ -624,7 +624,7 @@ msgstr  ""
 msgid   "Client version: %s\n"
 msgstr  ""
 
-#: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614 lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54 lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733 lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593 lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316 lxc/storage_volume.go:477 lxc/storage_volume.go:556 lxc/storage_volume.go:798 lxc/storage_volume.go:995 lxc/storage_volume.go:1167 lxc/storage_volume.go:1197 lxc/storage_volume.go:1313 lxc/storage_volume.go:1392 lxc/storage_volume.go:1485
+#: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614 lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54 lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745 lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593 lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316 lxc/storage_volume.go:477 lxc/storage_volume.go:556 lxc/storage_volume.go:798 lxc/storage_volume.go:995 lxc/storage_volume.go:1167 lxc/storage_volume.go:1197 lxc/storage_volume.go:1313 lxc/storage_volume.go:1392 lxc/storage_volume.go:1485
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -663,7 +663,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328 lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:931 lxc/storage_volume.go:961
+#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328 lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -798,7 +798,7 @@ msgstr  ""
 msgid   "Create new instance file templates"
 msgstr  ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid   "Create new networks"
 msgstr  ""
 
@@ -841,7 +841,7 @@ msgstr  ""
 msgid   "DATABASE"
 msgstr  ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883 lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895 lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -885,7 +885,7 @@ msgstr  ""
 msgid   "Delete instances and snapshots"
 msgstr  ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid   "Delete networks"
 msgstr  ""
 
@@ -905,15 +905,15 @@ msgstr  ""
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154 lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422 lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52 lxc/config_metadata.go:174 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20 lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109 lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379 lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730 lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024 lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384 lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626 lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:599 lxc/remote.go:661 lxc/remote.go:711 lxc/remote.go:749 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:587 lxc/storage.go:661 lxc/storage.go:745 lxc/storage_volume.go:37 lxc/storage_volume.go:152 lxc/storage_volume.go:225 lxc/storage_volume.go:312 lxc/storage_volume.go:474 lxc/storage_volume.go:553 lxc/storage_volume.go:629 lxc/storage_volume.go:711 lxc/storage_volume.go:792 lxc/storage_volume.go:992 lxc/storage_volume.go:1083 lxc/storage_volume.go:1163 lxc/storage_volume.go:1194 lxc/storage_volume.go:1307 lxc/storage_volume.go:1383 lxc/storage_volume.go:1482 lxc/storage_volume.go:1516 lxc/storage_volume.go:1608 lxc/storage_volume.go:1669 lxc/storage_volume.go:1804 lxc/version.go:22
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154 lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422 lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52 lxc/config_metadata.go:174 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20 lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109 lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391 lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742 lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036 lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384 lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626 lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:599 lxc/remote.go:661 lxc/remote.go:711 lxc/remote.go:749 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:587 lxc/storage.go:661 lxc/storage.go:745 lxc/storage_volume.go:37 lxc/storage_volume.go:152 lxc/storage_volume.go:225 lxc/storage_volume.go:312 lxc/storage_volume.go:474 lxc/storage_volume.go:553 lxc/storage_volume.go:629 lxc/storage_volume.go:711 lxc/storage_volume.go:792 lxc/storage_volume.go:992 lxc/storage_volume.go:1083 lxc/storage_volume.go:1163 lxc/storage_volume.go:1194 lxc/storage_volume.go:1307 lxc/storage_volume.go:1383 lxc/storage_volume.go:1482 lxc/storage_volume.go:1516 lxc/storage_volume.go:1608 lxc/storage_volume.go:1669 lxc/storage_volume.go:1804 lxc/version.go:22
 msgid   "Description"
 msgstr  ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid   "Detach network interfaces from instances"
 msgstr  ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid   "Detach network interfaces from profiles"
 msgstr  ""
 
@@ -1036,7 +1036,7 @@ msgstr  ""
 msgid   "Edit instance or server configurations as YAML"
 msgstr  ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid   "Edit network configurations as YAML"
 msgstr  ""
 
@@ -1167,7 +1167,7 @@ msgstr  ""
 msgid   "FINGERPRINT"
 msgstr  ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid   "Failed to connect to cluster member"
 msgstr  ""
 
@@ -1194,7 +1194,7 @@ msgstr  ""
 msgid   "Fast mode (same as --columns=nsacPt)"
 msgstr  ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
@@ -1242,7 +1242,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238 lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155 lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515 lxc/storage_volume.go:1085
+#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238 lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155 lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515 lxc/storage_volume.go:1085
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
@@ -1281,7 +1281,7 @@ msgstr  ""
 msgid   "Get image properties"
 msgstr  ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid   "Get runtime information on networks"
 msgstr  ""
 
@@ -1293,7 +1293,7 @@ msgstr  ""
 msgid   "Get values for instance or server configuration keys"
 msgstr  ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid   "Get values for network configuration keys"
 msgstr  ""
 
@@ -1317,7 +1317,7 @@ msgstr  ""
 msgid   "Group ID to run the command as (default 0)"
 msgstr  ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid   "HOSTNAME"
 msgstr  ""
 
@@ -1343,15 +1343,15 @@ msgstr  ""
 msgid   "IMAGES"
 msgstr  ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid   "IP ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid   "IPV4"
 msgstr  ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid   "IPV6"
 msgstr  ""
 
@@ -1543,7 +1543,7 @@ msgstr  ""
 msgid   "Invalid target %s"
 msgstr  ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid   "Ips:"
 msgstr  ""
 
@@ -1560,7 +1560,7 @@ msgstr  ""
 msgid   "LAST USED AT"
 msgstr  ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165 lxc/storage_volume.go:1144
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165 lxc/storage_volume.go:1144
 msgid   "LOCATION"
 msgstr  ""
 
@@ -1595,7 +1595,7 @@ msgstr  ""
 msgid   "Link speed: %dMbit/s (%s duplex)"
 msgstr  ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid   "List DHCP leases"
 msgstr  ""
 
@@ -1607,7 +1607,7 @@ msgstr  ""
 msgid   "List all the cluster members"
 msgstr  ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid   "List available networks"
 msgstr  ""
 
@@ -1770,11 +1770,11 @@ msgstr  ""
 msgid   "Log:"
 msgstr  ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid   "MAC ADDRESS"
 msgstr  ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid   "MAC address: %s"
 msgstr  ""
@@ -1784,7 +1784,7 @@ msgstr  ""
 msgid   "MAD: %s (%s)"
 msgstr  ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid   "MANAGED"
 msgstr  ""
 
@@ -1801,7 +1801,7 @@ msgstr  ""
 msgid   "MESSAGE"
 msgstr  ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid   "MTU: %d"
 msgstr  ""
@@ -1937,11 +1937,11 @@ msgstr  ""
 msgid   "Memory:"
 msgstr  ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid   "Migration API failure"
 msgstr  ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid   "Migration operation failure"
 msgstr  ""
 
@@ -1961,7 +1961,7 @@ msgstr  ""
 msgid   "Missing name"
 msgstr  ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403 lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756 lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053 lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415 lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768 lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065 lxc/network.go:1132
 msgid   "Missing network name"
 msgstr  ""
 
@@ -2009,7 +2009,7 @@ msgid   "Monitor a local or remote LXD server\n"
         "By default the monitor will listen to all message types."
 msgstr  ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673 lxc/storage_volume.go:754
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673 lxc/storage_volume.go:754
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
@@ -2038,11 +2038,11 @@ msgstr  ""
 msgid   "Must run as root to import from directory"
 msgstr  ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563 lxc/storage_volume.go:1138
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563 lxc/storage_volume.go:1138
 msgid   "NAME"
 msgstr  ""
 
@@ -2058,7 +2058,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429 lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540 lxc/remote.go:545
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429 lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540 lxc/remote.go:545
 msgid   "NO"
 msgstr  ""
 
@@ -2084,7 +2084,7 @@ msgstr  ""
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -2094,22 +2094,22 @@ msgstr  ""
 msgid   "Name: %v"
 msgstr  ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid   "Network %s created"
 msgstr  ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid   "Network %s deleted"
 msgstr  ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid   "Network %s pending on member %s"
 msgstr  ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid   "Network %s renamed to %s"
 msgstr  ""
@@ -2118,11 +2118,11 @@ msgstr  ""
 msgid   "Network name"
 msgstr  ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid   "Network type"
 msgstr  ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid   "Network usage:"
 msgstr  ""
 
@@ -2138,7 +2138,7 @@ msgstr  ""
 msgid   "New key/value to apply to a specific device"
 msgstr  ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid   "No device found for this network"
 msgstr  ""
 
@@ -2184,7 +2184,7 @@ msgstr  ""
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid   "Only managed networks can be modified"
 msgstr  ""
 
@@ -2226,11 +2226,11 @@ msgstr  ""
 msgid   "PUBLIC"
 msgstr  ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid   "Packets received"
 msgstr  ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid   "Packets sent"
 msgstr  ""
 
@@ -2265,7 +2265,7 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid   "Press enter to open the editor again"
 msgstr  ""
 
@@ -2537,7 +2537,7 @@ msgstr  ""
 msgid   "Rename instances and snapshots"
 msgstr  ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid   "Rename networks"
 msgstr  ""
 
@@ -2632,7 +2632,7 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid   "STATE"
 msgstr  ""
 
@@ -2710,11 +2710,11 @@ msgid   "Set instance or server configuration keys\n"
         "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr  ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid   "Set network configuration keys"
 msgstr  ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid   "Set network configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -2829,7 +2829,7 @@ msgstr  ""
 msgid   "Show local and remote versions"
 msgstr  ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid   "Show network configurations"
 msgstr  ""
 
@@ -2904,7 +2904,7 @@ msgstr  ""
 msgid   "Socket %d:"
 msgstr  ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid   "Some instances failed to %s"
 msgstr  ""
@@ -2922,7 +2922,7 @@ msgstr  ""
 msgid   "Starting %s"
 msgstr  ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid   "State: %s"
 msgstr  ""
@@ -3020,7 +3020,7 @@ msgstr  ""
 msgid   "TARGET"
 msgstr  ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879 lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891 lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid   "TYPE"
 msgstr  ""
 
@@ -3028,15 +3028,27 @@ msgstr  ""
 msgid   "The --instance-only flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid   "The --mode flag can't be used with --storage"
+msgstr  ""
+
+#: lxc/move.go:168
 msgid   "The --mode flag can't be used with --target"
+msgstr  ""
+
+#: lxc/move.go:193
+msgid   "The --stateless flag can't be used with --storage"
 msgstr  ""
 
 #: lxc/move.go:156
 msgid   "The --stateless flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid   "The --storage flag can't be used with --target"
+msgstr  ""
+
+#: lxc/move.go:180
 msgid   "The destination LXD server is not clustered"
 msgstr  ""
 
@@ -3074,15 +3086,15 @@ msgstr  ""
 msgid   "The profile device doesn't exist"
 msgstr  ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid   "The source LXD server is not clustered"
 msgstr  ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687 lxc/storage_volume.go:768
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687 lxc/storage_volume.go:768
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid   "The specified device doesn't match the network"
 msgstr  ""
 
@@ -3126,7 +3138,7 @@ msgstr  ""
 msgid   "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr  ""
 
-#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652 lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652 lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -3162,7 +3174,7 @@ msgstr  ""
 msgid   "Transferring instance: %s"
 msgstr  ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid   "Try `lxc info --show-log %s` for more info"
 msgstr  ""
@@ -3189,7 +3201,7 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572 lxc/storage_volume.go:1141
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572 lxc/storage_volume.go:1141
 msgid   "USED BY"
 msgstr  ""
 
@@ -3229,7 +3241,7 @@ msgstr  ""
 msgid   "Unset instance or server configuration keys"
 msgstr  ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid   "Unset network configuration keys"
 msgstr  ""
 
@@ -3321,7 +3333,7 @@ msgstr  ""
 msgid   "Whether or not to snapshot the instance's running state"
 msgstr  ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431 lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542 lxc/remote.go:547
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431 lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542 lxc/remote.go:547
 msgid   "YES"
 msgstr  ""
 
@@ -3337,7 +3349,7 @@ msgstr  ""
 msgid   "You must specify a destination instance name when using --target"
 msgstr  ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid   "You must specify a source instance name"
 msgstr  ""
 
@@ -3349,7 +3361,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr  ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28 lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:510 lxc/version.go:20
+#: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28 lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:510 lxc/version.go:20
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -3517,11 +3529,11 @@ msgstr  ""
 msgid   "[<remote>:]<member> <new-name>"
 msgstr  ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903 lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915 lxc/network.go:1104
 msgid   "[<remote>:]<network>"
 msgstr  ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid   "[<remote>:]<network> <instance> [<device name>]"
 msgstr  ""
 
@@ -3529,27 +3541,27 @@ msgstr  ""
 msgid   "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr  ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid   "[<remote>:]<network> <key>"
 msgstr  ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid   "[<remote>:]<network> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid   "[<remote>:]<network> <new-name>"
 msgstr  ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid   "[<remote>:]<network> <profile> [<device name>]"
 msgstr  ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid   "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr  ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid   "[<remote>:]<network> [key=value...]"
 msgstr  ""
 
@@ -3725,7 +3737,7 @@ msgstr  ""
 msgid   "enabled"
 msgstr  ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid   "error: %v"
 msgstr  ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgstr ""
 "###\n"
 "### NB: de naam is weergegeven, maar kan niet worden veranderd"
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -332,11 +332,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -594,7 +594,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -615,7 +615,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -624,11 +624,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -760,8 +760,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -809,7 +809,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -948,7 +948,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -1036,7 +1036,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -1081,10 +1081,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -1111,11 +1111,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1240,7 +1240,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1379,7 +1379,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1406,7 +1406,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1461,7 +1461,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1514,7 +1514,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1538,7 +1538,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1564,15 +1564,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1768,7 +1768,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1785,7 +1785,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1821,7 +1821,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1833,7 +1833,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -2018,7 +2018,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2174,11 +2174,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2204,10 +2204,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2266,7 +2266,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2296,11 +2296,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2318,7 +2318,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2356,22 +2356,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2380,11 +2380,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2400,7 +2400,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2446,7 +2446,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2488,11 +2488,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2527,7 +2527,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2803,7 +2803,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2900,7 +2900,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2984,11 +2984,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -3113,7 +3113,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3188,7 +3188,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3206,7 +3206,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3304,8 +3304,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3313,15 +3313,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3362,16 +3374,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3420,7 +3432,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3456,7 +3468,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3485,7 +3497,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3526,7 +3538,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3622,7 +3634,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3640,7 +3652,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3653,7 +3665,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3826,12 +3838,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3839,27 +3851,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -4041,7 +4053,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -175,7 +175,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -342,11 +342,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -535,7 +535,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -625,7 +625,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -770,8 +770,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -819,7 +819,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -958,7 +958,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -1001,7 +1001,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -1046,7 +1046,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -1091,10 +1091,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -1121,11 +1121,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1389,7 +1389,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1471,7 +1471,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1524,7 +1524,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1548,7 +1548,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1574,15 +1574,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1778,7 +1778,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1795,7 +1795,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1831,7 +1831,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1843,7 +1843,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -2014,11 +2014,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -2028,7 +2028,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -2045,7 +2045,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2184,11 +2184,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2214,10 +2214,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2276,7 +2276,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2306,11 +2306,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2328,7 +2328,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2356,7 +2356,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2366,22 +2366,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2390,11 +2390,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2456,7 +2456,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2498,11 +2498,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2537,7 +2537,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2813,7 +2813,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2994,11 +2994,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -3123,7 +3123,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3198,7 +3198,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3216,7 +3216,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3314,8 +3314,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3323,15 +3323,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3372,16 +3384,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3430,7 +3442,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3466,7 +3478,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3495,7 +3507,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3536,7 +3548,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3632,7 +3644,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3650,7 +3662,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3663,7 +3675,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3836,12 +3848,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3849,27 +3861,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -4051,7 +4063,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -178,7 +178,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -341,12 +341,12 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 #, fuzzy
 msgid "--console can't be used with --all"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -547,7 +547,7 @@ msgstr "Atribuir conjuntos de perfis aos containers"
 msgid "Attach network interfaces to instances"
 msgstr "Anexar interfaces de rede aos containers"
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr "Anexar interfaces de rede aos perfis"
 
@@ -620,7 +620,7 @@ msgstr "Editar arquivos no container"
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
@@ -641,7 +641,7 @@ msgstr "Propriedade ruim: %s"
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -650,11 +650,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Marca: %v"
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
@@ -788,8 +788,8 @@ msgstr "Versão do cliente: %s\n"
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -845,7 +845,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -993,7 +993,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr "Criar novas redes"
 
@@ -1037,7 +1037,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -1086,7 +1086,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "Delete instances and snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -1131,10 +1131,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -1161,12 +1161,12 @@ msgstr ""
 msgid "Description"
 msgstr "Descrição"
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 #, fuzzy
 msgid "Detach network interfaces from instances"
 msgstr "Desconectar interfaces de rede dos containers"
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr "Desconectar interfaces de rede dos perfis"
 
@@ -1299,7 +1299,7 @@ msgstr "Editar arquivos de metadados do container"
 msgid "Edit instance or server configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
@@ -1439,7 +1439,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1466,7 +1466,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1577,7 +1577,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for instance or server configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1602,7 +1602,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
@@ -1628,15 +1628,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr "IPV6"
 
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1851,7 +1851,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1887,7 +1887,7 @@ msgstr "Arquitetura: %v"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1899,7 +1899,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -2071,11 +2071,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -2085,7 +2085,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -2102,7 +2102,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2247,11 +2247,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2278,10 +2278,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2340,7 +2340,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2370,11 +2370,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2392,7 +2392,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2420,7 +2420,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2430,22 +2430,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2454,11 +2454,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2520,7 +2520,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2562,11 +2562,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2601,7 +2601,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2883,7 +2883,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2986,7 +2986,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -3073,11 +3073,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -3208,7 +3208,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3283,7 +3283,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s adicionado a %s"
@@ -3301,7 +3301,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3400,8 +3400,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3409,15 +3409,30 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+#, fuzzy
+msgid "The --mode flag can't be used with --storage"
+msgstr "--refresh só pode ser usado com containers"
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
 msgstr ""
+
+#: lxc/move.go:193
+#, fuzzy
+msgid "The --stateless flag can't be used with --storage"
+msgstr "--refresh só pode ser usado com containers"
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+#, fuzzy
+msgid "The --storage flag can't be used with --target"
+msgstr "--refresh só pode ser usado com containers"
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3458,16 +3473,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3516,7 +3531,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3552,7 +3567,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3581,7 +3596,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3626,7 +3641,7 @@ msgstr "Editar propriedades da imagem"
 msgid "Unset instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3723,7 +3738,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3741,7 +3756,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3754,7 +3769,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3932,12 +3947,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3945,27 +3960,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -4151,7 +4166,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -4453,6 +4468,10 @@ msgstr ""
 #: lxc/image.go:1079
 msgid "yes"
 msgstr "sim"
+
+#, fuzzy
+#~ msgid "The --instance-only flag can't be used with --storage"
+#~ msgstr "--refresh só pode ser usado com containers"
 
 #, fuzzy
 #~ msgid "Add devices to instances or profiles"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: 2020-10-08 08:16+0000\n"
 "Last-Translator: Artem <KovalevArtem.ru@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -177,7 +177,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network.\n"
@@ -343,11 +343,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr "- Порт %d (%s)"
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -552,7 +552,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -623,7 +623,7 @@ msgstr "Копирование образа: %s"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -653,11 +653,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
@@ -792,8 +792,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -841,7 +841,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -988,7 +988,7 @@ msgstr "Копирование образа: %s"
 msgid "Create new instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -1034,7 +1034,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -1082,7 +1082,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Delete instances and snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -1128,10 +1128,10 @@ msgstr "Копирование образа: %s"
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -1158,11 +1158,11 @@ msgstr "Копирование образа: %s"
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1293,7 +1293,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1519,7 +1519,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1560,7 +1560,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1596,7 +1596,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1622,15 +1622,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1831,7 +1831,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1848,7 +1848,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1884,7 +1884,7 @@ msgstr "Архитектура: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1897,7 +1897,7 @@ msgstr "Псевдонимы:"
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -2072,11 +2072,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -2086,7 +2086,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -2103,7 +2103,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2249,11 +2249,11 @@ msgstr " Использование памяти:"
 msgid "Memory:"
 msgstr " Использование памяти:"
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2281,10 +2281,10 @@ msgstr "Имя контейнера: %s"
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2376,11 +2376,11 @@ msgstr "Копирование образа: %s"
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2398,7 +2398,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2426,7 +2426,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2436,22 +2436,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2460,12 +2460,12 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 #, fuzzy
 msgid "Network type"
 msgstr " Использование сети:"
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
@@ -2482,7 +2482,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2529,7 +2529,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2571,11 +2571,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2610,7 +2610,7 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2889,7 +2889,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2991,7 +2991,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -3075,11 +3075,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -3206,7 +3206,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3282,7 +3282,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3300,7 +3300,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
@@ -3401,8 +3401,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3410,15 +3410,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3459,16 +3471,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3517,7 +3529,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3553,7 +3565,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3582,7 +3594,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3623,7 +3635,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3719,7 +3731,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3737,7 +3749,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3758,7 +3770,7 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 #, fuzzy
 msgid "[<remote>:]"
@@ -4099,8 +4111,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -4108,7 +4120,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 #, fuzzy
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
@@ -4124,7 +4136,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -4132,7 +4144,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -4140,7 +4152,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -4148,7 +4160,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
@@ -4156,7 +4168,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 #, fuzzy
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
@@ -4164,7 +4176,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 #, fuzzy
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
@@ -4494,7 +4506,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -102,7 +102,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,11 +215,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -692,7 +692,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -964,10 +964,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -994,11 +994,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1447,15 +1447,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1887,11 +1887,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2057,11 +2057,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,10 +2087,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2179,11 +2179,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2239,22 +2239,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2263,11 +2263,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2371,11 +2371,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2783,7 +2783,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2867,11 +2867,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3187,8 +3187,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3196,15 +3196,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3245,16 +3257,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3303,7 +3315,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3339,7 +3351,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3368,7 +3380,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3409,7 +3421,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3505,7 +3517,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3523,7 +3535,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3536,7 +3548,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3709,12 +3721,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3722,27 +3734,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3924,7 +3936,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-01-15 09:53-0500\n"
+"POT-Creation-Date: 2021-01-22 14:47+0000\n"
 "PO-Revision-Date: 2020-11-05 02:45+0000\n"
 "Last-Translator: wdggg <wdggg7@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -145,7 +145,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: lxc/network.go:558
+#: lxc/network.go:570
 msgid ""
 "### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -258,11 +258,11 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:270
+#: lxc/action.go:339
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:274
+#: lxc/action.go:343
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -451,7 +451,7 @@ msgstr ""
 msgid "Attach network interfaces to instances"
 msgstr ""
 
-#: lxc/network.go:181 lxc/network.go:182
+#: lxc/network.go:193 lxc/network.go:194
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
@@ -520,7 +520,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:290
+#: lxc/network.go:302
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -541,7 +541,7 @@ msgstr ""
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/action.go:237
+#: lxc/action.go:136 lxc/action.go:296
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -550,11 +550,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:558 lxc/network.go:789
+#: lxc/info.go:558 lxc/network.go:801
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:559 lxc/network.go:790
+#: lxc/info.go:559 lxc/network.go:802
 msgid "Bytes sent"
 msgstr ""
 
@@ -686,8 +686,8 @@ msgstr ""
 
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:737 lxc/copy.go:52 lxc/info.go:45 lxc/init.go:54
-#: lxc/move.go:57 lxc/network.go:257 lxc/network.go:675 lxc/network.go:733
-#: lxc/network.go:1030 lxc/network.go:1097 lxc/network.go:1159
+#: lxc/move.go:57 lxc/network.go:269 lxc/network.go:687 lxc/network.go:745
+#: lxc/network.go:1042 lxc/network.go:1109 lxc/network.go:1171
 #: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:593
 #: lxc/storage.go:665 lxc/storage.go:748 lxc/storage_volume.go:316
 #: lxc/storage_volume.go:477 lxc/storage_volume.go:556
@@ -735,7 +735,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
-#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:643
+#: lxc/config_metadata.go:142 lxc/image.go:431 lxc/network.go:655
 #: lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
 #: lxc/storage_volume.go:931 lxc/storage_volume.go:961
 #, c-format
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Create new instance file templates"
 msgstr ""
 
-#: lxc/network.go:254 lxc/network.go:255
+#: lxc/network.go:266 lxc/network.go:267
 msgid "Create new networks"
 msgstr ""
 
@@ -917,7 +917,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:883
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:431 lxc/network.go:895
 #: lxc/operation.go:160 lxc/storage.go:564 lxc/storage_volume.go:1139
 msgid "DESCRIPTION"
 msgstr ""
@@ -962,7 +962,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:328 lxc/network.go:329
+#: lxc/network.go:340 lxc/network.go:341
 msgid "Delete networks"
 msgstr ""
 
@@ -1007,10 +1007,10 @@ msgstr ""
 #: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40
 #: lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:20
 #: lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:109
-#: lxc/network.go:182 lxc/network.go:255 lxc/network.go:329 lxc/network.go:379
-#: lxc/network.go:464 lxc/network.go:549 lxc/network.go:672 lxc/network.go:730
-#: lxc/network.go:810 lxc/network.go:905 lxc/network.go:974 lxc/network.go:1024
-#: lxc/network.go:1094 lxc/network.go:1156 lxc/operation.go:24
+#: lxc/network.go:194 lxc/network.go:267 lxc/network.go:341 lxc/network.go:391
+#: lxc/network.go:476 lxc/network.go:561 lxc/network.go:684 lxc/network.go:742
+#: lxc/network.go:822 lxc/network.go:917 lxc/network.go:986 lxc/network.go:1036
+#: lxc/network.go:1106 lxc/network.go:1168 lxc/operation.go:24
 #: lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181
 #: lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244
 #: lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528
@@ -1037,11 +1037,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:378 lxc/network.go:379
+#: lxc/network.go:390 lxc/network.go:391
 msgid "Detach network interfaces from instances"
 msgstr ""
 
-#: lxc/network.go:463 lxc/network.go:464
+#: lxc/network.go:475 lxc/network.go:476
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1166,7 +1166,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: lxc/network.go:548 lxc/network.go:549
+#: lxc/network.go:560 lxc/network.go:561
 msgid "Edit network configurations as YAML"
 msgstr ""
 
@@ -1305,7 +1305,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:261 lxc/move.go:316
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1332,7 +1332,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:841 lxc/operation.go:131
+#: lxc/network.go:853 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1387,7 +1387,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:117 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:120 lxc/network.go:814 lxc/network.go:907 lxc/operation.go:104
+#: lxc/list.go:120 lxc/network.go:826 lxc/network.go:919 lxc/operation.go:104
 #: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1085
 msgid "Format (csv|json|table|yaml)"
@@ -1428,7 +1428,7 @@ msgstr ""
 msgid "Get image properties"
 msgstr ""
 
-#: lxc/network.go:729 lxc/network.go:730
+#: lxc/network.go:741 lxc/network.go:742
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1440,7 +1440,7 @@ msgstr ""
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:671 lxc/network.go:672
+#: lxc/network.go:683 lxc/network.go:684
 msgid "Get values for network configuration keys"
 msgstr ""
 
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:951
+#: lxc/network.go:963
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1490,15 +1490,15 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:953
+#: lxc/network.go:965
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:426 lxc/network.go:881
+#: lxc/list.go:426 lxc/network.go:893
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:427 lxc/network.go:882
+#: lxc/list.go:427 lxc/network.go:894
 msgid "IPV6"
 msgstr ""
 
@@ -1694,7 +1694,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:496 lxc/network.go:781
+#: lxc/info.go:496 lxc/network.go:793
 msgid "Ips:"
 msgstr ""
 
@@ -1711,7 +1711,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:459 lxc/network.go:957 lxc/operation.go:165
+#: lxc/list.go:459 lxc/network.go:969 lxc/operation.go:165
 #: lxc/storage_volume.go:1144
 msgid "LOCATION"
 msgstr ""
@@ -1747,7 +1747,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:904 lxc/network.go:905
+#: lxc/network.go:916 lxc/network.go:917
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1759,7 +1759,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:809 lxc/network.go:810
+#: lxc/network.go:821 lxc/network.go:822
 msgid "List available networks"
 msgstr ""
 
@@ -1930,11 +1930,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:952
+#: lxc/network.go:964
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:775
+#: lxc/network.go:787
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1944,7 +1944,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:880
+#: lxc/network.go:892
 msgid "MANAGED"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:776
+#: lxc/network.go:788
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2100,11 +2100,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:250
+#: lxc/move.go:278 lxc/move.go:329
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:255
+#: lxc/move.go:283 lxc/move.go:334
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2130,10 +2130,10 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:133 lxc/network.go:206 lxc/network.go:353 lxc/network.go:403
-#: lxc/network.go:488 lxc/network.go:593 lxc/network.go:698 lxc/network.go:756
-#: lxc/network.go:930 lxc/network.go:998 lxc/network.go:1053
-#: lxc/network.go:1120
+#: lxc/network.go:133 lxc/network.go:218 lxc/network.go:365 lxc/network.go:415
+#: lxc/network.go:500 lxc/network.go:605 lxc/network.go:710 lxc/network.go:768
+#: lxc/network.go:942 lxc/network.go:1010 lxc/network.go:1065
+#: lxc/network.go:1132
 msgid "Missing network name"
 msgstr ""
 
@@ -2192,7 +2192,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:423 lxc/network.go:508 lxc/storage_volume.go:673
+#: lxc/network.go:435 lxc/network.go:520 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2222,11 +2222,11 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:157
+#: lxc/action.go:216
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:878 lxc/profile.go:620
+#: lxc/cluster.go:132 lxc/list.go:438 lxc/network.go:890 lxc/profile.go:620
 #: lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:563
 #: lxc/storage_volume.go:1138
 msgid "NAME"
@@ -2244,7 +2244,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:855 lxc/operation.go:143 lxc/project.go:429
+#: lxc/network.go:867 lxc/operation.go:143 lxc/project.go:429
 #: lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/remote.go:540
 #: lxc/remote.go:545
 msgid "NO"
@@ -2272,7 +2272,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:451 lxc/network.go:774
+#: lxc/info.go:451 lxc/network.go:786
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2282,22 +2282,22 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:311
+#: lxc/network.go:323
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:363
+#: lxc/network.go:375
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:309
+#: lxc/network.go:321
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1020
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -2306,11 +2306,11 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/network.go:258
+#: lxc/network.go:270
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:566 lxc/network.go:788
+#: lxc/info.go:566 lxc/network.go:800
 msgid "Network usage:"
 msgstr ""
 
@@ -2326,7 +2326,7 @@ msgstr ""
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:432 lxc/network.go:517
+#: lxc/network.go:444 lxc/network.go:529
 msgid "No device found for this network"
 msgstr ""
 
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:619 lxc/network.go:1068
+#: lxc/network.go:631 lxc/network.go:1080
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2414,11 +2414,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:560 lxc/network.go:791
+#: lxc/info.go:560 lxc/network.go:803
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:561 lxc/network.go:792
+#: lxc/info.go:561 lxc/network.go:804
 msgid "Packets sent"
 msgstr ""
 
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/network.go:644 lxc/profile.go:499 lxc/project.go:305
+#: lxc/cluster.go:504 lxc/network.go:656 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:932 lxc/storage_volume.go:962
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2729,7 +2729,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network.go:973 lxc/network.go:974
+#: lxc/network.go:985 lxc/network.go:986
 msgid "Rename networks"
 msgstr ""
 
@@ -2826,7 +2826,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:887 lxc/storage.go:568
+#: lxc/cluster.go:135 lxc/list.go:443 lxc/network.go:899 lxc/storage.go:568
 msgid "STATE"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgid ""
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1023
+#: lxc/network.go:1035
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1024
+#: lxc/network.go:1036
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -3039,7 +3039,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1093 lxc/network.go:1094
+#: lxc/network.go:1105 lxc/network.go:1106
 msgid "Show network configurations"
 msgstr ""
 
@@ -3114,7 +3114,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:303
+#: lxc/action.go:372
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -3132,7 +3132,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:777
+#: lxc/network.go:789
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3230,8 +3230,8 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:879
-#: lxc/network.go:954 lxc/operation.go:159 lxc/storage_volume.go:1137
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:444 lxc/network.go:891
+#: lxc/network.go:966 lxc/operation.go:159 lxc/storage_volume.go:1137
 msgid "TYPE"
 msgstr ""
 
@@ -3239,15 +3239,27 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:164
+#: lxc/move.go:197
+msgid "The --mode flag can't be used with --storage"
+msgstr ""
+
+#: lxc/move.go:168
 msgid "The --mode flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:193
+msgid "The --stateless flag can't be used with --storage"
 msgstr ""
 
 #: lxc/move.go:156
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:176
+#: lxc/move.go:164
+msgid "The --storage flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:180
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -3288,16 +3300,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:266
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522 lxc/storage_volume.go:687
+#: lxc/network.go:449 lxc/network.go:534 lxc/storage_volume.go:687
 #: lxc/storage_volume.go:768
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:441 lxc/network.go:526
+#: lxc/network.go:453 lxc/network.go:538
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3346,7 +3358,7 @@ msgid "To start your first instance, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:278 lxc/config.go:416 lxc/config.go:566 lxc/config.go:652
-#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:762 lxc/storage.go:425
+#: lxc/copy.go:114 lxc/info.go:322 lxc/network.go:774 lxc/storage.go:425
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3382,7 +3394,7 @@ msgstr ""
 msgid "Transferring instance: %s"
 msgstr ""
 
-#: lxc/action.go:202 lxc/launch.go:104
+#: lxc/action.go:261 lxc/launch.go:104
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3411,7 +3423,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:884 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
+#: lxc/network.go:896 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:572
 #: lxc/storage_volume.go:1141
 msgid "USED BY"
 msgstr ""
@@ -3452,7 +3464,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1155 lxc/network.go:1156
+#: lxc/network.go:1167 lxc/network.go:1168
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -3548,7 +3560,7 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/network.go:857 lxc/operation.go:145 lxc/project.go:431
+#: lxc/network.go:869 lxc/operation.go:145 lxc/project.go:431
 #: lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/remote.go:542
 #: lxc/remote.go:547
 msgid "YES"
@@ -3566,7 +3578,7 @@ msgstr ""
 msgid "You must specify a destination instance name when using --target"
 msgstr ""
 
-#: lxc/copy.go:75 lxc/move.go:226
+#: lxc/copy.go:75 lxc/move.go:250 lxc/move.go:305
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -3579,7 +3591,7 @@ msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
 #: lxc/cluster.go:71 lxc/config_trust.go:112 lxc/monitor.go:28
-#: lxc/network.go:807 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
+#: lxc/network.go:819 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381
 #: lxc/storage.go:510 lxc/version.go:20
 msgid "[<remote>:]"
 msgstr ""
@@ -3752,12 +3764,12 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:326 lxc/network.go:547 lxc/network.go:728 lxc/network.go:903
-#: lxc/network.go:1092
+#: lxc/network.go:338 lxc/network.go:559 lxc/network.go:740 lxc/network.go:915
+#: lxc/network.go:1104
 msgid "[<remote>:]<network>"
 msgstr ""
 
-#: lxc/network.go:377
+#: lxc/network.go:389
 msgid "[<remote>:]<network> <instance> [<device name>]"
 msgstr ""
 
@@ -3765,27 +3777,27 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:670 lxc/network.go:1154
+#: lxc/network.go:682 lxc/network.go:1166
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1022
+#: lxc/network.go:1034
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:971
+#: lxc/network.go:983
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
-#: lxc/network.go:462
+#: lxc/network.go:474
 msgid "[<remote>:]<network> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:180
+#: lxc/network.go:192
 msgid "[<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:253
+#: lxc/network.go:265
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
@@ -3967,7 +3979,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:295
+#: lxc/action.go:364
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/shared/api/instance.go
+++ b/shared/api/instance.go
@@ -45,6 +45,9 @@ type InstancePost struct {
 	InstanceOnly  bool                `json:"instance_only" yaml:"instance_only"`
 	ContainerOnly bool                `json:"container_only" yaml:"container_only"` // Deprecated, use InstanceOnly.
 	Target        *InstancePostTarget `json:"target" yaml:"target"`
+
+	// API extension: instance_pool_move
+	Pool string `json:"pool" yaml:"pool"`
 }
 
 // InstancePostTarget represents the migration target host and operation.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -247,6 +247,7 @@ var APIExtensions = []string{
 	"instance_nic_bridged_port_isolation",
 	"instance_bulk_state_change",
 	"network_gvrp",
+	"instance_pool_move",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -105,6 +105,10 @@ test_basic_usage() {
 
   # Test container rename
   lxc move foo bar
+
+  # Check volatile.apply_template is altered during rename.
+  lxc config get bar volatile.apply_template | grep rename
+
   lxc list | grep -v foo
   lxc list | grep bar
 

--- a/test/suites/container_local_cross_pool_handling.sh
+++ b/test/suites/container_local_cross_pool_handling.sh
@@ -57,10 +57,19 @@ test_container_local_cross_pool_handling() {
         fi
 
         lxc init testimage c1
+
+        # Check volatile.apply_template is initialised during create.
+        lxc config get c1 volatile.apply_template | grep create
         lxc copy c1 c2 -s "lxdtest-$(basename "${LXD_DIR}")-${driver}1"
+
+        # Check volatile.apply_template is altered during copy.
+        lxc config get c2 volatile.apply_template | grep copy
         lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${driver}1" container/c2
         lxc delete -f c2
         lxc move c1 c2 -s "lxdtest-$(basename "${LXD_DIR}")-${driver}1"
+
+        # Check volatile.apply_template is not altered during move and rename.
+        lxc config get c2 volatile.apply_template | grep create
         ! lxc info c1 || false
         lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${driver}1" container/c2
         lxc delete -f c2

--- a/test/suites/container_local_cross_pool_handling.sh
+++ b/test/suites/container_local_cross_pool_handling.sh
@@ -57,6 +57,7 @@ test_container_local_cross_pool_handling() {
         fi
 
         lxc init testimage c1
+        originalPool=$(lxc profile device get default root pool)
 
         # Check volatile.apply_template is initialised during create.
         lxc config get c1 volatile.apply_template | grep create
@@ -72,6 +73,11 @@ test_container_local_cross_pool_handling() {
         lxc config get c2 volatile.apply_template | grep create
         ! lxc info c1 || false
         lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${driver}1" container/c2
+
+        # Test moving back to original pool without renaming.
+        lxc move c2 -s "${originalPool}"
+        lxc config get c2 volatile.apply_template | grep create
+        lxc storage volume show "${originalPool}" container/c2
         lxc delete -f c2
 
         lxc init testimage c1


### PR DESCRIPTION
Adds ability to move instance to a different storage pool server-side using:

```
lxc move a1 [new name] --storage blah
```

Continues work started in https://github.com/lxc/lxd/pull/8249
Fixes #7274