### PR TITLE
Swagger setup and initial endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,11 @@ update-schema:
 	go generate ./...
 	@echo "Code generation completed"
 
+.PHONY: update-api
+update-api:
+	go get -v -x github.com/go-swagger/go-swagger/cmd/swagger
+	swagger generate spec -o doc/rest-api.yaml -w ./lxd -m
+
 .PHONY: debug
 debug:
 ifeq ($(TAG_SQLITE3),)

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1,4 +1,105 @@
 definitions:
+  Certificate:
+    description: Certificate represents a LXD certificate
+    properties:
+      certificate:
+        example: X509 PEM certificate
+        type: string
+        x-go-name: Certificate
+      fingerprint:
+        example: fd200419b271f1dc2a5591b693cc5774b7f234e1ff8c6b78ad703b6888fe2b69
+        type: string
+        x-go-name: Fingerprint
+      name:
+        example: castiana
+        type: string
+        x-go-name: Name
+      projects:
+        description: 'API extension: certificate_project'
+        example:
+        - default
+        - foo
+        - bar
+        items:
+          type: string
+        type: array
+        x-go-name: Projects
+      restricted:
+        description: 'API extension: certificate_project'
+        example: true
+        type: boolean
+        x-go-name: Restricted
+      type:
+        example: client
+        type: string
+        x-go-name: Type
+    type: object
+    x-go-package: github.com/lxc/lxd/shared/api
+  CertificatePut:
+    description: 'API extension: certificate_update'
+    properties:
+      name:
+        example: castiana
+        type: string
+        x-go-name: Name
+      projects:
+        description: 'API extension: certificate_project'
+        example:
+        - default
+        - foo
+        - bar
+        items:
+          type: string
+        type: array
+        x-go-name: Projects
+      restricted:
+        description: 'API extension: certificate_project'
+        example: true
+        type: boolean
+        x-go-name: Restricted
+      type:
+        example: client
+        type: string
+        x-go-name: Type
+    title: CertificatePut represents the modifiable fields of a LXD certificate
+    type: object
+    x-go-package: github.com/lxc/lxd/shared/api
+  CertificatesPost:
+    description: CertificatesPost represents the fields of a new LXD certificate
+    properties:
+      certificate:
+        example: X509 PEM certificate
+        type: string
+        x-go-name: Certificate
+      name:
+        example: castiana
+        type: string
+        x-go-name: Name
+      password:
+        example: blah
+        type: string
+        x-go-name: Password
+      projects:
+        description: 'API extension: certificate_project'
+        example:
+        - default
+        - foo
+        - bar
+        items:
+          type: string
+        type: array
+        x-go-name: Projects
+      restricted:
+        description: 'API extension: certificate_project'
+        example: true
+        type: boolean
+        x-go-name: Restricted
+      type:
+        example: client
+        type: string
+        x-go-name: Type
+    type: object
+    x-go-package: github.com/lxc/lxd/shared/api
   Server:
     description: Server represents a LXD server
     properties:
@@ -361,6 +462,256 @@ paths:
       summary: Update the server configuration
       tags:
       - server
+  /1.0/certificates:
+    get:
+      description: Returns a list of trusted certificates (URLs).
+      operationId: certificates_get
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: API endpoints
+          schema:
+            description: Sync response
+            properties:
+              metadata:
+                description: List of endpoints
+                example: |-
+                  [
+                    "/1.0/certificates/390fdd27ed5dc2408edc11fe602eafceb6c025ddbad9341dfdcb1056a8dd98b1",
+                    "/1.0/certificates/22aee3f051f96abe6d7756892eecabf4b4b22e2ba877840a4ca981e9ea54030a"
+                  ]
+                items:
+                  type: string
+                type: array
+              status:
+                description: Status description
+                example: Success
+                type: string
+              status_code:
+                description: Status code
+                example: 200
+                type: int
+              type:
+                description: Response type
+                example: sync
+                type: string
+            type: object
+        "403":
+          $ref: '#/responses/Forbidden'
+        "500":
+          $ref: '#/responses/InternalServerError'
+      summary: Get the trusted certificates
+      tags:
+      - certificates
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Adds a certificate to the trust store.
+        In this mode, the `password` property is always ignored.
+      operationId: certificates_post
+      parameters:
+      - description: Certificate
+        in: body
+        name: certificate
+        required: true
+        schema:
+          $ref: '#/definitions/CertificatesPost'
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/EmptySyncResponse'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "403":
+          $ref: '#/responses/Forbidden'
+        "500":
+          $ref: '#/responses/InternalServerError'
+      summary: Add a trusted certificate
+      tags:
+      - certificates
+  /1.0/certificates/{fingerprint}:
+    delete:
+      description: Removes the certificate from the trust store.
+      operationId: certificate_delete
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/EmptySyncResponse'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "403":
+          $ref: '#/responses/Forbidden'
+        "500":
+          $ref: '#/responses/InternalServerError'
+      summary: Delete the trusted certificate
+      tags:
+      - certificates
+    get:
+      description: Gets a specific certificate entry from the trust store.
+      operationId: certificate_get
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Certificate
+          schema:
+            description: Sync response
+            properties:
+              metadata:
+                $ref: '#/definitions/Certificate'
+              status:
+                description: Status description
+                example: Success
+                type: string
+              status_code:
+                description: Status code
+                example: 200
+                type: int
+              type:
+                description: Response type
+                example: sync
+                type: string
+            type: object
+        "403":
+          $ref: '#/responses/Forbidden'
+        "500":
+          $ref: '#/responses/InternalServerError'
+      summary: Get the trusted certificate
+      tags:
+      - certificates
+    patch:
+      consumes:
+      - application/json
+      description: Updates a subset of the certificate configuration.
+      operationId: certificate_patch
+      parameters:
+      - description: Certificate configuration
+        in: body
+        name: certificate
+        required: true
+        schema:
+          $ref: '#/definitions/CertificatePut'
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/EmptySyncResponse'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "403":
+          $ref: '#/responses/Forbidden'
+        "412":
+          $ref: '#/responses/PreconditionFailed'
+        "500":
+          $ref: '#/responses/InternalServerError'
+      summary: Partially update the trusted certificate
+      tags:
+      - certificates
+    put:
+      consumes:
+      - application/json
+      description: Updates the entire certificate configuration.
+      operationId: certificate_put
+      parameters:
+      - description: Certificate configuration
+        in: body
+        name: certificate
+        required: true
+        schema:
+          $ref: '#/definitions/CertificatePut'
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/EmptySyncResponse'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "403":
+          $ref: '#/responses/Forbidden'
+        "412":
+          $ref: '#/responses/PreconditionFailed'
+        "500":
+          $ref: '#/responses/InternalServerError'
+      summary: Update the trusted certificate
+      tags:
+      - certificates
+  /1.0/certificates?public:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Adds a certificate to the trust store as an untrusted user.
+        In this mode, the `password` property must be set to the correct value.
+
+        The `certificate` field can be omitted in which case the TLS client
+        certificate in use for the connection will be retrieved and added to the
+        trust store.
+
+        The `?public` part of the URL isn't required, it's simply used to
+        separate the two behaviors of this endpoint.
+      operationId: certificates_post_untrusted
+      parameters:
+      - description: Certificate
+        in: body
+        name: certificate
+        required: true
+        schema:
+          $ref: '#/definitions/CertificatesPost'
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/EmptySyncResponse'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "403":
+          $ref: '#/responses/Forbidden'
+        "500":
+          $ref: '#/responses/InternalServerError'
+      summary: Add a trusted certificate
+      tags:
+      - certificates
+  /1.0/certificates?recursion=1:
+    get:
+      description: Returns a list of trusted certificates (structs).
+      operationId: certificates_get_recursion1
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: API endpoints
+          schema:
+            description: Sync response
+            properties:
+              metadata:
+                description: List of certificates
+                items:
+                  $ref: '#/definitions/Certificate'
+                type: array
+              status:
+                description: Status description
+                example: Success
+                type: string
+              status_code:
+                description: Status code
+                example: 200
+                type: int
+              type:
+                description: Response type
+                example: sync
+                type: string
+            type: object
+        "403":
+          $ref: '#/responses/Forbidden'
+        "500":
+          $ref: '#/responses/InternalServerError'
+      summary: Get the trusted certificates
+      tags:
+      - certificates
   /1.0?public:
     get:
       description: |-

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1,0 +1,492 @@
+definitions:
+  Server:
+    description: Server represents a LXD server
+    properties:
+      api_extensions:
+        example:
+        - etag
+        - patch
+        - network
+        - storage
+        items:
+          type: string
+        type: array
+        x-go-name: APIExtensions
+      api_status:
+        example: stable
+        type: string
+        x-go-name: APIStatus
+      api_version:
+        example: "1.0"
+        type: string
+        x-go-name: APIVersion
+      auth:
+        example: untrusted
+        type: string
+        x-go-name: Auth
+      auth_methods:
+        example:
+        - tls
+        - candid
+        items:
+          type: string
+        type: array
+        x-go-name: AuthMethods
+      config:
+        additionalProperties:
+          type: object
+        example:
+          core.https_address: :8443
+          core.trust_password: true
+        type: object
+        x-go-name: Config
+      environment:
+        $ref: '#/definitions/ServerEnvironment'
+      public:
+        example: true
+        type: boolean
+        x-go-name: Public
+    type: object
+    x-go-package: github.com/lxc/lxd/shared/api
+  ServerEnvironment:
+    description: ServerEnvironment represents the read-only environment fields of
+      a LXD server
+    properties:
+      addresses:
+        example:
+        - :8443
+        items:
+          type: string
+        type: array
+        x-go-name: Addresses
+      architectures:
+        example:
+        - x86_64
+        - i686
+        items:
+          type: string
+        type: array
+        x-go-name: Architectures
+      certificate:
+        example: X509 PEM certificate
+        type: string
+        x-go-name: Certificate
+      certificate_fingerprint:
+        example: fd200419b271f1dc2a5591b693cc5774b7f234e1ff8c6b78ad703b6888fe2b69
+        type: string
+        x-go-name: CertificateFingerprint
+      driver:
+        example: lxc | qemu
+        type: string
+        x-go-name: Driver
+      driver_version:
+        example: 4.0.7 | 5.2.0
+        type: string
+        x-go-name: DriverVersion
+      firewall:
+        example: nftables
+        type: string
+        x-go-name: Firewall
+      kernel:
+        example: Linux
+        type: string
+        x-go-name: Kernel
+      kernel_architecture:
+        example: x86_64
+        type: string
+        x-go-name: KernelArchitecture
+      kernel_features:
+        additionalProperties:
+          type: string
+        example:
+          netnsid_getifaddrs: "true"
+          seccomp_listener: "true"
+        type: object
+        x-go-name: KernelFeatures
+      kernel_version:
+        example: 5.4.0-36-generic
+        type: string
+        x-go-name: KernelVersion
+      lxc_features:
+        additionalProperties:
+          type: string
+        example:
+          cgroup2: "true"
+          devpts_fd: "true"
+          pidfd: "true"
+        type: object
+        x-go-name: LXCFeatures
+      os_name:
+        example: Ubuntu
+        type: string
+        x-go-name: OSName
+      os_version:
+        example: "20.04"
+        type: string
+        x-go-name: OSVersion
+      project:
+        example: default
+        type: string
+        x-go-name: Project
+      server:
+        example: lxd
+        type: string
+        x-go-name: Server
+      server_clustered:
+        example: false
+        type: boolean
+        x-go-name: ServerClustered
+      server_name:
+        example: castiana
+        type: string
+        x-go-name: ServerName
+      server_pid:
+        example: 1453969
+        format: int64
+        type: integer
+        x-go-name: ServerPid
+      server_version:
+        example: "4.11"
+        type: string
+        x-go-name: ServerVersion
+      storage:
+        example: dir | zfs
+        type: string
+        x-go-name: Storage
+      storage_version:
+        example: 1 | 0.8.4-1ubuntu11
+        type: string
+        x-go-name: StorageVersion
+    type: object
+    x-go-package: github.com/lxc/lxd/shared/api
+  ServerPut:
+    description: ServerPut represents the modifiable fields of a LXD server configuration
+    properties:
+      config:
+        additionalProperties:
+          type: object
+        example:
+          core.https_address: :8443
+          core.trust_password: true
+        type: object
+        x-go-name: Config
+    type: object
+    x-go-package: github.com/lxc/lxd/shared/api
+  ServerUntrusted:
+    description: ServerUntrusted represents a LXD server for an untrusted client
+    properties:
+      api_extensions:
+        example:
+        - etag
+        - patch
+        - network
+        - storage
+        items:
+          type: string
+        type: array
+        x-go-name: APIExtensions
+      api_status:
+        example: stable
+        type: string
+        x-go-name: APIStatus
+      api_version:
+        example: "1.0"
+        type: string
+        x-go-name: APIVersion
+      auth:
+        example: untrusted
+        type: string
+        x-go-name: Auth
+      auth_methods:
+        example:
+        - tls
+        - candid
+        items:
+          type: string
+        type: array
+        x-go-name: AuthMethods
+      public:
+        example: true
+        type: boolean
+        x-go-name: Public
+    type: object
+    x-go-package: github.com/lxc/lxd/shared/api
+info:
+  contact:
+    email: lxc-devel@lists.linuxcontainers.org
+    name: LXD upstream
+    url: https://github.com/lxc/lxd
+  description: |-
+    This is the REST API used by all LXD clients.
+    Internal endpoints aren't included in this documentation.
+
+    The LXD API is available over both a local unix+http and remote https API.
+    Authentication for local users relies on group membership and access to the unix socket.
+    For remote users, the default authentication method is TLS client
+    certificates with a macaroon based (candid) authentication method also
+    supported.
+
+    WARNING: This API documentation is a work in progress.
+    You may find the full documentation in its old format at "doc/rest-api.md".
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+  title: LXD external REST API
+  version: "1.0"
+paths:
+  /:
+    get:
+      description: |-
+        Returns a list of supported API versions (URLs).
+
+        Internal API endpoints are not reported as those aren't versioned and
+        should only be used by LXD itself.
+      operationId: api_get
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: API endpoints
+          schema:
+            description: Sync response
+            properties:
+              metadata:
+                description: List of endpoints
+                example:
+                - /1.0
+                items:
+                  type: string
+                type: array
+              status:
+                description: Status description
+                example: Success
+                type: string
+              status_code:
+                description: Status code
+                example: 200
+                type: int
+              type:
+                description: Response type
+                example: sync
+                type: string
+            type: object
+      summary: Get the supported API enpoints
+      tags:
+      - server
+  /1.0:
+    get:
+      description: Shows the full server environment and configuration.
+      operationId: server_get
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Server environment and configuration
+          schema:
+            description: Sync response
+            properties:
+              metadata:
+                $ref: '#/definitions/Server'
+              status:
+                description: Status description
+                example: Success
+                type: string
+              status_code:
+                description: Status code
+                example: 200
+                type: int
+              type:
+                description: Response type
+                example: sync
+                type: string
+            type: object
+        "500":
+          $ref: '#/responses/InternalServerError'
+      summary: Get the server environment and configuration
+      tags:
+      - server
+    patch:
+      consumes:
+      - application/json
+      description: Updates a subset of the server configuration.
+      operationId: server_patch
+      parameters:
+      - description: Server configuration
+        in: body
+        name: server
+        required: true
+        schema:
+          $ref: '#/definitions/ServerPut'
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/EmptySyncResponse'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "403":
+          $ref: '#/responses/Forbidden'
+        "412":
+          $ref: '#/responses/PreconditionFailed'
+        "500":
+          $ref: '#/responses/InternalServerError'
+      summary: Partially update the server configuration
+      tags:
+      - server
+    put:
+      consumes:
+      - application/json
+      description: Updates the entire server configuration.
+      operationId: server_put
+      parameters:
+      - description: Server configuration
+        in: body
+        name: server
+        required: true
+        schema:
+          $ref: '#/definitions/ServerPut'
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/EmptySyncResponse'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "403":
+          $ref: '#/responses/Forbidden'
+        "412":
+          $ref: '#/responses/PreconditionFailed'
+        "500":
+          $ref: '#/responses/InternalServerError'
+      summary: Update the server configuration
+      tags:
+      - server
+  /1.0?public:
+    get:
+      description: |-
+        Shows a small subset of the server environment and configuration
+        which is required by untrusted clients to reach a server.
+
+        The `?public` part of the URL isn't required, it's simply used to
+        separate the two behaviors of this endpoint.
+      operationId: server_get_untrusted
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Server environment and configuration
+          schema:
+            description: Sync response
+            properties:
+              metadata:
+                $ref: '#/definitions/ServerUntrusted'
+              status:
+                description: Status description
+                example: Success
+                type: string
+              status_code:
+                description: Status code
+                example: 200
+                type: int
+              type:
+                description: Response type
+                example: sync
+                type: string
+            type: object
+        "500":
+          $ref: '#/responses/InternalServerError'
+      summary: Get the server environment
+      tags:
+      - server
+responses:
+  BadRequest:
+    description: Bad Request
+    schema:
+      properties:
+        code:
+          example: 400
+          format: int64
+          type: integer
+          x-go-name: Code
+        error:
+          example: bad request
+          type: string
+          x-go-name: Error
+        type:
+          example: error
+          type: string
+          x-go-name: Type
+      type: object
+  EmptySyncResponse:
+    description: Empty sync response
+    schema:
+      properties:
+        status:
+          example: Success
+          type: string
+          x-go-name: Status
+        status_code:
+          example: 200
+          format: int64
+          type: integer
+          x-go-name: StatusCode
+        type:
+          example: sync
+          type: string
+          x-go-name: Type
+      type: object
+  Forbidden:
+    description: Forbidden
+    schema:
+      properties:
+        code:
+          example: 403
+          format: int64
+          type: integer
+          x-go-name: Code
+        error:
+          example: not authorized
+          type: string
+          x-go-name: Error
+        type:
+          example: error
+          type: string
+          x-go-name: Type
+      type: object
+  InternalServerError:
+    description: Internal Server Error
+    schema:
+      properties:
+        code:
+          example: 500
+          format: int64
+          type: integer
+          x-go-name: Code
+        error:
+          example: internal server error
+          type: string
+          x-go-name: Error
+        type:
+          example: error
+          type: string
+          x-go-name: Type
+      type: object
+  PreconditionFailed:
+    description: Precondition Failed
+    schema:
+      properties:
+        code:
+          example: 412
+          format: int64
+          type: integer
+          x-go-name: Code
+        error:
+          example: precondition failed
+          type: string
+          x-go-name: Error
+        type:
+          example: error
+          type: string
+          x-go-name: Type
+      type: object
+swagger: "2.0"

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -16,7 +16,43 @@ import (
 	"github.com/lxc/lxd/shared/logger"
 )
 
-// RestServer creates an http.Server capable of handling requests against the LXD REST API endpoint.
+// swagger:operation GET / server api_get
+//
+// Get the supported API enpoints
+//
+// Returns a list of supported API versions (URLs).
+//
+// Internal API endpoints are not reported as those aren't versioned and
+// should only be used by LXD itself.
+//
+// ---
+// produces:
+//   - application/json
+// responses:
+//   "200":
+//     description: API endpoints
+//     schema:
+//       type: object
+//       description: Sync response
+//       properties:
+//         type:
+//           type: string
+//           description: Response type
+//           example: sync
+//         status:
+//           type: string
+//           description: Status description
+//           example: Success
+//         status_code:
+//           type: int
+//           description: Status code
+//           example: 200
+//         metadata:
+//           type: array
+//           description: List of endpoints
+//           items:
+//             type: string
+//           example: ["/1.0"]
 func restServer(d *Daemon) *http.Server {
 	/* Setup the web server */
 	mux := mux.NewRouter()

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -89,6 +89,75 @@ var api10 = []APIEndpoint{
 	storagePoolVolumeTypeStateCmd,
 }
 
+// swagger:operation GET /1.0?public server server_get_untrusted
+//
+// Get the server environment
+//
+// Shows a small subset of the server environment and configuration
+// which is required by untrusted clients to reach a server.
+//
+// The `?public` part of the URL isn't required, it's simply used to
+// separate the two behaviors of this endpoint.
+//
+// ---
+// produces:
+//   - application/json
+// responses:
+//   "200":
+//     description: Server environment and configuration
+//     schema:
+//       type: object
+//       description: Sync response
+//       properties:
+//         type:
+//           type: string
+//           description: Response type
+//           example: sync
+//         status:
+//           type: string
+//           description: Status description
+//           example: Success
+//         status_code:
+//           type: int
+//           description: Status code
+//           example: 200
+//         metadata:
+//           $ref: "#/definitions/ServerUntrusted"
+//   "500":
+//     $ref: "#/responses/InternalServerError"
+
+// swagger:operation GET /1.0 server server_get
+//
+// Get the server environment and configuration
+//
+// Shows the full server environment and configuration.
+//
+// ---
+// produces:
+//   - application/json
+// responses:
+//   "200":
+//     description: Server environment and configuration
+//     schema:
+//       type: object
+//       description: Sync response
+//       properties:
+//         type:
+//           type: string
+//           description: Response type
+//           example: sync
+//         status:
+//           type: string
+//           description: Status description
+//           example: Success
+//         status_code:
+//           type: int
+//           description: Status code
+//           example: 200
+//         metadata:
+//           $ref: "#/definitions/Server"
+//   "500":
+//     $ref: "#/responses/InternalServerError"
 func api10Get(d *Daemon, r *http.Request) response.Response {
 	authMethods := []string{"tls"}
 	err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
@@ -276,6 +345,35 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	return response.SyncResponseETag(true, fullSrv, fullSrv.Config)
 }
 
+// swagger:operation PUT /1.0 server server_put
+//
+// Update the server configuration
+//
+// Updates the entire server configuration.
+//
+// ---
+// consumes:
+//   - application/json
+// produces:
+//   - application/json
+// parameters:
+//   - in: body
+//     name: server
+//     description: Server configuration
+//     required: true
+//     schema:
+//       $ref: "#/definitions/ServerPut"
+// responses:
+//   "200":
+//     $ref: "#/responses/EmptySyncResponse"
+//   "400":
+//     $ref: "#/responses/BadRequest"
+//   "403":
+//     $ref: "#/responses/Forbidden"
+//   "412":
+//     $ref: "#/responses/PreconditionFailed"
+//   "500":
+//     $ref: "#/responses/InternalServerError"
 func api10Put(d *Daemon, r *http.Request) response.Response {
 	// If a target was specified, forward the request to the relevant node.
 	resp := forwardedResponseIfTargetIsRemote(d, r)
@@ -325,6 +423,35 @@ func api10Put(d *Daemon, r *http.Request) response.Response {
 	return doApi10Update(d, req, false)
 }
 
+// swagger:operation PATCH /1.0 server server_patch
+//
+// Partially update the server configuration
+//
+// Updates a subset of the server configuration.
+//
+// ---
+// consumes:
+//   - application/json
+// produces:
+//   - application/json
+// parameters:
+//   - in: body
+//     name: server
+//     description: Server configuration
+//     required: true
+//     schema:
+//       $ref: "#/definitions/ServerPut"
+// responses:
+//   "200":
+//     $ref: "#/responses/EmptySyncResponse"
+//   "400":
+//     $ref: "#/responses/BadRequest"
+//   "403":
+//     $ref: "#/responses/Forbidden"
+//   "412":
+//     $ref: "#/responses/PreconditionFailed"
+//   "500":
+//     $ref: "#/responses/InternalServerError"
 func api10Patch(d *Daemon, r *http.Request) response.Response {
 	// If a target was specified, forward the request to the relevant node.
 	resp := forwardedResponseIfTargetIsRemote(d, r)

--- a/lxd/swagger.go
+++ b/lxd/swagger.go
@@ -1,0 +1,112 @@
+// LXD external REST API
+//
+// This is the REST API used by all LXD clients.
+// Internal endpoints aren't included in this documentation.
+//
+// The LXD API is available over both a local unix+http and remote https API.
+// Authentication for local users relies on group membership and access to the unix socket.
+// For remote users, the default authentication method is TLS client
+// certificates with a macaroon based (candid) authentication method also
+// supported.
+//
+// WARNING: This API documentation is a work in progress.
+// You may find the full documentation in its old format at "doc/rest-api.md".
+//
+//     Version: 1.0
+//     License: Apache-2.0 https://www.apache.org/licenses/LICENSE-2.0
+//     Contact: LXD upstream <lxc-devel@lists.linuxcontainers.org> https://github.com/lxc/lxd
+//
+// swagger:meta
+package main
+
+// Common error definitions.
+
+// Empty sync response
+//
+// swagger:response EmptySyncResponse
+type swaggerEmptySyncResponse struct {
+	// Empty sync response
+	// in: body
+	Body struct {
+		// Example: sync
+		Type string `json:"type"`
+
+		// Example: Success
+		Status string `json:"status"`
+
+		// Example: 200
+		StatusCode int `json:"status_code"`
+	}
+}
+
+// Bad Request
+//
+// swagger:response BadRequest
+type swaggerBadRequest struct {
+	// Bad Request
+	// in: body
+	Body struct {
+		// Example: error
+		Type string `json:"type"`
+
+		// Example: 400
+		Code int `json:"code"`
+
+		// Example: bad request
+		Error string `json:"error"`
+	}
+}
+
+// Forbidden
+//
+// swagger:response Forbidden
+type swaggerForbidden struct {
+	// Bad Request
+	// in: body
+	Body struct {
+		// Example: error
+		Type string `json:"type"`
+
+		// Example: 403
+		Code int `json:"code"`
+
+		// Example: not authorized
+		Error string `json:"error"`
+	}
+}
+
+// Precondition Failed
+//
+// swagger:response PreconditionFailed
+type swaggerPreconditionFailed struct {
+	// Internal server Error
+	// in: body
+	Body struct {
+		// Example: error
+		Type string `json:"type"`
+
+		// Example: 412
+		Code int `json:"code"`
+
+		// Example: precondition failed
+		Error string `json:"error"`
+	}
+}
+
+// Internal Server Error
+//
+// swagger:response InternalServerError
+type swaggerInternalServerError struct {
+	// Internal server Error
+	// in: body
+	Body struct {
+		// Example: error
+		Type string `json:"type"`
+
+		// Example: 500
+		Code int `json:"code"`
+
+		// Example: internal server error
+		Error string `json:"error"`
+	}
+}

--- a/shared/api/certificate.go
+++ b/shared/api/certificate.go
@@ -1,30 +1,51 @@
 package api
 
 // CertificatesPost represents the fields of a new LXD certificate
+//
+// swagger:model
 type CertificatesPost struct {
 	CertificatePut `yaml:",inline"`
 
+	// Example: X509 PEM certificate
 	Certificate string `json:"certificate" yaml:"certificate"`
-	Password    string `json:"password" yaml:"password"`
+
+	// Example: blah
+	Password string `json:"password" yaml:"password"`
 }
 
 // CertificatePut represents the modifiable fields of a LXD certificate
 //
 // API extension: certificate_update
+//
+// swagger:model
 type CertificatePut struct {
+	// Example: castiana
 	Name string `json:"name" yaml:"name"`
+
+	// Example: client
 	Type string `json:"type" yaml:"type"`
 
 	// API extension: certificate_project
-	Restricted bool     `json:"restricted" yaml:"restricted"`
-	Projects   []string `json:"projects" yaml:"projects"`
+	//
+	// Example: true
+	Restricted bool `json:"restricted" yaml:"restricted"`
+
+	// API extension: certificate_project
+	//
+	// Example: ["default", "foo", "bar"]
+	Projects []string `json:"projects" yaml:"projects"`
 }
 
 // Certificate represents a LXD certificate
+//
+// swagger:model
 type Certificate struct {
 	CertificatePut `yaml:",inline"`
 
+	// Example: X509 PEM certificate
 	Certificate string `json:"certificate" yaml:"certificate"`
+
+	// Example: fd200419b271f1dc2a5591b693cc5774b7f234e1ff8c6b78ad703b6888fe2b69
 	Fingerprint string `json:"fingerprint" yaml:"fingerprint"`
 }
 

--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -2,64 +2,125 @@ package api
 
 // ServerEnvironment represents the read-only environment fields of a LXD server
 type ServerEnvironment struct {
-	Addresses              []string `json:"addresses" yaml:"addresses"`
-	Architectures          []string `json:"architectures" yaml:"architectures"`
-	Certificate            string   `json:"certificate" yaml:"certificate"`
-	CertificateFingerprint string   `json:"certificate_fingerprint" yaml:"certificate_fingerprint"`
-	Driver                 string   `json:"driver" yaml:"driver"`
-	DriverVersion          string   `json:"driver_version" yaml:"driver_version"`
+	// Example: [":8443"]
+	Addresses []string `json:"addresses" yaml:"addresses"`
 
+	// Example: ["x86_64", "i686"]
+	Architectures []string `json:"architectures" yaml:"architectures"`
+
+	// Example: X509 PEM certificate
+	Certificate string `json:"certificate" yaml:"certificate"`
+
+	// Example: fd200419b271f1dc2a5591b693cc5774b7f234e1ff8c6b78ad703b6888fe2b69
+	CertificateFingerprint string `json:"certificate_fingerprint" yaml:"certificate_fingerprint"`
+
+	// Example: lxc | qemu
+	Driver string `json:"driver" yaml:"driver"`
+
+	// Example: 4.0.7 | 5.2.0
+	DriverVersion string `json:"driver_version" yaml:"driver_version"`
+
+	// Example: nftables
+	//
 	// API extension: firewall_driver
 	Firewall string `json:"firewall" yaml:"firewall"`
 
-	Kernel             string `json:"kernel" yaml:"kernel"`
+	// Example: Linux
+	Kernel string `json:"kernel" yaml:"kernel"`
+
+	// Example: x86_64
 	KernelArchitecture string `json:"kernel_architecture" yaml:"kernel_architecture"`
 
+	// Example: {"netnsid_getifaddrs": "true", "seccomp_listener": "true"}
+	//
 	// API extension: kernel_features
 	KernelFeatures map[string]string `json:"kernel_features" yaml:"kernel_features"`
 
+	// Example: 5.4.0-36-generic
 	KernelVersion string `json:"kernel_version" yaml:"kernel_version"`
 
+	// Example: {"cgroup2": "true", "devpts_fd": "true", "pidfd": "true"}
+	//
 	// API extension: lxc_features
 	LXCFeatures map[string]string `json:"lxc_features" yaml:"lxc_features"`
 
+	// Example: Ubuntu
+	//
 	// API extension: api_os
-	OSName    string `json:"os_name" yaml:"os_name"`
+	OSName string `json:"os_name" yaml:"os_name"`
+
+	// Example: 20.04
+	//
+	// API extension: api_os
 	OSVersion string `json:"os_version" yaml:"os_version"`
 
+	// Example: default
+	//
 	// API extension: projects
 	Project string `json:"project" yaml:"project"`
 
+	// Example: lxd
 	Server string `json:"server" yaml:"server"`
 
+	// Example: false
+	//
 	// API extension: clustering
-	ServerClustered bool   `json:"server_clustered" yaml:"server_clustered"`
-	ServerName      string `json:"server_name" yaml:"server_name"`
+	ServerClustered bool `json:"server_clustered" yaml:"server_clustered"`
 
-	ServerPid      int    `json:"server_pid" yaml:"server_pid"`
-	ServerVersion  string `json:"server_version" yaml:"server_version"`
-	Storage        string `json:"storage" yaml:"storage"`
+	// Example: castiana
+	//
+	// API extension: clustering
+	ServerName string `json:"server_name" yaml:"server_name"`
+
+	// Example: 1453969
+	ServerPid int `json:"server_pid" yaml:"server_pid"`
+
+	// Example: 4.11
+	ServerVersion string `json:"server_version" yaml:"server_version"`
+
+	// Example: dir | zfs
+	Storage string `json:"storage" yaml:"storage"`
+
+	// Example: 1 | 0.8.4-1ubuntu11
 	StorageVersion string `json:"storage_version" yaml:"storage_version"`
 }
 
 // ServerPut represents the modifiable fields of a LXD server configuration
+//
+// swagger:model
 type ServerPut struct {
+	// Example: {"core.https_address": ":8443", "core.trust_password": true}
 	Config map[string]interface{} `json:"config" yaml:"config"`
 }
 
 // ServerUntrusted represents a LXD server for an untrusted client
+//
+// swagger:model
 type ServerUntrusted struct {
+	// Example: ["etag", "patch", "network", "storage"]
 	APIExtensions []string `json:"api_extensions" yaml:"api_extensions"`
-	APIStatus     string   `json:"api_status" yaml:"api_status"`
-	APIVersion    string   `json:"api_version" yaml:"api_version"`
-	Auth          string   `json:"auth" yaml:"auth"`
-	Public        bool     `json:"public" yaml:"public"`
 
+	// Example: stable
+	APIStatus string `json:"api_status" yaml:"api_status"`
+
+	// Example: 1.0
+	APIVersion string `json:"api_version" yaml:"api_version"`
+
+	// Example: untrusted
+	Auth string `json:"auth" yaml:"auth"`
+
+	// Example: true
+	Public bool `json:"public" yaml:"public"`
+
+	// Example: ["tls", "candid"]
+	//
 	// API extension: macaroon_authentication
 	AuthMethods []string `json:"auth_methods" yaml:"auth_methods"`
 }
 
 // Server represents a LXD server
+//
+// swagger:model
 type Server struct {
 	ServerPut       `yaml:",inline"`
 	ServerUntrusted `yaml:",inline"`

--- a/test/suites/static_analysis.sh
+++ b/test/suites/static_analysis.sh
@@ -136,12 +136,12 @@ test_static_analysis() {
       run_deadcode() {
         for i in client fuidshift lxc lxc-to-lxd lxd lxd-agent lxd-benchmark lxd-p2c shared; do
           find "${i}" -type d | while read -r line; do
-            deadcode "./${line}"
+            deadcode "./${line}" 2>&1
           done
         done
       }
 
-      OUT=$(run_deadcode)
+      OUT=$(run_deadcode | grep -v lxd/swagger.go || true)
       if [ -n "${OUT}" ]; then
         echo "${OUT}" >&2
         false


### PR DESCRIPTION
This puts in place the infrastructure for describing our API through swagger and implements the `/` and `/1.0` endpoints.
Getting the full API labeled will take time and will be handled through subsequent PRs until we achieve full coverage and can replace the current manual `rest-api.md` with an automated one.