### PR TITLE
Network: Work around ovn-nbctl NAT bugs in LogicalRouterDNATSNATAdd

### DIFF
--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -287,12 +287,16 @@ func (o *OVN) LogicalRouterRouteAdd(routerName OVNRouter, destination *net.IPNet
 }
 
 // LogicalRouterRouteDelete deletes a static route from the logical router.
-// If nextHop is specified as nil, then any route matching the destination is removed.
-func (o *OVN) LogicalRouterRouteDelete(routerName OVNRouter, destination *net.IPNet, nextHop net.IP) error {
-	args := []string{"--if-exists", "lr-route-del", string(routerName), destination.String()}
+func (o *OVN) LogicalRouterRouteDelete(routerName OVNRouter, destinations ...*net.IPNet) error {
+	args := []string{}
 
-	if nextHop != nil {
-		args = append(args, nextHop.String())
+	for _, destination := range destinations {
+		if len(args) > 0 {
+			args = append(args, "--")
+		}
+
+		args = append(args, "--if-exists", "lr-route-del", string(routerName), destination.String())
+
 	}
 
 	_, err := o.nbctl(args...)

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -251,8 +251,18 @@ func (o *OVN) LogicalRouterDNATSNATAdd(routerName OVNRouter, extIP net.IP, intIP
 }
 
 // LogicalRouterDNATSNATDelete deletes a DNAT_AND_SNAT rule from a logical router.
-func (o *OVN) LogicalRouterDNATSNATDelete(routerName OVNRouter, extIP net.IP) error {
-	_, err := o.nbctl("--if-exists", "lr-nat-del", string(routerName), "dnat_and_snat", extIP.String())
+func (o *OVN) LogicalRouterDNATSNATDelete(routerName OVNRouter, extIPs ...net.IP) error {
+	args := []string{}
+
+	for _, extIP := range extIPs {
+		if len(args) > 0 {
+			args = append(args, "--")
+		}
+
+		args = append(args, "--if-exists", "lr-nat-del", string(routerName), "dnat_and_snat", extIP.String())
+	}
+
+	_, err := o.nbctl(args...)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -235,7 +235,7 @@ func (o *OVN) LogicalRouterDNATSNATAdd(routerName OVNRouter, extIP net.IP, intIP
 	args := []string{}
 
 	if mayExist {
-		args = append(args, "--may-exist")
+		args = append(args, "--if-exists", "lr-nat-del", string(routerName), "dnat_and_snat", extIP.String(), "--")
 	}
 
 	if stateless {

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -199,7 +199,7 @@ func (o *OVN) LogicalRouterSNATAdd(routerName OVNRouter, intNet *net.IPNet, extI
 	args := []string{}
 
 	if mayExist {
-		args = append(args, "--may-exist")
+		args = append(args, "--if-exists", "lr-nat-del", string(routerName), "snat", extIP.String(), "--")
 	}
 
 	_, err := o.nbctl(append(args, "lr-nat-add", string(routerName), "snat", extIP.String(), intNet.String())...)

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1096,17 +1096,11 @@ func (o *OVN) LogicalSwitchPortLinkRouter(switchPortName OVNSwitchPort, routerPo
 // LogicalSwitchPortLinkProviderNetwork links a logical switch port to a provider network.
 func (o *OVN) LogicalSwitchPortLinkProviderNetwork(switchPortName OVNSwitchPort, extNetworkName string) error {
 	// Forward any unknown MAC frames down this port.
-	_, err := o.nbctl("lsp-set-addresses", string(switchPortName), "unknown")
-	if err != nil {
-		return err
-	}
-
-	_, err = o.nbctl("lsp-set-type", string(switchPortName), "localnet")
-	if err != nil {
-		return err
-	}
-
-	_, err = o.nbctl("lsp-set-options", string(switchPortName), fmt.Sprintf("network_name=%s", extNetworkName))
+	_, err := o.nbctl(
+		"lsp-set-addresses", string(switchPortName), "unknown", "--",
+		"lsp-set-type", string(switchPortName), "localnet", "--",
+		"lsp-set-options", string(switchPortName), fmt.Sprintf("network_name=%s", extNetworkName),
+	)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1081,19 +1081,10 @@ func (o *OVN) LogicalSwitchPortDelete(portName OVNSwitchPort) error {
 // LogicalSwitchPortLinkRouter links a logical switch port to a logical router port.
 func (o *OVN) LogicalSwitchPortLinkRouter(switchPortName OVNSwitchPort, routerPortName OVNRouterPort) error {
 	// Connect logical router port to switch.
-	_, err := o.nbctl("lsp-set-type", string(switchPortName), "router")
-	if err != nil {
-		return err
-	}
-
-	_, err = o.nbctl("lsp-set-addresses", string(switchPortName), "router")
-	if err != nil {
-		return err
-	}
-
-	_, err = o.nbctl("lsp-set-options", string(switchPortName),
-		fmt.Sprintf("nat-addresses=%s", "router"),
-		fmt.Sprintf("router-port=%s", string(routerPortName)),
+	_, err := o.nbctl(
+		"lsp-set-type", string(switchPortName), "router", "--",
+		"lsp-set-addresses", string(switchPortName), "router", "--",
+		"lsp-set-options", string(switchPortName), fmt.Sprintf("nat-addresses=%s", "router"), fmt.Sprintf("router-port=%s", string(routerPortName)),
 	)
 	if err != nil {
 		return err

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1057,14 +1057,10 @@ func (o *OVN) LogicalSwitchPortGetDNS(portName OVNSwitchPort) (OVNDNSUUID, strin
 
 // LogicalSwitchPortDeleteDNS removes DNS records for a switch port.
 func (o *OVN) LogicalSwitchPortDeleteDNS(switchName OVNSwitch, dnsUUID OVNDNSUUID) error {
-	// Remove DNS record association from switch.
-	_, err := o.nbctl("remove", "logical_switch", string(switchName), "dns_records", string(dnsUUID))
-	if err != nil {
-		return err
-	}
-
-	// Remove DNS record entry itself.
-	_, err = o.nbctl("destroy", "dns", string(dnsUUID))
+	// Remove DNS record association from switch, and remove DNS record entry itself.
+	_, err := o.nbctl(
+		"remove", "logical_switch", string(switchName), "dns_records", string(dnsUUID), "--",
+		"destroy", "dns", string(dnsUUID))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When using `ovn-nbctl --may-exist lr-nat-add` if an existing NAT entry exists it should be ignored and no error returned. However some ovn-nbctl versions return an error.

So instead we delete any existing record and add a new one.

Also fixes issue where if network's `ipv{x}.nat` option is enabled after the instance is started, then when the instance is stopped the DNAT rules were not cleared up. Now always attempt to clear up DNAT rules on stop.

Also adds some optimisations to reduce calls to ovn-nbctl. Significantly speeds up adding DNAT rules for larger external routes.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>