### PR TITLE
Network: Refactors OVNEnsureACLs to be smarter in how it sets up referenced ACLs

### DIFF
--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -57,7 +57,7 @@ func ovnEnsureACLs(s *state.State, logger logger.Logger, client *openvswitch.OVN
 		portGroupName := OVNACLPortGroupName(aclNameIDs[aclName])
 
 		// Check if port group exists.
-		portGroupUUID, err := client.PortGroupUUID(portGroupName)
+		portGroupUUID, _, err := client.PortGroupInfo(portGroupName)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed getting port group UUID for security ACL %q setup", aclName)
 		}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2740,7 +2740,7 @@ func (n *ovn) InstanceDevicePortAdd(opts *OVNInstanceNICSetupOpts) (openvswitch.
 				portGroupName := acl.OVNACLPortGroupName(aclID)
 
 				// Check if port group exists.
-				portGroupUUID, err := client.PortGroupUUID(portGroupName)
+				portGroupUUID, _, err := client.PortGroupInfo(portGroupName)
 				if err != nil {
 					return "", errors.Wrapf(err, "Failed getting port group UUID for security ACL %q removal", aclName)
 				}


### PR DESCRIPTION
Previously we always created OVN port groups along with their respective ACL rules at the same time.

When we introduced the concept of referenced ACLs within another ACL rule, this then introduced the requirement to recursively setup port groups (and the ACL rules) of any referenced ACLs at the same time.

This was done to stop OVN complaining about missing port groups referenced in the ACL rules. However OVN doesn't actually require the referenced port groups to have ACLs, they just need to exist.
We only need to actually load the ACL rules into a port group when they are being directly referenced by a network or NIC.

So this changes OVNEnsureACLs to only create referenced port groups (and doesn't load them with ACL rules).
This has the benefit that we don't need to recurse, as we are only interested in satisfying the requirements for the referenced ACLs in our requested ACLs that we are setting up.

However because this introduces the possibility of having a partially setup OVN port group (i.e one that has been created without any ACLs), we also need to be smarter about how we treat existing port groups when they are being directly used.
This change now detects an existing empty port group, and applies the ACL rules.

This depends on the assumption that a fully setup port group should always have at least 1 ACL rule assigned (the default drop rule).