### PR TITLE
Storage: Ensure VolumeSnapshots returns snapshot list in age order (oldest first)

### DIFF
--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -141,7 +141,7 @@ func (d *btrfs) Create() error {
 		hostPath := shared.HostPath(d.config["source"])
 		if d.isSubvolume(hostPath) {
 			// Existing btrfs subvolume.
-			subvols, err := d.getSubvolumes(hostPath)
+			subvols, err := d.getSubvolumePaths(hostPath, true)
 			if err != nil {
 				return errors.Wrap(err, "Could not determine if existing btrfs subvolume is empty")
 			}

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -407,7 +407,7 @@ func (d *btrfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bo
 			srcSnapshot := GetVolumeMountPath(d.name, srcVol.volType, GetSnapshotVolumeName(srcVol.name, snapName))
 			dstSnapshot := GetVolumeMountPath(d.name, vol.volType, GetSnapshotVolumeName(vol.name, snapName))
 
-			err = d.snapshotSubvolume(srcSnapshot, dstSnapshot, false)
+			err = d.snapshotSubvolume(srcSnapshot, dstSnapshot, true)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -100,7 +100,7 @@ func genericVFSVolumeSnapshots(d Driver, vol Volume, op *operations.Operation) (
 			return snapshots, nil
 		}
 
-		return nil, errors.Wrapf(err, "Failed to list directory '%s'", snapshotDir)
+		return nil, errors.Wrapf(err, "Failed to list directory %q", snapshotDir)
 	}
 
 	for _, ent := range ents {


### PR DESCRIPTION
This is to ensure that when using optimised migrations and backup exports that the oldest snapshot is sent first, even if the newer snapshot comes earlier alphabetically.

This introduces a new `btrfsSubvolume` type and associated function `getSubVolume()`. This uses the `btrfs subvolume show` command and lays the ground work for transferring subvolumes more efficiently by taking into account their parents and original generations (https://github.com/lxc/lxd/issues/8410).

This function can also replace the use of `BTRFSSubVolumeIsRo()` avoiding the need to run an extra fork when retrieving info about a subvolume. 

Also fixes a bug in `CreateVolumeFromCopy` where subvolumes in snapshots weren't being copied.


