### PR TITLE
Network: Allow static IPs to be assigned to NICs when using fan bridge mode

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -100,37 +100,31 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 		netConfig := n.Config()
 
 		if d.config["ipv4.address"] != "" {
-			// Check that DHCPv4 is enabled on parent network (needed to use static assigned IPs).
-			if n.DHCPv4Subnet() == nil {
-				return fmt.Errorf("Cannot specify %q when DHCP is disabled on network %q", "ipv4.address", d.config["network"])
-			}
+			dhcpv4Subnet := n.DHCPv4Subnet()
 
-			_, subnet, err := net.ParseCIDR(netConfig["ipv4.address"])
-			if err != nil {
-				return errors.Wrapf(err, "Invalid network ipv4.address")
+			// Check that DHCPv4 is enabled on parent network (needed to use static assigned IPs).
+			if dhcpv4Subnet == nil {
+				return fmt.Errorf(`Cannot specify "ipv4.address" when DHCP is disabled on network %q`, d.config["network"])
 			}
 
 			// Check the static IP supplied is valid for the linked network. It should be part of the
 			// network's subnet, but not necessarily part of the dynamic allocation ranges.
-			if !dhcpalloc.DHCPValidIP(subnet, nil, net.ParseIP(d.config["ipv4.address"])) {
+			if !dhcpalloc.DHCPValidIP(dhcpv4Subnet, nil, net.ParseIP(d.config["ipv4.address"])) {
 				return fmt.Errorf("Device IP address %q not within network %q subnet", d.config["ipv4.address"], d.config["network"])
 			}
 		}
 
 		if d.config["ipv6.address"] != "" {
-			// Check that DHCPv6 is enabled on parent network (needed to use static assigned IPs).
-			if n.DHCPv6Subnet() == nil || !shared.IsTrue(netConfig["ipv6.dhcp.stateful"]) {
-				return fmt.Errorf("Cannot specify %q when DHCP or %q are disabled on network %q", "ipv6.address", "ipv6.dhcp.stateful", d.config["network"])
-			}
+			dhcpv6Subnet := n.DHCPv6Subnet()
 
-			_, subnet, err := net.ParseCIDR(netConfig["ipv6.address"])
-			if err != nil {
-				return errors.Wrapf(err, "Invalid network ipv6.address")
+			// Check that DHCPv6 is enabled on parent network (needed to use static assigned IPs).
+			if dhcpv6Subnet == nil || !shared.IsTrue(netConfig["ipv6.dhcp.stateful"]) {
+				return fmt.Errorf(`Cannot specify "ipv6.address" when DHCP or "ipv6.dhcp.stateful" are disabled on network %q`, d.config["network"])
 			}
 
 			// Check the static IP supplied is valid for the linked network. It should be part of the
 			// network's subnet, but not necessarily part of the dynamic allocation ranges.
-			if !dhcpalloc.DHCPValidIP(subnet, nil, net.ParseIP(d.config["ipv6.address"])) {
+			if !dhcpalloc.DHCPValidIP(dhcpv6Subnet, nil, net.ParseIP(d.config["ipv6.address"])) {
 				return fmt.Errorf("Device IP address %q not within network %q subnet", d.config["ipv6.address"], d.config["network"])
 			}
 		}


### PR DESCRIPTION
Extracts fan bridge's IPv4 address to generate DHCPv4 subnet for use in validating NIC statically assigned addresses.

Fixes issue discussed here: https://discuss.linuxcontainers.org/t/static-ips-in-fan-network-for-lxd-4-x/10046

Example  (network bridge `ipv4.address` is effectively derived from the underlay subnet):

```
lxc network show lxdfan0
config:
  bridge.mode: fan
  fan.underlay_subnet: 10.250.145.0/24
  ipv4.nat: "true"
description: ""
name: lxdfan0
type: bridge
```

Before, assigning static DHCP allocation to instance fails:
```
lxc config device override c2 eth0 ipv4.address=240.33.0.45
Error: Invalid devices: Device validation failed for "eth0": Cannot specify "ipv4.address" when DHCP is disabled on network "lxdfan0"
```

After, succeeds:

```
lxc config device override c2 eth0 ipv4.address=240.33.0.45
Device eth0 overridden for c2
```

And validation of static IP allocation within parent network's subnet works:

```
lxc config device set c2 eth0 ipv4.address=241.34.0.45
Error: Invalid devices: Device validation failed for "eth0": Device IP address "241.34.0.45" not within network "lxdfan0" subnet
```