### PR TITLE
Storage: Unset irrelevant BTRFS pool size property when creating from existing filesystem and not loop file

### DIFF
--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -159,7 +159,7 @@ func (d *btrfs) Create() error {
 				return fmt.Errorf("Provided path does not reside on a btrfs filesystem")
 			} else if strings.HasPrefix(cleanSource, lxdDir) {
 				if cleanSource != GetPoolMountPath(d.name) {
-					return fmt.Errorf("Only allowed source path under %s is %s", shared.VarPath(), GetPoolMountPath(d.name))
+					return fmt.Errorf("Only allowed source path under %q is %q", shared.VarPath(), GetPoolMountPath(d.name))
 				} else if !hasFilesystem(shared.VarPath("storage-pools"), util.FilesystemSuperMagicBtrfs) {
 					return fmt.Errorf("Provided path does not reside on a btrfs filesystem")
 				}
@@ -167,7 +167,7 @@ func (d *btrfs) Create() error {
 				// Delete the current directory to replace by subvolume.
 				err := os.Remove(cleanSource)
 				if err != nil && !os.IsNotExist(err) {
-					return errors.Wrapf(err, "Failed to remove '%s'", cleanSource)
+					return errors.Wrapf(err, "Failed to remove %q", cleanSource)
 				}
 			}
 
@@ -178,7 +178,7 @@ func (d *btrfs) Create() error {
 			}
 		}
 	} else {
-		return fmt.Errorf("Invalid \"source\" property")
+		return fmt.Errorf(`Invalid "source" property`)
 	}
 
 	return nil

--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -114,6 +114,9 @@ func (d *btrfs) Create() error {
 			return errors.Wrap(err, "Failed to format sparse file")
 		}
 	} else if shared.IsBlockdevPath(d.config["source"]) {
+		// Unset size property since it's irrelevant.
+		d.config["size"] = ""
+
 		// Format the block device.
 		_, err := makeFSType(d.config["source"], "btrfs", &mkfsOptions{Label: d.name})
 		if err != nil {
@@ -132,6 +135,9 @@ func (d *btrfs) Create() error {
 			d.config["source"] = devUUID
 		}
 	} else if d.config["source"] != "" {
+		// Unset size property since it's irrelevant.
+		d.config["size"] = ""
+
 		hostPath := shared.HostPath(d.config["source"])
 		if d.isSubvolume(hostPath) {
 			// Existing btrfs subvolume.

--- a/lxd/storage_pools_config.go
+++ b/lxd/storage_pools_config.go
@@ -165,8 +165,7 @@ func storagePoolValidateConfig(name string, driver string, config map[string]str
 func storagePoolFillDefault(name string, driver string, config map[string]string) error {
 	if driver == "dir" || driver == "ceph" || driver == "cephfs" {
 		if config["size"] != "" {
-			return fmt.Errorf(`The "size" property does not apply `+
-				`to %s storage pools`, driver)
+			return fmt.Errorf(`The "size" property does not apply to %q storage pools`, driver)
 		}
 	} else {
 		if config["size"] == "" {


### PR DESCRIPTION
Tested using:

```
lxc storage create btrfs btrfs # Create BTRFS pool on loop file
lxc storage show btrfs
config:
  size: 21GB
  source: /var/lib/lxd/disks/btrfs.img
```
Has `size` property generated.

Now create new BTRFS pool using existing filesystem:

```
mount | grep btrfs
/var/lib/lxd/disks/btrfs.img on /var/lib/lxd/storage-pools/btrfs type btrfs (rw,relatime,ssd,space_cache,user_subvol_rm_allowed,subvolid=5,subvol=/)
lxc storage create btrfs2 btrfs source=/var/lib/lxd/storage-pools/btrfs
lxc storage show btrfs2
config:
  source: /var/lib/lxd/storage-pools/btrfs
  volatile.initial_source: /var/lib/lxd/storage-pools/btrfs
```
Doesn't have `size` property.

There are similar lines in the `lvm` and `zfs` drivers already.

Reported from: https://discuss.linuxcontainers.org/t/btrfs-storage-size/10243