### PR TITLE
seccomp: block openat2()

### DIFF
--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -470,6 +470,7 @@ fsmount errno 38
 fspick errno 38
 open_tree errno 38
 move_mount errno 38
+openat2 errno 38
 `
 
 // We don't want to filter any of the following flag combinations since they do


### PR DESCRIPTION
LXC isn't a long-running daemon so in contrast to LXD it can't simply probe all
available new kernel features during startup as this would be too expensive. So
LXC doesn't follow the feature-probe logic but rather employs a model I like to
refer to as "gated feature checking". The idea being that a given kernel
feature that is reasonably cheap to check serves as a gate. Usually this gate
is a syscall. Every syscall that has been introduced earlier than the gating
syscall is assumed to be available.
A concrete example of gated feature checking is our use of the new mount api in
LXC. In order to make use of the new mount api LXC requires fsopen(),
fsconfig(), fsmount(), open_tree(), move_mount(), and openat2(). The gating
syscall here is openat2(). So if LXC detects that openat2() is available() it
will assume that the new mount api works and if a any of the above syscalls
fails LXC will fail to start the container (assuming it's located in a failure
sensitive codepath).
But the new mount api is a complex stateful beast that spreas mounting over
multiple syscalls which gets us into trouble with the seccomp notifier. So
currently LXD blocks all mount syscalls in the container's seccomp profile
whenever the seccomp syscall supervision is enabled for the container. But this
would mean we'd be invalidating the gating feature checks for nested LXD/LXC
containers. So let's block openat2() too when seccomp syscall supervision is
requested.

Cc: stable-4.0
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>