### PR TITLE
DB: Make checkpoint in progress a candidate for IsRetriableError (stable 4.0)

### DIFF
--- a/lxd/db/query/retry.go
+++ b/lxd/db/query/retry.go
@@ -76,5 +76,9 @@ func IsRetriableError(err error) bool {
 		return true
 	}
 
+	if strings.Contains(err.Error(), "checkpoint in progress") {
+		return true
+	}
+
 	return false
 }


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>