### PR TITLE
Network: Don't depend on kernel for ipvlan NIC cleanup

### DIFF
--- a/lxd/device/nic_ipvlan.go
+++ b/lxd/device/nic_ipvlan.go
@@ -146,7 +146,7 @@ func (d *nicIPVLAN) validateEnvironment() error {
 		return fmt.Errorf("Requires liblxc has following API extensions: network_ipvlan, network_l2proxy, network_gateway_device_route")
 	}
 
-	if !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", d.config["parent"])) {
+	if !network.InterfaceExists(d.config["parent"]) {
 		return fmt.Errorf("Parent device '%s' doesn't exist", d.config["parent"])
 	}
 
@@ -164,7 +164,7 @@ func (d *nicIPVLAN) validateEnvironment() error {
 
 	// If the effective parent doesn't exist and the vlan option is specified, it means we are going to create
 	// the VLAN parent at start, and we will configure the needed sysctls so don't need to check them yet.
-	if d.config["vlan"] != "" && !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", effectiveParentName)) {
+	if d.config["vlan"] != "" && !network.InterfaceExists(effectiveParentName) {
 		return nil
 	}
 

--- a/lxd/device/nic_ipvlan.go
+++ b/lxd/device/nic_ipvlan.go
@@ -172,7 +172,7 @@ func (d *nicIPVLAN) validateEnvironment() error {
 		// Check necessary sysctls are configured for use with l2proxy parent in IPVLAN l3s mode.
 		ipv4FwdPath := fmt.Sprintf("net/ipv4/conf/%s/forwarding", effectiveParentName)
 		sysctlVal, err := util.SysctlGet(ipv4FwdPath)
-		if err != nil || sysctlVal != "1\n" {
+		if err != nil {
 			return fmt.Errorf("Error reading net sysctl %s: %v", ipv4FwdPath, err)
 		}
 		if sysctlVal != "1\n" {

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -145,7 +145,7 @@ func (d *nicRouted) validateEnvironment() error {
 	if effectiveParentName != "" && d.config["ipv4.address"] != "" {
 		ipv4FwdPath := fmt.Sprintf("net/ipv4/conf/%s/forwarding", effectiveParentName)
 		sysctlVal, err := util.SysctlGet(ipv4FwdPath)
-		if err != nil || sysctlVal != "1\n" {
+		if err != nil {
 			return fmt.Errorf("Error reading net sysctl %s: %v", ipv4FwdPath, err)
 		}
 		if sysctlVal != "1\n" {

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -1064,7 +1064,7 @@ func InterfaceRemove(nic string) error {
 
 // InterfaceExists returns true if network interface exists.
 func InterfaceExists(nic string) bool {
-	if shared.PathExists(fmt.Sprintf("/sys/class/net/%s", nic)) {
+	if nic != "" && shared.PathExists(fmt.Sprintf("/sys/class/net/%s", nic)) {
 		return true
 	}
 


### PR DESCRIPTION
Detach ipvlan interface back to random host name on stop, then delete.

Fixes #8427