### PR TITLE
Instance: Volume cleanup on backup import failure

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -436,7 +436,7 @@ func internalImportFromRecovery(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	resp := internalImport(d, projectName, req)
+	resp := internalImport(d, projectName, req, true)
 	if resp.String() != "success" {
 		return resp
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3431,6 +3431,8 @@ func (d *lxc) Delete(force bool) error {
 				if err != nil {
 					return err
 				}
+			} else {
+				d.logger.Info("Skipping snapshot volume delete")
 			}
 		} else {
 			// Remove all snapshots by initialising each snapshot as an Instance and
@@ -3447,6 +3449,8 @@ func (d *lxc) Delete(force bool) error {
 				if err != nil {
 					return err
 				}
+			} else {
+				d.logger.Info("Skipping instance volume delete")
 			}
 		}
 	}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -684,7 +684,7 @@ func createFromBackup(d *Daemon, projectName string, data io.Reader, pool string
 			AllowNameOverride: instanceName != "",
 		}
 
-		resp := internalImport(d, bInfo.Project, req)
+		resp := internalImport(d, bInfo.Project, req, false)
 		if resp.String() != "success" {
 			return fmt.Errorf("Internal import request: %v", resp.String())
 		}


### PR DESCRIPTION
When importing a backup, if the import failed at a certain point, the storage volume records were not deleted.

Reported here: https://discuss.linuxcontainers.org/t/ghost-container-volume/10191