### PR TITLE
lxd/cluster: Improve heartbeat logging

### DIFF
--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -21,9 +21,11 @@ import (
 
 	dqlite "github.com/canonical/go-dqlite"
 	client "github.com/canonical/go-dqlite/client"
+
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
+	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/pkg/errors"
 )
@@ -395,6 +397,7 @@ func (g *Gateway) DialFunc() client.DialFunc {
 		// leader is ourselves, and we were recently elected. In that case
 		// trigger a full heartbeat now: it will be a no-op if we aren't
 		// actually leaders.
+		logger.Debug("Triggering an out of schedule hearbeat", log.Ctx{"address": address})
 		go g.heartbeat(g.ctx, true)
 
 		return conn, nil

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -205,7 +205,11 @@ func (g *Gateway) heartbeat(ctx context.Context, initialHeartbeat bool) {
 		return
 	}
 
-	logger.Debugf("Starting heartbeat round")
+	if initialHeartbeat {
+		logger.Debugf("Starting heartbeat round (full update)")
+	} else {
+		logger.Debugf("Starting heartbeat round")
+	}
 	if err != nil {
 		logger.Warnf("Failed to get current raft nodes: %v", err)
 		return
@@ -329,6 +333,7 @@ func (g *Gateway) heartbeat(ctx context.Context, initialHeartbeat bool) {
 	})
 	if err != nil {
 		logger.Warnf("Failed to update heartbeat: %v", err)
+		return
 	}
 
 	// If full node state was sent and node refresh task is specified, run it async.


### PR DESCRIPTION
With this, only one heartbeat can be running at any one time and
additional requests are ignored. It also replaces the previous logic of
doing a full heartbeat round on dqlite connections to instead doing one
automatically if no heartbeat round succeeded over the past two
intervals.

This should ensure that a newly elected leader will do a hearbeat round
almost immediately and that this heartbeat round will include all data
whereas existing leaders will keep doing normal heartbeats even if
dqlite connections get reset.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>