### PR TITLE
Network: Move where the ACL configs are loaded for OVN networks to caller of OVNEnsureACLs

### DIFF
--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -242,7 +242,7 @@ func OVNEnsureACLs(s *state.State, logger logger.Logger, client *openvswitch.OVN
 			revert.Add(func() { client.PortGroupDelete(netPortGroupName) })
 		}
 
-		// If aclInfo has been loaded, then we should use it to apply ACL rules to the existing port group
+		// If aclInfo has been set, then we should use it to apply ACL rules to the existing port group
 		// (and any per-ACL-per-network port groups needed).
 		if aclStatus.aclInfo != nil {
 			logger.Debug("Applying ACL rules to OVN port group", log.Ctx{"networkACL": aclStatus.name, "portGroup": portGroupName})

--- a/lxd/network/acl/driver_common.go
+++ b/lxd/network/acl/driver_common.go
@@ -556,7 +556,7 @@ func (d *common) Update(config *api.NetworkACLPut) error {
 		}
 
 		// Request that the ACL and any referenced ACLs in the ruleset are created in OVN.
-		r, err := OVNEnsureACLs(d.state, d.logger, client, d.projectName, aclNameIDs, aclNets, []string{d.info.Name}, true)
+		r, err := OVNEnsureACLs(d.state, d.logger, client, d.projectName, aclNameIDs, aclNets, []*api.NetworkACL{d.info}, true)
 		if err != nil {
 			return errors.Wrapf(err, "Failed ensuring ACL is configured in OVN")
 		}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2828,6 +2828,9 @@ func (n *ovn) InstanceDevicePortAdd(opts *OVNInstanceNICSetupOpts) (openvswitch.
 		}
 	}
 
+	// Add instance NIC switch port to port groups required. Always run this as the addChangeSet should always
+	// be populated even if no ACLs being applied, because the NIC port needs to be added to the network level
+	// port group.
 	n.logger.Debug("Applying instance NIC port group member change sets")
 	err = client.PortGroupMemberChange(addChangeSet, removeChangeSet)
 	if err != nil {


### PR DESCRIPTION
This is a precursor of per-instance-NIC default rules, as we will need to inspect the default action of each ACL applied to a NIC, so we should avoid loading them twice (inside OVNEnsureACLs and again when generating the NIC default rule).