### PR TITLE
Storage: Stop truncating BTRFS optimized image VM volumes to default volume size after image unpack

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -665,7 +665,12 @@ func (d *btrfs) SetVolumeQuota(vol Volume, size string, op *operations.Operation
 			return err
 		}
 
-		resized, err := ensureVolumeBlockFile(vol, rootBlockPath, sizeBytes)
+		// Pass VolumeTypeImage as unsupported resize type, as if the image volume doesn't match the
+		// requested size and vol.allowUnsafeResize=false, this needs to be rejected back to caller as
+		// ErrNotSupported so that the caller can take the appropriate action. In the case of optimized
+		// image volumes, this will cause the image volume to be deleted and regenerated with the new size.
+		// In other cases this is probably a bug and the operation should fail anyway.
+		resized, err := ensureVolumeBlockFile(vol, rootBlockPath, sizeBytes, VolumeTypeImage)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -69,9 +69,9 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 			return err
 		}
 
+		// Ignore ErrCannotBeShrunk when setting size this just means the filler has needed to increase
+		// the volume size beyond the default block volume size.
 		_, err = ensureVolumeBlockFile(vol, rootBlockPath, sizeBytes)
-
-		// Ignore ErrCannotBeShrunk as this just means the filler has needed to increase the volume size.
 		if err != nil && errors.Cause(err) != ErrCannotBeShrunk {
 			return err
 		}


### PR DESCRIPTION
When a VM image block file is greater than the default block volume size (10GB) it was being truncated to 10GB during the creation of BTRFS optimized image volumes (if `volume.size` on the storage pool wasn't set). 

There was explicit detection of the scenario where an image was larger than the default and to do not resize, however this was being overridden due to the use of `vol.allowUnsafeResize = true` in `CreateVolume` introduced with f245258acf7e23b74d6d16e050ab9656bde99c18 and 059863e24bcca4e9f53cff413541553e8a3d6f39.

This was added to allow the `ImageUnpack` called from `runFiller` to shrink the optimized block volumes on storage drivers that have to pre-create the volume before they know the size, and for `genericVFSBackupUnpack` to shrink the volume before unpack if needed.

However for BTRFS, we don't want to allow block volumes to be truncated during `Create()`, so we need to avoid setting `vol.allowUnsafeResize = true` before calling `ensureVolumeBlockFile` from `CreateVolume()`. However this would prevent us being allowed to grow image volumes (which is required if the image file is smaller than the specified `volume.size` or the default block size as we expect LXD to create an optimized image volume at that size).

What we needed was a way to tell `ensureVolumeBlockFile` to operate in a safe way (don't allow truncations) but to not forbid growing an image volume. So I have removed `vol.allowUnsafeResize = true` in `CreateVolume()` and instead, updated `ensureVolumeBlockFile` to support specifying a list of volume types that should not be resized, and now pass `VolumeTypeImage` from `SetVolumeQuota` so that once an image volume is fully created (including R/O snapshot) it cannot be resized. This is important, as the error code returned from `SetVolumeQuota` when trying to resize an image volume needs to be `ErrNotsupported` so that when changing the pool's `volume.size` setting, LXD will detect that resizing the image volume isn't possible and will opt instead to delete and regenerate it.

There was also an explicit check for being able to publish a VM image >10GB and using it, which was passing for BTRFS, but this was because in the test the VM with cloud-init was not started after being grown to 11GB and this meant that the filesystem was only 7GB and so the truncation at 10GB was not corrupting the filesystem. https://github.com/lxc/lxc-ci/blob/master/bin/test-lxd-vm#L146-L166

This is fixed in https://github.com/lxc/lxc-ci/pull/250

Fixes https://discuss.linuxcontainers.org/t/error-starting-instance-from-custom-published-image/10337