### PR TITLE
Network: Support OVN ACLs

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1318,3 +1318,6 @@ allowing for set number of days after which an unused cached remote image will b
 Adds a new `restricted` property to certificates in the API as well as
 `projects` holding a list of project names that the certificate has
 access to.
+
+## network\_ovn\_acl
+Adds a new `security.acls` property to OVN networks and OVN NICs, allowing Network ACLs to be applied.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -392,6 +392,7 @@ ipv6.address            | string  | -                 | no       | no      | An 
 ipv4.routes.external    | string  | -                 | no       | no      | Comma delimited list of IPv4 static routes to route to the NIC and publish on uplink network
 ipv6.routes.external    | string  | -                 | no       | no      | Comma delimited list of IPv6 static routes to route to the NIC and publish on uplink network
 boot.priority           | integer | -                 | no       | no      | Boot priority for VMs (higher boots first)
+security.acls           | string  | -                 | no       | no      | Comma separated list of Network ACLs to apply
 
 #### nic: physical
 

--- a/doc/metadata.yaml
+++ b/doc/metadata.yaml
@@ -28,6 +28,9 @@ navigation:
         - title: Networks
           location: networks.md
 
+        - title: Network ACLs
+          location: network-acls.md
+
         - title: Preseed files
           location: preseed.md
 

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -308,6 +308,7 @@ ipv6.dhcp                       | boolean   | ipv6 address          | true      
 ipv6.dhcp.stateful              | boolean   | ipv6 dhcp             | false                     | Whether to allocate addresses using DHCP
 ipv6.nat                        | boolean   | ipv6 address          | false                     | Whether to NAT (will default to true if unset and a random ipv6.address is generated)
 network                         | string    | -                     | -                         | Uplink network to use for external network access
+security.acls                   | string    | -                     | -                         | Comma separated list of Network ACLs to apply to NICs connected to this network
 
 ## network: physical
 

--- a/lxd/db/network_acls.go
+++ b/lxd/db/network_acls.go
@@ -27,7 +27,7 @@ func (c *Cluster) GetNetworkACLs(project string) ([]string, error) {
 		return nil, err
 	}
 
-	response := []string{}
+	response := make([]string, 0, len(result))
 	for _, r := range result {
 		response = append(response, r[0].(string))
 	}

--- a/lxd/db/network_acls.go
+++ b/lxd/db/network_acls.go
@@ -35,6 +35,30 @@ func (c *Cluster) GetNetworkACLs(project string) ([]string, error) {
 	return response, nil
 }
 
+// GetNetworkACLIDsByNames returns a map of names to IDs of existing Network ACLs.
+func (c *Cluster) GetNetworkACLIDsByNames(project string) (map[string]int64, error) {
+	q := `SELECT id, name FROM networks_acls
+		WHERE project_id = (SELECT id FROM projects WHERE name = ? LIMIT 1)
+		ORDER BY id
+	`
+	inargs := []interface{}{project}
+
+	var id int64
+	var name string
+	outfmt := []interface{}{id, name}
+	result, err := queryScan(c, q, inargs, outfmt)
+	if err != nil {
+		return nil, err
+	}
+
+	response := make(map[string]int64, len(result))
+	for _, r := range result {
+		response[r[1].(string)] = r[0].(int64)
+	}
+
+	return response, nil
+}
+
 // GetNetworkACL returns the Network ACL with the given name in the given project.
 func (c *Cluster) GetNetworkACL(projectName string, name string) (int64, *api.NetworkACL, error) {
 	var id int64 = int64(-1)

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -38,6 +38,7 @@ func nicValidationRules(requiredFields []string, optionalFields []string) map[st
 		"ipv6.host_table":         validate.Optional(validate.IsUint32),
 		"ipv4.routes.external":    validate.Optional(validate.IsNetworkV4List),
 		"ipv6.routes.external":    validate.Optional(validate.IsNetworkV6List),
+		"security.acls":           validate.IsAny,
 	}
 
 	validators := map[string]func(value string) error{}

--- a/lxd/network/acl/acl_load.go
+++ b/lxd/network/acl/acl_load.go
@@ -28,6 +28,7 @@ func LoadByName(s *state.State, projectName string, name string) (NetworkACL, er
 // Create validates supplied record and creates new Network ACL record in the database.
 func Create(s *state.State, projectName string, aclInfo *api.NetworkACLsPost) error {
 	var acl NetworkACL = &common{} // Only a single driver currently.
+	acl.init(s, -1, projectName, nil)
 
 	err := acl.validateName(aclInfo.Name)
 	if err != nil {

--- a/lxd/network/acl/acl_load.go
+++ b/lxd/network/acl/acl_load.go
@@ -3,6 +3,8 @@ package acl
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"github.com/lxc/lxd/lxd/db"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/project"
@@ -75,37 +77,173 @@ func Exists(s *state.State, projectName string, name ...string) error {
 	return nil
 }
 
-// UsedBy finds all networks and instance NICs that use an ACL and executes usageFunc with info about the usage.
-func UsedBy(s *state.State, projectName string, aclName string, usageFunc func(usageType string, projectName string, name string, config map[string]string) error) error {
-	return s.Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+// UsedBy finds all networks, profiles and instance NICs that use any of the specified ACLs and executes usageFunc
+// once for each resource using one or more of the ACLs with info about the resource and matched ACLs being used.
+func UsedBy(s *state.State, aclProjectName string, usageFunc func(matchedACLNames []string, usageType interface{}, nicName string, nicConfig map[string]string) error, matchACLNames ...string) error {
+	if len(matchACLNames) <= 0 {
+		return nil
+	}
+
+	// Find networks using the ACLs. Cheapest to do.
+	networkNames, err := s.Cluster.GetCreatedNetworks(aclProjectName)
+	if err != nil && err != db.ErrNoSuchObject {
+		return errors.Wrapf(err, "Failed loading networks for project %q", aclProjectName)
+	}
+
+	for _, networkName := range networkNames {
+		_, network, _, err := s.Cluster.GetNetworkInAnyState(aclProjectName, networkName)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to get network config for %q", networkName)
+		}
+
+		netACLNames := util.SplitNTrimSpace(network.Config["security.acls"], ",", -1, true)
+		matchedACLNames := []string{}
+		for _, netACLName := range netACLNames {
+			if shared.StringInSlice(netACLName, matchACLNames) {
+				matchedACLNames = append(matchedACLNames, netACLName)
+			}
+		}
+
+		if len(matchedACLNames) > 0 {
+			// Call usageFunc with a list of matched ACLs and info about the network.
+			err := usageFunc(matchedACLNames, network, "", nil)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// Look for profiles. Next cheapest to do.
+	var profiles []db.Profile
+	err = s.Cluster.Transaction(func(tx *db.ClusterTx) error {
+		profiles, err = tx.GetProfiles(db.ProfileFilter{})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, profile := range profiles {
+		// Get the profiles's effective network project name.
+		profileNetworkProjectName, _, err := project.NetworkProject(s.Cluster, profile.Project)
+		if err != nil {
+			return err
+		}
+
+		// Skip profiles who's effective network project doesn't match this Network ACL's project.
+		if profileNetworkProjectName != aclProjectName {
+			return nil
+		}
+
+		// Iterate through each of the instance's devices, looking for NICs that are using any of the ACLs.
+		for devName, devConfig := range deviceConfig.NewDevices(profile.Devices) {
+			matchedACLNames := isInUseByDevice(devConfig, matchACLNames...)
+			if len(matchedACLNames) > 0 {
+				// Call usageFunc with a list of matched ACLs and info about the instance NIC.
+				err := usageFunc(matchedACLNames, profile, devName, devConfig)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	// Find ACLs that have rules that reference the ACLs.
+	aclNames, err := s.Cluster.GetNetworkACLs(aclProjectName)
+	if err != nil {
+		return err
+	}
+
+	for _, aclName := range aclNames {
+		_, aclInfo, err := s.Cluster.GetNetworkACL(aclProjectName, aclName)
+		if err != nil {
+			return err
+		}
+
+		matchedACLNames := []string{}
+
+		// Ingress rules can specify ACL names in their Source subjects.
+		for _, rule := range aclInfo.Ingress {
+			for _, subject := range util.SplitNTrimSpace(rule.Source, ",", -1, true) {
+
+				// Look for matching ACLs, but ignore our own ACL reference in our own rules.
+				if shared.StringInSlice(subject, matchACLNames) && subject != aclName {
+					matchedACLNames = append(matchedACLNames, subject)
+				}
+			}
+		}
+
+		// Egress rules can specify ACL names in their Destination subjects.
+		for _, rule := range aclInfo.Egress {
+			for _, subject := range util.SplitNTrimSpace(rule.Destination, ",", -1, true) {
+
+				// Look for matching ACLs, but ignore our own ACL reference in our own rules.
+				if shared.StringInSlice(subject, matchACLNames) && subject != aclName {
+					matchedACLNames = append(matchedACLNames, subject)
+				}
+			}
+		}
+
+		if len(matchedACLNames) > 0 {
+			// Call usageFunc with a list of matched ACLs and info about the ACL.
+			err := usageFunc(matchedACLNames, aclInfo, "", nil)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// Find instances using the ACLs. Most expensive to do.
+	err = s.Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 
 		// Skip instances who's effective network project doesn't match this Network ACL's project.
-		if instNetworkProject != projectName {
+		if instNetworkProject != aclProjectName {
 			return nil
 		}
 
-		devices := db.ExpandInstanceDevices(deviceConfig.NewDevices(inst.Devices), profiles).CloneNative()
+		devices := db.ExpandInstanceDevices(deviceConfig.NewDevices(inst.Devices), profiles)
 
-		// Iterate through each of the instance's devices, looking for NICs that are linked this ACL.
-		for _, devConfig := range devices {
-			// Only NICs linked to managed networks can use network ACLs.
-			if devConfig["type"] != "nic" || devConfig["network"] == "" {
-				continue
-			}
-
-			nicACLNames := util.SplitNTrimSpace(devConfig["security.acls"], ",", -1, true)
-			for _, nicACLName := range nicACLNames {
-				if nicACLName == aclName {
-					err := usageFunc("instance", inst.Project, inst.Name, devConfig)
-					if err != nil {
-						return err
-					}
+		// Iterate through each of the instance's devices, looking for NICs that are using any of the ACLs.
+		for devName, devConfig := range devices {
+			matchedACLNames := isInUseByDevice(devConfig, matchACLNames...)
+			if len(matchedACLNames) > 0 {
+				// Call usageFunc with a list of matched ACLs and info about the instance NIC.
+				err := usageFunc(matchedACLNames, inst, devName, devConfig)
+				if err != nil {
+					return err
 				}
 			}
 		}
 
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// isInUseByDevice returns any of the supplied matching ACL names found referenced by the NIC device.
+func isInUseByDevice(d deviceConfig.Device, matchACLNames ...string) []string {
+	matchedACLNames := []string{}
+
+	// Only NICs linked to managed networks can use network ACLs.
+	if d["type"] != "nic" || d["network"] == "" {
+		return matchedACLNames
+	}
+
+	for _, nicACLName := range util.SplitNTrimSpace(d["security.acls"], ",", -1, true) {
+		if shared.StringInSlice(nicACLName, matchACLNames) {
+			matchedACLNames = append(matchedACLNames, nicACLName)
+		}
+	}
+
+	return matchedACLNames
 }

--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -1,0 +1,312 @@
+package acl
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/lxc/lxd/lxd/network/openvswitch"
+	"github.com/lxc/lxd/lxd/state"
+	"github.com/lxc/lxd/lxd/util"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/validate"
+)
+
+// OVN ACL rule priorities.
+const ovnACLPrioritySwitchAllow = 10
+const ovnACLPriorityPortGroupDefaultDrop = 0
+const ovnACLPriorityPortGroupAllow = 20
+const ovnACLPriorityPortGroupReject = 30
+const ovnACLPriorityPortGroupDrop = 40
+
+// OVNACLPortGroupName returns the port group name for a Network ACL ID.
+func OVNACLPortGroupName(networkACLID int64) openvswitch.OVNPortGroup {
+	// OVN doesn't match port groups that have a "-" in them. So use an "_" for the separator.
+	return openvswitch.OVNPortGroup(fmt.Sprintf("lxd_acl%d", networkACLID))
+}
+
+// OVNApplyToPortGroup applies the rules in the specified ACL to the specified port group.
+func OVNApplyToPortGroup(s *state.State, client *openvswitch.OVN, aclInfo *api.NetworkACL, portGroupName openvswitch.OVNPortGroup, aclNameIDs map[string]int64) error {
+	// Create slice for port group rules that has the capacity for ingress and egress rules, plus default drop.
+	portGroupRules := make([]openvswitch.OVNACLRule, 0, len(aclInfo.Ingress)+len(aclInfo.Egress)+1)
+
+	// convertACLRules converts the ACL rules to OVN ACL rules.
+	convertACLRules := func(direction string, rules ...api.NetworkACLRule) error {
+		for ruleIndex, rule := range rules {
+			if rule.State == "disabled" {
+				continue
+			}
+
+			portGroupRule, err := ovnRuleCriteriaToOVNPortGroupRule(direction, &rule, portGroupName, aclNameIDs)
+			if err != nil {
+				return err
+			}
+
+			if rule.State == "logged" {
+				portGroupRule.Log = true
+				portGroupRule.LogName = fmt.Sprintf("%s-%s-%d", portGroupName, direction, ruleIndex)
+			}
+
+			portGroupRules = append(portGroupRules, portGroupRule)
+		}
+
+		return nil
+	}
+
+	err := convertACLRules("ingress", aclInfo.Ingress...)
+	if err != nil {
+		return errors.Wrapf(err, "Failed converting ACL %q ingress rules for port group %q", aclInfo.Name, portGroupName)
+	}
+
+	err = convertACLRules("egress", aclInfo.Egress...)
+	if err != nil {
+		return errors.Wrapf(err, "Failed converting ACL %q egress rules for port group %q", aclInfo.Name, portGroupName)
+	}
+
+	// Add default drop rule to port group ACL.
+	portGroupRules = append(portGroupRules, openvswitch.OVNACLRule{
+		Direction: "to-lport", // Always use this so that outport is available to Match.
+		Action:    "drop",
+		Priority:  0, // Lowest priority to catch only unmatched traffic.
+		Match:     fmt.Sprintf("inport == @%s || outport == @%s", portGroupName, portGroupName),
+		Log:       true,
+		LogName:   string(portGroupName),
+	})
+
+	err = client.PortGroupSetACLRules(portGroupName, portGroupRules...)
+	if err != nil {
+		return errors.Wrapf(err, "Failed applying ACL %q rules to port group %q", aclInfo.Name, portGroupName)
+	}
+
+	return nil
+}
+
+// ovnRuleCriteriaToOVNPortGroupRule converts an ACL rule into an OVNACLRule for a port group.
+func ovnRuleCriteriaToOVNPortGroupRule(direction string, rule *api.NetworkACLRule, portGroupName openvswitch.OVNPortGroup, aclNameIDs map[string]int64) (openvswitch.OVNACLRule, error) {
+	portGroupRule := openvswitch.OVNACLRule{
+		Direction: "to-lport", // Always use this so that outport is available to Match.
+	}
+
+	// Populate Action and Priority based on rule's Action.
+	switch rule.Action {
+	case "allow":
+		portGroupRule.Action = "allow-related" // TODO add stateless support.
+		portGroupRule.Priority = ovnACLPriorityPortGroupAllow
+	case "reject":
+		portGroupRule.Action = "reject"
+		portGroupRule.Priority = ovnACLPriorityPortGroupReject
+	case "drop":
+		portGroupRule.Action = "drop"
+		portGroupRule.Priority = ovnACLPriorityPortGroupDrop
+	}
+
+	var matchParts []string
+
+	// Add directional port filter so we only apply this rule to the ports in the port group.
+	switch direction {
+	case "ingress":
+		matchParts = []string{fmt.Sprintf("outport == @%s", portGroupName)} // Traffic going to Instance.
+	case "egress":
+		matchParts = []string{fmt.Sprintf("inport == @%s", portGroupName)} // Traffic leaving Instance.
+	default:
+		matchParts = []string{fmt.Sprintf("inport == @%s || outport == @%s", portGroupName, portGroupName)}
+	}
+
+	// Add subject filters.
+	if rule.Source != "" {
+		match, err := ovnRuleSubjectToOVNACLMatch("src", aclNameIDs, util.SplitNTrimSpace(rule.Source, ",", -1, false)...)
+		if err != nil {
+			return openvswitch.OVNACLRule{}, err
+		}
+
+		matchParts = append(matchParts, match)
+	}
+
+	if rule.Destination != "" {
+		match, err := ovnRuleSubjectToOVNACLMatch("dst", aclNameIDs, util.SplitNTrimSpace(rule.Destination, ",", -1, false)...)
+		if err != nil {
+			return openvswitch.OVNACLRule{}, err
+		}
+
+		matchParts = append(matchParts, match)
+	}
+
+	// Add protocol filters.
+	if shared.StringInSlice(rule.Protocol, []string{"tcp", "udp"}) {
+		matchParts = append(matchParts, fmt.Sprintf("%s", rule.Protocol))
+
+		if rule.SourcePort != "" {
+			matchParts = append(matchParts, ovnRulePortToOVNACLMatch(rule.Protocol, "src", util.SplitNTrimSpace(rule.SourcePort, ",", -1, false)...))
+		}
+
+		if rule.DestinationPort != "" {
+			matchParts = append(matchParts, ovnRulePortToOVNACLMatch(rule.Protocol, "dst", util.SplitNTrimSpace(rule.DestinationPort, ",", -1, false)...))
+		}
+	} else if shared.StringInSlice(rule.Protocol, []string{"icmp4", "icmp6"}) {
+		matchParts = append(matchParts, fmt.Sprintf("%s", rule.Protocol))
+
+		if rule.ICMPType != "" {
+			matchParts = append(matchParts, fmt.Sprintf("%s.type == %s", rule.Protocol, rule.ICMPType))
+		}
+
+		if rule.ICMPCode != "" {
+			matchParts = append(matchParts, fmt.Sprintf("%s.code == %s", rule.Protocol, rule.ICMPCode))
+		}
+	}
+
+	// Populate the Match field with the generated match parts.
+	portGroupRule.Match = fmt.Sprintf("(%s)", strings.Join(matchParts, ") && ("))
+
+	return portGroupRule, nil
+}
+
+// ovnRulePortToOVNACLMatch converts protocol (tcp/udp), direction (src/dst) and port criteria list into an OVN
+// match statement.
+func ovnRulePortToOVNACLMatch(protocol string, direction string, portCriteria ...string) string {
+	fieldParts := make([]string, 0, len(portCriteria))
+
+	for _, portCriterion := range portCriteria {
+		criterionParts := strings.SplitN(portCriterion, "-", 2)
+		if len(criterionParts) > 1 {
+			fieldParts = append(fieldParts, fmt.Sprintf("(%s.%s >= %s && %s.%s <= %s)", protocol, direction, criterionParts[0], protocol, direction, criterionParts[1]))
+		} else {
+			fieldParts = append(fieldParts, fmt.Sprintf("%s.%s == %s", protocol, direction, criterionParts[0]))
+		}
+	}
+
+	return strings.Join(fieldParts, " || ")
+}
+
+// ovnRuleSubjectToOVNACLMatch converts direction (src/dst) and subject criteria list into an OVN match statement.
+func ovnRuleSubjectToOVNACLMatch(direction string, aclNameIDs map[string]int64, subjectCriteria ...string) (string, error) {
+	fieldParts := make([]string, 0, len(subjectCriteria))
+
+	// For each criterion check if value looks like an IP range or IP CIDR, and if not use it as an ACL name.
+	for _, subjectCriterion := range subjectCriteria {
+		if validate.IsNetworkRange(subjectCriterion) == nil {
+			criterionParts := strings.SplitN(subjectCriterion, "-", 2)
+			if len(criterionParts) > 1 {
+				ip := net.ParseIP(criterionParts[0])
+				if ip != nil {
+					protocol := "ip4"
+					if ip.To4() == nil {
+						protocol = "ip6"
+					}
+
+					fieldParts = append(fieldParts, fmt.Sprintf("(%s.%s >= %s && %s.%s <= %s)", protocol, direction, criterionParts[0], protocol, direction, criterionParts[1]))
+				}
+			} else {
+				return "", fmt.Errorf("Invalid IP range %q", subjectCriterion)
+			}
+		} else {
+			ip, _, err := net.ParseCIDR(subjectCriterion)
+			if err == nil {
+				protocol := "ip4"
+				if ip.To4() == nil {
+					protocol = "ip6"
+				}
+
+				fieldParts = append(fieldParts, fmt.Sprintf("%s.%s == %s", protocol, direction, subjectCriterion))
+			} else {
+				// If not valid IP subnet, then assume this is an OVN port group name.
+				portType := "inport"
+				if direction == "dst" {
+					portType = "outport"
+				}
+
+				aclID, found := aclNameIDs[subjectCriterion]
+				if !found {
+					return "", fmt.Errorf("Cannot find security ACL ID for %q", subjectCriterion)
+				}
+
+				fieldParts = append(fieldParts, fmt.Sprintf("%s == @%s", portType, OVNACLPortGroupName(aclID)))
+			}
+		}
+	}
+
+	return strings.Join(fieldParts, " || "), nil
+}
+
+// OVNApplyNetworkBaselineRules applies preset baseline logical switch rules to a allow access to network services.
+func OVNApplyNetworkBaselineRules(client *openvswitch.OVN, switchName openvswitch.OVNSwitch, routerPortName openvswitch.OVNSwitchPort, intRouterIPs []*net.IPNet, dnsIPs []net.IP) error {
+	rules := []openvswitch.OVNACLRule{
+		{
+			Direction: "to-lport",
+			Action:    "allow",
+			Priority:  ovnACLPrioritySwitchAllow,
+			Match:     "arp || nd", // Neighbour discovery.
+		},
+		{
+			Direction: "to-lport",
+			Action:    "allow",
+			Priority:  ovnACLPrioritySwitchAllow,
+			Match:     fmt.Sprintf(`inport == "%s" && nd_ra`, routerPortName), // IPv6 router adverts from router.
+		},
+		{
+			Direction: "to-lport",
+			Action:    "allow",
+			Priority:  ovnACLPrioritySwitchAllow,
+			Match:     fmt.Sprintf(`outport == "%s" && nd_rs`, routerPortName), // IPv6 router solicitation to router.
+		},
+		{
+			Direction: "to-lport",
+			Action:    "allow",
+			Priority:  ovnACLPrioritySwitchAllow,
+			Match:     fmt.Sprintf(`outport == "%s" && ((ip4 && udp.dst == 67) || (ip6 && udp.dst == 547)) `, routerPortName), // DHCP to router.
+		},
+	}
+
+	// Add rules to allow ping to/from internal router IPs.
+	for _, intRouterIP := range intRouterIPs {
+		ipVersion := 4
+		icmpPingType := 8
+		icmpPingReplyType := 0
+		if intRouterIP.IP.To4() == nil {
+			ipVersion = 6
+			icmpPingType = 128
+			icmpPingReplyType = 129
+		}
+
+		rules = append(rules,
+			openvswitch.OVNACLRule{
+				Direction: "to-lport",
+				Action:    "allow",
+				Priority:  ovnACLPrioritySwitchAllow,
+				Match:     fmt.Sprintf(`outport == "%s" && icmp%d.type == %d && ip%d.dst == %s`, routerPortName, ipVersion, icmpPingType, ipVersion, intRouterIP.IP),
+			},
+			openvswitch.OVNACLRule{
+				Direction: "to-lport",
+				Action:    "allow",
+				Priority:  ovnACLPrioritySwitchAllow,
+				Match:     fmt.Sprintf(`inport == "%s" && icmp%d.type == %d && ip%d.src == %s`, routerPortName, ipVersion, icmpPingReplyType, ipVersion, intRouterIP.IP),
+			},
+		)
+	}
+
+	// Add rules to allow DNS to DNS IPs.
+	for _, dnsIP := range dnsIPs {
+		ipVersion := 4
+		if dnsIP.To4() == nil {
+			ipVersion = 6
+		}
+
+		rules = append(rules,
+			openvswitch.OVNACLRule{
+				Direction: "to-lport",
+				Action:    "allow",
+				Priority:  ovnACLPrioritySwitchAllow,
+				Match:     fmt.Sprintf(`outport == "%s" && ip%d.dst == %s && (udp.dst == 53 || tcp.dst == 53)`, routerPortName, ipVersion, dnsIP),
+			},
+		)
+	}
+
+	err := client.LogicalSwitchSetACLRules(switchName, rules...)
+	if err != nil {
+		return errors.Wrapf(err, "Failed applying baseline ACL rules to logical switch %q", switchName)
+	}
+
+	return nil
+}

--- a/lxd/network/acl/driver_common.go
+++ b/lxd/network/acl/driver_common.go
@@ -36,15 +36,16 @@ type common struct {
 
 // init initialise internal variables.
 func (d *common) init(state *state.State, id int64, projectName string, info *api.NetworkACL) {
-	d.logger = logging.AddContext(logger.Log, log.Ctx{"project": projectName, "networkACL": info.Name})
+	if info == nil {
+		d.info = &api.NetworkACL{}
+	} else {
+		d.info = info
+	}
+
+	d.logger = logging.AddContext(logger.Log, log.Ctx{"project": projectName, "networkACL": d.info.Name})
 	d.id = id
 	d.projectName = projectName
-	d.info = info
 	d.state = state
-
-	if d.info == nil {
-		d.info = &api.NetworkACL{}
-	}
 
 	if d.info.Ingress == nil {
 		d.info.Ingress = []api.NetworkACLRule{}

--- a/lxd/network/acl/driver_common.go
+++ b/lxd/network/acl/driver_common.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/network/openvswitch"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/util"
@@ -262,9 +264,25 @@ func (d *common) validateRule(direction ruleDirection, rule api.NetworkACLRule) 
 		return fmt.Errorf("State must be one of: %s", strings.Join(validStates, ", "))
 	}
 
+	// Get map of ACL names to DB IDs (used for generating OVN port group names).
+	acls, err := d.state.Cluster.GetNetworkACLIDsByNames(d.Project())
+	if err != nil {
+		return errors.Wrapf(err, "Failed getting network ACLs for security ACL subject validation")
+	}
+
+	aclNames := make([]string, len(acls))
+	for aclName := range acls {
+		aclNames = append(aclNames, aclName)
+	}
+
 	// Validate Source field.
 	if rule.Source != "" {
-		err := d.validateRuleSubjects(util.SplitNTrimSpace(rule.Source, ",", -1, false), nil)
+		var validACLNames []string
+		if direction == ruleDirectionIngress {
+			validACLNames = aclNames // ACL names are only allowed in ingress rule sources.
+		}
+
+		err := d.validateRuleSubjects(util.SplitNTrimSpace(rule.Source, ",", -1, false), validACLNames)
 		if err != nil {
 			return errors.Wrapf(err, "Invalid Source")
 		}
@@ -272,7 +290,12 @@ func (d *common) validateRule(direction ruleDirection, rule api.NetworkACLRule) 
 
 	// Validate Destination field.
 	if rule.Destination != "" {
-		err := d.validateRuleSubjects(util.SplitNTrimSpace(rule.Destination, ",", -1, false), nil)
+		var validACLNames []string
+		if direction == ruleDirectionEgress {
+			validACLNames = aclNames // ACL names are only allowed in egress rule destinations.
+		}
+
+		err := d.validateRuleSubjects(util.SplitNTrimSpace(rule.Destination, ",", -1, false), validACLNames)
 		if err != nil {
 			return errors.Wrapf(err, "Invalid Destination")
 		}
@@ -439,6 +462,66 @@ func (d *common) Update(config *api.NetworkACLPut) error {
 	// Apply changes internally and reinitialise.
 	d.info.NetworkACLPut = *config
 	d.init(d.state, d.id, d.projectName, d.info)
+
+	// OVN networks share ACL port group definitions so we only need to apply changes once for all OVN nets.
+	applyToOVN := false
+
+	// Find all networks and instance NICs that use this Network ACL and check if any are OVN.
+	err = UsedBy(d.state, d.projectName, func(_ []string, usageType interface{}, _ string, nicConfig map[string]string) error {
+		switch u := usageType.(type) {
+		case db.Instance, db.Profile:
+			_, network, _, err := d.state.Cluster.GetNetworkInAnyState(d.projectName, nicConfig["network"])
+			if err != nil {
+				return errors.Wrapf(err, "Failed to load network %q", nicConfig["network"])
+			}
+
+			if network.Type == "ovn" {
+				applyToOVN = true
+
+				// Only OVN networks support ACLs at this time so no need to search further.
+				return db.ErrInstanceListStop
+			}
+		case *api.Network:
+			if u.Type == "ovn" {
+				applyToOVN = true
+
+				// Only OVN networks support ACLs at this time so no need to search further.
+				return db.ErrInstanceListStop
+			}
+		case *api.NetworkACL:
+			return nil // Nothing to do for ACL rules referencing us.
+		default:
+			return fmt.Errorf("Unrecognised usage type %T", u)
+		}
+
+		return nil
+	}, d.Info().Name)
+	if err != nil && err != db.ErrInstanceListStop {
+		return errors.Wrapf(err, "Failed getting ACL usage")
+	}
+
+	if applyToOVN {
+		portGroupName := OVNACLPortGroupName(d.ID())
+		d.logger.Debug("Applying ACL rules to OVN port group", log.Ctx{"portGroup": portGroupName})
+		nbConnection, err := cluster.ConfigGetString(d.state.Cluster, "network.ovn.northbound_connection")
+		if err != nil {
+			return errors.Wrapf(err, "Failed to get OVN northbound connection string")
+		}
+
+		client := openvswitch.NewOVN()
+		client.SetDatabaseAddress(nbConnection)
+
+		// Get map of ACL names to DB IDs (used for generating OVN port group names).
+		acls, err := d.state.Cluster.GetNetworkACLIDsByNames(d.Project())
+		if err != nil {
+			return errors.Wrapf(err, "Failed getting network ACL IDs for security ACL update")
+		}
+
+		err = OVNApplyToPortGroup(d.state, client, d.info, portGroupName, acls)
+		if err != nil {
+			return errors.Wrapf(err, "Failed applying ACL %q rules to OVN port group %q", d.info.Name, portGroupName)
+		}
+	}
 
 	return nil
 }

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -72,10 +72,12 @@ type OVNInstanceNICOpts struct {
 type OVNInstanceNICSetupOpts struct {
 	OVNInstanceNICOpts
 
-	UplinkConfig map[string]string
-	DNSName      string
-	MAC          net.HardwareAddr
-	IPs          []net.IP
+	UplinkConfig       map[string]string
+	DNSName            string
+	MAC                net.HardwareAddr
+	IPs                []net.IP
+	SecurityACLs       []string
+	SecurityACLsRemove []string
 }
 
 // ovn represents a LXD OVN network.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -216,6 +216,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		"ipv6.nat":           validate.Optional(validate.IsBool),
 		"dns.domain":         validate.IsAny,
 		"dns.search":         validate.IsAny,
+		"security.acls":      validate.IsAny,
 
 		// Volatile keys populated automatically as needed.
 		ovnVolatileUplinkIPv4: validate.Optional(validate.IsNetworkAddressV4),
@@ -348,6 +349,14 @@ func (n *ovn) Validate(config map[string]string) error {
 					return fmt.Errorf("External subnet %q overlaps with another OVN NIC's external route", externalSubnet.String())
 				}
 			}
+		}
+	}
+
+	// Check Security ACLs exist.
+	if config["security.acls"] != "" {
+		err = acl.Exists(n.state, n.project, util.SplitNTrimSpace(config["security.acls"], ",", -1, true)...)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -1897,6 +1906,53 @@ func (n *ovn) setup(update bool) error {
 		return errors.Wrapf(err, "Failed applying baseline ACL rules to internal switch")
 	}
 
+	// Ensure any network assigned security ACL port groups are created ready for instance NICs to use.
+	securityACLS := util.SplitNTrimSpace(n.config["security.acls"], ",", -1, true)
+	if len(securityACLS) > 0 {
+		// Get map of ACL names to DB IDs (used for generating OVN port group names).
+		acls, err := n.state.Cluster.GetNetworkACLIDsByNames(n.Project())
+		if err != nil {
+			return errors.Wrapf(err, "Failed getting network ACL IDs for security ACL setup")
+		}
+
+		// Create ACLs port groups if needed.
+		for _, aclName := range securityACLS {
+			aclID, found := acls[aclName]
+			if !found {
+				return fmt.Errorf("Cannot find security ACL ID for %q", aclName)
+			}
+
+			portGroupName := acl.OVNACLPortGroupName(aclID)
+
+			// Get port group UUID.
+			portGroupUUID, err := client.PortGroupUUID(portGroupName)
+			if err != nil {
+				return errors.Wrapf(err, "Failed getting port group UUID for security ACL %q setup", aclName)
+			}
+
+			// Create port group (and add ACL rules) if doesn't exist.
+			if portGroupUUID == "" {
+				err = client.PortGroupAdd(portGroupName)
+				if err != nil {
+					return errors.Wrapf(err, "Failed creating port group %q for security ACL %q setup", portGroupName, aclName)
+				}
+				revert.Add(func() { client.PortGroupDelete(portGroupName) })
+
+				n.logger.Debug("Created ACL port group", log.Ctx{"networkACL": aclName, "portGroup": portGroupName})
+
+				_, aclInfo, err := n.state.Cluster.GetNetworkACL(n.Project(), aclName)
+				if err != nil {
+					return errors.Wrapf(err, "Failed loading Network ACL %q", aclName)
+				}
+
+				err = acl.OVNApplyToPortGroup(n.state, client, aclInfo, portGroupName, acls)
+				if err != nil {
+					return errors.Wrapf(err, "Failed adding ACL rules to port group %q for security ACL %q setup", portGroupName, aclName)
+				}
+			}
+		}
+	}
+
 	revert.Success()
 	return nil
 }
@@ -2053,6 +2109,15 @@ func (n *ovn) Delete(clientType request.ClientType) error {
 		if err != nil {
 			return err
 		}
+
+		// Check for port groups that will become unused (and need deleting) as this network is deleted.
+		securityACLs := util.SplitNTrimSpace(n.config["security.acls"], ",", -1, true)
+		if len(securityACLs) > 0 {
+			err = n.PortGroupDeleteIfUnused(n, "", securityACLs...)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return n.common.delete(clientType)
@@ -2174,6 +2239,109 @@ func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clientType re
 		err = n.setup(true)
 		if err != nil {
 			return err
+		}
+
+		// Work out which ACLs have been added and removed.
+		oldACLs := util.SplitNTrimSpace(oldNetwork.Config["security.acls"], ",", -1, true)
+		newACLs := util.SplitNTrimSpace(newNetwork.Config["security.acls"], ",", -1, true)
+		removedACLs := []string{}
+		for _, oldACL := range oldACLs {
+			if !shared.StringInSlice(oldACL, newACLs) {
+				removedACLs = append(removedACLs, oldACL)
+			}
+		}
+
+		addedACLs := []string{}
+		for _, newACL := range newACLs {
+			if !shared.StringInSlice(newACL, oldACLs) {
+				addedACLs = append(addedACLs, newACL)
+			}
+		}
+
+		// Apply security ACL changes.
+		if len(addedACLs) > 0 || len(removedACLs) > 0 {
+			client, err := n.getClient()
+			if err != nil {
+				return err
+			}
+
+			// Get map of ACL names to DB IDs (used for generating OVN port group names).
+			acls, err := n.state.Cluster.GetNetworkACLIDsByNames(n.Project())
+			if err != nil {
+				return errors.Wrapf(err, "Failed getting network ACL IDs for security ACL update")
+			}
+
+			// Apply ACL changes to running instance NICs that use this network.
+			err = usedByInstanceDevices(n.state, n.project, n.name, func(inst db.Instance, nicName string, nicConfig map[string]string) error {
+				nicACLs := util.SplitNTrimSpace(nicConfig["security.acls"], ",", -1, true)
+
+				// Get logical port UUID and name.
+				instancePortName := n.getInstanceDevicePortName(inst.Config["volatile.uuid"], nicName)
+
+				portUUID, err := client.LogicalSwitchPortUUID(instancePortName)
+				if err != nil {
+					return errors.Wrapf(err, "Failed getting logical port UUID for security ACL update")
+				}
+
+				if portUUID == "" {
+					return nil // No need to update a port that isn't started yet.
+				}
+
+				// Check whether we need to add any of the new ACLs to the NIC.
+				for _, addedACL := range addedACLs {
+					if shared.StringInSlice(addedACL, nicACLs) {
+						continue // NIC already has this ACL applied directly, so no need to add.
+					}
+
+					aclID, found := acls[addedACL]
+					if !found {
+						return fmt.Errorf("Cannot find security ACL ID for %q", addedACL)
+					}
+
+					portGroupName := acl.OVNACLPortGroupName(aclID)
+
+					// Add port to port group.
+					err = client.PortGroupMemberAdd(portGroupName, portUUID)
+					if err != nil {
+						return errors.Wrapf(err, "Failed adding logical port %q to port group %q for security ACL %q update", instancePortName, portGroupName, addedACL)
+					}
+					n.logger.Debug("Added logical port to ACL port group", log.Ctx{"networkACL": addedACL, "portGroup": portGroupName, "port": instancePortName})
+				}
+
+				// Check whether we need to remove any of the removed ACLs from the NIC.
+				for _, removedACL := range removedACLs {
+					if shared.StringInSlice(removedACL, nicACLs) {
+						continue // NIC still has this ACL applied directly, so don't remove.
+					}
+
+					aclID, found := acls[removedACL]
+					if !found {
+						return fmt.Errorf("Cannot find security ACL ID for %q", removedACL)
+					}
+
+					portGroupName := acl.OVNACLPortGroupName(aclID)
+
+					// Remove port from port group.
+					err = client.PortGroupMemberDelete(portGroupName, portUUID)
+					if err != nil {
+						return errors.Wrapf(err, "Failed removing logical port %q from port group %q for security ACL %q update", instancePortName, portGroupName, removedACL)
+					}
+					n.logger.Debug("Removed logical port from ACL port group", log.Ctx{"networkACL": removedACL, "portGroup": portGroupName, "port": instancePortName})
+				}
+
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+
+			// Check if any of the removed ACLs should also have their unused port groups deleted.
+			if len(removedACLs) > 0 {
+				err = n.PortGroupDeleteIfUnused(n, "", removedACLs...)
+				if err != nil {
+					return errors.Wrapf(err, "Failed removing unused OVN port groups")
+				}
+			}
 		}
 	}
 

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1247,6 +1247,16 @@ func (o *OVN) PortGroupMemberAdd(portGroupName OVNPortGroup, portMemberUUID OVNS
 	return nil
 }
 
+// PortGroupMemberDelete deleted a logical switch port (by UUID) from an existing port group.
+func (o *OVN) PortGroupMemberDelete(portGroupName OVNPortGroup, portMemberUUID OVNSwitchPortUUID) error {
+	_, err := o.nbctl("--if-exists", "remove", "port_group", string(portGroupName), "ports", string(portMemberUUID))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // PortGroupSetACLRules applies a set of rules to the specified port group. Any existing rules are removed.
 func (o *OVN) PortGroupSetACLRules(portGroupName OVNPortGroup, aclRules ...OVNACLRule) error {
 	// Remove any existing rules.

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -35,6 +35,12 @@ type OVNDNSUUID string
 // OVNDHCPOptionsUUID DHCP Options set UUID.
 type OVNDHCPOptionsUUID string
 
+// OVNPortGroup OVN port group name.
+type OVNPortGroup string
+
+// OVNPortGroupUUID OVN port group UUID.
+type OVNPortGroupUUID string
+
 // OVNIPAllocationOpts defines IP allocation settings that can be applied to a logical switch.
 type OVNIPAllocationOpts struct {
 	PrefixIPv4  *net.IPNet
@@ -1133,4 +1139,23 @@ func (o *OVN) ChassisGroupChassisDelete(haChassisGroupName OVNChassisGroup, chas
 	}
 
 	return nil
+}
+
+// PortGroupUUID returns the port group UUID or empty string if port doesn't exist.
+func (o *OVN) PortGroupUUID(portGroupName OVNPortGroup) (OVNPortGroupUUID, error) {
+	groupInfo, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--colum=_uuid,name", "find", "port_group",
+		fmt.Sprintf("name=%s", string(portGroupName)),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	groupParts := util.SplitNTrimSpace(groupInfo, ",", 2, false)
+	if len(groupParts) == 2 {
+		if groupParts[1] == string(portGroupName) {
+			return OVNPortGroupUUID(groupParts[0]), nil
+		}
+	}
+
+	return "", nil
 }

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1175,3 +1175,13 @@ func (o *OVN) PortGroupAdd(portGroupName OVNPortGroup, initialPortMembers ...OVN
 
 	return nil
 }
+
+// PortGroupMemberAdd adds a logical switch port (by UUID) to an existing port group.
+func (o *OVN) PortGroupMemberAdd(portGroupName OVNPortGroup, portMemberUUID OVNSwitchPortUUID) error {
+	_, err := o.nbctl("add", "port_group", string(portGroupName), "ports", string(portMemberUUID))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -106,6 +106,16 @@ type OVNSwitchPortOpts struct {
 	DHCPv6OptsID OVNDHCPOptionsUUID // Optional, if empty, no DHCPv6 enabled on port.
 }
 
+// OVNACLRule represents an ACL rule that can be added to a logical switch or port group.
+type OVNACLRule struct {
+	Direction string // Either "from-lport" or "to-lport".
+	Action    string // Either "allow-related", "allow", "drop", or "reject".
+	Match     string // Match criteria. See OVN Southbound database's Logical_Flow table match column usage.
+	Priority  int    // Priority (between 0 and 32767, inclusive). Higher values take precedence.
+	Log       bool   // Whether or not to log matched packets.
+	LogName   string // Log label name (requires Log be true).
+}
+
 // NewOVN initialises new OVN wrapper.
 func NewOVN() *OVN {
 	return &OVN{}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1159,3 +1159,19 @@ func (o *OVN) PortGroupUUID(portGroupName OVNPortGroup) (OVNPortGroupUUID, error
 
 	return "", nil
 }
+
+// PortGroupAdd creates a new port group and optionally adds logical switch ports to the group.
+func (o *OVN) PortGroupAdd(portGroupName OVNPortGroup, initialPortMembers ...OVNSwitchPort) error {
+	args := []string{"pg-add", string(portGroupName)}
+
+	for _, portName := range initialPortMembers {
+		args = append(args, string(portName))
+	}
+
+	_, err := o.nbctl(args...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1186,6 +1186,28 @@ func (o *OVN) PortGroupAdd(portGroupName OVNPortGroup, initialPortMembers ...OVN
 	return nil
 }
 
+// PortGroupDelete deletes a port group and all ACLs associated to it.
+func (o *OVN) PortGroupDelete(portGroupName OVNPortGroup) error {
+	// ovn-nbctl doesn't provide an "--if-exists" option for removing port groups.
+	uuid, err := o.PortGroupUUID(portGroupName)
+	if err != nil {
+		return err
+	}
+
+	// Nothing to do if port group doesn't exist.
+	if uuid == "" {
+		return nil
+	}
+
+	// Delete port group.
+	_, err = o.nbctl("pg-del", string(portGroupName))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // PortGroupMemberAdd adds a logical switch port (by UUID) to an existing port group.
 func (o *OVN) PortGroupMemberAdd(portGroupName OVNPortGroup, portMemberUUID OVNSwitchPortUUID) error {
 	_, err := o.nbctl("add", "port_group", string(portGroupName), "ports", string(portMemberUUID))

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -258,6 +258,7 @@ var APIExtensions = []string{
 	"projects_compression",
 	"projects_images_remote_cache_expiry",
 	"certificate_project",
+	"network_ovn_acl",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR provides the ability to assign Network ACLs to OVN networks and OVN NICs (either directly or via a profile).

E.g.

```
lxc network set ovn1 security.acls=test1,test2
lxc profile device set default eth0 security.acls=test1
lxc config device set c1 eth0 security.acls=test3,test4
```

- Network assigned ACLs are applied to all OVN Instance NICs that are connected to that network (in addition to any specified on the Instance NIC itself).
- LXD will create the OVN port groups (with ACL rules) as needed, and remove them when they are no longer referenced by any LXD resource.
- LXD will update the OVN port group ACL rules when the rules of a LXD Network ACL change.
- LXD will add baseline OVN ACL rules to OVN networks when they are added/updated to allow instance access to services provided by the network.
- When an ACL is applied to an Instance NIC, a default drop rule is added implicitly to the ACL.
- At this time ACL names cannot be used within other ACL rules.

Associated CI tests: https://github.com/lxc/lxc-ci/pull/244