### PR TITLE
shared/api/netork/acl: Adds missing example doc fields

### DIFF
--- a/lxc/network_acl.go
+++ b/lxc/network_acl.go
@@ -446,7 +446,8 @@ func (c *cmdNetworkACLEdit) helpTemplate() string {
 ### description: test desc
 ### egress: []
 ### ingress:
-### - action: accept
+### - action: allow
+###   state: enabled
 ###   source: ""
 ###   destination: ""
 ###   protocol: ""

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -201,7 +201,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -563,7 +564,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 #, fuzzy
 msgid "Add rules to an ACL"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -934,7 +935,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, fuzzy, c-format
@@ -1186,7 +1187,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Delete instances and snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1243,9 +1244,9 @@ msgstr "Kein Zertifikat für diese Verbindung"
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2397,7 +2398,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Manage instance metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2517,8 +2518,8 @@ msgid "Missing name"
 msgstr "Fehlende Zusammenfassung."
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Profilname kann nicht geändert werden"
@@ -2708,12 +2709,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Network ACL %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Profil %s erstellt\n"
@@ -2880,7 +2881,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -3137,7 +3138,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -3155,7 +3156,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3178,7 +3179,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -4212,7 +4213,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr ""
@@ -4220,7 +4221,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
@@ -4244,7 +4245,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -125,7 +125,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -392,7 +393,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -736,7 +737,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -968,7 +969,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1023,9 +1024,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2100,7 +2101,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2212,8 +2213,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2394,12 +2395,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2562,7 +2563,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2809,7 +2810,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2825,7 +2826,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2846,7 +2847,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3778,11 +3779,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3794,7 +3795,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -209,7 +209,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -540,7 +541,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -889,7 +890,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -1128,7 +1129,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1183,9 +1184,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2266,7 +2267,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2380,8 +2381,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nombre del contenedor es: %s"
@@ -2565,12 +2566,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
@@ -2731,7 +2732,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2981,7 +2982,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2997,7 +2998,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -3019,7 +3020,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3962,12 +3963,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] [<filters>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3982,7 +3983,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -202,7 +202,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -561,7 +562,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr "Création du conteneur"
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 #, fuzzy
 msgid "Add rules to an ACL"
 msgstr "Création du conteneur"
@@ -928,7 +929,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -1199,7 +1200,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Delete instances and snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1256,9 +1257,9 @@ msgstr "Copie de l'image : %s"
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2456,7 +2457,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Manage instance metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Copie de l'image : %s"
@@ -2579,8 +2580,8 @@ msgid "Missing name"
 msgstr "Résumé manquant."
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nom du réseau"
@@ -2773,12 +2774,12 @@ msgstr "Le réseau %s a été créé"
 msgid "Network ACL %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Le réseau %s a été créé"
@@ -2957,7 +2958,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
@@ -3215,7 +3216,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -3233,7 +3234,7 @@ msgstr "Création du conteneur"
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "Création du conteneur"
@@ -3256,7 +3257,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -4330,12 +4331,12 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
@@ -4359,7 +4360,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -202,7 +202,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -532,7 +533,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -877,7 +878,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -1118,7 +1119,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1173,9 +1174,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2262,7 +2263,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2374,8 +2375,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Il nome del container è: %s"
@@ -2558,12 +2559,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2725,7 +2726,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2974,7 +2975,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2991,7 +2992,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -3013,7 +3014,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3962,12 +3963,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] [<filters>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -3982,7 +3983,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "Creazione del container in corso"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: 2021-02-02 15:21+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -199,7 +199,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -540,7 +541,7 @@ msgstr "新たに信頼済みのクライアントを追加します"
 msgid "Add profiles to instances"
 msgstr "インスタンスにプロファイルを追加します"
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 #, fuzzy
 msgid "Add rules to an ACL"
 msgstr "インスタンスにプロファイルを追加します"
@@ -895,7 +896,7 @@ msgstr "移動先のインスタンスに適用するキー/値の設定"
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -1136,7 +1137,7 @@ msgstr "インスタンスのファイルテンプレートを削除します"
 msgid "Delete instances and snapshots"
 msgstr "インスタンスとスナップショットを削除します"
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 #, fuzzy
 msgid "Delete network ACLs"
 msgstr "ネットワークを削除します"
@@ -1192,9 +1193,9 @@ msgstr "ストレージボリュームを削除します"
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2460,7 +2461,7 @@ msgstr "インスタンスのファイルテンプレートを管理します"
 msgid "Manage instance metadata files"
 msgstr "インスタンスのメタデータファイルを管理します"
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "ネットワーク名を変更します"
@@ -2577,8 +2578,8 @@ msgid "Missing name"
 msgstr "名前を指定する必要があります"
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "ネットワーク名を指定する必要があります"
@@ -2765,12 +2766,12 @@ msgstr "ネットワーク名 %s を %s に変更しました"
 msgid "Network ACL %s created"
 msgstr "ネットワーク %s を作成しました"
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "ネットワーク %s を削除しました"
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "ネットワーク名 %s を %s に変更しました"
@@ -2932,7 +2933,7 @@ msgid "Ports:"
 msgstr "ポート:"
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr "再度エディタを開くためには Enter キーを押します"
@@ -3179,7 +3180,7 @@ msgstr "クラスタからメンバを削除します"
 msgid "Remove aliases"
 msgstr "エイリアスを削除します"
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -3195,7 +3196,7 @@ msgstr "インスタンスからプロファイルを削除します"
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "インスタンスからプロファイルを削除します"
@@ -3217,7 +3218,7 @@ msgstr "エイリアスの名前を変更します"
 msgid "Rename instances and snapshots"
 msgstr "インスタンスまたはインスタンスのスナップショットの名前を変更します"
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 #, fuzzy
 msgid "Rename network ACLs"
 msgstr "ネットワーク名を変更します"
@@ -4232,12 +4233,12 @@ msgstr "[<remote>:] [<filter>...]"
 msgid "[<remote>:] [<filters>...]"
 msgstr "[<remote>:] [<filters>...]"
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "[<remote>:]"
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "[<remote>:]<project> <key>=<value>..."
@@ -4252,7 +4253,7 @@ msgstr "[<remote>:]<pool> <key>"
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "[<remote>:]<network> <key>=<value>..."
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "[<remote>:]<alias> <new-name>"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2021-03-04 14:35-0500\n"
+        "POT-Creation-Date: 2021-03-05 18:14+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -115,7 +115,8 @@ msgid   "### This is a YAML representation of the network ACL.\n"
         "### description: test desc\n"
         "### egress: []\n"
         "### ingress:\n"
-        "### - action: accept\n"
+        "### - action: allow\n"
+        "###   state: enabled\n"
         "###   source: \"\"\n"
         "###   destination: \"\"\n"
         "###   protocol: \"\"\n"
@@ -371,7 +372,7 @@ msgstr  ""
 msgid   "Add profiles to instances"
 msgstr  ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid   "Add rules to an ACL"
 msgstr  ""
 
@@ -699,7 +700,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328 lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431 lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941 lxc/storage_volume.go:971
+#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328 lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431 lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941 lxc/storage_volume.go:971
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -925,7 +926,7 @@ msgstr  ""
 msgid   "Delete instances and snapshots"
 msgstr  ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid   "Delete network ACLs"
 msgstr  ""
 
@@ -949,7 +950,7 @@ msgstr  ""
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154 lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422 lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52 lxc/config_metadata.go:174 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:73 lxc/config_trust.go:135 lxc/config_trust.go:247 lxc/config_trust.go:325 lxc/config_trust.go:368 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558 lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671 lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384 lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626 lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:599 lxc/remote.go:661 lxc/remote.go:711 lxc/remote.go:749 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:587 lxc/storage.go:661 lxc/storage.go:745 lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235 lxc/storage_volume.go:322 lxc/storage_volume.go:484 lxc/storage_volume.go:563 lxc/storage_volume.go:639 lxc/storage_volume.go:721 lxc/storage_volume.go:802 lxc/storage_volume.go:1002 lxc/storage_volume.go:1090 lxc/storage_volume.go:1177 lxc/storage_volume.go:1361 lxc/storage_volume.go:1392 lxc/storage_volume.go:1505 lxc/storage_volume.go:1581 lxc/storage_volume.go:1680 lxc/storage_volume.go:1714 lxc/storage_volume.go:1806 lxc/storage_volume.go:1867 lxc/storage_volume.go:2002 lxc/version.go:22
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154 lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422 lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52 lxc/config_metadata.go:174 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:73 lxc/config_trust.go:135 lxc/config_trust.go:247 lxc/config_trust.go:325 lxc/config_trust.go:368 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:45 lxc/main.go:50 lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:36 lxc/network.go:33 lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559 lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672 lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384 lxc/project.go:482 lxc/project.go:537 lxc/project.go:597 lxc/project.go:626 lxc/project.go:679 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:599 lxc/remote.go:661 lxc/remote.go:711 lxc/remote.go:749 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:587 lxc/storage.go:661 lxc/storage.go:745 lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235 lxc/storage_volume.go:322 lxc/storage_volume.go:484 lxc/storage_volume.go:563 lxc/storage_volume.go:639 lxc/storage_volume.go:721 lxc/storage_volume.go:802 lxc/storage_volume.go:1002 lxc/storage_volume.go:1090 lxc/storage_volume.go:1177 lxc/storage_volume.go:1361 lxc/storage_volume.go:1392 lxc/storage_volume.go:1505 lxc/storage_volume.go:1581 lxc/storage_volume.go:1680 lxc/storage_volume.go:1714 lxc/storage_volume.go:1806 lxc/storage_volume.go:1867 lxc/storage_volume.go:2002 lxc/version.go:22
 msgid   "Description"
 msgstr  ""
 
@@ -1964,7 +1965,7 @@ msgstr  ""
 msgid   "Manage instance metadata files"
 msgstr  ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid   "Manage network ACL rules"
 msgstr  ""
 
@@ -2065,7 +2066,7 @@ msgstr  ""
 msgid   "Missing name"
 msgstr  ""
 
-#: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283 lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580 lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283 lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581 lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid   "Missing network ACL name"
 msgstr  ""
 
@@ -2227,12 +2228,12 @@ msgstr  ""
 msgid   "Network ACL %s created"
 msgstr  ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid   "Network ACL %s deleted"
 msgstr  ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid   "Network ACL %s renamed to %s"
 msgstr  ""
@@ -2392,7 +2393,7 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660 lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
+#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660 lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid   "Press enter to open the editor again"
 msgstr  ""
 
@@ -2636,7 +2637,7 @@ msgstr  ""
 msgid   "Remove aliases"
 msgstr  ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid   "Remove all rules that match"
 msgstr  ""
 
@@ -2652,7 +2653,7 @@ msgstr  ""
 msgid   "Remove remotes"
 msgstr  ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid   "Remove rules from an ACL"
 msgstr  ""
 
@@ -2672,7 +2673,7 @@ msgstr  ""
 msgid   "Rename instances and snapshots"
 msgstr  ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid   "Rename network ACLs"
 msgstr  ""
 
@@ -3563,11 +3564,11 @@ msgstr  ""
 msgid   "[<remote>:] [<filters>...]"
 msgstr  ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid   "[<remote>:]<ACL>"
 msgstr  ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid   "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr  ""
 
@@ -3579,7 +3580,7 @@ msgstr  ""
 msgid   "[<remote>:]<ACL> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid   "[<remote>:]<ACL> <new-name>"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -201,7 +201,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -527,7 +528,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -870,7 +871,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -1102,7 +1103,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1157,9 +1158,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2231,7 +2232,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2341,8 +2342,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2523,12 +2524,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2689,7 +2690,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2936,7 +2937,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2952,7 +2953,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2973,7 +2974,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3905,11 +3906,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3921,7 +3922,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -207,7 +207,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -545,7 +546,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -888,7 +889,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -1120,7 +1121,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1175,9 +1176,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2249,7 +2250,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2359,8 +2360,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2541,12 +2542,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2707,7 +2708,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2954,7 +2955,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2970,7 +2971,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2991,7 +2992,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3923,11 +3924,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3939,7 +3940,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -206,7 +206,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -550,7 +551,7 @@ msgstr "Adicionar novos clientes confiáveis"
 msgid "Add profiles to instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 #, fuzzy
 msgid "Add rules to an ACL"
 msgstr "Adicionar perfis aos containers"
@@ -910,7 +911,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -1157,7 +1158,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "Delete instances and snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 #, fuzzy
 msgid "Delete network ACLs"
 msgstr "Criar novas redes"
@@ -1213,9 +1214,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2312,7 +2313,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "Manage instance metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2426,8 +2427,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nome de membro do cluster"
@@ -2609,12 +2610,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2775,7 +2776,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -3027,7 +3028,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -3044,7 +3045,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "Adicionar perfis aos containers"
@@ -3066,7 +3067,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 #, fuzzy
 msgid "Rename network ACLs"
 msgstr "Criar novas redes"
@@ -4029,12 +4030,12 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "Criar perfis"
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
@@ -4049,7 +4050,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "Criar perfis"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: 2020-10-08 08:16+0000\n"
 "Last-Translator: Artem <KovalevArtem.ru@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -205,7 +205,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -557,7 +558,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -905,7 +906,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -1151,7 +1152,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Delete instances and snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1207,9 +1208,9 @@ msgstr "Копирование образа: %s"
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2305,7 +2306,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Manage instance metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Копирование образа: %s"
@@ -2422,8 +2423,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Имя контейнера: %s"
@@ -2608,12 +2609,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2777,7 +2778,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -3025,7 +3026,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -3042,7 +3043,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -3064,7 +3065,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -4045,7 +4046,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr ""
@@ -4053,7 +4054,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
@@ -4077,7 +4078,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: 2020-11-05 02:45+0000\n"
 "Last-Translator: wdggg <wdggg7@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -176,7 +176,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -443,7 +444,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -786,7 +787,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -1018,7 +1019,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1073,9 +1074,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2147,7 +2148,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2257,8 +2258,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2439,12 +2440,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2605,7 +2606,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2852,7 +2853,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2868,7 +2869,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2889,7 +2890,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3821,11 +3822,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3837,7 +3838,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-01 12:23-0500\n"
+"POT-Creation-Date: 2021-03-05 18:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -122,7 +122,8 @@ msgid ""
 "### description: test desc\n"
 "### egress: []\n"
 "### ingress:\n"
-"### - action: accept\n"
+"### - action: allow\n"
+"###   state: enabled\n"
 "###   source: \"\"\n"
 "###   destination: \"\"\n"
 "###   protocol: \"\"\n"
@@ -389,7 +390,7 @@ msgstr ""
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/network_acl.go:670 lxc/network_acl.go:671
+#: lxc/network_acl.go:671 lxc/network_acl.go:672
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -732,7 +733,7 @@ msgstr ""
 
 #: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
-#: lxc/network.go:659 lxc/network_acl.go:525 lxc/profile.go:498
+#: lxc/network.go:659 lxc/network_acl.go:526 lxc/profile.go:498
 #: lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:941
 #: lxc/storage_volume.go:971
 #, c-format
@@ -964,7 +965,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:606 lxc/network_acl.go:607
+#: lxc/network_acl.go:607 lxc/network_acl.go:608
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1019,9 +1020,9 @@ msgstr ""
 #: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
 #: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
 #: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:558
-#: lxc/network_acl.go:607 lxc/network_acl.go:656 lxc/network_acl.go:671
-#: lxc/network_acl.go:792 lxc/operation.go:24 lxc/operation.go:53
+#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:559
+#: lxc/network_acl.go:608 lxc/network_acl.go:657 lxc/network_acl.go:672
+#: lxc/network_acl.go:793 lxc/operation.go:24 lxc/operation.go:53
 #: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
 #: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
 #: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
@@ -2093,7 +2094,7 @@ msgstr ""
 msgid "Manage instance metadata files"
 msgstr ""
 
-#: lxc/network_acl.go:655 lxc/network_acl.go:656
+#: lxc/network_acl.go:656 lxc/network_acl.go:657
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -2203,8 +2204,8 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network_acl.go:180 lxc/network_acl.go:233 lxc/network_acl.go:283
-#: lxc/network_acl.go:370 lxc/network_acl.go:479 lxc/network_acl.go:580
-#: lxc/network_acl.go:629 lxc/network_acl.go:749 lxc/network_acl.go:816
+#: lxc/network_acl.go:370 lxc/network_acl.go:480 lxc/network_acl.go:581
+#: lxc/network_acl.go:630 lxc/network_acl.go:750 lxc/network_acl.go:817
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -2385,12 +2386,12 @@ msgstr ""
 msgid "Network ACL %s created"
 msgstr ""
 
-#: lxc/network_acl.go:639
+#: lxc/network_acl.go:640
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: lxc/network_acl.go:590
+#: lxc/network_acl.go:591
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -2551,7 +2552,7 @@ msgid "Ports:"
 msgstr ""
 
 #: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
-#: lxc/network_acl.go:526 lxc/profile.go:499 lxc/project.go:305
+#: lxc/network_acl.go:527 lxc/profile.go:499 lxc/project.go:305
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
 msgstr ""
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_acl.go:793
+#: lxc/network_acl.go:794
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -2814,7 +2815,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/network_acl.go:791 lxc/network_acl.go:792
+#: lxc/network_acl.go:792 lxc/network_acl.go:793
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Rename instances and snapshots"
 msgstr ""
 
-#: lxc/network_acl.go:557 lxc/network_acl.go:558
+#: lxc/network_acl.go:558 lxc/network_acl.go:559
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -3767,11 +3768,11 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:604
+#: lxc/network_acl.go:156 lxc/network_acl.go:428 lxc/network_acl.go:605
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: lxc/network_acl.go:669 lxc/network_acl.go:790
+#: lxc/network_acl.go:670 lxc/network_acl.go:791
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
@@ -3783,7 +3784,7 @@ msgstr ""
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_acl.go:555
+#: lxc/network_acl.go:556
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 

--- a/shared/api/network_acl.go
+++ b/shared/api/network_acl.go
@@ -14,7 +14,7 @@ type NetworkACLRule struct {
 	Action string `json:"action" yaml:"action"`
 
 	// Source address
-	// Example:
+	// Example: #internal
 	Source string `json:"source" yaml:"source"`
 
 	// Destination address
@@ -22,11 +22,11 @@ type NetworkACLRule struct {
 	Destination string `json:"destination" yaml:"destination"`
 
 	// Protocol
-	// Example:
+	// Example: udp
 	Protocol string `json:"protocol" yaml:"protocol"`
 
 	// Source port
-	// Example:
+	// Example: 1234
 	SourcePort string `json:"source_port" yaml:"source_port"`
 
 	// Destination port
@@ -34,11 +34,11 @@ type NetworkACLRule struct {
 	DestinationPort string `json:"destination_port" yaml:"destination_port"`
 
 	// Type of ICMP message (for ICMP protocol)
-	// Example:
+	// Example: 8
 	ICMPType string `json:"icmp_type" yaml:"icmp_type"`
 
 	// ICMP message code (for ICMP protocol)
-	// Example:
+	// Example: 0
 	ICMPCode string `json:"icmp_code" yaml:"icmp_code"`
 
 	// Description of the rule


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>