### PR TITLE
Fix a typo in rest-api.md for renaming a network ACL

### DIFF
--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -2441,7 +2441,7 @@ Input:
  * Operation: sync
  * Return: standard return value or standard error
 
-Input (rename a network):
+Input (rename a network ACL):
 
 ```json
 {


### PR DESCRIPTION
Signed-off-by: Hiroaki Nakamura <hnakamur@gmail.com>