### PR TITLE
ACL: Deprecate #internal and #external and replace with @internal and @external

### DIFF
--- a/client/lxd.go
+++ b/client/lxd.go
@@ -3,6 +3,7 @@ package lxd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -160,7 +161,7 @@ func lxdParseResponse(resp *http.Response) (*api.Response, string, error) {
 
 	// Handle errors
 	if response.Type == api.ErrorResponse {
-		return nil, "", fmt.Errorf(response.Error)
+		return nil, "", errors.New(response.Error)
 	}
 
 	return &response, etag, nil

--- a/doc/network-acls.md
+++ b/doc/network-acls.md
@@ -52,8 +52,8 @@ Property          | Type       | Required | Description
 action            | string     | yes      | Action to take for matching traffic (`allow`, `reject` or `drop`)
 state             | string     | yes      | State of rule (`enabled`, `disabled` or `logged`)
 description       | string     | no       | Description of rule
-source            | string     | no       | Comma separated list of CIDR or IP ranges, source ACL names or #external/#internal (for ingress rules), or empty for any
-destination       | string     | no       | Comma separated list of CIDR or IP ranges, destination ACL names or #external/#internal (for egress rules), or empty for any
+source            | string     | no       | Comma separated list of CIDR or IP ranges, source ACL names or @external/@internal (for ingress rules), or empty for any
+destination       | string     | no       | Comma separated list of CIDR or IP ranges, destination ACL names or @external/@internal (for egress rules), or empty for any
 protocol          | string     | no       | Protocol to match (`icmp4`, `icmp6`, `tcp`, `udp`) or empty for any
 source\_port      | string     | no       | If Protocol is `udp` or `tcp`, then comma separated list of ports or port ranges (start-end inclusive), or empty for any
 destination\_port | string     | no       | If Protocol is `udp` or `tcp`, then comma separated list of ports or port ranges (start-end inclusive), or empty for any
@@ -77,7 +77,7 @@ Rules cannot be explicitly ordered. However LXD will order the rules based on th
 The Instance NICs that are assigned a particular ACL make up a logical port group that can then be referenced by
 name in other ACL rules.
 
-There are also two special selectors called `#internal` and `#external` which represent network local and external
+There are also two special selectors called `@internal` and `@external` which represent network local and external
 traffic respectively.
 
 Port group selectors can be used in the `source` field for ingress rules and in the `destination` field for egress rules.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -501,22 +501,27 @@ definitions:
         x-go-name: DestinationPort
       icmp_code:
         description: ICMP message code (for ICMP protocol)
+        example: "0"
         type: string
         x-go-name: ICMPCode
       icmp_type:
         description: Type of ICMP message (for ICMP protocol)
+        example: "8"
         type: string
         x-go-name: ICMPType
       protocol:
         description: Protocol
+        example: udp
         type: string
         x-go-name: Protocol
       source:
         description: Source address
+        example: '@internal'
         type: string
         x-go-name: Source
       source_port:
         description: Source port
+        example: "1234"
         type: string
         x-go-name: SourcePort
       state:

--- a/shared/api/network_acl.go
+++ b/shared/api/network_acl.go
@@ -14,7 +14,7 @@ type NetworkACLRule struct {
 	Action string `json:"action" yaml:"action"`
 
 	// Source address
-	// Example: #internal
+	// Example: @internal
 	Source string `json:"source,omitempty" yaml:"source,omitempty"`
 
 	// Destination address


### PR DESCRIPTION
To avoid YAML editors treating unquoted `#` prefixed subject names as comments and removing them.

Also I noticed that the `lxc` client was attempting to parse error responses from the LXD server through `fmt.Error()` causing any `%` in the output to trigger a fmt error.