### PR TITLE
Network: Use OVN TCP flag constants for OVN ACL baseline rules

### DIFF
--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -614,7 +614,7 @@ func OVNApplyNetworkBaselineRules(client *openvswitch.OVN, switchName openvswitc
 			Direction: "to-lport",
 			Action:    "allow",
 			Priority:  ovnACLPrioritySwitchAllow,
-			Match:     "tcp && tcp.flags == 0x014", // TCP RST|ACK messages for ACL reject.
+			Match:     fmt.Sprintf("tcp && tcp.flags == %#.03x", openvswitch.TCPRST|openvswitch.TCPACK), // TCP RST|ACK messages for ACL reject.
 		},
 	}
 

--- a/lxd/network/openvswitch/ovs.go
+++ b/lxd/network/openvswitch/ovs.go
@@ -14,6 +14,19 @@ import (
 // ovnBridgeMappingMutex locks access to read/write external-ids:ovn-bridge-mappings.
 var ovnBridgeMappingMutex sync.Mutex
 
+// OVS TCP Flags from OVS lib/packets.h.
+const (
+	TCPFIN = 0x001
+	TCPSYN = 0x002
+	TCPRST = 0x004
+	TCPPSH = 0x008
+	TCPACK = 0x010
+	TCPURG = 0x020
+	TCPECE = 0x040
+	TCPCWR = 0x080
+	TCPNS  = 0x100
+)
+
 // NewOVS initialises new OVS wrapper.
 func NewOVS() *OVS {
 	return &OVS{}


### PR DESCRIPTION
Suggested by @fnordahl 