### PR TITLE
lxd/device: Fix instance type validations

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -223,7 +223,7 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 			}
 
 			if contentType == db.StoragePoolVolumeContentTypeBlock {
-				if instConf.Type() != instancetype.VM {
+				if instConf.Type() == instancetype.Container {
 					return fmt.Errorf("Custom block volumes cannot be used on containers")
 				}
 

--- a/lxd/device/gpu_physical.go
+++ b/lxd/device/gpu_physical.go
@@ -46,7 +46,7 @@ func (d *gpuPhysical) validateConfig(instConf instance.ConfigReader) error {
 		"pci",
 	}
 
-	if instConf.Type() == instancetype.Container {
+	if instConf.Type() == instancetype.Container || instConf.Type() == instancetype.Any {
 		optionalFields = append(optionalFields, "uid", "gid", "mode")
 	}
 

--- a/lxd/device/nic_physical.go
+++ b/lxd/device/nic_physical.go
@@ -34,7 +34,7 @@ func (d *nicPhysical) validateConfig(instConf instance.ConfigReader) error {
 		"gvrp",
 	}
 
-	if instConf.Type() == instancetype.Container {
+	if instConf.Type() == instancetype.Container || instConf.Type() == instancetype.Any {
 		optionalFields = append(optionalFields, "mtu", "hwaddr", "vlan")
 	}
 

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -90,7 +90,7 @@ func (d *nicSRIOV) validateConfig(instConf instance.ConfigReader) error {
 	}
 
 	// For VMs only NIC properties that can be specified on the parent's VF settings are controllable.
-	if instConf.Type() == instancetype.Container {
+	if instConf.Type() == instancetype.Container || instConf.Type() == instancetype.Any {
 		optionalFields = append(optionalFields, "mtu")
 	}
 


### PR DESCRIPTION
When validating the instance type as part of device config validation,
we need to keep in mind that instancetype.Any is a valid value.

This is used for profiles as they can apply to any of the types.

In such cases, the config validation should only error out when directly
applied to an instance and further checks should be added for a start
time error on instances getting the device through profiles.

Closes #8377

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>