### PR TITLE
Network: Adds support for live updating NIC fields when using network property

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -350,7 +350,7 @@ This adds support for btrfs as a storage volume filesystem, in addition to ext4
 and xfs.
 
 ## resources
-This adds support for querying an LXD daemon for the system resources it has
+This adds support for querying a LXD daemon for the system resources it has
 available.
 
 ## kernel\_limits

--- a/doc/preseed.md
+++ b/doc/preseed.md
@@ -61,7 +61,7 @@ in the [RESTful API](rest-api.md).
 
 Note however, that the rollback itself might potentially fail as well,
 although rarely (typically due to backend bugs or limitations). Thus
-care must be taken when trying to reconfigure an LXD daemon via
+care must be taken when trying to reconfigure a LXD daemon via
 preseed.
 
 ## Default profile

--- a/lxd/api_cluster_test.go
+++ b/lxd/api_cluster_test.go
@@ -346,7 +346,7 @@ func TestCluster_JoinDifferentServerAddress(t *testing.T) {
 	assert.Equal(t, "Online", nodes[1].Status)
 }
 
-// If an LXD node is already for networking and the user asks to configure a
+// If a LXD node is already for networking and the user asks to configure a
 // the same address as cluster address, the request still succeeds.
 func TestCluster_JoinSameServerAddress(t *testing.T) {
 	t.Skip("issue #6122")

--- a/lxd/device/device_common.go
+++ b/lxd/device/device_common.go
@@ -73,7 +73,7 @@ func (d *deviceCommon) CanHotPlug() bool {
 }
 
 // UpdatableFields returns an empty list of updatable fields as most devices do not support updates.
-func (d *deviceCommon) UpdatableFields() []string {
+func (d *deviceCommon) UpdatableFields(oldDevice Type) []string {
 	return []string{}
 }
 

--- a/lxd/device/device_interface.go
+++ b/lxd/device/device_interface.go
@@ -16,14 +16,19 @@ type VolatileSetter func(map[string]string) error
 // and should remove the prefix before being returned.
 type VolatileGetter func() map[string]string
 
-// Device represents a device that can be added to an instance.
-type Device interface {
+// Type represents a LXD device type.
+type Type interface {
 	// CanHotPlug returns true if device can be managed whilst instance is running.
 	CanHotPlug() bool
 
 	// UpdatableFields returns a slice of config fields that can be updated. If only fields in this list have
 	// changed then Update() is called rather triggering a device remove & add.
-	UpdatableFields() []string
+	UpdatableFields(oldDevice Type) []string
+}
+
+// Device represents a device that can be added to an instance.
+type Device interface {
+	Type
 
 	// Add performs any host-side setup when a device is added to an instance.
 	// It is called irrespective of whether the instance is running or not.

--- a/lxd/device/device_load.go
+++ b/lxd/device/device_load.go
@@ -3,18 +3,18 @@ package device
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/device/nictype"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/state"
 )
 
-// load instantiates a device and initialises its internal state. It does not validate the config supplied.
-func load(inst instance.Instance, state *state.State, projectName string, name string, conf deviceConfig.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) (device, error) {
-	// Warning: When validating a profile, inst is expected to be provided as nil.
-
+// newByType returns a new unitialised device based of the type indicated by the project and device config.
+func newByType(state *state.State, projectName string, conf deviceConfig.Device) (device, error) {
 	if conf["type"] == "" {
-		return nil, fmt.Errorf("Missing device type for device %q", name)
+		return nil, fmt.Errorf("Missing device type in config")
 	}
 
 	// NIC type is required to lookup network devices.
@@ -84,6 +84,17 @@ func load(inst instance.Instance, state *state.State, projectName string, name s
 		return nil, ErrUnsupportedDevType
 	}
 
+	return dev, nil
+}
+
+// load instantiates a device and initialises its internal state. It does not validate the config supplied.
+func load(inst instance.Instance, state *state.State, projectName string, name string, conf deviceConfig.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) (device, error) {
+	// Warning: When validating a profile, inst is expected to be provided as nil.
+	dev, err := newByType(state, projectName, conf)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed loading device %q", name)
+	}
+
 	// Setup the device's internal variables.
 	dev.init(inst, state, name, conf, volatileGet, volatileSet)
 
@@ -94,6 +105,7 @@ func load(inst instance.Instance, state *state.State, projectName string, name s
 // If the device type is valid, but the other config validation fails then an instantiated device
 // is still returned with the validation error. If an unknown device is requested or the device is
 // not compatible with the instance type then an ErrUnsupportedDevType error is returned.
+// Note: The supplied config may be modified during validation to enrich. If this is not desired, supply a copy.
 func New(inst instance.Instance, state *state.State, name string, conf deviceConfig.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) (Device, error) {
 	dev, err := load(inst, state, inst.Project(), name, conf, volatileGet, volatileSet)
 	if err != nil {
@@ -110,6 +122,7 @@ func New(inst instance.Instance, state *state.State, name string, conf deviceCon
 
 // Validate checks a device's config is valid. This only requires an instance.ConfigReader rather than an full
 // blown instance to allow profile devices to be validated too.
+// Note: The supplied config may be modified during validation to enrich. If this is not desired, supply a copy.
 func Validate(instConfig instance.ConfigReader, state *state.State, name string, conf deviceConfig.Device) error {
 	dev, err := load(nil, state, instConfig.Project(), name, conf, nil, nil)
 	if err != nil {
@@ -117,4 +130,15 @@ func Validate(instConfig instance.ConfigReader, state *state.State, name string,
 	}
 
 	return dev.validateConfig(instConfig)
+}
+
+// LoadByType loads a device by type based on its project and config.
+// It does not validate config beyond the type fields.
+func LoadByType(state *state.State, projectName string, conf deviceConfig.Device) (Type, error) {
+	dev, err := newByType(state, projectName, conf)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed loading device type")
+	}
+
+	return dev, nil
 }

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -274,7 +274,13 @@ func (d *disk) validateEnvironment() error {
 }
 
 // UpdatableFields returns a list of fields that can be updated without triggering a device remove & add.
-func (d *disk) UpdatableFields() []string {
+func (d *disk) UpdatableFields(oldDevice Type) []string {
+	// Check old and new device types match.
+	_, match := oldDevice.(*disk)
+	if !match {
+		return []string{}
+	}
+
 	return []string{"limits.max", "limits.read", "limits.write", "size", "size.state"}
 }
 

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -212,7 +212,13 @@ func (d *nicBridged) validateEnvironment() error {
 }
 
 // UpdatableFields returns a list of fields that can be updated without triggering a device remove & add.
-func (d *nicBridged) UpdatableFields() []string {
+func (d *nicBridged) UpdatableFields(oldDevice Type) []string {
+	// Check old and new device types match.
+	_, match := oldDevice.(*nicBridged)
+	if !match {
+		return []string{}
+	}
+
 	return []string{"limits.ingress", "limits.egress", "limits.max", "ipv4.routes", "ipv6.routes", "ipv4.address", "ipv6.address", "security.mac_filtering", "security.ipv4_filtering", "security.ipv6_filtering"}
 }
 

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -271,8 +271,8 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 	// Populate device config with volatile fields if needed.
 	networkVethFillFromVolatile(d.config, saveData)
 
-	// Apply host-side routes.
-	err = networkSetupHostVethRoutes(d.state, d.config, nil, saveData)
+	// Apply host-side routes to bridge interface.
+	err = networkNICRouteAdd(d.config["parent"], append(util.SplitNTrimSpace(d.config["ipv4.routes"], ",", -1, true), util.SplitNTrimSpace(d.config["ipv6.routes"], ",", -1, true)...)...)
 	if err != nil {
 		return nil, err
 	}
@@ -357,6 +357,11 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 // Update applies configuration changes to a started device.
 func (d *nicBridged) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 	oldConfig := oldDevices[d.name]
+	v := d.volatileGet()
+
+	// Populate device config with volatile fields if needed.
+	networkVethFillFromVolatile(d.config, v)
+	networkVethFillFromVolatile(oldConfig, v)
 
 	// If an IPv6 address has changed, flush all existing IPv6 leases for instance so instance
 	// isn't allocated old IP. This is important with IPv6 because DHCPv6 supports multiple IP
@@ -368,11 +373,6 @@ func (d *nicBridged) Update(oldDevices deviceConfig.Devices, isRunning bool) err
 		}
 	}
 
-	v := d.volatileGet()
-
-	// Populate device config with volatile fields if needed.
-	networkVethFillFromVolatile(d.config, v)
-
 	// If instance is running, apply host side limits and filters first before rebuilding
 	// dnsmasq config below so that existing config can be used as part of the filter removal.
 	if isRunning {
@@ -381,8 +381,17 @@ func (d *nicBridged) Update(oldDevices deviceConfig.Devices, isRunning bool) err
 			return err
 		}
 
-		// Apply host-side routes.
-		err = networkSetupHostVethRoutes(d.state, d.config, oldConfig, v)
+		// Validate old config so that it is enriched with network parent config needed for route removal.
+		err = Validate(d.inst, d.state, d.name, oldConfig)
+		if err != nil {
+			return err
+		}
+
+		// Remove old host-side routes from bridge interface.
+		networkNICRouteDelete(oldConfig["parent"], append(util.SplitNTrimSpace(oldConfig["ipv4.routes"], ",", -1, true), util.SplitNTrimSpace(oldConfig["ipv6.routes"], ",", -1, true)...)...)
+
+		// Apply host-side routes to bridge interface.
+		err = networkNICRouteAdd(d.config["parent"], append(util.SplitNTrimSpace(d.config["ipv4.routes"], ",", -1, true), util.SplitNTrimSpace(d.config["ipv6.routes"], ",", -1, true)...)...)
 		if err != nil {
 			return err
 		}
@@ -442,7 +451,7 @@ func (d *nicBridged) postStop() error {
 
 	networkVethFillFromVolatile(d.config, v)
 
-	if d.config["host_name"] != "" && shared.PathExists(fmt.Sprintf("/sys/class/net/%s", d.config["host_name"])) {
+	if d.config["host_name"] != "" && network.InterfaceExists(d.config["host_name"]) {
 		// Detach host-side end of veth pair from bridge (required for openvswitch particularly).
 		err := network.DetachInterface(d.config["parent"], d.config["host_name"])
 		if err != nil {
@@ -456,7 +465,8 @@ func (d *nicBridged) postStop() error {
 		}
 	}
 
-	networkRemoveVethRoutes(d.state, d.config)
+	// Remove host-side routes from bridge interface.
+	networkNICRouteDelete(d.config["parent"], append(util.SplitNTrimSpace(d.config["ipv4.routes"], ",", -1, true), util.SplitNTrimSpace(d.config["ipv6.routes"], ",", -1, true)...)...)
 	d.removeFilters(d.config)
 
 	return nil

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -503,7 +503,7 @@ func (d *nicBridged) Remove() error {
 	return nil
 }
 
-// rebuildDnsmasqEntry rebuilds the dnsmasq host entry if connected to an LXD managed network and reloads dnsmasq.
+// rebuildDnsmasqEntry rebuilds the dnsmasq host entry if connected to a LXD managed network and reloads dnsmasq.
 func (d *nicBridged) rebuildDnsmasqEntry() error {
 	// Rebuild dnsmasq config if a bridged device has changed and parent is a managed network.
 	if !shared.PathExists(shared.VarPath("networks", d.config["parent"], "dnsmasq.pid")) {

--- a/lxd/device/nic_p2p.go
+++ b/lxd/device/nic_p2p.go
@@ -51,7 +51,13 @@ func (d *nicP2P) validateEnvironment() error {
 }
 
 // UpdatableFields returns a list of fields that can be updated without triggering a device remove & add.
-func (d *nicP2P) UpdatableFields() []string {
+func (d *nicP2P) UpdatableFields(oldDevice Type) []string {
+	// Check old and new device types match.
+	_, match := oldDevice.(*nicP2P)
+	if !match {
+		return []string{}
+	}
+
 	return []string{"limits.ingress", "limits.egress", "limits.max", "ipv4.routes", "ipv6.routes"}
 }
 

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -29,7 +29,13 @@ func (d *nicRouted) CanHotPlug() bool {
 }
 
 // UpdatableFields returns a list of fields that can be updated without triggering a device remove & add.
-func (d *nicRouted) UpdatableFields() []string {
+func (d *nicRouted) UpdatableFields(oldDevice Type) []string {
+	// Check old and new device types match.
+	_, match := oldDevice.(*nicRouted)
+	if !match {
+		return []string{}
+	}
+
 	return []string{"limits.ingress", "limits.egress", "limits.max"}
 }
 

--- a/lxd/firewall/firewall_interface.go
+++ b/lxd/firewall/firewall_interface.go
@@ -6,7 +6,7 @@ import (
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 )
 
-// Firewall represents an LXD firewall.
+// Firewall represents a LXD firewall.
 type Firewall interface {
 	String() string
 	Compat() (bool, error)

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -328,7 +328,7 @@ func (d *common) TemplatesPath() string {
 // SECTION: internal functions
 //
 
-// deviceResetVolatile resets a device's volatile data when its removed or updated in such a way
+// deviceVolatileReset resets a device's volatile data when its removed or updated in such a way
 // that it is removed then added immediately afterwards.
 func (d *common) deviceVolatileReset(devName string, oldConfig, newConfig deviceConfig.Device) error {
 	volatileClear := make(map[string]string)

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3862,31 +3862,22 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 	}
 
 	// Diff the devices
-	removeDevices, addDevices, updateDevices, updateDiff := oldExpandedDevices.Update(d.expandedDevices, func(oldDevice deviceConfig.Device, newDevice deviceConfig.Device) []string {
+	removeDevices, addDevices, updateDevices, allUpdatedKeys := oldExpandedDevices.Update(d.expandedDevices, func(oldDevice deviceConfig.Device, newDevice deviceConfig.Device) []string {
 		// This function needs to return a list of fields that are excluded from differences
 		// between oldDevice and newDevice. The result of this is that as long as the
 		// devices are otherwise identical except for the fields returned here, then the
 		// device is considered to be being "updated" rather than "added & removed".
-		oldNICType, err := nictype.NICType(d.state, d.Project(), newDevice)
-		if err != nil {
-			return []string{} // Cannot hot-update due to config error.
-		}
-
-		newNICType, err := nictype.NICType(d.state, d.Project(), oldDevice)
-		if err != nil {
-			return []string{} // Cannot hot-update due to config error.
-		}
-
-		if oldDevice["type"] != newDevice["type"] || oldNICType != newNICType {
-			return []string{} // Device types aren't the same, so this cannot be an update.
-		}
-
-		dev, err := device.New(d, d.state, "", newDevice, nil, nil)
+		oldDevType, err := device.LoadByType(d.state, d.Project(), oldDevice)
 		if err != nil {
 			return []string{} // Couldn't create Device, so this cannot be an update.
 		}
 
-		return dev.UpdatableFields()
+		newDevType, err := device.LoadByType(d.state, d.Project(), newDevice)
+		if err != nil {
+			return []string{} // Couldn't create Device, so this cannot be an update.
+		}
+
+		return newDevType.UpdatableFields(oldDevType)
 	})
 
 	if userRequested {
@@ -3976,7 +3967,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 	// Update MAAS (must run after the MAC addresses have been generated).
 	updateMAAS := false
 	for _, key := range []string{"maas.subnet.ipv4", "maas.subnet.ipv6", "ipv4.address", "ipv6.address"} {
-		if shared.StringInSlice(key, updateDiff) {
+		if shared.StringInSlice(key, allUpdatedKeys) {
 			updateMAAS = true
 			break
 		}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -4351,7 +4351,7 @@ func (d *lxc) updateDevices(removeDevices deviceConfig.Devices, addDevices devic
 		// Check whether we are about to add the same device back with updated config and
 		// if not, or if the device type has changed, then remove all volatile keys for
 		// this device (as its an actual removal or a device type change).
-		err = d.deviceResetVolatile(dev.Name, dev.Config, addDevices[dev.Name])
+		err = d.deviceVolatileReset(dev.Name, dev.Config, addDevices[dev.Name])
 		if err != nil {
 			return errors.Wrapf(err, "Failed to reset volatile data for device %q", dev.Name)
 		}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1730,54 +1730,6 @@ func (d *lxc) deviceRemove(deviceName string, rawConfig deviceConfig.Device, ins
 	return dev.Remove()
 }
 
-// deviceResetVolatile resets a device's volatile data when its removed or updated in such a way
-// that it is removed then added immediately afterwards.
-func (d *lxc) deviceResetVolatile(devName string, oldConfig, newConfig deviceConfig.Device) error {
-	volatileClear := make(map[string]string)
-	devicePrefix := fmt.Sprintf("volatile.%s.", devName)
-
-	newNICType, err := nictype.NICType(d.state, d.Project(), newConfig)
-	if err != nil {
-		return err
-	}
-
-	oldNICType, err := nictype.NICType(d.state, d.Project(), oldConfig)
-	if err != nil {
-		return err
-	}
-
-	// If the device type has changed, remove all old volatile keys.
-	// This will occur if the newConfig is empty (i.e the device is actually being removed) or
-	// if the device type is being changed but keeping the same name.
-	if newConfig["type"] != oldConfig["type"] || newNICType != oldNICType {
-		for k := range d.localConfig {
-			if !strings.HasPrefix(k, devicePrefix) {
-				continue
-			}
-
-			volatileClear[k] = ""
-		}
-
-		return d.VolatileSet(volatileClear)
-	}
-
-	// If the device type remains the same, then just remove any volatile keys that have
-	// the same key name present in the new config (i.e the new config is replacing the
-	// old volatile key).
-	for k := range d.localConfig {
-		if !strings.HasPrefix(k, devicePrefix) {
-			continue
-		}
-
-		devKey := strings.TrimPrefix(k, devicePrefix)
-		if _, found := newConfig[devKey]; found {
-			volatileClear[k] = ""
-		}
-	}
-
-	return d.VolatileSet(volatileClear)
-}
-
 // DeviceEventHandler actions the results of a RunConfig after an event has occurred on a device.
 func (d *lxc) DeviceEventHandler(runConf *deviceConfig.RunConfig) error {
 	// Device events can only be processed when the container is running.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3365,26 +3365,17 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		// between oldDevice and newDevice. The result of this is that as long as the
 		// devices are otherwise identical except for the fields returned here, then the
 		// device is considered to be being "updated" rather than "added & removed".
-		oldNICType, err := nictype.NICType(d.state, d.Project(), newDevice)
-		if err != nil {
-			return []string{} // Cannot hot-update due to config error.
-		}
-
-		newNICType, err := nictype.NICType(d.state, d.Project(), oldDevice)
-		if err != nil {
-			return []string{} // Cannot hot-update due to config error.
-		}
-
-		if oldDevice["type"] != newDevice["type"] || oldNICType != newNICType {
-			return []string{} // Device types aren't the same, so this cannot be an update.
-		}
-
-		dev, err := device.New(d, d.state, "", newDevice, nil, nil)
+		oldDevType, err := device.LoadByType(d.state, d.Project(), oldDevice)
 		if err != nil {
 			return []string{} // Couldn't create Device, so this cannot be an update.
 		}
 
-		return dev.UpdatableFields()
+		newDevType, err := device.LoadByType(d.state, d.Project(), newDevice)
+		if err != nil {
+			return []string{} // Couldn't create Device, so this cannot be an update.
+		}
+
+		return newDevType.UpdatableFields(oldDevType)
 	})
 
 	if userRequested {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3664,54 +3664,6 @@ func (d *qemu) deviceUpdate(deviceName string, rawConfig deviceConfig.Device, ol
 	return nil
 }
 
-// deviceResetVolatile resets a device's volatile data when its removed or updated in such a way
-// that it is removed then added immediately afterwards.
-func (d *qemu) deviceResetVolatile(devName string, oldConfig, newConfig deviceConfig.Device) error {
-	volatileClear := make(map[string]string)
-	devicePrefix := fmt.Sprintf("volatile.%s.", devName)
-
-	newNICType, err := nictype.NICType(d.state, d.Project(), newConfig)
-	if err != nil {
-		return err
-	}
-
-	oldNICType, err := nictype.NICType(d.state, d.Project(), oldConfig)
-	if err != nil {
-		return err
-	}
-
-	// If the device type has changed, remove all old volatile keys.
-	// This will occur if the newConfig is empty (i.e the device is actually being removed) or
-	// if the device type is being changed but keeping the same name.
-	if newConfig["type"] != oldConfig["type"] || newNICType != oldNICType {
-		for k := range d.localConfig {
-			if !strings.HasPrefix(k, devicePrefix) {
-				continue
-			}
-
-			volatileClear[k] = ""
-		}
-
-		return d.VolatileSet(volatileClear)
-	}
-
-	// If the device type remains the same, then just remove any volatile keys that have
-	// the same key name present in the new config (i.e the new config is replacing the
-	// old volatile key).
-	for k := range d.localConfig {
-		if !strings.HasPrefix(k, devicePrefix) {
-			continue
-		}
-
-		devKey := strings.TrimPrefix(k, devicePrefix)
-		if _, found := newConfig[devKey]; found {
-			volatileClear[k] = ""
-		}
-	}
-
-	return d.VolatileSet(volatileClear)
-}
-
 func (d *qemu) removeUnixDevices() error {
 	// Check that we indeed have devices to remove.
 	if !shared.PathExists(d.DevicesPath()) {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3609,7 +3609,7 @@ func (d *qemu) updateDevices(removeDevices deviceConfig.Devices, addDevices devi
 		// Check whether we are about to add the same device back with updated config and
 		// if not, or if the device type has changed, then remove all volatile keys for
 		// this device (as its an actual removal or a device type change).
-		err = d.deviceResetVolatile(dev.Name, dev.Config, addDevices[dev.Name])
+		err = d.deviceVolatileReset(dev.Name, dev.Config, addDevices[dev.Name])
 		if err != nil {
 			return errors.Wrapf(err, "Failed to reset volatile data for device %q", dev.Name)
 		}

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -11,7 +11,7 @@ import (
 	"github.com/lxc/lxd/shared/api"
 )
 
-// Type represents an LXD network driver type.
+// Type represents a LXD network driver type.
 type Type interface {
 	FillConfig(config map[string]string) error
 	Info() Info

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -222,7 +222,7 @@ func (d *btrfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcDat
 		return "", fmt.Errorf("Could not find %q", srcFile)
 	}
 
-	// unpackVolume unpacks all subvolumes in an LXD volume from a backup tarball file.
+	// unpackVolume unpacks all subvolumes in a LXD volume from a backup tarball file.
 	unpackVolume := func(v Volume, srcFilePrefix string) error {
 		_, snapName, _ := shared.InstanceGetParentAndSnapshotName(v.name)
 
@@ -466,7 +466,7 @@ func (d *btrfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, v
 		})
 	}
 
-	// receiveVolume receives all subvolumes in an LXD volume from the source.
+	// receiveVolume receives all subvolumes in a LXD volume from the source.
 	receiveVolume := func(v Volume, receivePath string) error {
 		_, snapName, _ := shared.InstanceGetParentAndSnapshotName(v.name)
 

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -114,7 +114,7 @@ func (d *lvm) Create() error {
 	defer revert.Fail()
 
 	if d.config["source"] == "" || d.config["source"] == defaultSource {
-		// We are using an LXD internal loopback file.
+		// We are using a LXD internal loopback file.
 		d.config["source"] = defaultSource
 		if d.config["lvm.vg_name"] == "" {
 			d.config["lvm.vg_name"] = d.name

--- a/test/suites/database.sh
+++ b/test/suites/database.sh
@@ -19,7 +19,7 @@ EOF
   # Create the version 1 schema as the database
   sqlite3 "${MIGRATE_DB}" > /dev/null < deps/schema1.sql
 
-  # Start an LXD demon in the tmp directory. This should start the updates.
+  # Start a LXD daemon in the tmp directory. This should start the updates.
   spawn_lxd "${LXD_MIGRATE_DIR}" true
 
   # Assert there are enough tables.


### PR DESCRIPTION
Previously some NIC devices have supported "live update" of certain config fields. These config settings were able to be applied on the host without removing and re-adding the NIC device inside the instance.

However with the introduction of the `network` property that caused the NIC device to inherit the `nictype` (implicitly) and other settings (explicitly) from the network's config, this caused the live-update feature to break, causing all modification of NIC config fields to trigger a remove and re-add.

This was because the helper function passed to `oldExpandedDevices.Update` in the instance driver's `Update()` function was causing the device to be initialised (which triggers validation, which in turn modifies the supplied config with the explicitly inherited network settings). This meant that the new device config always looked sufficiently different to the old device config to trigger a full remove and re-add (because it appeared to have changed its parent key).

The only reason the `oldExpandedDevices.Update` helper function was initialising the device was to ascertain the updatable field list for that device type by calling the `UpdatableFields` function. 

To avoid this I have added a new `Type` interface (similar to that in the `network` package) which allows loading a device by type, to just get access to its type-specific functions. This is now used in `oldExpandedDevices.Update` which avoids triggering validation and associated config enrichment, and restores the ability to live-update certain fields.

However this in turn exposed an issue that in the subsequent call to `d.updateDevices`, some devices actually depended on the `oldExpandedDevices` config being pre-enriched with the network inherited fields from the validation run in `oldExpandedDevices.Update`'s helper function.

To fix this the devices that depended on this behaviour now explicitly call `device.Validate` with the old device config to make explicit that they require on post-validate enriched config.

I also found that the instance drivers each had a function called `deviceResetVolatile` which was equivalent to the common function `deviceVolatileReset` so have switched to that and removed the duplicated functions.