### PR TITLE
Storage: Ceph utils util.SplitNTrimSpace usage

### DIFF
--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pborman/uuid"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/ioprogress"
 	log "github.com/lxc/lxd/shared/log15"
@@ -81,9 +82,7 @@ func (d *ceph) rbdCreateVolume(vol Volume, size string) error {
 	}
 
 	if d.config["ceph.rbd.features"] != "" {
-		for _, feature := range strings.Split(d.config["ceph.rbd.features"], ",") {
-			feature = strings.TrimSpace(feature)
-
+		for _, feature := range util.SplitNTrimSpace(d.config["ceph.rbd.features"], ",", -1, true) {
 			cmd = append(cmd, "--image-feature", feature)
 		}
 	} else {
@@ -325,9 +324,7 @@ func (d *ceph) rbdCreateClone(sourceVol Volume, sourceSnapshotName string, targe
 	}
 
 	if d.config["ceph.rbd.features"] != "" {
-		for _, feature := range strings.Split(d.config["ceph.rbd.features"], ",") {
-			feature = strings.TrimSpace(feature)
-
+		for _, feature := range util.SplitNTrimSpace(d.config["ceph.rbd.features"], ",", -1, true) {
 			cmd = append(cmd, "--image-feature", feature)
 		}
 	} else {


### PR DESCRIPTION
@stgraber @brauner the change in https://github.com/lxc/lxd/pull/8524 caught my eye as it looked like a good candidate for the `util.SplitNTrimSpace` I added as part of the OVN ACL feature.

I noticed that parsing a (usually comma) separated list and removing white space between the elements was a common pattern for us, so added a function to do it to reduce repetition.

Also, although not so useful in this case because there is a separate not-empty check, but in cases where you don't need to do anything if the option list is empty the `util.SplitNTrimSpace` takes a boolean argument to return a nil slice when the input is an empty string (which avoids returning a single element slice containing an empty string).

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>