### PR TITLE
Instance: Fix missing retry when generating NIC volatile.%s.name key (stable-4.0)

### DIFF
--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -960,9 +960,7 @@ func CreateInstanceConfig(tx *sql.Tx, id int, config map[string]string) error {
 
 		_, err := stmt.Exec(id, k, v)
 		if err != nil {
-			logger.Debugf("Error adding configuration item %s = %s to container %d",
-				k, v, id)
-			return err
+			return errors.Wrapf(err, "Error adding configuration item %q = %q to instance %d", k, v, id)
 		}
 	}
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -30,7 +30,6 @@ import (
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/daemon"
 	"github.com/lxc/lxd/lxd/db"
-	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/lxd/device"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/device/nictype"
@@ -6144,95 +6143,58 @@ func (d *lxc) FillNetworkDevice(name string, m deviceConfig.Device) (deviceConfi
 		}
 	}
 
-	updateKey := func(key string, value string) error {
-		tx, err := d.state.Cluster.Begin()
-		if err != nil {
-			return err
-		}
-
-		err = db.CreateInstanceConfig(tx, d.id, map[string]string{key: value})
-		if err != nil {
-			tx.Rollback()
-			return err
-		}
-
-		err = db.TxCommit(tx)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}
-
 	nicType, err := nictype.NICType(d.state, m)
 	if err != nil {
 		return nil, err
 	}
 
-	// Fill in the MAC address
+	// Fill in the MAC address.
 	if !shared.StringInSlice(nicType, []string{"physical", "ipvlan", "sriov"}) && m["hwaddr"] == "" {
 		configKey := fmt.Sprintf("volatile.%s.hwaddr", name)
 		volatileHwaddr := d.localConfig[configKey]
 		if volatileHwaddr == "" {
-			// Generate a new MAC address
+			// Generate a new MAC address.
 			volatileHwaddr, err = instance.DeviceNextInterfaceHWAddr()
 			if err != nil {
 				return nil, err
 			}
 
-			// Update the database
-			err = query.Retry(func() error {
-				err := updateKey(configKey, volatileHwaddr)
-				if err != nil {
-					// Check if something else filled it in behind our back
-					value, err1 := d.state.Cluster.GetInstanceConfig(d.id, configKey)
-					if err1 != nil || value == "" {
-						return err
-					}
-
-					d.localConfig[configKey] = value
-					d.expandedConfig[configKey] = value
-					return nil
-				}
-
-				d.localConfig[configKey] = volatileHwaddr
-				d.expandedConfig[configKey] = volatileHwaddr
-				return nil
-			})
+			// Update the database and update volatileHwaddr with stored value.
+			volatileHwaddr, err = d.insertConfigkey(configKey, volatileHwaddr)
 			if err != nil {
-				return nil, err
+				return nil, errors.Wrapf(err, "Failed storing generated config key %q", configKey)
 			}
+
+			// Set stored value into current instance config.
+			d.localConfig[configKey] = volatileHwaddr
+			d.expandedConfig[configKey] = volatileHwaddr
 		}
+
 		newDevice["hwaddr"] = volatileHwaddr
 	}
 
-	// Fill in the name
+	// Fill in the interface name.
 	if m["name"] == "" {
 		configKey := fmt.Sprintf("volatile.%s.name", name)
 		volatileName := d.localConfig[configKey]
 		if volatileName == "" {
-			// Generate a new interface name
+			// Generate a new interface name.
 			volatileName, err := nextInterfaceName()
 			if err != nil {
 				return nil, err
 			}
 
-			// Update the database
-			err = updateKey(configKey, volatileName)
+			// Update the database and update volatileName with stored value.
+			volatileName, err = d.insertConfigkey(configKey, volatileName)
 			if err != nil {
-				// Check if something else filled it in behind our back
-				value, err1 := d.state.Cluster.GetInstanceConfig(d.id, configKey)
-				if err1 != nil || value == "" {
-					return nil, err
-				}
-
-				d.localConfig[configKey] = value
-				d.expandedConfig[configKey] = value
-			} else {
-				d.localConfig[configKey] = volatileName
-				d.expandedConfig[configKey] = volatileName
+				return nil, errors.Wrapf(err, "Failed storing generated config key %q", configKey)
 			}
+
+			// Set stored value into current instance config.
+			d.localConfig[configKey] = volatileName
+			d.expandedConfig[configKey] = volatileName
 		}
+
 		newDevice["name"] = volatileName
 	}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -31,7 +31,6 @@ import (
 	"github.com/lxc/lxd/lxd/cgroup"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
-	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/lxd/device"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/device/nictype"
@@ -4571,65 +4570,34 @@ func (d *qemu) FillNetworkDevice(name string, m deviceConfig.Device) (deviceConf
 	var err error
 
 	newDevice := m.Clone()
-	updateKey := func(key string, value string) error {
-		tx, err := d.state.Cluster.Begin()
-		if err != nil {
-			return err
-		}
-
-		err = db.CreateInstanceConfig(tx, d.id, map[string]string{key: value})
-		if err != nil {
-			tx.Rollback()
-			return err
-		}
-
-		err = db.TxCommit(tx)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}
 
 	nicType, err := nictype.NICType(d.state, m)
 	if err != nil {
 		return nil, err
 	}
 
-	// Fill in the MAC address
+	// Fill in the MAC address.
 	if !shared.StringInSlice(nicType, []string{"physical", "ipvlan", "sriov"}) && m["hwaddr"] == "" {
 		configKey := fmt.Sprintf("volatile.%s.hwaddr", name)
 		volatileHwaddr := d.localConfig[configKey]
 		if volatileHwaddr == "" {
-			// Generate a new MAC address
+			// Generate a new MAC address.
 			volatileHwaddr, err = instance.DeviceNextInterfaceHWAddr()
 			if err != nil {
 				return nil, err
 			}
 
-			// Update the database
-			err = query.Retry(func() error {
-				err := updateKey(configKey, volatileHwaddr)
-				if err != nil {
-					// Check if something else filled it in behind our back
-					value, err1 := d.state.Cluster.GetInstanceConfig(d.id, configKey)
-					if err1 != nil || value == "" {
-						return err
-					}
-
-					d.localConfig[configKey] = value
-					d.expandedConfig[configKey] = value
-					return nil
-				}
-
-				d.localConfig[configKey] = volatileHwaddr
-				d.expandedConfig[configKey] = volatileHwaddr
-				return nil
-			})
+			// Update the database and update volatileHwaddr with stored value.
+			volatileHwaddr, err = d.insertConfigkey(configKey, volatileHwaddr)
 			if err != nil {
-				return nil, err
+				return nil, errors.Wrapf(err, "Failed storing generated config key %q", configKey)
 			}
+
+			// Set stored value into current instance config.
+			d.localConfig[configKey] = volatileHwaddr
+			d.expandedConfig[configKey] = volatileHwaddr
 		}
+
 		newDevice["hwaddr"] = volatileHwaddr
 	}
 


### PR DESCRIPTION
- Adds insertConfigkey function which uses DB Retry function for retrying transactions.
- Refactors FillNetworkDevice to use shared insertConfigkey function for both instance drivers.
- Improves error message on failed inserts in CreateInstanceConfig.

Fixes #8359