### PR TITLE
Images auto update

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1321,3 +1321,7 @@ access to.
 
 ## network\_ovn\_acl
 Adds a new `security.acls` property to OVN networks and OVN NICs, allowing Network ACLs to be applied.
+
+## projects\_images\_auto\_update
+Adds new `images.auto_update_cached` and `images.auto_update_interval` config keys which
+allows configuration of images auto update in projects

--- a/doc/projects.md
+++ b/doc/projects.md
@@ -22,6 +22,8 @@ features.images                      | boolean   | -                     | true 
 features.networks                    | boolean   | -                     | false                     | Separate set of networks for the project
 features.profiles                    | boolean   | -                     | true                      | Separate set of profiles for the project
 features.storage.volumes             | boolean   | -                     | true                      | Separate set of storage volumes for the project
+images.auto\_update\_cached          | boolean   | -                     | -                         | Whether to automatically update any image that LXD caches
+images.auto\_update\_interval        | integer   | -                     | -                         | Interval in hours at which to look for update to cached images (0 disables it)
 images.compression\_algorithm        | string    | -                     | -                         | Compression algorithm to use for images (bzip2, gzip, lzma, xz or none) in the project
 images.remote\_cache\_expiry         | integer   | -                     | -                         | Number of days after which an unused cached remote image will be flushed in the project
 limits.instances                     | integer   | -                     | -                         | Maximum number of total instances that can be created in the project

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -652,9 +652,7 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		case "candid.api.url":
 			candidChanged = true
 		case "images.auto_update_interval":
-			if !d.os.MockMode {
-				d.taskAutoUpdate.Reset()
-			}
+			fallthrough
 		case "images.remote_cache_expiry":
 			if !d.os.MockMode {
 				d.taskPruneImages.Reset()

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -525,6 +525,8 @@ func projectValidateConfig(s *state.State, config map[string]string) error {
 		"features.images":                validate.Optional(validate.IsBool),
 		"features.storage.volumes":       validate.Optional(validate.IsBool),
 		"features.networks":              validate.Optional(validate.IsBool),
+		"images.auto_update_cached":      validate.Optional(validate.IsBool),
+		"images.auto_update_interval":    validate.Optional(validate.IsInt64),
 		"images.compression_algorithm":   validate.IsCompressionAlgorithm,
 		"images.remote_cache_expiry":     validate.Optional(validate.IsInt64),
 		"limits.instances":               validate.Optional(validate.IsUint32),

--- a/lxd/cluster/config.go
+++ b/lxd/cluster/config.go
@@ -89,18 +89,6 @@ func (c *Config) RBACServer() (string, string, int64, string, string, string, st
 		c.m.GetString("rbac.agent.public_key")
 }
 
-// AutoUpdateInterval returns the configured images auto update interval.
-func (c *Config) AutoUpdateInterval() time.Duration {
-	n := c.m.GetInt64("images.auto_update_interval")
-	return time.Duration(n) * time.Hour
-}
-
-// RemoteCacheExpiry returns the configured expiration value for remote images
-// expiration.
-func (c *Config) RemoteCacheExpiry() int64 {
-	return c.m.GetInt64("images.remote_cache_expiry")
-}
-
 // ProxyHTTPS returns the configured HTTPS proxy, if any.
 func (c *Config) ProxyHTTPS() string {
 	return c.m.GetString("core.proxy_https")

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -85,7 +85,9 @@ type Daemon struct {
 
 	// Indexes of tasks that need to be reset when their execution interval changes
 	taskPruneImages *task.Task
-	taskAutoUpdate  *task.Task
+
+	// Stores startup time of daemon
+	startTime time.Time
 
 	config    *DaemonConfig
 	endpoints *endpoints.Endpoints
@@ -1212,6 +1214,8 @@ func (d *Daemon) Ready() error {
 		d.startClusterTasks()
 	}
 
+	d.startTime = time.Now()
+
 	// FIXME: There's no hard reason for which we should not run these
 	//        tasks in mock mode. However it requires that we tweak them so
 	//        they exit gracefully without blocking (something we should do
@@ -1226,7 +1230,7 @@ func (d *Daemon) Ready() error {
 		d.taskPruneImages = d.tasks.Add(pruneExpiredImagesTask(d))
 
 		// Auto-update images (every 6 hours, configurable)
-		d.taskAutoUpdate = d.tasks.Add(autoUpdateImagesTask(d))
+		d.tasks.Add(autoUpdateImagesTask(d))
 
 		// Auto-update instance types (daily)
 		d.tasks.Add(instanceRefreshTypesTask(d))

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -63,9 +63,19 @@ func createFromImage(d *Daemon, projectName string, req *api.InstancesPost) resp
 
 		var info *api.Image
 		if req.Source.Server != "" {
-			autoUpdate, err := cluster.ConfigGetBool(d.cluster, "images.auto_update_cached")
+			var autoUpdate bool
+			p, err := d.cluster.GetProject(projectName)
 			if err != nil {
 				return err
+			}
+
+			if p.Config["images.auto_update_cached"] != "" {
+				autoUpdate = shared.IsTrue(p.Config["images.auto_update_cached"])
+			} else {
+				autoUpdate, err = cluster.ConfigGetBool(d.cluster, "images.auto_update_cached")
+				if err != nil {
+					return err
+				}
 			}
 
 			// Detect image type based on instance type requested.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -259,6 +259,7 @@ var APIExtensions = []string{
 	"projects_images_remote_cache_expiry",
 	"certificate_project",
 	"network_ovn_acl",
+	"projects_images_auto_update",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
It's a third part of "Add `images.*` and `backups.*` server config keys to per-project #7900" issue.

Not sure about projectsAutoUpdateTime map but we need to keep somewhere times of autoUpdateTask execution per project. So we know when run it next time.
I've made also some cleanup staff related with remote_cache_expiry and auto_update_interval keys.