### PR TITLE
Network: Validate NIC interface name and prevent duplicates

### DIFF
--- a/lxd/device/infiniband_physical.go
+++ b/lxd/device/infiniband_physical.go
@@ -28,7 +28,7 @@ func (d *infinibandPhysical) validateConfig(instConf instance.ConfigReader) erro
 		"hwaddr",
 	}
 
-	rules := nicValidationRules(requiredFields, optionalFields)
+	rules := nicValidationRules(requiredFields, optionalFields, instConf)
 	rules["hwaddr"] = func(value string) error {
 		if value == "" {
 			return nil

--- a/lxd/device/infiniband_sriov.go
+++ b/lxd/device/infiniband_sriov.go
@@ -29,7 +29,7 @@ func (d *infinibandSRIOV) validateConfig(instConf instance.ConfigReader) error {
 		"hwaddr",
 	}
 
-	rules := nicValidationRules(requiredFields, optionalFields)
+	rules := nicValidationRules(requiredFields, optionalFields, instConf)
 	rules["hwaddr"] = func(value string) error {
 		if value == "" {
 			return nil

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -8,7 +8,7 @@ import (
 func nicValidationRules(requiredFields []string, optionalFields []string) map[string]func(value string) error {
 	// Define a set of default validators for each field name.
 	defaultValidators := map[string]func(value string) error{
-		"name":                    validate.IsAny,
+		"name":                    validate.Optional(validate.IsInterfaceName),
 		"parent":                  validate.IsAny,
 		"network":                 validate.IsAny,
 		"mtu":                     validate.Optional(validate.IsNetworkMTU),

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -94,3 +94,22 @@ func nicHasAutoGateway(value string) bool {
 
 	return false
 }
+
+// nicCheckNamesUnique checks that all the NICs in the instConf's expanded devices have a unique (or unset) name.
+func nicCheckNamesUnique(instConf instance.ConfigReader) error {
+	seenNICNames := []string{}
+
+	for _, devConfig := range instConf.ExpandedDevices() {
+		if devConfig["type"] != "nic" || devConfig["name"] == "" {
+			continue
+		}
+
+		if shared.StringInSlice(devConfig["name"], seenNICNames) {
+			return fmt.Errorf("Duplicate NIC name detected %q", devConfig["name"])
+		}
+
+		seenNICNames = append(seenNICNames, devConfig["name"])
+	}
+
+	return nil
+}

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -1,14 +1,18 @@
 package device
 
 import (
+	"fmt"
+
+	"github.com/lxc/lxd/lxd/instance"
+	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/validate"
 )
 
 // nicValidationRules returns config validation rules for nic devices.
-func nicValidationRules(requiredFields []string, optionalFields []string) map[string]func(value string) error {
+func nicValidationRules(requiredFields []string, optionalFields []string, instConf instance.ConfigReader) map[string]func(value string) error {
 	// Define a set of default validators for each field name.
 	defaultValidators := map[string]func(value string) error{
-		"name":                    validate.Optional(validate.IsInterfaceName),
+		"name":                    validate.Optional(validate.IsInterfaceName, func(_ string) error { return nicCheckNamesUnique(instConf) }),
 		"parent":                  validate.IsAny,
 		"network":                 validate.IsAny,
 		"mtu":                     validate.Optional(validate.IsNetworkMTU),

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -156,7 +156,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 		}
 	}
 
-	rules := nicValidationRules(requiredFields, optionalFields)
+	rules := nicValidationRules(requiredFields, optionalFields, instConf)
 
 	// Add bridge specific vlan validation.
 	rules["vlan"] = func(value string) error {

--- a/lxd/device/nic_ipvlan.go
+++ b/lxd/device/nic_ipvlan.go
@@ -46,7 +46,7 @@ func (d *nicIPVLAN) validateConfig(instConf instance.ConfigReader) error {
 		"gvrp",
 	}
 
-	rules := nicValidationRules(requiredFields, optionalFields)
+	rules := nicValidationRules(requiredFields, optionalFields, instConf)
 	rules["gvrp"] = validate.Optional(validate.IsBool)
 	rules["ipv4.address"] = func(value string) error {
 		if value == "" {

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -82,7 +82,7 @@ func (d *nicMACVLAN) validateConfig(instConf instance.ConfigReader) error {
 		requiredFields = append(requiredFields, "parent")
 	}
 
-	err := d.config.Validate(nicValidationRules(requiredFields, optionalFields))
+	err := d.config.Validate(nicValidationRules(requiredFields, optionalFields, instConf))
 	if err != nil {
 		return err
 	}

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -162,7 +162,7 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 	// Apply network level config options to device config before validation.
 	d.config["mtu"] = fmt.Sprintf("%s", netConfig["bridge.mtu"])
 
-	rules := nicValidationRules(requiredFields, optionalFields)
+	rules := nicValidationRules(requiredFields, optionalFields, instConf)
 
 	// Now run normal validation.
 	err = d.config.Validate(rules)

--- a/lxd/device/nic_p2p.go
+++ b/lxd/device/nic_p2p.go
@@ -33,7 +33,7 @@ func (d *nicP2P) validateConfig(instConf instance.ConfigReader) error {
 		"ipv6.routes",
 		"boot.priority",
 	}
-	err := d.config.Validate(nicValidationRules([]string{}, optionalFields))
+	err := d.config.Validate(nicValidationRules([]string{}, optionalFields, instConf))
 	if err != nil {
 		return err
 	}

--- a/lxd/device/nic_physical.go
+++ b/lxd/device/nic_physical.go
@@ -38,7 +38,7 @@ func (d *nicPhysical) validateConfig(instConf instance.ConfigReader) error {
 		optionalFields = append(optionalFields, "mtu", "hwaddr", "vlan")
 	}
 
-	err := d.config.Validate(nicValidationRules(requiredFields, optionalFields))
+	err := d.config.Validate(nicValidationRules(requiredFields, optionalFields, instConf))
 	if err != nil {
 		return err
 	}

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -65,7 +65,7 @@ func (d *nicRouted) validateConfig(instConf instance.ConfigReader) error {
 		"gvrp",
 	}
 
-	rules := nicValidationRules(requiredFields, optionalFields)
+	rules := nicValidationRules(requiredFields, optionalFields, instConf)
 	rules["ipv4.address"] = validate.Optional(validate.IsNetworkAddressV4List)
 	rules["ipv6.address"] = validate.Optional(validate.IsNetworkAddressV6List)
 	rules["gvrp"] = validate.Optional(validate.IsBool)

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -95,7 +95,7 @@ func (d *nicSRIOV) validateConfig(instConf instance.ConfigReader) error {
 		optionalFields = append(optionalFields, "mtu")
 	}
 
-	err := d.config.Validate(nicValidationRules(requiredFields, optionalFields))
+	err := d.config.Validate(nicValidationRules(requiredFields, optionalFields, instConf))
 	if err != nil {
 		return err
 	}

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -170,7 +170,7 @@ func (n *bridge) populateAutoConfig(config map[string]string) error {
 
 // ValidateName validates network name.
 func (n *bridge) ValidateName(name string) error {
-	err := validInterfaceName(name)
+	err := validate.IsInterfaceName(name)
 	if err != nil {
 		return err
 	}
@@ -189,7 +189,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		"bridge.external_interfaces": validate.Optional(func(value string) error {
 			for _, entry := range strings.Split(value, ",") {
 				entry = strings.TrimSpace(entry)
-				if err := validInterfaceName(entry); err != nil {
+				if err := validate.IsInterfaceName(entry); err != nil {
 					return errors.Wrapf(err, "Invalid interface name %q", entry)
 				}
 			}
@@ -301,7 +301,7 @@ func (n *bridge) Validate(config map[string]string) error {
 			case "id":
 				rules[k] = validate.Optional(validate.IsInt64)
 			case "inteface":
-				rules[k] = validInterfaceName
+				rules[k] = validate.IsInterfaceName
 			case "ttl":
 				rules[k] = validate.Optional(validate.IsUint8)
 			}

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -27,7 +27,7 @@ func (n *macvlan) DBType() db.NetworkType {
 // Validate network config.
 func (n *macvlan) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
-		"parent":           validate.Required(validate.IsNotEmpty, validInterfaceName),
+		"parent":           validate.Required(validate.IsNotEmpty, validate.IsInterfaceName),
 		"mtu":              validate.Optional(validate.IsNetworkMTU),
 		"vlan":             validate.Optional(validate.IsNetworkVLAN),
 		"gvrp":             validate.Optional(validate.IsBool),

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -34,7 +34,7 @@ func (n *physical) DBType() db.NetworkType {
 // Validate network config.
 func (n *physical) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
-		"parent":              validate.Required(validate.IsNotEmpty, validInterfaceName),
+		"parent":              validate.Required(validate.IsNotEmpty, validate.IsInterfaceName),
 		"mtu":                 validate.Optional(validate.IsNetworkMTU),
 		"vlan":                validate.Optional(validate.IsNetworkVLAN),
 		"gvrp":                validate.Optional(validate.IsBool),

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -27,7 +27,7 @@ func (n *sriov) DBType() db.NetworkType {
 // Validate network config.
 func (n *sriov) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
-		"parent":           validate.Required(validate.IsNotEmpty, validInterfaceName),
+		"parent":           validate.Required(validate.IsNotEmpty, validate.IsInterfaceName),
 		"mtu":              validate.Optional(validate.IsNetworkMTU),
 		"vlan":             validate.Optional(validate.IsNetworkVLAN),
 		"maas.subnet.ipv4": validate.IsAny,

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -10,7 +10,6 @@ import (
 	"math/rand"
 	"net"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -33,26 +32,6 @@ import (
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/version"
 )
-
-// validInterfaceName validates a real network interface name.
-func validInterfaceName(value string) error {
-	// Validate the length.
-	if len(value) < 2 {
-		return fmt.Errorf("Network interface is too short (minimum 2 characters)")
-	}
-
-	if len(value) > 15 {
-		return fmt.Errorf("Network interface is too long (maximum 15 characters)")
-	}
-
-	// Validate the character set.
-	match, _ := regexp.MatchString("^[-_a-zA-Z0-9.]*$", value)
-	if !match {
-		return fmt.Errorf("Network interface contains invalid characters")
-	}
-
-	return nil
-}
 
 func networkValidPort(value string) error {
 	if value == "" {

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -154,6 +154,26 @@ func IsDeviceID(value string) error {
 	return nil
 }
 
+// IsInterfaceName validates a real network interface name.
+func IsInterfaceName(value string) error {
+	// Validate the length.
+	if len(value) < 2 {
+		return fmt.Errorf("Network interface is too short (minimum 2 characters)")
+	}
+
+	if len(value) > 15 {
+		return fmt.Errorf("Network interface is too long (maximum 15 characters)")
+	}
+
+	// Validate the character set.
+	match, _ := regexp.MatchString("^[-_a-zA-Z0-9.]+$", value)
+	if !match {
+		return fmt.Errorf("Network interface contains invalid characters")
+	}
+
+	return nil
+}
+
 // IsNetworkMAC validates an Ethernet MAC address. e.g. "00:00:5e:00:53:01".
 func IsNetworkMAC(value string) error {
 	_, err := net.ParseMAC(value)


### PR DESCRIPTION
- Checks a NIC's `name` property is a valid interface name and not conflicting with another interface on the instance.
- Prevents passing `%` char as interface name to avoid letting the kernel generate part of the NIC name and losing knowledge of what the NIC's interface name is.

Fixes https://github.com/lxc/lxd/issues/8501