### PR TITLE
Implement VM stateful stop/start

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1296,3 +1296,6 @@ Add new `/1.0/storage-pools/POOL/volumes/VOLUME/state` API endpoint to get usage
 
 ## network\_acl
 This adds the concept of network ACLs to API under the API endpoint prefix `/1.0/network-acls`.
+
+## migration\_stateful
+Add a new `migration.stateful` config key.

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1299,3 +1299,6 @@ This adds the concept of network ACLs to API under the API endpoint prefix `/1.0
 
 ## migration\_stateful
 Add a new `migration.stateful` config key.
+
+## disk\_state\_quota
+This introduces the `size.state` device config key on `disk` devices.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -685,6 +685,7 @@ source              | string    | -         | yes       | Path on the host, eith
 required            | boolean   | true      | no        | Controls whether to fail if the source doesn't exist
 readonly            | boolean   | false     | no        | Controls whether to make the mount read-only
 size                | string    | -         | no        | Disk size in bytes (various suffixes supported, see below). This is only supported for the rootfs (/)
+size.state          | string    | -         | no        | Same as size above but applies to the filesystem volume used for saving runtime state in virtual machines.
 recursive           | boolean   | false     | no        | Whether or not to recursively mount the source path
 pool                | string    | -         | no        | The storage pool the disk device belongs to. This is only applicable for storage volumes managed by LXD
 propagation         | string    | -         | no        | Controls how a bind-mount is shared between the instance and the host. (Can be one of `private`, the default, or `shared`, `slave`, `unbindable`,  `rshared`, `rslave`, `runbindable`,  `rprivate`. Please see the Linux Kernel [shared subtree](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt) documentation for a full explanation)

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -62,6 +62,7 @@ linux.kernel\_modules                       | string    | -                 | ye
 migration.incremental.memory                | boolean   | false             | yes           | container                 | Incremental memory transfer of the instance's memory to reduce downtime
 migration.incremental.memory.goal           | integer   | 70                | yes           | container                 | Percentage of memory to have in sync before stopping the instance
 migration.incremental.memory.iterations     | integer   | 10                | yes           | container                 | Maximum number of transfer operations to go through before stopping the instance
+migration.stateful                          | boolean   | false             | no            | virtual-machine           | Allow for stateful stop/start and snapshots. This will prevent the use of some features that are incompatible with it
 nvidia.driver.capabilities                  | string    | compute,utility   | no            | container                 | What driver capabilities the instance needs (sets libnvidia-container NVIDIA\_DRIVER\_CAPABILITIES)
 nvidia.runtime                              | boolean   | false             | no            | container                 | Pass the host NVIDIA and CUDA runtime libraries into the instance
 nvidia.require.cuda                         | string    | -                 | no            | container                 | Version expression for the required CUDA version (sets libnvidia-container NVIDIA\_REQUIRE\_CUDA)

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -472,7 +472,7 @@ func internalImportFromRecovery(d *Daemon, r *http.Request) response.Response {
 	// opportunity to reinitialise the quota based on the new storage volume's DB ID).
 	_, rootConfig, err := shared.GetRootDiskDevice(inst.ExpandedDevices().CloneNative())
 	if err == nil {
-		err = pool.SetInstanceQuota(inst, rootConfig["size"], nil)
+		err = pool.SetInstanceQuota(inst, rootConfig["size"], rootConfig["size.state"], nil)
 		if err != nil {
 			return response.SmartError(errors.Wrapf(err, "Failed reinitializing root disk quota %q", rootConfig["size"]))
 		}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -634,7 +634,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					}
 				}
 
-				if cmd != "" {
+				if !shared.IsTrue(d.inst.ExpandedConfig()["migration.stateful"]) && cmd != "" {
 					// Start the virtiofsd process in non-daemon mode.
 					proc, err := subprocess.NewProcess(cmd, []string{fmt.Sprintf("--socket-path=%s", sockPath), "-o", fmt.Sprintf("source=%s", srcPath)}, logPath, logPath)
 					if err != nil {

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -105,6 +105,7 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 		"limits.write":      validate.IsAny,
 		"limits.max":        validate.IsAny,
 		"size":              validate.Optional(validate.IsSize),
+		"size.state":        validate.Optional(validate.IsSize),
 		"pool":              validate.IsAny,
 		"propagation":       validatePropagation,
 		"raw.mount.options": validate.IsAny,
@@ -137,6 +138,10 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 
 	if d.config["size"] != "" && d.config["path"] != "/" {
 		return fmt.Errorf("Only the root disk may have a size quota")
+	}
+
+	if d.config["size.state"] != "" && d.config["path"] != "/" {
+		return fmt.Errorf("Only the root disk may have a migration size quota")
 	}
 
 	if d.config["recursive"] != "" && (d.config["path"] == "/" || !shared.IsDir(shared.HostPath(d.config["source"]))) {
@@ -270,7 +275,7 @@ func (d *disk) validateEnvironment() error {
 
 // UpdatableFields returns a list of fields that can be updated without triggering a device remove & add.
 func (d *disk) UpdatableFields() []string {
-	return []string{"limits.max", "limits.read", "limits.write", "size"}
+	return []string{"limits.max", "limits.read", "limits.write", "size", "size.state"}
 }
 
 // Register calls mount for the disk volume (which should already be mounted) to reinitialise the reference counter
@@ -727,9 +732,11 @@ func (d *disk) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 		// Deal with quota changes.
 		oldRootDiskDeviceSize := oldDevices[oldRootDiskDeviceKey]["size"]
 		newRootDiskDeviceSize := expandedDevices[newRootDiskDeviceKey]["size"]
+		oldRootDiskDeviceMigrationSize := oldDevices[oldRootDiskDeviceKey]["size.state"]
+		newRootDiskDeviceMigrationSize := expandedDevices[newRootDiskDeviceKey]["size.state"]
 
 		// Apply disk quota changes.
-		if newRootDiskDeviceSize != oldRootDiskDeviceSize {
+		if newRootDiskDeviceSize != oldRootDiskDeviceSize || oldRootDiskDeviceMigrationSize != newRootDiskDeviceMigrationSize {
 			// Remove any outstanding volatile apply_quota key if applying a new quota.
 			v := d.volatileGet()
 			if v["apply_quota"] != "" {
@@ -739,15 +746,15 @@ func (d *disk) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 				}
 			}
 
-			err := d.applyQuota(newRootDiskDeviceSize, false)
+			err := d.applyQuota(false)
 			if err == storageDrivers.ErrInUse {
 				// Save volatile apply_quota key for next boot if cannot apply now.
-				err = d.volatileSet(map[string]string{"apply_quota": newRootDiskDeviceSize})
+				err = d.volatileSet(map[string]string{"apply_quota": "true"})
 				if err != nil {
 					return err
 				}
 
-				d.logger.Warn("Could not apply quota because disk is in use, deferring until next start", log.Ctx{"quota": newRootDiskDeviceSize})
+				d.logger.Warn("Could not apply quota because disk is in use, deferring until next start")
 			} else if err != nil {
 				return err
 			}
@@ -776,11 +783,11 @@ func (d *disk) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 func (d *disk) applyDeferredQuota() error {
 	v := d.volatileGet()
 	if v["apply_quota"] != "" {
-		d.logger.Info("Applying deferred quota change", log.Ctx{"quota": v["apply_quota"]})
+		d.logger.Info("Applying deferred quota change")
 
 		// Indicate that we want applyQuota to unmount the volume first, this is so we can perform resizes
 		// that cannot be done when the volume is in use.
-		err := d.applyQuota(v["apply_quota"], true)
+		err := d.applyQuota(true)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to apply deferred quota from %q", fmt.Sprintf("volatile.%s.apply_quota", d.name))
 		}
@@ -797,7 +804,15 @@ func (d *disk) applyDeferredQuota() error {
 
 // applyQuota attempts to resize the instance root disk to the specified size.
 // If unmount is true, attempts to unmount first before resizing.
-func (d *disk) applyQuota(newSize string, unmount bool) error {
+func (d *disk) applyQuota(unmount bool) error {
+	rootDisk, _, err := shared.GetRootDiskDevice(d.inst.ExpandedDevices().CloneNative())
+	if err != nil {
+		return errors.Wrap(err, "Detect root disk device")
+	}
+
+	newSize := d.inst.ExpandedDevices()[rootDisk]["size"]
+	newMigrationSize := d.inst.ExpandedDevices()[rootDisk]["size.state"]
+
 	pool, err := storagePools.GetPoolByInstance(d.state, d.inst)
 	if err != nil {
 		return err
@@ -814,7 +829,7 @@ func (d *disk) applyQuota(newSize string, unmount bool) error {
 		}
 	}
 
-	err = pool.SetInstanceQuota(d.inst, newSize, nil)
+	err = pool.SetInstanceQuota(d.inst, newSize, newMigrationSize, nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/device/gpu_mdev.go
+++ b/lxd/device/gpu_mdev.go
@@ -174,6 +174,10 @@ func (d *gpuMdev) validateConfig(instConf instance.ConfigReader) error {
 
 // validateEnvironment checks the runtime environment for correctness.
 func (d *gpuMdev) validateEnvironment() error {
+	if d.inst.Type() == instancetype.VM && shared.IsTrue(d.inst.ExpandedConfig()["migration.stateful"]) {
+		return fmt.Errorf("GPU devices cannot be used when migration.stateful is enabled")
+	}
+
 	return validatePCIDevice(d.config["pci"])
 }
 

--- a/lxd/device/gpu_physical.go
+++ b/lxd/device/gpu_physical.go
@@ -78,6 +78,10 @@ func (d *gpuPhysical) validateConfig(instConf instance.ConfigReader) error {
 
 // validateEnvironment checks the runtime environment for correctness.
 func (d *gpuPhysical) validateEnvironment() error {
+	if d.inst.Type() == instancetype.VM && shared.IsTrue(d.inst.ExpandedConfig()["migration.stateful"]) {
+		return fmt.Errorf("GPU devices cannot be used when migration.stateful is enabled")
+	}
+
 	return validatePCIDevice(d.config["pci"])
 }
 

--- a/lxd/device/gpu_sriov.go
+++ b/lxd/device/gpu_sriov.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/resources"
 	"github.com/lxc/lxd/lxd/revert"
+	"github.com/lxc/lxd/shared"
 )
 
 type gpuSRIOV struct {
@@ -64,6 +65,10 @@ func (d *gpuSRIOV) validateConfig(instConf instance.ConfigReader) error {
 
 // validateEnvironment checks the runtime environment for correctness.
 func (d *gpuSRIOV) validateEnvironment() error {
+	if d.inst.Type() == instancetype.VM && shared.IsTrue(d.inst.ExpandedConfig()["migration.stateful"]) {
+		return fmt.Errorf("GPU devices cannot be used when migration.stateful is enabled")
+	}
+
 	return validatePCIDevice(d.config["pci"])
 }
 

--- a/lxd/device/nic_physical.go
+++ b/lxd/device/nic_physical.go
@@ -48,6 +48,10 @@ func (d *nicPhysical) validateConfig(instConf instance.ConfigReader) error {
 
 // validateEnvironment checks the runtime environment for correctness.
 func (d *nicPhysical) validateEnvironment() error {
+	if d.inst.Type() == instancetype.VM && shared.IsTrue(d.inst.ExpandedConfig()["migration.stateful"]) {
+		return fmt.Errorf("Network physical devices cannot be used when migration.stateful is enabled")
+	}
+
 	if d.inst.Type() == instancetype.Container && d.config["name"] == "" {
 		return fmt.Errorf("Requires name property to start")
 	}

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -105,6 +105,10 @@ func (d *nicSRIOV) validateConfig(instConf instance.ConfigReader) error {
 
 // validateEnvironment checks the runtime environment for correctness.
 func (d *nicSRIOV) validateEnvironment() error {
+	if d.inst.Type() == instancetype.VM && shared.IsTrue(d.inst.ExpandedConfig()["migration.stateful"]) {
+		return fmt.Errorf("Network SR-IOV devices cannot be used when migration.stateful is enabled")
+	}
+
 	if d.inst.Type() == instancetype.Container && d.config["name"] == "" {
 		return fmt.Errorf("Requires name property to start")
 	}

--- a/lxd/device/pci.go
+++ b/lxd/device/pci.go
@@ -1,6 +1,7 @@
 package device
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -9,6 +10,7 @@ import (
 	pcidev "github.com/lxc/lxd/lxd/device/pci"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/validate"
 )
 
@@ -38,6 +40,10 @@ func (d *pci) validateConfig(instConf instance.ConfigReader) error {
 
 // validateEnvironment checks if the PCI device is available.
 func (d *pci) validateEnvironment() error {
+	if d.inst.Type() == instancetype.VM && shared.IsTrue(d.inst.ExpandedConfig()["migration.stateful"]) {
+		return fmt.Errorf("PCI devices cannot be used when migration.stateful is enabled")
+	}
+
 	return validatePCIDevice(d.config["address"])
 }
 

--- a/lxd/device/usb.go
+++ b/lxd/device/usb.go
@@ -158,6 +158,10 @@ func (d *usb) startContainer() (*deviceConfig.RunConfig, error) {
 }
 
 func (d *usb) startVM() (*deviceConfig.RunConfig, error) {
+	if d.inst.Type() == instancetype.VM && shared.IsTrue(d.inst.ExpandedConfig()["migration.stateful"]) {
+		return nil, fmt.Errorf("USB devices cannot be used when migration.stateful is enabled")
+	}
+
 	usbs, err := d.loadUsb()
 	if err != nil {
 		return nil, err

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -707,6 +707,11 @@ func (d *qemu) Start(stateful bool) error {
 		return fmt.Errorf("The instance is already running")
 	}
 
+	// Check for stateful.
+	if stateful && !shared.IsTrue(d.expandedConfig["migration.stateful"]) {
+		return fmt.Errorf("Stateful start requires migration.stateful to be set to true")
+	}
+
 	// Setup a new operation
 	exists, op, err := operationlock.CreateWaitGet(d.id, "start", []string{"restart", "restore"}, false, false)
 	if err != nil {
@@ -2677,6 +2682,11 @@ func (d *qemu) Stop(stateful bool) error {
 	// Must be run prior to creating the operation lock.
 	if !d.IsRunning() {
 		return fmt.Errorf("The instance is already stopped")
+	}
+
+	// Check for stateful.
+	if stateful && !shared.IsTrue(d.expandedConfig["migration.stateful"]) {
+		return fmt.Errorf("Stateful stop requires migration.stateful to be set to true")
 	}
 
 	// Setup a new operation.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -796,7 +796,7 @@ func (d *qemu) Start(stateful bool) error {
 		}
 	}
 
-	if cmd != "" {
+	if !shared.IsTrue(d.expandedConfig["migration.stateful"]) && cmd != "" {
 		// Start the virtiofsd process in non-daemon mode.
 		proc, err := subprocess.NewProcess(cmd, []string{fmt.Sprintf("--socket-path=%s", sockPath), "-o", fmt.Sprintf("source=%s", filepath.Join(d.Path(), "config"))}, "", "")
 		if err != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -926,7 +927,36 @@ func (d *qemu) Start(stateful bool) error {
 		"-readconfig", confFile,
 		"-pidfile", d.pidFilePath(),
 		"-D", d.LogFilePath(),
-		"-chroot", d.Path(),
+	}
+
+	// If stateful, restore now.
+	if stateful {
+		if !d.stateful {
+			err = fmt.Errorf("Instance has no existing state to restore")
+			op.Done(err)
+			return err
+		}
+
+		qemuCmd = append(qemuCmd, "-incoming", "defer")
+	} else {
+		// The chroot option can't be used when restoring a migration stream.
+		qemuCmd = append(qemuCmd, "-chroot", d.Path())
+
+		if d.stateful {
+			// Stateless start requested but state is present, delete it.
+			err := os.Remove(d.StatePath())
+			if err != nil && !os.IsNotExist(err) {
+				op.Done(err)
+				return err
+			}
+
+			d.stateful = false
+			err = d.state.Cluster.UpdateInstanceStatefulFlag(d.id, false)
+			if err != nil {
+				op.Done(err)
+				return errors.Wrap(err, "Error updating instance stateful flag")
+			}
+		}
 	}
 
 	// SMBIOS only on x86_64 and aarch64.
@@ -934,8 +964,8 @@ func (d *qemu) Start(stateful bool) error {
 		qemuCmd = append(qemuCmd, "-smbios", "type=2,manufacturer=Canonical Ltd.,product=LXD")
 	}
 
-	// Attempt to drop privileges.
-	if d.state.OS.UnprivUser != "" {
+	// Attempt to drop privileges (doesn't work when restoring state).
+	if !stateful && d.state.OS.UnprivUser != "" {
 		qemuCmd = append(qemuCmd, "-runas", d.state.OS.UnprivUser)
 
 		// Change ownership of config directory files so they are accessible to the
@@ -1132,11 +1162,68 @@ func (d *qemu) Start(stateful bool) error {
 	// Reset timeout to 30s.
 	op.Reset()
 
+	// Restore the state.
+	if stateful {
+		stateFile, err := os.Open(d.StatePath())
+		if err != nil {
+			op.Done(err)
+			return err
+		}
+
+		uncompressedState, err := gzip.NewReader(stateFile)
+		if err != nil {
+			stateFile.Close()
+			op.Done(err)
+			return err
+		}
+
+		pipeRead, pipeWrite, err := os.Pipe()
+		if err != nil {
+			uncompressedState.Close()
+			stateFile.Close()
+			op.Done(err)
+			return err
+		}
+
+		go func() {
+			io.Copy(pipeWrite, uncompressedState)
+			uncompressedState.Close()
+			stateFile.Close()
+			pipeWrite.Close()
+			pipeRead.Close()
+		}()
+
+		err = monitor.SendFile("migration", pipeRead)
+		if err != nil {
+			op.Done(err)
+			return err
+		}
+
+		err = monitor.MigrateIncoming("fd:migration")
+		if err != nil {
+			op.Done(err)
+			return err
+		}
+	}
+
 	// Start the VM.
 	err = monitor.Start()
 	if err != nil {
 		op.Done(err)
 		return err
+	}
+
+	// Finish handling stateful start.
+	if stateful {
+		// Cleanup state.
+		os.Remove(d.StatePath())
+		d.stateful = false
+
+		err = d.state.Cluster.UpdateInstanceStatefulFlag(d.id, false)
+		if err != nil {
+			op.Done(err)
+			return errors.Wrap(err, "Error updating instance stateful flag")
+		}
 	}
 
 	// Database updates
@@ -2699,13 +2786,6 @@ func (d *qemu) Stop(stateful bool) error {
 		return nil
 	}
 
-	// Check that no stateful stop was requested.
-	if stateful {
-		err = fmt.Errorf("Stateful stop isn't supported for VMs at this time")
-		op.Done(err)
-		return err
-	}
-
 	// Connect to the monitor.
 	monitor, err := qmp.Connect(d.monitorPath(), qemuSerialChardevName, d.getMonitorEventHandler())
 	if err != nil {
@@ -2730,6 +2810,70 @@ func (d *qemu) Stop(stateful bool) error {
 
 		op.Done(err)
 		return err
+	}
+
+	// Handle stateful stop.
+	if stateful {
+		os.Remove(d.StatePath())
+
+		// Prepare the state file.
+		stateFile, err := os.Create(d.StatePath())
+		if err != nil {
+			op.Done(err)
+			return err
+		}
+
+		compressedState, err := gzip.NewWriterLevel(stateFile, gzip.BestSpeed)
+		if err != nil {
+			stateFile.Close()
+			op.Done(err)
+			return err
+		}
+
+		pipeRead, pipeWrite, err := os.Pipe()
+		if err != nil {
+			compressedState.Close()
+			stateFile.Close()
+			op.Done(err)
+			return err
+		}
+		defer pipeRead.Close()
+		defer pipeWrite.Close()
+
+		go io.Copy(compressedState, pipeRead)
+
+		// Send the target file to qemu.
+		err = monitor.SendFile("migration", pipeWrite)
+		if err != nil {
+			compressedState.Close()
+			stateFile.Close()
+			op.Done(err)
+			return err
+		}
+
+		// Issue the migration command.
+		err = monitor.Migrate("fd:migration")
+		if err != nil {
+			compressedState.Close()
+			stateFile.Close()
+			op.Done(err)
+			return err
+		}
+
+		// Close the file to avoid unmount delays.
+		compressedState.Close()
+		stateFile.Close()
+
+		// Reset the timer.
+		op.Reset()
+
+		// Mark the instance as having state.
+		d.stateful = true
+		err = d.state.Cluster.UpdateInstanceStatefulFlag(d.id, true)
+		if err != nil {
+			op.Done(err)
+			return err
+		}
 	}
 
 	// Send the quit command.

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/instance"
+	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/response"
@@ -151,6 +152,10 @@ func instanceSnapshotsPost(d *Daemon, r *http.Request) response.Response {
 		if err != nil {
 			return response.BadRequest(err)
 		}
+	}
+
+	if inst.Type() == instancetype.VM && req.Stateful {
+		return response.BadRequest(fmt.Errorf("Can't perform a stateful snapshot of a virtual machine"))
 	}
 
 	snapshot := func(op *operations.Operation) error {

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -148,7 +148,7 @@ func (b *mockBackend) GetInstanceUsage(inst instance.Instance) (int64, error) {
 	return 0, nil
 }
 
-func (b *mockBackend) SetInstanceQuota(inst instance.Instance, size string, op *operations.Operation) error {
+func (b *mockBackend) SetInstanceQuota(inst instance.Instance, size string, vmStateSize string, op *operations.Operation) error {
 	return nil
 }
 

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -20,8 +20,8 @@ const tmpVolSuffix = ".lxdtmp"
 // defaultBlockSize Default size of block volumes.
 const defaultBlockSize = "10GB"
 
-// vmBlockFilesystemSize is the size of a VM block volume's associated filesystem volume.
-const vmBlockFilesystemSize = "100MB"
+// DefaultVMBlockFilesystemSize is the size of a VM block volume's associated filesystem volume.
+const DefaultVMBlockFilesystemSize = "100MB"
 
 // DefaultFilesystem filesytem to use for block devices by default.
 const DefaultFilesystem = "ext4"
@@ -305,7 +305,7 @@ func (v Volume) IsVMBlock() bool {
 }
 
 // NewVMBlockFilesystemVolume returns a copy of the volume with the content type set to ContentTypeFS and the
-// config "size" property set to vmBlockFilesystemSize.
+// config "size" property set to "size.state" or DefaultVMBlockFilesystemSize if not set.
 func (v Volume) NewVMBlockFilesystemVolume() Volume {
 	// Copy volume config so modifications don't affect original volume.
 	newConf := make(map[string]string, len(v.config))
@@ -313,8 +313,12 @@ func (v Volume) NewVMBlockFilesystemVolume() Volume {
 		newConf[k] = v
 	}
 
-	// VM Block filesystems are a fixed size.
-	newConf["size"] = vmBlockFilesystemSize
+	if v.config["size.state"] != "" {
+		newConf["size"] = v.config["size.state"]
+	} else {
+		// Fallback to the default VM filesystem size.
+		newConf["size"] = DefaultVMBlockFilesystemSize
+	}
 
 	return NewVolume(v.driver, v.pool, v.volType, ContentTypeFS, v.name, newConf, v.poolConfig)
 }
@@ -327,6 +331,11 @@ func (v Volume) SetQuota(size string, op *operations.Operation) error {
 // SetConfigSize sets the size config property on the Volume (does not resize volume).
 func (v Volume) SetConfigSize(size string) {
 	v.config["size"] = size
+}
+
+// SetConfigStateSize sets the size.state config property on the Volume (does not resize volume).
+func (v Volume) SetConfigStateSize(size string) {
+	v.config["size.state"] = size
 }
 
 // ConfigBlockFilesystem returns the filesystem to use for block volumes. Returns config value "block.filesystem"

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -58,7 +58,7 @@ type Pool interface {
 	BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error
 
 	GetInstanceUsage(inst instance.Instance) (int64, error)
-	SetInstanceQuota(inst instance.Instance, size string, op *operations.Operation) error
+	SetInstanceQuota(inst instance.Instance, size string, vmStateSize string, op *operations.Operation) error
 
 	MountInstance(inst instance.Instance, op *operations.Operation) (*MountInfo, error)
 	UnmountInstance(inst instance.Instance, op *operations.Operation) (bool, error)

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -188,6 +188,7 @@ var KnownInstanceConfigKeys = map[string]func(value string) error{
 	"migration.incremental.memory":            validate.Optional(validate.IsBool),
 	"migration.incremental.memory.iterations": validate.Optional(validate.IsUint32),
 	"migration.incremental.memory.goal":       validate.Optional(validate.IsUint32),
+	"migration.stateful":                      validate.Optional(validate.IsBool),
 
 	"nvidia.runtime":             validate.Optional(validate.IsBool),
 	"nvidia.driver.capabilities": validate.IsAny,

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -252,6 +252,7 @@ var APIExtensions = []string{
 	"pci_device_type",
 	"storage_volume_state",
 	"network_acl",
+	"migration_stateful",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -253,6 +253,7 @@ var APIExtensions = []string{
 	"storage_volume_state",
 	"network_acl",
 	"migration_stateful",
+	"disk_state_quota",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
With this, a VM can be configured using:
 - lxc config set v1 migration.stateful true
 - lxc config device set v1 root size.state 2GiB

Then after start, it can be stopped and restarted while conserving state using:
 - lxc stop v1 --stateful
 - lxc start v1

Stateful snapshots will be next but this will need a bunch of cleanups I want to do separately.
For now this branch just prevents them entirely.