### PR TITLE
lxd/instance/qemu: Don't use the RAM backend

### DIFF
--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -260,7 +260,7 @@ mem-path = "{{$hugepages}}"
 prealloc = "on"
 discard-data = "on"
 {{- else}}
-qom-type = "memory-backend-ram"
+qom-type = "memory-backend-memfd"
 {{- end }}
 size = "{{$memory}}M"
 host-nodes = "{{$element}}"


### PR DESCRIPTION
We were using an inconsistent mix of ram & memfd in some situations
which apparently causes memory issues.

Closes #8400

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>