### PR TITLE
Network: Don't fail when missing vfListPath in sriovGetFreeVFInterface

### DIFF
--- a/lxd/network/network_utils_sriov.go
+++ b/lxd/network/network_utils_sriov.go
@@ -200,7 +200,7 @@ func sriovGetFreeVFInterface(reservedDevices map[string]struct{}, parentDev stri
 		vfListPath := fmt.Sprintf("/sys/class/net/%s/device/virtfn%d/net", parentDev, vfID)
 
 		if !shared.PathExists(vfListPath) {
-			return -1, "", nil
+			continue // The vfListPath won't exist if the VF has been unbound and used with a VM.
 		}
 
 		ents, err := ioutil.ReadDir(vfListPath)


### PR DESCRIPTION
When a VM has used a VF it is unbound from the host OS so the `/sys/class/net/%s/device/virtfn%d/net` directory won't exist.

This is OK, and we should just skip the VF as its in use.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>

Related CI test update: https://github.com/lxc/lxc-ci/pull/253