### PR TITLE
Network: Adds full unused OVN ACL port group clean up

### DIFF
--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -118,7 +118,7 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 
 	ovnNet, ok := n.(ovnNet)
 	if !ok {
-		return fmt.Errorf("Network is not OVN type")
+		return fmt.Errorf("Network is not ovnNet interface type")
 	}
 
 	d.network = ovnNet // Stored loaded instance for use by other functions.

--- a/lxd/network/acl/acl_load.go
+++ b/lxd/network/acl/acl_load.go
@@ -170,8 +170,8 @@ func UsedBy(s *state.State, aclProjectName string, usageFunc func(matchedACLName
 		for _, rule := range aclInfo.Ingress {
 			for _, subject := range util.SplitNTrimSpace(rule.Source, ",", -1, true) {
 
-				// Look for matching ACLs, but ignore our own ACL reference in our own rules.
-				if shared.StringInSlice(subject, matchACLNames) && subject != aclName {
+				// Look for new matching ACLs, but ignore our own ACL reference in our own rules.
+				if shared.StringInSlice(subject, matchACLNames) && !shared.StringInSlice(subject, matchedACLNames) && subject != aclInfo.Name {
 					matchedACLNames = append(matchedACLNames, subject)
 				}
 			}
@@ -181,8 +181,8 @@ func UsedBy(s *state.State, aclProjectName string, usageFunc func(matchedACLName
 		for _, rule := range aclInfo.Egress {
 			for _, subject := range util.SplitNTrimSpace(rule.Destination, ",", -1, true) {
 
-				// Look for matching ACLs, but ignore our own ACL reference in our own rules.
-				if shared.StringInSlice(subject, matchACLNames) && subject != aclName {
+				// Look for new matching ACLs, but ignore our own ACL reference in our own rules.
+				if shared.StringInSlice(subject, matchACLNames) && !shared.StringInSlice(subject, matchedACLNames) && subject != aclInfo.Name {
 					matchedACLNames = append(matchedACLNames, subject)
 				}
 			}

--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/network/openvswitch"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/state"
@@ -513,6 +515,168 @@ func OVNApplyNetworkBaselineRules(client *openvswitch.OVN, switchName openvswitc
 	err := client.LogicalSwitchSetACLRules(switchName, rules...)
 	if err != nil {
 		return errors.Wrapf(err, "Failed applying baseline ACL rules to logical switch %q", switchName)
+	}
+
+	return nil
+}
+
+// OVNPortGroupDeleteIfUnused deletes unused port groups. Accepts optional ignoreUsageType and ignoreUsageNicName
+// arguments, allowing the used by logic to ignore an instance or profile NIC or network (useful if config not
+// applied to database yet). Also accepts optional list of ACLs to explicitly consider in use by OVN.
+// The combination of ignoring the specifified usage type and explicit keep ACLs allows the caller to ensure that
+// the desired ACLs are considered unused by the usage type even if the referring config has not yet been removed
+// from the database.
+func OVNPortGroupDeleteIfUnused(s *state.State, logger logger.Logger, client *openvswitch.OVN, aclProjectName string, ignoreUsageType interface{}, ignoreUsageNicName string, keepACLs ...string) error {
+	// Get map of ACL names to DB IDs (used for generating OVN port group names).
+	aclNameIDs, err := s.Cluster.GetNetworkACLIDsByNames(aclProjectName)
+	if err != nil {
+		return errors.Wrapf(err, "Failed getting network ACL IDs for security ACL port group removal")
+	}
+
+	aclNames := make([]string, 0, len(aclNameIDs))
+	for aclName := range aclNameIDs {
+		aclNames = append(aclNames, aclName)
+	}
+
+	ovnUsedACLs := make(map[string]struct{}, len(keepACLs))
+
+	// Add keepACLs to ovnUsedACLs to indicate they are explicitly in use by OVN.
+	// This is important because it also ensures that indirectly referred ACLs in the rulesets of these ACLs
+	// will also be kept.
+	for _, keepACL := range keepACLs {
+		ovnUsedACLs[keepACL] = struct{}{}
+	}
+
+	aclUsedACLS := make(map[string][]string, 0)
+
+	// Find alls ACLs that are either directly referred to by OVN entities (networks, instance/profile NICs) or
+	// by indirectly by being referred to in a ruleset of another ACL that is itself in use by OVN entities.
+	// For the indirectly referred to ACLs, store a list of the ACLs that are referring to it.
+	err = UsedBy(s, aclProjectName, func(matchedACLNames []string, usageType interface{}, nicName string, nicConfig map[string]string) error {
+		switch u := usageType.(type) {
+		case db.Instance:
+			ignoreInst, isIgnoreInst := ignoreUsageType.(instance.Instance)
+
+			if isIgnoreInst && ignoreUsageNicName == "" {
+				return fmt.Errorf("ignoreUsageNicName should be specified when providing an instance in ignoreUsageType")
+			}
+
+			// If an ignore instance was provided, then skip the device that the ACLs were just removed
+			// from. In case DB record is not updated until the update process has completed otherwise
+			// we would still consider it using the ACL.
+			if isIgnoreInst && ignoreInst.Name() == u.Name && ignoreInst.Project() == u.Project && ignoreUsageNicName == nicName {
+				return nil
+			}
+
+			_, network, _, err := s.Cluster.GetNetworkInAnyState(aclProjectName, nicConfig["network"])
+			if err != nil {
+				return errors.Wrapf(err, "Failed to load network %q", nicConfig["network"])
+			}
+
+			if network.Type == "ovn" {
+				for _, matchedACLName := range matchedACLNames {
+					ovnUsedACLs[matchedACLName] = struct{}{} // Record as in use by OVN entity.
+				}
+			}
+		case *api.Network:
+			ignoreNet, isIgnoreNet := ignoreUsageType.(*api.Network)
+
+			if isIgnoreNet && ignoreUsageNicName != "" {
+				return fmt.Errorf("ignoreUsageNicName should be empty when providing a network in ignoreUsageType")
+			}
+
+			// If an ignore network was provided, then skip the network that the ACLs were just removed
+			// from. In case DB record is not updated until the update process has completed otherwise
+			// we would still consider it using the ACL.
+			if isIgnoreNet && ignoreNet.Name == u.Name {
+				return nil
+			}
+
+			if u.Type == "ovn" {
+				for _, matchedACLName := range matchedACLNames {
+					ovnUsedACLs[matchedACLName] = struct{}{} // Record as in use by OVN entity.
+				}
+			}
+		case db.Profile:
+			ignoreProfile, isIgnoreProfile := ignoreUsageType.(db.Profile)
+
+			if isIgnoreProfile && ignoreUsageNicName == "" {
+				return fmt.Errorf("ignoreUsageNicName should be specified when providing a profile in ignoreUsageType")
+			}
+
+			// If an ignore profile was provided, then skip the device that the ACLs were just removed
+			// from. In case DB record is not updated until the update process has completed otherwise
+			// we would still consider it using the ACL.
+			if isIgnoreProfile && ignoreProfile.Name == u.Name && ignoreProfile.Project == u.Project && ignoreUsageNicName == nicName {
+				return nil
+			}
+
+			_, network, _, err := s.Cluster.GetNetworkInAnyState(aclProjectName, nicConfig["network"])
+			if err != nil {
+				return errors.Wrapf(err, "Failed to load network %q", nicConfig["network"])
+			}
+
+			if network.Type == "ovn" {
+				for _, matchedACLName := range matchedACLNames {
+					ovnUsedACLs[matchedACLName] = struct{}{} // Record as in use by OVN entity.
+				}
+			}
+		case *api.NetworkACL:
+			// Record which ACLs this ACL's ruleset refers to.
+			for _, matchedACLName := range matchedACLNames {
+				if aclUsedACLS[matchedACLName] == nil {
+					aclUsedACLS[matchedACLName] = make([]string, 0, 1)
+				}
+
+				if !shared.StringInSlice(u.Name, aclUsedACLS[matchedACLName]) {
+					// Record as in use by another ACL entity.
+					aclUsedACLS[matchedACLName] = append(aclUsedACLS[matchedACLName], u.Name)
+				}
+			}
+		default:
+			return fmt.Errorf("Unrecognised usage type %T", u)
+		}
+
+		return nil
+	}, aclNames...)
+	if err != nil && err != db.ErrInstanceListStop {
+		return errors.Wrapf(err, "Failed getting ACL usage")
+	}
+
+	// usedByOvn checks if any of the aclNames are in use by an OVN entity (network or instance/profile NIC).
+	usedByOvn := func(aclNames ...string) bool {
+		for _, aclName := range aclNames {
+			if _, found := ovnUsedACLs[aclName]; found {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	for aclName := range aclNameIDs {
+		if usedByOvn(aclName) {
+			continue // ACL is directly used an OVN entity (network or instance/profile NIC).
+		}
+
+		// Check to see if any of the ACLs referencing this ACL are directly in use by an OVN entity.
+		refACLs, found := aclUsedACLS[aclName]
+		if found && usedByOvn(refACLs...) {
+			continue // ACL is indirectly used by an OVN entity.
+		}
+
+		aclID, found := aclNameIDs[aclName]
+		if !found {
+			return fmt.Errorf("Cannot find security ACL ID for %q", aclName)
+		}
+
+		portGroupName := OVNACLPortGroupName(aclID)
+		err = client.PortGroupDelete(portGroupName)
+		if err != nil {
+			return errors.Wrapf(err, "Failed deleting OVN port group %q for security ACL %q", portGroupName, aclName)
+		}
+
+		logger.Debug("Deleted unused ACL OVN port group", log.Ctx{"portGroup": portGroupName, "networkACL": aclName})
 	}
 
 	return nil

--- a/lxd/network/acl/driver_common.go
+++ b/lxd/network/acl/driver_common.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/network/openvswitch"
 	"github.com/lxc/lxd/lxd/project"
@@ -515,13 +514,10 @@ func (d *common) Update(config *api.NetworkACLPut) error {
 
 	if applyToOVN {
 		d.logger.Debug("Applying ACL rules to OVN")
-		nbConnection, err := cluster.ConfigGetString(d.state.Cluster, "network.ovn.northbound_connection")
+		client, err := openvswitch.NewOVN(d.state)
 		if err != nil {
-			return errors.Wrapf(err, "Failed to get OVN northbound connection string")
+			return errors.Wrapf(err, "Failed to get OVN client")
 		}
-
-		client := openvswitch.NewOVN()
-		client.SetDatabaseAddress(nbConnection)
 
 		// Get map of ACL names to DB IDs (used for generating OVN port group names).
 		aclNameIDs, err := d.state.Cluster.GetNetworkACLIDsByNames(d.Project())

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2235,7 +2235,7 @@ func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clientType re
 			}
 
 			// Get map of ACL names to DB IDs (used for generating OVN port group names).
-			acls, err := n.state.Cluster.GetNetworkACLIDsByNames(n.Project())
+			aclNameIDs, err := n.state.Cluster.GetNetworkACLIDsByNames(n.Project())
 			if err != nil {
 				return errors.Wrapf(err, "Failed getting network ACL IDs for security ACL update")
 			}
@@ -2262,7 +2262,7 @@ func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clientType re
 						continue // NIC already has this ACL applied directly, so no need to add.
 					}
 
-					aclID, found := acls[addedACL]
+					aclID, found := aclNameIDs[addedACL]
 					if !found {
 						return fmt.Errorf("Cannot find security ACL ID for %q", addedACL)
 					}
@@ -2283,7 +2283,7 @@ func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clientType re
 						continue // NIC still has this ACL applied directly, so don't remove.
 					}
 
-					aclID, found := acls[removedACL]
+					aclID, found := aclNameIDs[removedACL]
 					if !found {
 						return fmt.Errorf("Cannot find security ACL ID for %q", removedACL)
 					}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -7,6 +7,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
+	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 )
@@ -116,9 +120,17 @@ type OVNACLRule struct {
 	LogName   string // Log label name (requires Log be true).
 }
 
-// NewOVN initialises new OVN wrapper.
-func NewOVN() *OVN {
-	return &OVN{}
+// NewOVN initialises new OVN client wrapper with the connection set in network.ovn.northbound_connection config.
+func NewOVN(s *state.State) (*OVN, error) {
+	nbConnection, err := cluster.ConfigGetString(s.Cluster, "network.ovn.northbound_connection")
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to get OVN northbound connection string")
+	}
+
+	client := &OVN{}
+	client.SetDatabaseAddress(nbConnection)
+
+	return client, err
 }
 
 // OVN command wrapper.


### PR DESCRIPTION
Extends clean up routine to support indirectly usage ACLs (ACLs referred to by other ACL rules).

Tests updated here: https://github.com/lxc/lxc-ci/pull/247