### PR TITLE
Network: Adds OVN #internal/#external port subjects

### DIFF
--- a/doc/network-acls.md
+++ b/doc/network-acls.md
@@ -11,8 +11,8 @@ The Instance NICs that have a particular ACL applied (either explicitly or impli
 logical group that can be referenced from other rules as a source or destination. This makes it possible to define
 rules for groups of instances without needing to maintain IP lists or create additional subnets.
 
-Network ACLs come with an implicit default drop rule, so if traffic doesn't match one of the defined rules in an
-ACL then all other traffic is dropped.
+Network ACLs come with an implicit default rule (that defaults to `reject` unless `default.action` is set), so if
+traffic doesn't match one of the defined rules in an ACL then all other traffic is dropped.
 
 Rules are defined on for a particular direction (ingress or egress) in relation to the Instance NIC.
 Ingress rules apply to traffic going towards the NIC, and egress rules apply to traffic leave the NIC.
@@ -36,22 +36,29 @@ name             | string     | yes      | Unique name of Network ACL in Project
 description      | string     | no       | Description of Network ACL
 ingress          | rule list  | no       | Ingress traffic rules
 egress           | rule list  | no       | Egress traffic rules
-config           | string set | no       | Config key/value pairs (only `user.*` custom keys allowed)
+config           | string set | no       | Config key/value pairs (in addition to `user.*` custom keys, see below)
 
-ACL rules have the following properties:
+Config properties:
 
 Property         | Type       | Required | Description
 :--              | :--        | :--      | :--
-action           | string     | yes      | Action to take for matching traffic (`allow`, `reject` or `drop`)
-state            | string     | yes      | State of rule (`enabled`, `disabled` or `logged`)
-description      | string     | no       | Description of rule
-source           | string     | no       | Comma separated list of CIDR or IP ranges, source ACL names or #external/#internal (for ingress rules), or empty for any
-destination      | string     | no       | Comma separated list of CIDR or IP ranges, destination ACL names or #external/#internal (for egress rules), or empty for any
-protocol         | string     | no       | Protocol to match (`icmp4`, `icmp6`, `tcp`, `udp`) or empty for any
-source_port      | string     | no       | If Protocol is `udp` or `tcp`, then comma separated list of ports or port ranges (start-end inclusive), or empty for any.
-destination_port | string     | no       | If Protocol is `udp` or `tcp`, then comma separated list of ports or port ranges (start-end inclusive), or empty for any.
-icmp_type        | string     | no       | If Protocol is `icmp4` or `icmp6`, then ICMP Type number, or empty for any.
-icmp_code        | string     | no       | If Protocol is `icmp4` or `icmp6`, then ICMP Code number, or empty for any.
+default.action   | string     | no       | What action to take for traffic hitting the default rule (default `reject`)
+default.logged   | boolean    | no       | Whether or not to log traffic hitting the default rule (default `false`)
+
+ACL rules have the following properties:
+
+Property          | Type       | Required | Description
+:--               | :--        | :--      | :--
+action            | string     | yes      | Action to take for matching traffic (`allow`, `reject` or `drop`)
+state             | string     | yes      | State of rule (`enabled`, `disabled` or `logged`)
+description       | string     | no       | Description of rule
+source            | string     | no       | Comma separated list of CIDR or IP ranges, source ACL names or #external/#internal (for ingress rules), or empty for any
+destination       | string     | no       | Comma separated list of CIDR or IP ranges, destination ACL names or #external/#internal (for egress rules), or empty for any
+protocol          | string     | no       | Protocol to match (`icmp4`, `icmp6`, `tcp`, `udp`) or empty for any
+source\_port      | string     | no       | If Protocol is `udp` or `tcp`, then comma separated list of ports or port ranges (start-end inclusive), or empty for any
+destination\_port | string     | no       | If Protocol is `udp` or `tcp`, then comma separated list of ports or port ranges (start-end inclusive), or empty for any
+icmp\_type        | string     | no       | If Protocol is `icmp4` or `icmp6`, then ICMP Type number, or empty for any
+icmp\_code        | string     | no       | If Protocol is `icmp4` or `icmp6`, then ICMP Code number, or empty for any
 
 ## Rule ordering and priorities
 
@@ -60,7 +67,7 @@ Rules cannot be explicitly ordered. However LXD will order the rules based on th
  - `drop`
  - `reject`
  - `allow`
- - Automatic default drop rule for any unmatched traffic
+ - Automatic default rule action for any unmatched traffic (defaults to `reject` if `default.action` not specified).
 
  This means that multiple ACLs can be applied to a NIC without having to specify the combined rule ordering.
  As soon as one of the rules in the ACLs matches then that action is taken and no other rules are considered.

--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -580,6 +580,18 @@ func OVNApplyNetworkBaselineRules(client *openvswitch.OVN, switchName openvswitc
 			Direction: "to-lport",
 			Action:    "allow",
 			Priority:  ovnACLPrioritySwitchAllow,
+			Match:     "icmp6 && icmp6.type == 143 && ip.ttl == 1 && ip6.dst == ff02::16", // IPv6 ICMP Multicast Listener Discovery reports.
+		},
+		{
+			Direction: "to-lport",
+			Action:    "allow",
+			Priority:  ovnACLPrioritySwitchAllow,
+			Match:     "igmp && ip.ttl == 1 && ip4.mcast", // IPv4 IGMP.
+		},
+		{
+			Direction: "to-lport",
+			Action:    "allow",
+			Priority:  ovnACLPrioritySwitchAllow,
 			Match:     fmt.Sprintf(`outport == "%s" && ((ip4 && udp.dst == 67) || (ip6 && udp.dst == 547))`, routerPortName), // DHCP to router.
 		},
 	}

--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -26,6 +26,9 @@ const ovnACLPriorityPortGroupAllow = 20
 const ovnACLPriorityPortGroupReject = 30
 const ovnACLPriorityPortGroupDrop = 40
 
+// ovnACLPortGroupPrefix prefix used when naming ACL related port groups in OVN.
+const ovnACLPortGroupPrefix = "lxd_acl"
+
 // OVNACLPortGroupName returns the port group name for a Network ACL ID.
 func OVNACLPortGroupName(networkACLID int64) openvswitch.OVNPortGroup {
 	// OVN doesn't match port groups that have a "-" in them. So use an "_" for the separator.

--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -32,7 +32,35 @@ const ovnACLPortGroupPrefix = "lxd_acl"
 // OVNACLPortGroupName returns the port group name for a Network ACL ID.
 func OVNACLPortGroupName(networkACLID int64) openvswitch.OVNPortGroup {
 	// OVN doesn't match port groups that have a "-" in them. So use an "_" for the separator.
-	return openvswitch.OVNPortGroup(fmt.Sprintf("lxd_acl%d", networkACLID))
+	// This is because OVN port group names must match: [a-zA-Z_.][a-zA-Z_.0-9]*.
+	return openvswitch.OVNPortGroup(fmt.Sprintf("%s%d", ovnACLPortGroupPrefix, networkACLID))
+}
+
+// OVNACLNetworkPortGroupName returns the port group name for a Network ACL ID and Network ID.
+func OVNACLNetworkPortGroupName(networkACLID int64, networkID int64) openvswitch.OVNPortGroup {
+	// OVN doesn't match port groups that have a "-" in them. So use an "_" for the separator.
+	// This is because OVN port group names must match: [a-zA-Z_.][a-zA-Z_.0-9]*.
+	return openvswitch.OVNPortGroup(fmt.Sprintf("%s%d_net%d", ovnACLPortGroupPrefix, networkACLID, networkID))
+}
+
+// OVNIntSwitchPortGroupName returns the port group name for a Network ID.
+func OVNIntSwitchPortGroupName(networkID int64) openvswitch.OVNPortGroup {
+	return openvswitch.OVNPortGroup(fmt.Sprintf("lxd_net%d", networkID))
+}
+
+// OVNNetworkPrefix returns the prefix used for OVN entities related to a Network ID.
+func OVNNetworkPrefix(networkID int64) string {
+	return fmt.Sprintf("lxd-net%d", networkID)
+}
+
+// OVNIntSwitchName returns the internal logical switch name for a Network ID.
+func OVNIntSwitchName(networkID int64) openvswitch.OVNSwitch {
+	return openvswitch.OVNSwitch(fmt.Sprintf("%s-ls-int", OVNNetworkPrefix(networkID)))
+}
+
+// OVNIntSwitchRouterPortName returns OVN logical internal switch router port name.
+func OVNIntSwitchRouterPortName(networkID int64) openvswitch.OVNSwitchPort {
+	return openvswitch.OVNSwitchPort(fmt.Sprintf("%s-lsp-router", OVNIntSwitchName(networkID)))
 }
 
 // OVNEnsureACLs ensures that the requested aclNames exist as OVN port groups (creates & applies ACL rules if not),

--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -787,3 +787,14 @@ func OVNPortGroupDeleteIfUnused(s *state.State, logger logger.Logger, client *op
 
 	return nil
 }
+
+// OVNPortGroupInstanceNICSchedule adds the specified NIC port to the specified port groups in the changeSet.
+func OVNPortGroupInstanceNICSchedule(portUUID openvswitch.OVNSwitchPortUUID, changeSet map[openvswitch.OVNPortGroup][]openvswitch.OVNSwitchPortUUID, portGroups ...openvswitch.OVNPortGroup) {
+	for _, portGroupName := range portGroups {
+		if _, found := changeSet[portGroupName]; !found {
+			changeSet[portGroupName] = []openvswitch.OVNSwitchPortUUID{}
+		}
+
+		changeSet[portGroupName] = append(changeSet[portGroupName], portUUID)
+	}
+}

--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -256,8 +256,12 @@ func ovnAddReferencedACLs(info *api.NetworkACL, referencedACLNames map[string]st
 				continue // Skip subjects already seen.
 			}
 
+			if subject == ruleSubjectInternal || subject == ruleSubjectExternal {
+				continue // Skip special reserved subjects that are not ACL names.
+			}
+
 			if validate.IsNetworkAddressCIDR(subject) == nil || validate.IsNetworkRange(subject) == nil {
-				continue // Skip  if the subject is an IP CIDR or IP range.
+				continue // Skip if the subject is an IP CIDR or IP range.
 			}
 
 			// Anything else must be a referenced ACL name.

--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -552,7 +552,7 @@ func OVNApplyNetworkBaselineRules(client *openvswitch.OVN, switchName openvswitc
 			Direction: "to-lport",
 			Action:    "allow",
 			Priority:  ovnACLPrioritySwitchAllow,
-			Match:     fmt.Sprintf(`outport == "%s" && ((ip4 && udp.dst == 67) || (ip6 && udp.dst == 547)) `, routerPortName), // DHCP to router.
+			Match:     fmt.Sprintf(`outport == "%s" && ((ip4 && udp.dst == 67) || (ip6 && udp.dst == 547))`, routerPortName), // DHCP to router.
 		},
 	}
 

--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -609,7 +609,7 @@ func OVNApplyNetworkBaselineRules(client *openvswitch.OVN, switchName openvswitc
 }
 
 // OVNPortGroupDeleteIfUnused deletes unused port groups. Accepts optional ignoreUsageType and ignoreUsageNicName
-// arguments, allowing the used by logic to ignore an instance or profile NIC or network (useful if config not
+// arguments, allowing the used by logic to ignore an instance/profile NIC or network (useful if config not
 // applied to database yet). Also accepts optional list of ACLs to explicitly consider in use by OVN.
 // The combination of ignoring the specifified usage type and explicit keep ACLs allows the caller to ensure that
 // the desired ACLs are considered unused by the usage type even if the referring config has not yet been removed
@@ -637,8 +637,8 @@ func OVNPortGroupDeleteIfUnused(s *state.State, logger logger.Logger, client *op
 
 	aclUsedACLS := make(map[string][]string, 0)
 
-	// Find alls ACLs that are either directly referred to by OVN entities (networks, instance/profile NICs) or
-	// by indirectly by being referred to in a ruleset of another ACL that is itself in use by OVN entities.
+	// Find alls ACLs that are either directly referred to by OVN entities (networks, instance/profile NICs)
+	// or indirectly by being referred to by a ruleset of another ACL that is itself in use by OVN entities.
 	// For the indirectly referred to ACLs, store a list of the ACLs that are referring to it.
 	err = UsedBy(s, aclProjectName, func(matchedACLNames []string, usageType interface{}, nicName string, nicConfig map[string]string) error {
 		switch u := usageType.(type) {

--- a/lxd/network/acl/driver_common.go
+++ b/lxd/network/acl/driver_common.go
@@ -32,7 +32,7 @@ const ruleSubjectInternal = "#internal"
 const ruleSubjectExternal = "#external"
 
 // Define valid actions for rules.
-var validActions = []string{"allow", "drop"}
+var validActions = []string{"allow", "drop", "reject"}
 
 // common represents a Network ACL.
 type common struct {

--- a/lxd/network/acl/driver_common.go
+++ b/lxd/network/acl/driver_common.go
@@ -27,6 +27,10 @@ type ruleDirection string
 const ruleDirectionIngress ruleDirection = "ingress"
 const ruleDirectionEgress ruleDirection = "egress"
 
+// Define reserved ACL subjects.
+const ruleSubjectInternal = "#internal"
+const ruleSubjectExternal = "#external"
+
 // common represents a Network ACL.
 type common struct {
 	logger      logger.Logger

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -461,7 +461,7 @@ func (n *ovn) getOptimalBridgeMTU() (uint32, error) {
 
 // getNetworkPrefix returns OVN network prefix to use for object names.
 func (n *ovn) getNetworkPrefix() string {
-	return fmt.Sprintf("lxd-net%d", n.id)
+	return acl.OVNNetworkPrefix(n.id)
 }
 
 // getChassisGroup returns OVN chassis group name to use.
@@ -567,12 +567,12 @@ func (n *ovn) getExtSwitchProviderPortName() openvswitch.OVNSwitchPort {
 
 // getIntSwitchName returns OVN logical internal switch name.
 func (n *ovn) getIntSwitchName() openvswitch.OVNSwitch {
-	return openvswitch.OVNSwitch(fmt.Sprintf("%s-ls-int", n.getNetworkPrefix()))
+	return acl.OVNIntSwitchName(n.id)
 }
 
 // getIntSwitchRouterPortName returns OVN logical internal switch router port name.
 func (n *ovn) getIntSwitchRouterPortName() openvswitch.OVNSwitchPort {
-	return openvswitch.OVNSwitchPort(fmt.Sprintf("%s-lsp-router", n.getIntSwitchName()))
+	return acl.OVNIntSwitchRouterPortName(n.id)
 }
 
 // getIntSwitchInstancePortPrefix returns OVN logical internal switch instance port name prefix.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1477,6 +1477,16 @@ func (n *ovn) setup(update bool) error {
 		return errors.Wrapf(err, "Failed to load network restrictions from project %q", n.project)
 	}
 
+	// Get project ID.
+	var projectID int64
+	err = n.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
+		projectID, err = tx.GetProjectID(n.project)
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "Failed getting project ID for project %q", n.project)
+	}
+
 	// Check project restrictions and get uplink network to use.
 	uplinkNetwork, err := n.validateUplinkNetwork(p, n.config["network"])
 	if err != nil {
@@ -1902,7 +1912,7 @@ func (n *ovn) setup(update bool) error {
 	if intPortGroupUUID == "" {
 		// Create internal port group and associated it with the logical switch, so that it will be
 		// removed when the logical switch is removed.
-		err = client.PortGroupAdd(intPortGroupName, "", n.getIntSwitchName())
+		err = client.PortGroupAdd(projectID, intPortGroupName, "", n.getIntSwitchName())
 		if err != nil {
 			return errors.Wrapf(err, "Failed creating port group %q for network %q setup", intPortGroupName, n.Name())
 		}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1232,11 +1232,24 @@ func (o *OVN) PortGroupInfo(portGroupName OVNPortGroup) (OVNPortGroupUUID, bool,
 }
 
 // PortGroupAdd creates a new port group and optionally adds logical switch ports to the group.
-func (o *OVN) PortGroupAdd(portGroupName OVNPortGroup, initialPortMembers ...OVNSwitchPort) error {
+func (o *OVN) PortGroupAdd(projectID int64, portGroupName OVNPortGroup, associatedPortGroup OVNPortGroup, associatedSwitch OVNSwitch, initialPortMembers ...OVNSwitchPort) error {
 	args := []string{"pg-add", string(portGroupName)}
-
 	for _, portName := range initialPortMembers {
 		args = append(args, string(portName))
+	}
+
+	args = append(args, "--", "set", "port_group", string(portGroupName),
+		fmt.Sprintf("external_ids:lxd_project_id=%d", projectID),
+	)
+
+	if associatedPortGroup != "" || associatedSwitch != "" {
+		if associatedPortGroup != "" {
+			args = append(args, fmt.Sprintf("external_ids:lxd_port_group=%s", associatedPortGroup))
+		}
+
+		if associatedSwitch != "" {
+			args = append(args, fmt.Sprintf("external_ids:lxd_switch=%s", associatedSwitch))
+		}
 	}
 
 	_, err := o.nbctl(args...)

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -787,28 +787,14 @@ func (o *OVN) logicalSwitchDNSRecordsDelete(switchName OVNSwitch) error {
 
 // LogicalSwitchSetACLRules applies a set of rules to the specified logical switch. Any existing rules are removed.
 func (o *OVN) LogicalSwitchSetACLRules(switchName OVNSwitch, aclRules ...OVNACLRule) error {
-	// Remove any existing rules.
-	_, err := o.nbctl("clear", "logical_switch", string(switchName), "acls")
-	if err != nil {
-		return err
+	// Add new rules.
+	externalIDs := map[string]string{
+		"lxd_switch": string(switchName),
 	}
 
-	// Add new rules.
-	for _, rule := range aclRules {
-		args := []string{"--type=switch"}
-
-		if rule.Log {
-			args = append(args, "--log")
-
-			if rule.LogName != "" {
-				args = append(args, fmt.Sprintf("--name=%s", rule.LogName))
-			}
-		}
-
-		_, err := o.nbctl(append(args, "acl-add", string(switchName), rule.Direction, fmt.Sprintf("%d", rule.Priority), rule.Match, rule.Action)...)
-		if err != nil {
-			return err
-		}
+	err := o.setACLRules("logical_switch", string(switchName), externalIDs, nil, aclRules...)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1260,21 +1260,19 @@ func (o *OVN) PortGroupAdd(projectID int64, portGroupName OVNPortGroup, associat
 	return nil
 }
 
-// PortGroupDelete deletes a port group and all ACLs associated to it.
-func (o *OVN) PortGroupDelete(portGroupName OVNPortGroup) error {
-	// ovn-nbctl doesn't provide an "--if-exists" option for removing port groups.
-	uuid, _, err := o.PortGroupInfo(portGroupName)
-	if err != nil {
-		return err
+// PortGroupDelete deletes port groups along with their ACL rules.
+func (o *OVN) PortGroupDelete(portGroupNames ...OVNPortGroup) error {
+	args := make([]string, 0)
+
+	for _, portGroupName := range portGroupNames {
+		if len(args) > 0 {
+			args = append(args, "--")
+		}
+
+		args = append(args, "--if-exists", "destroy", "port_group", string(portGroupName))
 	}
 
-	// Nothing to do if port group doesn't exist.
-	if uuid == "" {
-		return nil
-	}
-
-	// Delete port group.
-	_, err = o.nbctl("pg-del", string(portGroupName))
+	_, err := o.nbctl(args...)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1280,6 +1280,26 @@ func (o *OVN) PortGroupDelete(portGroupNames ...OVNPortGroup) error {
 	return nil
 }
 
+// PortGroupListByProject finds the port groups that are associated to the project ID.
+func (o *OVN) PortGroupListByProject(projectID int64) ([]OVNPortGroup, error) {
+	output, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--colum=name", "find", "port_group",
+		fmt.Sprintf("external_ids:lxd_project_id=%d", projectID),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	output = strings.TrimSpace(output)
+	lines := util.SplitNTrimSpace(output, "\n", -1, true)
+	portGroups := make([]OVNPortGroup, 0, len(lines))
+
+	for _, line := range lines {
+		portGroups = append(portGroups, OVNPortGroup(line))
+	}
+
+	return portGroups, nil
+}
+
 // PortGroupMemberChange adds/removes logical switch ports (by UUID) to/from existing port groups.
 func (o *OVN) PortGroupMemberChange(addMembers map[OVNPortGroup][]OVNSwitchPortUUID, removeMembers map[OVNPortGroup][]OVNSwitchPortUUID) error {
 	args := []string{}


### PR DESCRIPTION
Adds support for using `#external` and `#internal` special subjects in the `source` and `destination` rule fields where one would be able to use an ACL name.

- `#external` is to select any traffic coming to/from the external gateway port of a logical network.
- `#internal` is to select any traffic coming to/from any of the instance NIC ports connect to the logical network (even if they don't have any ACLs assigned to them).

In order to support this I have used several new OVN port groups:

1. When an OVN network is created, a per-network port group is created (irrespective of whether ACLs are assigned or not). When an instance NIC starts that is connected to this network its port is added to the per-network port group. This is what creates the classification of ports that are considered `#internal`.
2. When an ACL is assigned to an OVN network (either explicitly or implicitly via an instance/profile NIC device) a per-ACL-per-network port group is created (in addition to the per-ACL port group that contains the existing ACL rules). This new per-ACL-per-network port group will be used to store any rules that use the `#external` or `#internal` subjects. These rules will be duplicated into each per-ACL-per-network port group for each of the networks using the ACL. In order to link the per-ACL-per-network port group to each logical network switch, the network's gateway port is added to the port group (this way it will apply to all ports on the logical switch).

Each rule that is applied to a the per-ACL-per-network port groups will have the `#internal` subject replaced with the port group selector for its particular network (so that it applies to all internal instance NIC ports) and the `#external` subject will be replaced with a port selector of the network's gateway port (so that only traffic to/from that port is considered "external").

All port groups created now use LXD specific external ID fields to allow us to inspect OVN and see which port groups related to networks, ACLs, and projects.

The `OVNPortGroupDeleteIfUnused` function has been updated to introspect OVN and request all port groups that exist for a project, it will now remove per-ACL-per-network port groups when a network no longer uses a particular ACL.

Also I have started using the `--` argument for `ovn-nbctl` to combine multiple commands into a single invocation of the command, this is to improve performance by reducing the amount of separate commands we run.

Note: Existing networks will need to be "re-setup" to trigger the creation of the per-network port group. The easiest way to do this is to change something in their config (such as mtu) to trigger regeneration of OVN config.

Associated tests: https://github.com/lxc/lxc-ci/pull/251

 