### PR TITLE
lxd: improve unix fd retrieval infrastructure

### DIFF
--- a/lxd/include/macro.h
+++ b/lxd/include/macro.h
@@ -282,4 +282,29 @@ enum {
 #define CLONE_NEWCGROUP	0x02000000
 #endif
 
+#define BUILD_BUG_ON_ZERO(e) ((int)(sizeof(struct { int:(-!!(e)); })))
+
+/*
+ * Compile time versions of __arch_hweightN()
+ */
+#define __const_hweight8(w)		\
+	((unsigned int)			\
+	 ((!!((w) & (1ULL << 0))) +	\
+	  (!!((w) & (1ULL << 1))) +	\
+	  (!!((w) & (1ULL << 2))) +	\
+	  (!!((w) & (1ULL << 3))) +	\
+	  (!!((w) & (1ULL << 4))) +	\
+	  (!!((w) & (1ULL << 5))) +	\
+	  (!!((w) & (1ULL << 6))) +	\
+	  (!!((w) & (1ULL << 7)))))
+
+#define __const_hweight16(w) (__const_hweight8(w)  + __const_hweight8((w)  >> 8 ))
+#define __const_hweight32(w) (__const_hweight16(w) + __const_hweight16((w) >> 16))
+#define __const_hweight64(w) (__const_hweight32(w) + __const_hweight32((w) >> 32))
+
+#define hweight8(w) __const_hweight8(w)
+#define hweight16(w) __const_hweight16(w)
+#define hweight32(w) __const_hweight32(w)
+#define hweight64(w) __const_hweight64(w)
+
 #endif /* __LXC_MACRO_H */

--- a/lxd/include/memory_utils.h
+++ b/lxd/include/memory_utils.h
@@ -62,4 +62,6 @@ static inline void free_string_list(char **list)
 define_cleanup_function(char **, free_string_list);
 #define __do_free_string_list call_cleaner(free_string_list)
 
+#define zalloc(__size__) (calloc(1, __size__))
+
 #endif /* __LXC_MEMORY_UTILS_H */

--- a/lxd/main_forkproxy.go
+++ b/lxd/main_forkproxy.go
@@ -533,7 +533,7 @@ func (c *cmdForkproxy) Run(cmd *cobra.Command, args []string) error {
 	files := []*os.File{}
 	for range lAddr.Addr {
 	rAgain:
-		f, err := netutils.AbstractUnixReceiveFd(forkproxyUDSSockFDNum)
+		f, err := netutils.AbstractUnixReceiveFd(forkproxyUDSSockFDNum, netutils.UnixFdsAcceptExact)
 		if err != nil {
 			errno, ok := shared.GetErrno(err)
 			if ok && (errno == unix.EAGAIN) {

--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -879,7 +879,7 @@ func (siov *Iovec) PutSeccompIovec() {
 
 // ReceiveSeccompIovec receives a seccomp iovec.
 func (siov *Iovec) ReceiveSeccompIovec(fd int) (uint64, error) {
-	bytes, fds, err := netutils.AbstractUnixReceiveFdData(fd, 3, unsafe.Pointer(siov.iov), 4)
+	bytes, fds, err := netutils.AbstractUnixReceiveFdData(fd, 3, netutils.UnixFdsAcceptLess, unsafe.Pointer(siov.iov), 4)
 	if err != nil || err == io.EOF {
 		return 0, err
 	}

--- a/shared/netutils/unixfd.c
+++ b/shared/netutils/unixfd.c
@@ -70,10 +70,15 @@ ssize_t lxc_abstract_unix_recv_fds_iov(int fd, struct unix_fds *ret_fds,
 	size_t cmsgbufsize = CMSG_SPACE(sizeof(struct ucred)) +
 			     CMSG_SPACE(ret_fds->fd_count_max * sizeof(int));
 
-	cmsgbuf = malloc(cmsgbufsize);
+	if (ret_fds->flags & ~UNIX_FDS_ACCEPT_MASK)
+		return ret_errno(EINVAL);
+
+	if (hweight32((ret_fds->flags & ~UNIX_FDS_ACCEPT_NONE)) > 1)
+		return ret_errno(EINVAL);
+
+	cmsgbuf = zalloc(cmsgbufsize);
 	if (!cmsgbuf)
 		return ret_errno(ENOMEM);
-	memset(cmsgbuf, 0, cmsgbufsize);
 
 	msg.msg_control		= cmsgbuf;
 	msg.msg_controllen	= cmsgbufsize;
@@ -120,7 +125,21 @@ again:
 				return -EFBIG;
 			}
 
+			if (msg.msg_flags & MSG_CTRUNC) {
+				for (idx = 0; idx < num_raw; idx++)
+					close(fds_raw[idx]);
+
+				return -EFBIG;
+			}
+
 			if (ret_fds->fd_count_max > num_raw) {
+				if (!(ret_fds->flags & UNIX_FDS_ACCEPT_LESS)) {
+					for (idx = 0; idx < num_raw; idx++)
+						close(fds_raw[idx]);
+
+					return -EINVAL;
+				}
+
 				/*
 				 * Make sure any excess entries in the fd array
 				 * are set to -EBADF so our cleanup functions
@@ -128,19 +147,47 @@ again:
 				 */
 				for (idx = num_raw; idx < ret_fds->fd_count_max; idx++)
 					ret_fds->fd[idx] = -EBADF;
+
+				ret_fds->flags |= UNIX_FDS_RECEIVED_LESS;
 			} else if (ret_fds->fd_count_max < num_raw) {
+				if (!(ret_fds->flags & UNIX_FDS_ACCEPT_MORE)) {
+					for (idx = 0; idx < num_raw; idx++)
+						close(fds_raw[idx]);
+
+					return -EINVAL;
+				}
+
 				/* Make sure we close any excess fds we received. */
 				for (idx = ret_fds->fd_count_max; idx < num_raw; idx++)
 					close(fds_raw[idx]);
 
 				/* Cap the number of received file descriptors. */
 				num_raw = ret_fds->fd_count_max;
+				ret_fds->flags |= UNIX_FDS_RECEIVED_MORE;
+			} else {
+				ret_fds->flags |= UNIX_FDS_RECEIVED_EXACT;
+			}
+
+			if (hweight32((ret_fds->flags & ~UNIX_FDS_ACCEPT_MASK)) > 1) {
+				for (idx = 0; idx < num_raw; idx++)
+					close(fds_raw[idx]);
+
+				return -EINVAL;
 			}
 
 			memcpy(ret_fds->fd, CMSG_DATA(cmsg), num_raw * sizeof(int));
 			ret_fds->fd_count_ret = num_raw;
 			break;
 		}
+	}
+
+	if (ret_fds->fd_count_ret == 0) {
+		ret_fds->flags |= UNIX_FDS_RECEIVED_NONE;
+
+		/* We expected to receive file descriptors. */
+		if ((ret_fds->flags & UNIX_FDS_ACCEPT_MASK) &&
+		    !(ret_fds->flags & UNIX_FDS_ACCEPT_NONE))
+			return -EINVAL;
 	}
 
 	return ret;

--- a/shared/netutils/unixfd.h
+++ b/shared/netutils/unixfd.h
@@ -8,15 +8,25 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 
-/*
- * Technically 253 is the kernel limit but we want to the struct to be a
- * multiple of 8.
- */
-#define KERNEL_SCM_MAX_FD 252
+#define KERNEL_SCM_MAX_FD 253
+
+/* Allow the caller to set expectations. */
+#define UNIX_FDS_ACCEPT_EXACT	((__u32)(1 << 0)) /* default */
+#define UNIX_FDS_ACCEPT_LESS	((__u32)(1 << 1))
+#define UNIX_FDS_ACCEPT_MORE	((__u32)(1 << 2)) /* wipe any extra fds */
+#define UNIX_FDS_ACCEPT_NONE	((__u32)(1 << 3))
+#define UNIX_FDS_ACCEPT_MASK (UNIX_FDS_ACCEPT_EXACT | UNIX_FDS_ACCEPT_LESS | UNIX_FDS_ACCEPT_MORE | UNIX_FDS_ACCEPT_NONE)
+
+/* Allow the callee to disappoint them. */
+#define UNIX_FDS_RECEIVED_EXACT	((__u32)(1 << 16))
+#define UNIX_FDS_RECEIVED_LESS	((__u32)(1 << 17))
+#define UNIX_FDS_RECEIVED_MORE	((__u32)(1 << 18))
+#define UNIX_FDS_RECEIVED_NONE	((__u32)(1 << 19))
 
 struct unix_fds {
 	__u32 fd_count_max;
 	__u32 fd_count_ret;
+	__u32 flags;
 	__s32 fd[KERNEL_SCM_MAX_FD];
 } __attribute__((aligned(8)));
 


### PR DESCRIPTION
Enable caller and callee to express expectations and the reality of fd
retrieval. If the expectations of the caller aren't fulfilled then the cleanup
of any received fds will happen in the low-lever helper directly instead of
forcing it upon the caller to cleanup fds.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>