### PR TITLE
Network: OVN ACL precursor changes

### DIFF
--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -30,8 +30,8 @@ type ovnNet interface {
 
 	InstanceDevicePortValidateExternalRoutes(deviceInstance instance.Instance, deviceName string, externalRoutes []*net.IPNet) error
 	InstanceDevicePortConfigParse(deviceConfig map[string]string) (net.HardwareAddr, []net.IP, []*net.IPNet, []*net.IPNet, error)
-	InstanceDevicePortAdd(uplinkConfig map[string]string, instanceUUID string, instanceName string, deviceName string, mac net.HardwareAddr, ips []net.IP, internalRoutes []*net.IPNet, externalRoutes []*net.IPNet) (openvswitch.OVNSwitchPort, error)
-	InstanceDevicePortDelete(instanceUUID string, deviceName string, ovsExternalOVNPort openvswitch.OVNSwitchPort, internalRoutes []*net.IPNet, externalRoutes []*net.IPNet) error
+	InstanceDevicePortAdd(opts *network.OVNInstanceNICSetupOpts) (openvswitch.OVNSwitchPort, error)
+	InstanceDevicePortDelete(ovsExternalOVNPort openvswitch.OVNSwitchPort, opts *network.OVNInstanceNICOpts) error
 	InstanceDevicePortDynamicIPs(instanceUUID string, deviceName string) ([]net.IP, error)
 }
 

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -272,7 +272,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 			ExternalRoutes: externalRoutes,
 		},
 		UplinkConfig: uplink.Config,
-		InstanceName: d.inst.Name(),
+		DNSName:      d.inst.Name(),
 		MAC:          mac,
 		IPs:          ips,
 	})

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2912,7 +2912,7 @@ func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]
 							ExternalRoutes: externalRoutes,
 						},
 						UplinkConfig: uplinkConfig,
-						InstanceName: inst.Name,
+						DNSName:      inst.Name,
 						MAC:          mac,
 						IPs:          ips,
 					})

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -72,7 +72,7 @@ type OVNInstanceNICSetupOpts struct {
 	OVNInstanceNICOpts
 
 	UplinkConfig map[string]string
-	InstanceName string
+	DNSName      string
 	MAC          net.HardwareAddr
 	IPs          []net.IP
 }

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2880,13 +2880,13 @@ func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]
 					// Check if instance port exists, if not then we can skip.
 					instanceUUID := inst.Config["volatile.uuid"]
 					instancePortName := n.getInstanceDevicePortName(instanceUUID, devName)
-					portExists, err := client.LogicalSwitchPortExists(instancePortName)
+					portUUID, err := client.LogicalSwitchPortUUID(instancePortName)
 					if err != nil {
 						n.logger.Error("Failed checking instance OVN NIC port exists", log.Ctx{"project": inst.Project, "instance": inst.Name, "err": err})
 						continue
 					}
 
-					if !portExists {
+					if portUUID == "" {
 						continue // No need to update a port that isn't started yet.
 					}
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2567,16 +2567,16 @@ func (n *ovn) InstanceDevicePortDynamicIPs(instanceUUID string, deviceName strin
 }
 
 // InstanceDevicePortDelete deletes an instance device port from the internal logical switch.
-func (n *ovn) InstanceDevicePortDelete(instanceUUID string, deviceName string, ovsExternalOVNPort openvswitch.OVNSwitchPort, internalRoutes []*net.IPNet, externalRoutes []*net.IPNet) error {
+func (n *ovn) InstanceDevicePortDelete(ovsExternalOVNPort openvswitch.OVNSwitchPort, opts *OVNInstanceNICOpts) error {
 	// Decide whether to use OVS provided OVN port name or internally derived OVN port name.
 	instancePortName := ovsExternalOVNPort
 	source := "OVS"
 	if ovsExternalOVNPort == "" {
-		if instanceUUID == "" {
+		if opts.InstanceUUID == "" {
 			return fmt.Errorf("Instance UUID is required")
 		}
 
-		instancePortName = n.getInstanceDevicePortName(instanceUUID, deviceName)
+		instancePortName = n.getInstanceDevicePortName(opts.InstanceUUID, opts.DeviceName)
 		source = "internal"
 	}
 
@@ -2626,7 +2626,7 @@ func (n *ovn) InstanceDevicePortDelete(instanceUUID string, deviceName string, o
 	}
 
 	// Delete each internal route.
-	for _, internalRoute := range internalRoutes {
+	for _, internalRoute := range opts.InternalRoutes {
 		err = client.LogicalRouterRouteDelete(n.getRouterName(), internalRoute, nil)
 		if err != nil {
 			return err
@@ -2634,7 +2634,7 @@ func (n *ovn) InstanceDevicePortDelete(instanceUUID string, deviceName string, o
 	}
 
 	// Delete each external route.
-	for _, externalRoute := range externalRoutes {
+	for _, externalRoute := range opts.ExternalRoutes {
 		err = client.LogicalRouterRouteDelete(n.getRouterName(), externalRoute, nil)
 		if err != nil {
 			return err

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -59,6 +59,24 @@ type ovnUplinkPortBridgeVars struct {
 	ovsEnd    string
 }
 
+// OVNInstanceNICOpts options for starting and stopping an OVN Instance NIC.
+type OVNInstanceNICOpts struct {
+	InstanceUUID   string
+	DeviceName     string
+	InternalRoutes []*net.IPNet
+	ExternalRoutes []*net.IPNet
+}
+
+// OVNInstanceNICSetupOpts options for starting an OVN Instance NIC.
+type OVNInstanceNICSetupOpts struct {
+	OVNInstanceNICOpts
+
+	UplinkConfig map[string]string
+	InstanceName string
+	MAC          net.HardwareAddr
+	IPs          []net.IP
+}
+
 // ovn represents a LXD OVN network.
 type ovn struct {
 	common

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2903,7 +2903,18 @@ func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]
 
 					// Re-add logical switch port to apply the l2proxy DNAT_AND_SNAT rules.
 					n.logger.Debug("Re-adding instance OVN NIC port to apply ingress mode changes", log.Ctx{"project": inst.Project, "instance": inst.Name, "device": devName})
-					_, err = n.InstanceDevicePortAdd(uplinkConfig, instanceUUID, inst.Name, devName, mac, ips, internalRoutes, externalRoutes)
+					_, err = n.InstanceDevicePortAdd(&OVNInstanceNICSetupOpts{
+						OVNInstanceNICOpts: OVNInstanceNICOpts{
+							InstanceUUID:   instanceUUID,
+							DeviceName:     devName,
+							InternalRoutes: internalRoutes,
+							ExternalRoutes: externalRoutes,
+						},
+						UplinkConfig: uplinkConfig,
+						InstanceName: inst.Name,
+						MAC:          mac,
+						IPs:          ips,
+					})
 					if err != nil {
 						n.logger.Error("Failed re-adding instance OVN NIC port", log.Ctx{"project": inst.Project, "instance": inst.Name, "err": err})
 						continue

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1766,7 +1766,7 @@ func (n *ovn) setup(update bool) error {
 	}
 
 	// Configure DHCP option sets.
-	var dhcpv4UUID, dhcpv6UUID string
+	var dhcpv4UUID, dhcpv6UUID openvswitch.OVNDHCPOptionsUUID
 	dhcpV4Subnet := n.DHCPv4Subnet()
 	dhcpV6Subnet := n.DHCPv6Subnet()
 
@@ -1777,7 +1777,8 @@ func (n *ovn) setup(update bool) error {
 			return errors.Wrapf(err, "Failed getting existing DHCP settings for internal switch")
 		}
 
-		var deleteDHCPRecords []string // DHCP option records to delete if DHCP is being disabled.
+		// DHCP option records to delete if DHCP is being disabled.
+		var deleteDHCPRecords []openvswitch.OVNDHCPOptionsUUID
 
 		for _, existingOpt := range existingOpts {
 			if existingOpt.CIDR.IP.To4() == nil {
@@ -2355,7 +2356,7 @@ func (n *ovn) InstanceDevicePortAdd(opts *OVNInstanceNICSetupOpts) (openvswitch.
 		return "", fmt.Errorf("Instance UUID is required")
 	}
 
-	var dhcpV4ID, dhcpv6ID string
+	var dhcpV4ID, dhcpv6ID openvswitch.OVNDHCPOptionsUUID
 
 	revert := revert.New()
 	defer revert.Fail()
@@ -2440,7 +2441,7 @@ func (n *ovn) InstanceDevicePortAdd(opts *OVNInstanceNICSetupOpts) (openvswitch.
 
 	// Add DNS records for port's IPs, and retrieve the IP addresses used.
 	dnsName := fmt.Sprintf("%s.%s", opts.InstanceName, n.getDomainName())
-	var dnsUUID string
+	var dnsUUID openvswitch.OVNDNSUUID
 	var dnsIPv4, dnsIPv6 net.IP
 
 	// Retry a few times in case port has not yet allocated dynamic IPs.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2440,7 +2440,7 @@ func (n *ovn) InstanceDevicePortAdd(opts *OVNInstanceNICSetupOpts) (openvswitch.
 	}
 
 	// Add DNS records for port's IPs, and retrieve the IP addresses used.
-	dnsName := fmt.Sprintf("%s.%s", opts.InstanceName, n.getDomainName())
+	dnsName := fmt.Sprintf("%s.%s", opts.DNSName, n.getDomainName())
 	var dnsUUID openvswitch.OVNDNSUUID
 	var dnsIPv4, dnsIPv6 net.IP
 

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -23,8 +23,17 @@ type OVNSwitch string
 // OVNSwitchPort OVN switch port name.
 type OVNSwitchPort string
 
+// OVNSwitchPortUUID OVN switch port UUID.
+type OVNSwitchPortUUID string
+
 // OVNChassisGroup OVN HA chassis group name.
 type OVNChassisGroup string
+
+// OVNDNSUUID OVN DNS record UUID.
+type OVNDNSUUID string
+
+// OVNDHCPOptionsUUID DHCP Options set UUID.
+type OVNDHCPOptionsUUID string
 
 // OVNIPAllocationOpts defines IP allocation settings that can be applied to a logical switch.
 type OVNIPAllocationOpts struct {
@@ -61,7 +70,7 @@ type OVNIPv6RAOpts struct {
 
 // OVNDHCPOptsSet is an existing DHCP options set in the northbound database.
 type OVNDHCPOptsSet struct {
-	UUID string
+	UUID OVNDHCPOptionsUUID
 	CIDR *net.IPNet
 }
 
@@ -85,10 +94,10 @@ type OVNDHCPv6Opts struct {
 
 // OVNSwitchPortOpts options that can be applied to a swich port.
 type OVNSwitchPortOpts struct {
-	MAC          net.HardwareAddr // Optional, if nil will be set to dynamic.
-	IPs          []net.IP         // Optional, if empty IPs will be set to dynamic.
-	DHCPv4OptsID string           // Optional, if empty, no DHCPv4 enabled on port.
-	DHCPv6OptsID string           // Optional, if empty, no DHCPv6 enabled on port.
+	MAC          net.HardwareAddr   // Optional, if nil will be set to dynamic.
+	IPs          []net.IP           // Optional, if empty IPs will be set to dynamic.
+	DHCPv4OptsID OVNDHCPOptionsUUID // Optional, if empty, no DHCPv4 enabled on port.
+	DHCPv6OptsID OVNDHCPOptionsUUID // Optional, if empty, no DHCPv6 enabled on port.
 }
 
 // NewOVN initialises new OVN wrapper.
@@ -486,11 +495,11 @@ func (o *OVN) LogicalSwitchSetIPAllocation(switchName OVNSwitch, opts *OVNIPAllo
 // LogicalSwitchDHCPv4OptionsSet creates or updates a DHCPv4 option set associated with the specified switchName
 // and subnet. If uuid is non-empty then the record that exists with that ID is updated, otherwise a new record
 // is created.
-func (o *OVN) LogicalSwitchDHCPv4OptionsSet(switchName OVNSwitch, uuid string, subnet *net.IPNet, opts *OVNDHCPv4Opts) error {
+func (o *OVN) LogicalSwitchDHCPv4OptionsSet(switchName OVNSwitch, uuid OVNDHCPOptionsUUID, subnet *net.IPNet, opts *OVNDHCPv4Opts) error {
 	var err error
 
 	if uuid != "" {
-		_, err = o.nbctl("set", "dhcp_option", uuid,
+		_, err = o.nbctl("set", "dhcp_option", string(uuid),
 			fmt.Sprintf("external_ids:lxd_switch=%s", string(switchName)),
 			fmt.Sprintf("cidr=%s", subnet.String()),
 		)
@@ -498,7 +507,7 @@ func (o *OVN) LogicalSwitchDHCPv4OptionsSet(switchName OVNSwitch, uuid string, s
 			return err
 		}
 	} else {
-		uuid, err = o.nbctl("create", "dhcp_option",
+		uuidRaw, err := o.nbctl("create", "dhcp_option",
 			fmt.Sprintf("external_ids:lxd_switch=%s", string(switchName)),
 			fmt.Sprintf("cidr=%s", subnet.String()),
 		)
@@ -506,12 +515,12 @@ func (o *OVN) LogicalSwitchDHCPv4OptionsSet(switchName OVNSwitch, uuid string, s
 			return err
 		}
 
-		uuid = strings.TrimSpace(uuid)
+		uuid = OVNDHCPOptionsUUID(strings.TrimSpace(uuidRaw))
 	}
 
 	// We have to use dhcp-options-set-options rather than the command above as its the only way to allow the
 	// domain_name option to be properly escaped.
-	args := []string{"dhcp-options-set-options", uuid,
+	args := []string{"dhcp-options-set-options", string(uuid),
 		fmt.Sprintf("server_id=%s", opts.ServerID.String()),
 		fmt.Sprintf("server_mac=%s", opts.ServerMAC.String()),
 		fmt.Sprintf("lease_time=%d", opts.LeaseTime/time.Second),
@@ -554,11 +563,11 @@ func (o *OVN) LogicalSwitchDHCPv4OptionsSet(switchName OVNSwitch, uuid string, s
 // LogicalSwitchDHCPv6OptionsSet creates or updates a DHCPv6 option set associated with the specified switchName
 // and subnet. If uuid is non-empty then the record that exists with that ID is updated, otherwise a new record
 // is created.
-func (o *OVN) LogicalSwitchDHCPv6OptionsSet(switchName OVNSwitch, uuid string, subnet *net.IPNet, opts *OVNDHCPv6Opts) error {
+func (o *OVN) LogicalSwitchDHCPv6OptionsSet(switchName OVNSwitch, uuid OVNDHCPOptionsUUID, subnet *net.IPNet, opts *OVNDHCPv6Opts) error {
 	var err error
 
 	if uuid != "" {
-		_, err = o.nbctl("set", "dhcp_option", uuid,
+		_, err = o.nbctl("set", "dhcp_option", string(uuid),
 			fmt.Sprintf("external_ids:lxd_switch=%s", string(switchName)),
 			fmt.Sprintf(`cidr="%s"`, subnet.String()), // Special quoting to allow IPv6 address.
 		)
@@ -566,7 +575,7 @@ func (o *OVN) LogicalSwitchDHCPv6OptionsSet(switchName OVNSwitch, uuid string, s
 			return err
 		}
 	} else {
-		uuid, err = o.nbctl("create", "dhcp_option",
+		uuidRaw, err := o.nbctl("create", "dhcp_option",
 			fmt.Sprintf("external_ids:lxd_switch=%s", string(switchName)),
 			fmt.Sprintf(`cidr="%s"`, subnet.String()), // Special quoting to allow IPv6 address.
 		)
@@ -574,12 +583,12 @@ func (o *OVN) LogicalSwitchDHCPv6OptionsSet(switchName OVNSwitch, uuid string, s
 			return err
 		}
 
-		uuid = strings.TrimSpace(uuid)
+		uuid = OVNDHCPOptionsUUID(strings.TrimSpace(uuidRaw))
 	}
 
 	// We have to use dhcp-options-set-options rather than the command above as its the only way to allow the
 	// domain_name option to be properly escaped.
-	args := []string{"dhcp-options-set-options", uuid,
+	args := []string{"dhcp-options-set-options", string(uuid),
 		fmt.Sprintf("server_id=%s", opts.ServerID.String()),
 	}
 
@@ -610,7 +619,7 @@ func (o *OVN) LogicalSwitchDHCPv6OptionsSet(switchName OVNSwitch, uuid string, s
 }
 
 // LogicalSwitchDHCPOptionsGetID returns the UUID for DHCP options set associated to the logical switch and subnet.
-func (o *OVN) LogicalSwitchDHCPOptionsGetID(switchName OVNSwitch, subnet *net.IPNet) (string, error) {
+func (o *OVN) LogicalSwitchDHCPOptionsGetID(switchName OVNSwitch, subnet *net.IPNet) (OVNDHCPOptionsUUID, error) {
 	uuid, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--colum=_uuid", "find", "dhcp_options",
 		fmt.Sprintf("external_ids:lxd_switch=%s", string(switchName)),
 		fmt.Sprintf(`cidr="%s"`, subnet.String()), // Special quoting to support IPv6 subnets.
@@ -619,7 +628,7 @@ func (o *OVN) LogicalSwitchDHCPOptionsGetID(switchName OVNSwitch, subnet *net.IP
 		return "", err
 	}
 
-	return strings.TrimSpace(uuid), nil
+	return OVNDHCPOptionsUUID(strings.TrimSpace(uuid)), nil
 }
 
 // LogicalSwitchDHCPOptionsGet retrieves the existing DHCP options defined for a logical switch.
@@ -647,7 +656,7 @@ func (o *OVN) LogicalSwitchDHCPOptionsGet(switchName OVNSwitch) ([]OVNDHCPOptsSe
 			}
 
 			dhcpOpts = append(dhcpOpts, OVNDHCPOptsSet{
-				UUID: rowParts[0],
+				UUID: OVNDHCPOptionsUUID(rowParts[0]),
 				CIDR: cidr,
 			})
 		}
@@ -658,7 +667,7 @@ func (o *OVN) LogicalSwitchDHCPOptionsGet(switchName OVNSwitch) ([]OVNDHCPOptsSe
 
 // LogicalSwitchDHCPOptionsDelete deletes any DHCP options defined for a switch.
 // Optionally accepts one or more specific UUID records to delete (if they are associated to the specified switch).
-func (o *OVN) LogicalSwitchDHCPOptionsDelete(switchName OVNSwitch, onlyUUID ...string) error {
+func (o *OVN) LogicalSwitchDHCPOptionsDelete(switchName OVNSwitch, onlyUUID ...OVNDHCPOptionsUUID) error {
 	existingOpts, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--colum=_uuid", "find", "dhcp_options",
 		fmt.Sprintf("external_ids:lxd_switch=%s", string(switchName)),
 	)
@@ -672,7 +681,7 @@ func (o *OVN) LogicalSwitchDHCPOptionsDelete(switchName OVNSwitch, onlyUUID ...s
 		}
 
 		for _, uuid := range onlyUUID {
-			if existingUUID == uuid {
+			if OVNDHCPOptionsUUID(existingUUID) == uuid {
 				return true
 			}
 		}
@@ -718,7 +727,7 @@ func (o *OVN) logicalSwitchDNSRecordsDelete(switchName OVNSwitch) error {
 }
 
 // LogicalSwitchPortUUID returns the logical switch port UUID or empty string if port doesn't exist.
-func (o *OVN) LogicalSwitchPortUUID(portName OVNSwitchPort) (string, error) {
+func (o *OVN) LogicalSwitchPortUUID(portName OVNSwitchPort) (OVNSwitchPortUUID, error) {
 	portInfo, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--colum=_uuid,name", "find", "logical_switch_port",
 		fmt.Sprintf("name=%s", string(portName)),
 	)
@@ -729,7 +738,7 @@ func (o *OVN) LogicalSwitchPortUUID(portName OVNSwitchPort) (string, error) {
 	portParts := util.SplitNTrimSpace(portInfo, ",", 2, false)
 	if len(portParts) == 2 {
 		if portParts[1] == string(portName) {
-			return portParts[0], nil
+			return OVNSwitchPortUUID(portParts[0]), nil
 		}
 	}
 
@@ -777,14 +786,14 @@ func (o *OVN) LogicalSwitchPortSet(portName OVNSwitchPort, opts *OVNSwitchPortOp
 	}
 
 	if opts.DHCPv4OptsID != "" {
-		_, err = o.nbctl("lsp-set-dhcpv4-options", string(portName), opts.DHCPv4OptsID)
+		_, err = o.nbctl("lsp-set-dhcpv4-options", string(portName), string(opts.DHCPv4OptsID))
 		if err != nil {
 			return err
 		}
 	}
 
 	if opts.DHCPv6OptsID != "" {
-		_, err = o.nbctl("lsp-set-dhcpv6-options", string(portName), opts.DHCPv6OptsID)
+		_, err = o.nbctl("lsp-set-dhcpv6-options", string(portName), string(opts.DHCPv6OptsID))
 		if err != nil {
 			return err
 		}
@@ -828,7 +837,7 @@ func (o *OVN) LogicalSwitchPortDynamicIPs(portName OVNSwitchPort) ([]net.IP, err
 // LogicalSwitchPortSetDNS sets up the switch DNS records for the DNS name resolving to the IPs of the switch port.
 // Attempts to find at most one IP for each IP protocol, preferring static addresses over dynamic.
 // Returns the DNS record UUID, IPv4 and IPv6 addresses used for DNS records.
-func (o *OVN) LogicalSwitchPortSetDNS(switchName OVNSwitch, portName OVNSwitchPort, dnsName string) (string, net.IP, net.IP, error) {
+func (o *OVN) LogicalSwitchPortSetDNS(switchName OVNSwitch, portName OVNSwitchPort, dnsName string) (OVNDNSUUID, net.IP, net.IP, error) {
 	var dnsIPv4, dnsIPv6 net.IP
 
 	// checkAndStoreIP checks if the supplied IP is valid and can be used for a missing DNS IP variable.
@@ -938,11 +947,11 @@ func (o *OVN) LogicalSwitchPortSetDNS(switchName OVNSwitch, portName OVNSwitchPo
 		return "", nil, nil, err
 	}
 
-	return dnsUUID, dnsIPv4, dnsIPv6, nil
+	return OVNDNSUUID(dnsUUID), dnsIPv4, dnsIPv6, nil
 }
 
 // LogicalSwitchPortGetDNS returns the logical switch port DNS info (UUID, name and IPs).
-func (o *OVN) LogicalSwitchPortGetDNS(portName OVNSwitchPort) (string, string, []net.IP, error) {
+func (o *OVN) LogicalSwitchPortGetDNS(portName OVNSwitchPort) (OVNDNSUUID, string, []net.IP, error) {
 	// Get UUID and DNS IPs for a switch port in the format: "<DNS UUID>,<DNS NAME>=<IP> <IP>"
 	output, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--colum=_uuid,records", "find", "dns",
 		fmt.Sprintf("external_ids:lxd_switch_port=%s", string(portName)),
@@ -973,19 +982,19 @@ func (o *OVN) LogicalSwitchPortGetDNS(portName OVNSwitchPort) (string, string, [
 
 	}
 
-	return dnsUUID, dnsName, ips, nil
+	return OVNDNSUUID(dnsUUID), dnsName, ips, nil
 }
 
 // LogicalSwitchPortDeleteDNS removes DNS records for a switch port.
-func (o *OVN) LogicalSwitchPortDeleteDNS(switchName OVNSwitch, dnsUUID string) error {
+func (o *OVN) LogicalSwitchPortDeleteDNS(switchName OVNSwitch, dnsUUID OVNDNSUUID) error {
 	// Remove DNS record association from switch.
-	_, err := o.nbctl("remove", "logical_switch", string(switchName), "dns_records", dnsUUID)
+	_, err := o.nbctl("remove", "logical_switch", string(switchName), "dns_records", string(dnsUUID))
 	if err != nil {
 		return err
 	}
 
 	// Remove DNS record entry itself.
-	_, err = o.nbctl("destroy", "dns", dnsUUID)
+	_, err = o.nbctl("destroy", "dns", string(dnsUUID))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Some non-ACL specific OVN changes that will allow accommodation of forthcoming ACL features.

- Move concrete UUID types to avoid confusion now we are using UUIDs for various different object types.
- Change instance device port management functions to use options struct as argument list was getting long.
- Clarify the `InstanceName` option actually mean `DNSName` (which we pass the instance name to).