### PR TITLE
In-cluster progress information

### DIFF
--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -875,7 +875,7 @@ func (c *migrationSink) Do(state *state.State, migrateOp *operations.Operation) 
 			Name:          args.Instance.Name(),
 			MigrationType: respTypes[0],
 			Refresh:       args.Refresh,    // Indicate to receiver volume should exist.
-			TrackProgress: false,           // Do not use a progress tracker on receiver.
+			TrackProgress: true,            // Use a progress tracker on receiver to get in-cluster progress information.
 			Live:          args.Live,       // Indicates we will get a final rootfs sync.
 			VolumeSize:    args.VolumeSize, // Block size setting override.
 		}


### PR DESCRIPTION
@stgraber I'd like to clarify some stuff. It will be easier to discuss with an examle so I made PR draft.

Regarding your conversation #8005 with gzhang1218 `containerPostClusteringMigrate` is only called when instance is moved. You said that we need match operation id we got from the `CopyInstance` call with operation from handler function. But from `CopyInstance` we got operation "Creating instance" and information about progress is in "Migrating instance" operation. This is why I'va added third parameter to `CopyInstance` returning migration operation ID.

In case of copy operation `containerPostClusteringMigrate` method isn't called. So I chose `createFromMigration` to implement metadata updating because we've got there access to migration operation and operation which should be updated.

What do you think about it?