### PR TITLE
doc/rest-api: Updates backup endpoint docs

### DIFF
--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -1642,10 +1642,11 @@ Input:
 
 ```js
 {
-    "name": "backupName",      // unique identifier for the backup
-    "expiry": 3600,            // when to delete the backup automatically
-    "instance_only": true,     // if True, snapshots aren't included
-    "optimized_storage": true  // if True, btrfs send or zfs send is used for instance and snapshots (can only be imported on matching storage pool driver)
+    "name": "backupName",                      // unique identifier for the backup
+    "expires_at": "2018-04-23T12:16:09+02:00", // when to delete the backup automatically
+    "instance_only": true,                     // if True, snapshots aren't included
+    "optimized_storage": true,                 // if True, btrfs send or zfs send is used for instance and snapshots (can only be imported on matching storage pool driver)
+    "compression_algorithm": "xz"              // Override the compression algorithm for the backup (optional)
 }
 ```
 
@@ -3411,10 +3412,11 @@ Input:
 
 ```js
 {
-    "name": "backupName",      // unique identifier for the backup
-    "expiry": 3600,            // when to delete the backup automatically
-    "volume_only": true,     // if True, snapshots aren't included
-    "optimized_storage": true  // if True, btrfs send or zfs send is used for volume and snapshots
+    "name": "backupName",                      // unique identifier for the backup
+    "expires_at": "2018-04-23T12:16:09+02:00", // when to delete the backup automatically
+    "volume_only": true,                       // if True, snapshots aren't included
+    "optimized_storage": true,                 // if True, btrfs send or zfs send is used for volume and snapshots
+    "compression_algorithm": "xz"              // Override the compression algorithm for the backup (optional)
 }
 ```
 


### PR DESCRIPTION
Updates REST API doc with fields from:

https://github.com/lxc/lxd/pull/6292
https://github.com/lxc/lxd/pull/6294

Reported from: https://discuss.linuxcontainers.org/t/container-backup-expiry-ignored/10323/

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>