### PR TITLE
utils: trim whitespace from block device UUID

### DIFF
--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -207,7 +207,13 @@ func tryExists(path string) bool {
 
 // fsUUID returns the filesystem UUID for the given block path.
 func fsUUID(path string) (string, error) {
-	return shared.RunCommand("blkid", "-s", "UUID", "-o", "value", path)
+	val, err := shared.RunCommand("blkid", "-s", "UUID", "-o", "value", path)
+	if err != nil {
+		return "", err
+	}
+
+	val = strings.TrimSpace(val)
+	return val, nil
 }
 
 // hasFilesystem checks if a given path is backed by a specified filesystem.


### PR DESCRIPTION
When creating a storage (btrfs) pool backed by a block device as in this
example

lxc storage create pool-btrfs btrfs source=/dev/sdc

we create the storage pool based on the volatile device path /dev/sdc. Since
this is obviously a bad idea we have logic to replace this device path with the
reliable /dev/disk/by-uuid/<uuid> path based on the uuid we just generated when
creating the filesystem. So we call

blkid -s UUID -o value /dev/sdc

and use the returned uuid in a tryExists(/dev/disk/by-uuid/<uuid>) loop for 10
seconds. This consistently failed for me which means I ended up with the
unreliable /dev/sdc device path as the source property of the storage pool
which I couldn't change later. The reason this happens is that whitespace
is sneaking in making the path whose existence we test for useless. Fix this by
trimming whitespace.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>