### PR TITLE
Change the import path for the macaroon bakery to use a new v3 version.

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"gopkg.in/macaroon-bakery.v3/httpbakery"
 
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 
 	"github.com/gorilla/websocket"
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"gopkg.in/macaroon-bakery.v3/bakery"
+	"gopkg.in/macaroon-bakery.v3/httpbakery"
 
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"

--- a/lxc/config/remote.go
+++ b/lxc/config/remote.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/juju/persistent-cookiejar"
 	schemaform "gopkg.in/juju/environschema.v1/form"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
-	"gopkg.in/macaroon-bakery.v2/httpbakery/form"
+	"gopkg.in/macaroon-bakery.v3/httpbakery"
+	"gopkg.in/macaroon-bakery.v3/httpbakery/form"
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/shared"

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -25,10 +25,10 @@ import (
 	"golang.org/x/sys/unix"
 	liblxc "gopkg.in/lxc/go-lxc.v2"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v2/bakery/identchecker"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"gopkg.in/macaroon-bakery.v3/bakery"
+	"gopkg.in/macaroon-bakery.v3/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v3/bakery/identchecker"
+	"gopkg.in/macaroon-bakery.v3/httpbakery"
 
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/daemon"

--- a/lxd/rbac/server.go
+++ b/lxd/rbac/server.go
@@ -14,9 +14,9 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
-	"gopkg.in/macaroon-bakery.v2/httpbakery/agent"
+	"gopkg.in/macaroon-bakery.v3/bakery"
+	"gopkg.in/macaroon-bakery.v3/httpbakery"
+	"gopkg.in/macaroon-bakery.v3/httpbakery/agent"
 
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"

--- a/test/godeps.list
+++ b/test/godeps.list
@@ -9,7 +9,7 @@ github.com/lxc/lxd/shared/logger
 github.com/lxc/lxd/shared/simplestreams
 github.com/lxc/lxd/shared/units
 gopkg.in/juju/environschema.v1/form
-gopkg.in/macaroon-bakery.v2/bakery
-gopkg.in/macaroon-bakery.v2/httpbakery
-gopkg.in/macaroon-bakery.v2/httpbakery/form
+gopkg.in/macaroon-bakery.v3/bakery
+gopkg.in/macaroon-bakery.v3/httpbakery
+gopkg.in/macaroon-bakery.v3/httpbakery/form
 gopkg.in/yaml.v2

--- a/test/macaroon-identity/auth.go
+++ b/test/macaroon-identity/auth.go
@@ -7,10 +7,10 @@ import (
 	"log"
 	"net/http"
 
-	"gopkg.in/macaroon-bakery.v2/bakery"
-	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
-	"gopkg.in/macaroon-bakery.v2/httpbakery"
-	"gopkg.in/macaroon-bakery.v2/httpbakery/form"
+	"gopkg.in/macaroon-bakery.v3/bakery"
+	"gopkg.in/macaroon-bakery.v3/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v3/httpbakery"
+	"gopkg.in/macaroon-bakery.v3/httpbakery/form"
 
 	"github.com/juju/httprequest"
 	"github.com/rogpeppe/fastuuid"

--- a/test/macaroon-identity/formschema.go
+++ b/test/macaroon-identity/formschema.go
@@ -4,7 +4,7 @@ import (
 	"github.com/juju/schema"
 
 	"gopkg.in/juju/environschema.v1"
-	"gopkg.in/macaroon-bakery.v2/httpbakery/form"
+	"gopkg.in/macaroon-bakery.v3/httpbakery/form"
 )
 
 var schemaResponse = form.SchemaResponse{


### PR DESCRIPTION
The bakery v3 version at `gopkg.in/macaroon-bakery.v3` picks up mgo from the juju fork `github.com/juju/mgo/v2` instead of `gopkg.in/mgo.v2.
The juju version has a few bug fixes which are not upstream.
