### PR TITLE
Network: Use volatile VF MAC if VF has no automatic MAC set

### DIFF
--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -108,8 +108,8 @@ func (d *nicSRIOV) validateEnvironment() error {
 		return fmt.Errorf("Requires name property to start")
 	}
 
-	if !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", d.config["parent"])) {
-		return fmt.Errorf("Parent device '%s' doesn't exist", d.config["parent"])
+	if !network.InterfaceExists(d.config["parent"]) {
+		return fmt.Errorf("Parent device %q doesn't exist", d.config["parent"])
 	}
 
 	return nil

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -143,12 +144,16 @@ func (d *nicSRIOV) Start() (*deviceConfig.RunConfig, error) {
 	}
 
 	if d.inst.Type() == instancetype.Container {
+		macSet := false
+
 		// Set the MAC address.
 		if d.config["hwaddr"] != "" {
 			_, err := shared.RunCommand("ip", "link", "set", "dev", saveData["host_name"], "address", d.config["hwaddr"])
 			if err != nil {
-				return nil, fmt.Errorf("Failed to set the MAC address: %s", err)
+				return nil, errors.Wrapf(err, "Failed setting MAC address %q on %q", d.config["hwaddr"], saveData["host_name"])
 			}
+
+			macSet = true
 		}
 
 		// Set the MTU.
@@ -162,7 +167,40 @@ func (d *nicSRIOV) Start() (*deviceConfig.RunConfig, error) {
 		// Bring the interface up.
 		_, err = shared.RunCommand("ip", "link", "set", "dev", saveData["host_name"], "up")
 		if err != nil {
-			return nil, fmt.Errorf("Failed to bring up the interface: %v", err)
+			if macSet {
+				return nil, errors.Wrapf(err, "Failed to bring up VF interface %q", saveData["host_name"])
+			}
+
+			upErr := err
+
+			// If interface fails to come up and MAC not previously set, some NICs require us to set
+			// a specific MAC before being allowed to bring up the VF interface. So check if interface
+			// has an empty MAC and set a random one if needed.
+			vfIF, err := net.InterfaceByName(saveData["host_name"])
+			if err != nil {
+				return nil, errors.Wrapf(err, "Failed getting interface info for VF %q", saveData["host_name"])
+			}
+
+			// If the VF interface has a MAC already, something else prevented bringing interface up.
+			if vfIF.HardwareAddr.String() != "00:00:00:00:00:00" {
+				return nil, errors.Wrapf(upErr, "Failed to bring up VF interface %q", saveData["host_name"])
+			}
+
+			// Try using a random MAC address and bringing interface up.
+			randMAC, err := instance.DeviceNextInterfaceHWAddr()
+			if err != nil {
+				return nil, errors.Wrapf(err, "Failed generating random MAC for VF %q", saveData["host_name"])
+			}
+
+			_, err = shared.RunCommand("ip", "link", "set", "dev", saveData["host_name"], "address", randMAC)
+			if err != nil {
+				return nil, errors.Wrapf(err, "Failed to set random MAC address %q on %q", randMAC, saveData["host_name"])
+			}
+
+			_, err = shared.RunCommand("ip", "link", "set", "dev", saveData["host_name"], "up")
+			if err != nil {
+				return nil, errors.Wrapf(err, "Failed to bring up VF interface %q", saveData["host_name"])
+			}
 		}
 	}
 

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -1160,7 +1160,7 @@ func SubnetParseAppend(subnets []*net.IPNet, parseSubnet ...string) ([]*net.IPNe
 // InterfaceBindWait waits for network interface to appear after being bound to a driver.
 func InterfaceBindWait(ifName string) error {
 	for i := 0; i < 10; i++ {
-		if shared.PathExists(fmt.Sprintf("/sys/class/net/%s", ifName)) {
+		if InterfaceExists(ifName) {
 			return nil
 		}
 


### PR DESCRIPTION
Some SR-IOV NICs require setting an explicit VF MAC on the interface before being brought up it seems.

Fixes #8162