### PR TITLE
Projects restricted cluster target

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1325,3 +1325,7 @@ Adds a new `security.acls` property to OVN networks and OVN NICs, allowing Netwo
 ## projects\_images\_auto\_update
 Adds new `images.auto_update_cached` and `images.auto_update_interval` config keys which
 allows configuration of images auto update in projects
+
+## projects\_restricted\_cluster\_target
+Adds new `restricted.cluster.target` config key to project which prevent the user from using --target
+to specify what cluster member to place a workload on or the ability to move a workload between members.

--- a/doc/projects.md
+++ b/doc/projects.md
@@ -35,6 +35,7 @@ limits.networks                      | integer   | -                     | -    
 limits.processes                     | integer   | -                     | -                         | Maximum value for the sum of individual "limits.processes" configs set on the instances of the project
 limits.virtual-machines              | integer   | -                     | -                         | Maximum number of VMs that can be created in the project
 restricted                           | boolean   | -                     | false                     | Block access to security-sensitive features
+restricted.cluster.target            | string    | -                     | block                     | Prevents direct targeting of cluster members when creating or moving instances.
 restricted.containers.lowlevel       | string    | -                     | block                     | Prevents use of low-level container options like raw.lxc, raw.idmap, volatile, etc.
 restricted.containers.nesting        | string    | -                     | block                     | Prevents setting security.nesting=true.
 restricted.containers.privilege      | string    | -                     | unpriviliged              | If "unpriviliged", prevents setting security.privileged=true. If "isolated", prevents setting security.privileged=true and also security.idmap.isolated=true. If "allow", no restriction apply.

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -782,6 +782,7 @@ func projectValidateConfig(s *state.State, config map[string]string) error {
 		"limits.disk":                    validate.Optional(validate.IsSize),
 		"limits.networks":                validate.Optional(validate.IsUint32),
 		"restricted":                     validate.Optional(validate.IsBool),
+		"restricted.cluster.target":      isEitherAllowOrBlock,
 		"restricted.containers.nesting":  isEitherAllowOrBlock,
 		"restricted.containers.lowlevel": isEitherAllowOrBlock,
 		"restricted.containers.privilege": func(value string) error {

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -38,7 +38,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	project := projectParam(r)
+	projectName := projectParam(r)
 
 	name := mux.Vars(r)["name"]
 	targetNode := queryParam(r, "target")
@@ -73,6 +73,12 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 				return errors.Wrap(err, "Failed to load LXD config")
 			}
 
+			// Check if user is allowed to use cluster member targeting
+			err = project.CheckClusterTargetRestriction(tx, r, projectName, targetNode)
+			if err != nil {
+				return err
+			}
+
 			// Load target node.
 			node, err := tx.GetNodeByName(targetNode)
 			if err != nil {
@@ -81,7 +87,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 			targetNodeOffline = node.IsOffline(config.OfflineThreshold())
 
 			// Load source node.
-			address, err := tx.GetNodeAddressOfInstance(project, name, instanceType)
+			address, err := tx.GetNodeAddressOfInstance(projectName, name, instanceType)
 			if err != nil {
 				return errors.Wrap(err, "Failed to get address of instance's node")
 			}
@@ -130,7 +136,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 	// and we'll either forward the request or load the container.
 	if targetNode == "" || !sourceNodeOffline {
 		// Handle requests targeted to a container on a different node.
-		resp, err := forwardedResponseIfInstanceIsRemote(d, r, project, name, instanceType)
+		resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -166,7 +172,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		stateful = req.Live
 	}
 
-	inst, err := instance.LoadByProjectAndName(d.State(), project, name)
+	inst, err := instance.LoadByProjectAndName(d.State(), projectName, name)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -181,7 +187,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 
 			resources := map[string][]string{}
 			resources["instances"] = []string{name}
-			op, err := operations.OperationCreate(d.State(), project, operations.OperationClassTask, db.OperationInstanceMigrate, resources, nil, run, nil, nil)
+			op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceMigrate, resources, nil, run, nil, nil)
 			if err != nil {
 				return response.InternalError(err)
 			}
@@ -191,7 +197,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 
 		if targetNode != "" {
 			// Check if instance has backups.
-			backups, err := d.cluster.GetInstanceBackups(project, name)
+			backups, err := d.cluster.GetInstanceBackups(projectName, name)
 			if err != nil {
 				err = errors.Wrap(err, "Failed to fetch instance's backups")
 				return response.SmartError(err)
@@ -206,7 +212,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Check if we are migrating a ceph-based container.
-			poolName, err := d.cluster.GetInstancePool(project, name)
+			poolName, err := d.cluster.GetInstancePool(projectName, name)
 			if err != nil {
 				err = errors.Wrap(err, "Failed to fetch instance's pool name")
 				return response.SmartError(err)
@@ -217,7 +223,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 				return response.SmartError(err)
 			}
 			if pool.Driver == "ceph" {
-				return instancePostClusteringMigrateWithCeph(d, inst, project, name, req.Name, targetNode, instanceType)
+				return instancePostClusteringMigrateWithCeph(d, inst, projectName, name, req.Name, targetNode, instanceType)
 			}
 
 			// If this is not a ceph-based container, make sure
@@ -261,7 +267,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 				return response.InternalError(err)
 			}
 
-			op, err := operations.OperationCreate(d.State(), project, operations.OperationClassTask, db.OperationInstanceMigrate, resources, nil, run, nil, nil)
+			op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceMigrate, resources, nil, run, nil, nil)
 			if err != nil {
 				return response.InternalError(err)
 			}
@@ -270,7 +276,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Pull mode.
-		op, err := operations.OperationCreate(d.State(), project, operations.OperationClassWebsocket, db.OperationInstanceMigrate, resources, ws.Metadata(), run, cancel, ws.Connect)
+		op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassWebsocket, db.OperationInstanceMigrate, resources, ws.Metadata(), run, cancel, ws.Connect)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -279,7 +285,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Check that the name isn't already in use.
-	id, _ := d.cluster.GetInstanceID(project, req.Name)
+	id, _ := d.cluster.GetInstanceID(projectName, req.Name)
 	if id > 0 {
 		return response.Conflict(fmt.Errorf("Name '%s' already in use", req.Name))
 	}
@@ -295,7 +301,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(d.State(), project, operations.OperationClassTask, db.OperationInstanceRename, resources, nil, run, nil, nil)
+	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceRename, resources, nil, run, nil, nil)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -772,6 +772,12 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	targetNode := queryParam(r, "target")
+	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
+		return project.CheckClusterTargetRestriction(tx, r, targetProject, targetNode)
+	})
+	if err != nil {
+		return response.SmartError(err)
+	}
 	if targetNode == "" {
 		// If no target node was specified, pick the node with the
 		// least number of containers. If there's just one node, or if

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -260,6 +260,7 @@ var APIExtensions = []string{
 	"certificate_project",
 	"network_ovn_acl",
 	"projects_images_auto_update",
+	"projects_restricted_cluster_target",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
@stgraber not sure about adding new HasFlagTarget field to InstancePost and InstanceSource structs but we need to pass info about use of flag '--target' by user. I thought about using targetNode var (which is used in `lxd/instance_post.go:instancePost` and `lxd/instances_post.go:instancesPost`) but this var is also set in code when request goes to second node.