### PR TITLE
lxd/db/images: Fix incorrect cached attribute handling

### DIFF
--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -24,6 +24,7 @@ import (
 //
 //go:generate mapper stmt -p db -e image objects
 //go:generate mapper stmt -p db -e image objects-by-Project
+//go:generate mapper stmt -p db -e image objects-by-Project-and-Cached
 //go:generate mapper stmt -p db -e image objects-by-Project-and-Public
 //go:generate mapper stmt -p db -e image objects-by-Project-and-Fingerprint
 //go:generate mapper stmt -p db -e image objects-by-Project-and-Fingerprint-and-Public


### PR DESCRIPTION
This fixed a very nasty regression introduced in 4b5ba96f19 which
switched the function fetching expired images to filter on a per-project
basis.

That part made total sense but unfortunately what we missed is that we
had no code-generated DB code for that particular filter
(Project-Cached) so instead only the project filter was used, causing
the Cached field to be ignored entirely.

This then resulted in all expired images to be returned to the image
pruner EVEN if an image wasn't cached, causing the deletion of manually
created images that weren't used recently...

Reported at: https://discuss.linuxcontainers.org/t/images-vanished/10498/

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>