### PR TITLE
docs: typo on JSON schema

### DIFF
--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -341,7 +341,7 @@ Return value (if trusted):
         "kernel_version": "3.16",
         "server": "lxd",
         "server_pid": 10224,
-        "server_version": "0.8.1"}
+        "server_version": "0.8.1",
         "storage": "btrfs",
         "storage_version": "3.19",
     },


### PR DESCRIPTION
Nothing so critical, just noticed this disturbing typo about the JSON structure.