### PR TITLE
lxd/db: Don't fail preparing statements for activateifneeded

### DIFF
--- a/lxd/db/cluster/stmt.go
+++ b/lxd/db/cluster/stmt.go
@@ -20,12 +20,12 @@ func RegisterStmt(sql string) int {
 
 // PrepareStmts prepares all registered statements and returns an index from
 // statement code to prepared statement object.
-func PrepareStmts(db *sql.DB) (map[int]*sql.Stmt, error) {
+func PrepareStmts(db *sql.DB, skipErrors bool) (map[int]*sql.Stmt, error) {
 	index := map[int]*sql.Stmt{}
 
 	for code, sql := range stmts {
 		stmt, err := db.Prepare(sql)
-		if err != nil {
+		if err != nil && !skipErrors {
 			return nil, errors.Wrapf(err, "%q", sql)
 		}
 		index[code] = stmt

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -248,7 +248,7 @@ func OpenCluster(name string, store driver.NodeStore, address, dir string, timeo
 		return cluster, ErrSomeNodesAreBehind
 	}
 
-	stmts, err := cluster.PrepareStmts(db)
+	stmts, err := cluster.PrepareStmts(db, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to prepare statements")
 	}
@@ -316,7 +316,7 @@ func ForLocalInspection(db *sql.DB) *Cluster {
 func ForLocalInspectionWithPreparedStmts(db *sql.DB) (*Cluster, error) {
 	c := ForLocalInspection(db)
 
-	stmts, err := cluster.PrepareStmts(c.db)
+	stmts, err := cluster.PrepareStmts(c.db, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "Prepare database statements")
 	}


### PR DESCRIPTION
On startup, we call "lxd activateifneeded", this does a number of simple
database access using sqlite directly. We only need a fraction of the
tables at that point and this will run ahead of any on-startup database
schema update.

This change makes it so that new prepared statements for tables that do
not yet exist won't prevent activateifneeded from accessing the
database.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>