### PR TITLE
Patches: Adds db_nodes_autoinc patch

### DIFF
--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -606,6 +606,9 @@ func (g *Gateway) Reset(cert *shared.CertInfo) error {
 	return g.init()
 }
 
+// ErrNodeIsNotClustered indicates the node is not clustered.
+var ErrNodeIsNotClustered error = fmt.Errorf("Node is not clustered")
+
 // LeaderAddress returns the address of the current raft leader.
 func (g *Gateway) LeaderAddress() (string, error) {
 	g.lock.RLock()
@@ -613,7 +616,7 @@ func (g *Gateway) LeaderAddress() (string, error) {
 
 	// If we aren't clustered, return an error.
 	if g.memoryDial != nil {
-		return "", fmt.Errorf("Node is not clustered")
+		return "", ErrNodeIsNotClustered
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/lxd/cluster/gateway_test.go
+++ b/lxd/cluster/gateway_test.go
@@ -54,7 +54,7 @@ func TestGateway_Single(t *testing.T) {
 
 	leader, err := gateway.LeaderAddress()
 	assert.Equal(t, "", leader)
-	assert.EqualError(t, err, "Node is not clustered")
+	assert.EqualError(t, err, cluster.ErrNodeIsNotClustered.Error())
 
 	driver, err := driver.New(
 		gateway.NodeStore(),


### PR DESCRIPTION
Recreates nodes table id column with AUTOINCREMENT.

Related to https://github.com/canonical/raft/pull/176
Related to https://github.com/lxc/lxd/pull/8521

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>