### PR TITLE
Network: Bridge forkdns return empty AAAA record response when equivalent A record exists

### DIFF
--- a/lxd/main_forkdns.go
+++ b/lxd/main_forkdns.go
@@ -279,7 +279,7 @@ func (h *dnsHandler) handleA(r *dns.Msg) (dns.Msg, error) {
 		return *resp, nil
 	}
 
-	// Record not found in any of the remove servers.
+	// Record not found in any of the remote servers.
 	msg.SetRcode(r, dns.RcodeNameError)
 	return msg, nil
 }

--- a/lxd/main_forkdns.go
+++ b/lxd/main_forkdns.go
@@ -89,11 +89,18 @@ func (h *dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 			logger.Errorf("PTR record lookup failed for %s: %v", r.Question[0].Name, err)
 			msg.SetRcode(r, dns.RcodeNameError)
 		}
-	} else if r.Question[0].Qtype == dns.TypeA {
+	} else if r.Question[0].Qtype == dns.TypeA || r.Question[0].Qtype == dns.TypeAAAA {
 		msg, err = h.handleA(r)
 		if err != nil {
 			logger.Errorf("A record lookup failed for %s: %v", r.Question[0].Name, err)
 			msg.SetRcode(r, dns.RcodeNameError)
+		}
+
+		// Currently forkdns doesn't support IPv6, but to ensure compatbility and expected behavior with
+		// DNS clients, we return an empty AAAA response if the A record was found (meaning the domain
+		// exists, but no AAAA records).
+		if r.Question[0].Qtype == dns.TypeAAAA && msg.Rcode == dns.RcodeSuccess {
+			msg.Answer = []dns.RR{} // Empty response for AAAA if equivalent A record exists.
 		}
 	} else {
 		// Fallback to NXDOMAIN
@@ -264,8 +271,8 @@ func (h *dnsHandler) handleA(r *dns.Msg) (dns.Msg, error) {
 		req.Id = r.Id
 
 		resp, err := dns.Exchange(&req, fmt.Sprintf("%s:1053", server))
-		if err != nil || len(resp.Answer) == 0 {
-			// Error or empty response, try the next one
+		if err != nil || resp.Rcode != dns.RcodeSuccess {
+			// Error sending request or error response, try next server.
 			continue
 		}
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -1661,6 +1661,12 @@ test_clustering_dns() {
     false
   fi
 
+  # Test querying forkdns1 for AAAA record when equivalent A record is on forkdns2 network
+  if ! dig @127.0.1.1"${ipRand}" -p1053 AAAA test1.lxd | grep "status: NOERROR" ; then
+    echo "test1.lxd empty AAAAA DNS resolution failed"
+    false
+  fi
+
   # Test querying forkdns1 for PTR record that is on forkdns2 network
   if ! dig @127.0.1.1"${ipRand}" -p1053 -x 10.140.78.145 | grep "test1.lxd" ; then
     echo "10.140.78.145 PTR DNS resolution failed"


### PR DESCRIPTION
Fixes compatibility with nslookup that looks up A and AAAA records and returns with non-zero exit status if AAAA is returned as NXDOMAIN.

Fixes #8389

Tested in Alpine 3.13:

Before
```
c2:~# nslookup c1; echo $?
Server:		240.33.0.1
Address:	240.33.0.1#53

Name:	c1.lxd
Address: 240.126.0.249
** server can't find c1.lxd: NXDOMAIN

1
```

After:
```
c2:~# nslookup c1; echo $?
Server:		240.33.0.1
Address:	240.33.0.1#53

Name:	c1.lxd
Address: 240.126.0.249

0
```