### PR TITLE
containers: Attach of The Living Dead

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5518,6 +5518,7 @@ func (d *lxc) Exec(req api.InstanceExecPost, stdin *os.File, stdout *os.File, st
 
 	attachedPid := shared.ReadPid(rStatus)
 	if attachedPid <= 0 {
+		cmd.Wait()
 		d.logger.Error("Failed to retrieve PID of executing child process")
 		return nil, fmt.Errorf("Failed to retrieve PID of executing child process")
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5511,11 +5511,10 @@ func (d *lxc) Exec(req api.InstanceExecPost, stdin *os.File, stdout *os.File, st
 
 	cmd.ExtraFiles = []*os.File{stdin, stdout, stderr, wStatus}
 	err = cmd.Start()
+	wStatus.Close()
 	if err != nil {
-		wStatus.Close()
 		return nil, err
 	}
-	wStatus.Close()
 
 	attachedPid := shared.ReadPid(rStatus)
 	if attachedPid <= 0 {


### PR DESCRIPTION
When we fail to attach to a container we can end up leaving zombies behind.
This rarely happens as this is a pathological case, i.e. something went severly
wrong in the attach codepath which is likely why we have rarely seen this.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>