### PR TITLE
Updated instanceLogDelete function

### DIFF
--- a/lxd/instance_logs.go
+++ b/lxd/instance_logs.go
@@ -144,11 +144,11 @@ func instanceLogDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	project := projectParam(r)
+	projectName := projectParam(r)
 	name := mux.Vars(r)["name"]
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, project, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -171,5 +171,5 @@ func instanceLogDelete(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("lxc.log and lxc.conf may not be deleted"))
 	}
 
-	return response.SmartError(os.Remove(shared.LogPath(name, file)))
+	return response.SmartError(os.Remove(shared.LogPath(project.Instance(projectName, name), file)))
 }


### PR DESCRIPTION
Updated instanceLogDelete() function to allow deleting of logs from instances in a project other than default