### PR TITLE
Fix incorrect client function naming

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -193,7 +193,7 @@ type InstanceServer interface {
 	DeleteInstanceLogfile(name string, filename string) (err error)
 
 	GetInstanceMetadata(name string) (metadata *api.ImageMetadata, ETag string, err error)
-	SetInstanceMetadata(name string, metadata api.ImageMetadata, ETag string) (err error)
+	UpdateInstanceMetadata(name string, metadata api.ImageMetadata, ETag string) (err error)
 
 	GetInstanceTemplateFiles(instanceName string) (templates []string, err error)
 	GetInstanceTemplateFile(instanceName string, templateName string) (content io.ReadCloser, err error)

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -198,7 +198,6 @@ type InstanceServer interface {
 	GetInstanceTemplateFiles(instanceName string) (templates []string, err error)
 	GetInstanceTemplateFile(instanceName string, templateName string) (content io.ReadCloser, err error)
 	CreateInstanceTemplateFile(instanceName string, templateName string, content io.ReadSeeker) (err error)
-	UpdateInstanceTemplateFile(instanceName string, templateName string, content io.ReadSeeker) (err error)
 	DeleteInstanceTemplateFile(name string, templateName string) (err error)
 
 	// Event handling functions

--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -1480,15 +1480,6 @@ func (r *ProtocolLXD) GetContainerTemplateFile(containerName string, templateNam
 
 // CreateContainerTemplateFile creates an a template for a container.
 func (r *ProtocolLXD) CreateContainerTemplateFile(containerName string, templateName string, content io.ReadSeeker) error {
-	return r.setContainerTemplateFile(containerName, templateName, content, "POST")
-}
-
-// UpdateContainerTemplateFile updates the content for a container template file.
-func (r *ProtocolLXD) UpdateContainerTemplateFile(containerName string, templateName string, content io.ReadSeeker) error {
-	return r.setContainerTemplateFile(containerName, templateName, content, "PUT")
-}
-
-func (r *ProtocolLXD) setContainerTemplateFile(containerName string, templateName string, content io.ReadSeeker, httpMethod string) error {
 	if !r.HasExtension("container_edit_metadata") {
 		return fmt.Errorf("The server is missing the required \"container_edit_metadata\" API extension")
 	}
@@ -1500,7 +1491,7 @@ func (r *ProtocolLXD) setContainerTemplateFile(containerName string, templateNam
 		return err
 	}
 
-	req, err := http.NewRequest(httpMethod, url, content)
+	req, err := http.NewRequest("POST", url, content)
 	if err != nil {
 		return err
 	}
@@ -1521,6 +1512,11 @@ func (r *ProtocolLXD) setContainerTemplateFile(containerName string, templateNam
 		}
 	}
 	return err
+}
+
+// UpdateContainerTemplateFile updates the content for a container template file.
+func (r *ProtocolLXD) UpdateContainerTemplateFile(containerName string, templateName string, content io.ReadSeeker) error {
+	return r.CreateContainerTemplateFile(containerName, templateName, content)
 }
 
 // DeleteContainerTemplateFile deletes a template file for a container.

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -1662,8 +1662,8 @@ func (r *ProtocolLXD) GetInstanceMetadata(name string) (*api.ImageMetadata, stri
 	return &metadata, etag, err
 }
 
-// SetInstanceMetadata sets the content of the instance metadata file.
-func (r *ProtocolLXD) SetInstanceMetadata(name string, metadata api.ImageMetadata, ETag string) error {
+// UpdateInstanceMetadata sets the content of the instance metadata file.
+func (r *ProtocolLXD) UpdateInstanceMetadata(name string, metadata api.ImageMetadata, ETag string) error {
 	path, _, err := r.instanceTypeToPath(api.InstanceTypeAny)
 	if err != nil {
 		return err

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -1751,15 +1751,6 @@ func (r *ProtocolLXD) GetInstanceTemplateFile(instanceName string, templateName 
 
 // CreateInstanceTemplateFile creates an a template for a instance.
 func (r *ProtocolLXD) CreateInstanceTemplateFile(instanceName string, templateName string, content io.ReadSeeker) error {
-	return r.setInstanceTemplateFile(instanceName, templateName, content, "POST")
-}
-
-// UpdateInstanceTemplateFile updates the content for a instance template file.
-func (r *ProtocolLXD) UpdateInstanceTemplateFile(instanceName string, templateName string, content io.ReadSeeker) error {
-	return r.setInstanceTemplateFile(instanceName, templateName, content, "PUT")
-}
-
-func (r *ProtocolLXD) setInstanceTemplateFile(instanceName string, templateName string, content io.ReadSeeker, httpMethod string) error {
 	path, _, err := r.instanceTypeToPath(api.InstanceTypeAny)
 	if err != nil {
 		return err
@@ -1776,7 +1767,7 @@ func (r *ProtocolLXD) setInstanceTemplateFile(instanceName string, templateName 
 		return err
 	}
 
-	req, err := http.NewRequest(httpMethod, url, content)
+	req, err := http.NewRequest("POST", url, content)
 	if err != nil {
 		return err
 	}

--- a/lxc/config_metadata.go
+++ b/lxc/config_metadata.go
@@ -112,7 +112,7 @@ func (c *cmdConfigMetadataEdit) Run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		return resource.server.SetInstanceMetadata(resource.name, metadata, "")
+		return resource.server.UpdateInstanceMetadata(resource.name, metadata, "")
 	}
 
 	metadata, etag, err := resource.server.GetInstanceMetadata(resource.name)
@@ -134,7 +134,7 @@ func (c *cmdConfigMetadataEdit) Run(cmd *cobra.Command, args []string) error {
 		metadata := api.ImageMetadata{}
 		err = yaml.Unmarshal(content, &metadata)
 		if err == nil {
-			err = resource.server.SetInstanceMetadata(resource.name, metadata, etag)
+			err = resource.server.UpdateInstanceMetadata(resource.name, metadata, etag)
 		}
 
 		// Respawn the editor

--- a/lxc/config_template.go
+++ b/lxc/config_template.go
@@ -176,7 +176,7 @@ func (c *cmdConfigTemplateEdit) Run(cmd *cobra.Command, args []string) error {
 
 	// Edit instance file template
 	if !termios.IsTerminal(getStdinFd()) {
-		return resource.server.UpdateInstanceTemplateFile(resource.name, args[1], os.Stdin)
+		return resource.server.CreateInstanceTemplateFile(resource.name, args[1], os.Stdin)
 	}
 
 	reader, err := resource.server.GetInstanceTemplateFile(resource.name, args[1])
@@ -196,7 +196,7 @@ func (c *cmdConfigTemplateEdit) Run(cmd *cobra.Command, args []string) error {
 
 	for {
 		reader := bytes.NewReader(content)
-		err := resource.server.UpdateInstanceTemplateFile(resource.name, args[1], reader)
+		err := resource.server.CreateInstanceTemplateFile(resource.name, args[1], reader)
 		// Respawn the editor
 		if err != nil {
 			fmt.Fprintf(os.Stderr, i18n.G("Error updating template file: %s")+"\n", err)

--- a/lxd/instance_metadata.go
+++ b/lxd/instance_metadata.go
@@ -238,7 +238,7 @@ func instanceMetadataTemplatesGet(d *Daemon, r *http.Request) response.Response 
 }
 
 // Add a container template file
-func instanceMetadataTemplatesPostPut(d *Daemon, r *http.Request) response.Response {
+func instanceMetadataTemplatesPost(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
 		return response.SmartError(err)
@@ -291,10 +291,6 @@ func instanceMetadataTemplatesPostPut(d *Daemon, r *http.Request) response.Respo
 	templatePath, err := getContainerTemplatePath(c, templateName)
 	if err != nil {
 		return response.SmartError(err)
-	}
-
-	if r.Method == "POST" && shared.PathExists(templatePath) {
-		return response.BadRequest(fmt.Errorf("Template already exists"))
 	}
 
 	// Write the new template

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -141,8 +141,7 @@ var instanceMetadataTemplatesCmd = APIEndpoint{
 	},
 
 	Get:    APIEndpointAction{Handler: instanceMetadataTemplatesGet, AccessHandler: allowProjectPermission("containers", "view")},
-	Post:   APIEndpointAction{Handler: instanceMetadataTemplatesPostPut, AccessHandler: allowProjectPermission("containers", "manage-containers")},
-	Put:    APIEndpointAction{Handler: instanceMetadataTemplatesPostPut, AccessHandler: allowProjectPermission("containers", "manage-containers")},
+	Post:   APIEndpointAction{Handler: instanceMetadataTemplatesPost, AccessHandler: allowProjectPermission("containers", "manage-containers")},
 	Delete: APIEndpointAction{Handler: instanceMetadataTemplatesDelete, AccessHandler: allowProjectPermission("containers", "manage-containers")},
 }
 

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -128,8 +128,9 @@ var instanceMetadataCmd = APIEndpoint{
 		{Name: "vmMetadata", Path: "virtual-machines/{name}/metadata"},
 	},
 
-	Get: APIEndpointAction{Handler: instanceMetadataGet, AccessHandler: allowProjectPermission("containers", "view")},
-	Put: APIEndpointAction{Handler: instanceMetadataPut, AccessHandler: allowProjectPermission("containers", "manage-containers")},
+	Get:   APIEndpointAction{Handler: instanceMetadataGet, AccessHandler: allowProjectPermission("containers", "view")},
+	Patch: APIEndpointAction{Handler: instanceMetadataPatch, AccessHandler: allowProjectPermission("containers", "manage-containers")},
+	Put:   APIEndpointAction{Handler: instanceMetadataPut, AccessHandler: allowProjectPermission("containers", "manage-containers")},
 }
 
 var instanceMetadataTemplatesCmd = APIEndpoint{


### PR DESCRIPTION
This renames a `SettInstanceMetadata` function to `UpdateInstanceMetadata`, following our normal naming scheme.

I'm not touching the much older `SetContainerMetadata` function as that one would be a pretty serious API break but it seems very unlikely that anyone other than ourselves made the switch over to the `Instance` variant and with my plan to deprecate all the `Container` functions with the release of 5.0 in 2022, this will let us get rid of this inconsistency.

If someone files a bug about it, I'm happy to re-introduce it as an alias with a deprecation warning, but I very much doubt that will be necessary.