### PR TITLE
Network: Remove default.action and default.logged ACL settings

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1333,3 +1333,7 @@ to specify what cluster member to place a workload on or the ability to move a w
 ## images\_default\_architecture
 Adds new `images.default_architecture` global config key and matching per-project key which lets user tell LXD
 what architecture to go with when no specific one is specified as part of the image request.
+
+## network\_ovn\_acl\_defaults
+Adds new `security.acls.default.{in,e}gress.action` and `security.acls.default.{in,e}gress.logged` config keys for
+OVN networks and NICs. This replaces the removed ACL `default.action` and `default.logged` keys.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -381,20 +381,24 @@ Uses an existing OVN network and creates a virtual device pair to connect the in
 
 Device configuration properties:
 
-Key                     | Type    | Default           | Required | Managed | Description
-:--                     | :--     | :--               | :--      | :--     | :--
-network                 | string  | -                 | yes      | yes     | The LXD network to link device to
-name                    | string  | kernel assigned   | no       | no      | The name of the interface inside the instance
-host\_name              | string  | randomly assigned | no       | no      | The name of the interface inside the host
-hwaddr                  | string  | randomly assigned | no       | no      | The MAC address of the new interface
-ipv4.address            | string  | -                 | no       | no      | An IPv4 address to assign to the instance through DHCP
-ipv6.address            | string  | -                 | no       | no      | An IPv6 address to assign to the instance through DHCP
-ipv4.routes             | string  | -                 | no       | no      | Comma delimited list of IPv4 static routes to route to the NIC
-ipv6.routes             | string  | -                 | no       | no      | Comma delimited list of IPv6 static routes to route to the NIC
-ipv4.routes.external    | string  | -                 | no       | no      | Comma delimited list of IPv4 static routes to route to the NIC and publish on uplink network
-ipv6.routes.external    | string  | -                 | no       | no      | Comma delimited list of IPv6 static routes to route to the NIC and publish on uplink network
-boot.priority           | integer | -                 | no       | no      | Boot priority for VMs (higher boots first)
-security.acls           | string  | -                 | no       | no      | Comma separated list of Network ACLs to apply
+Key                                  | Type    | Default           | Required | Managed | Description
+:--                                  | :--     | :--               | :--      | :--     | :--
+network                              | string  | -                 | yes      | yes     | The LXD network to link device to
+name                                 | string  | kernel assigned   | no       | no      | The name of the interface inside the instance
+host\_name                           | string  | randomly assigned | no       | no      | The name of the interface inside the host
+hwaddr                               | string  | randomly assigned | no       | no      | The MAC address of the new interface
+ipv4.address                         | string  | -                 | no       | no      | An IPv4 address to assign to the instance through DHCP
+ipv6.address                         | string  | -                 | no       | no      | An IPv6 address to assign to the instance through DHCP
+ipv4.routes                          | string  | -                 | no       | no      | Comma delimited list of IPv4 static routes to route to the NIC
+ipv6.routes                          | string  | -                 | no       | no      | Comma delimited list of IPv6 static routes to route to the NIC
+ipv4.routes.external                 | string  | -                 | no       | no      | Comma delimited list of IPv4 static routes to route to the NIC and publish on uplink network
+ipv6.routes.external                 | string  | -                 | no       | no      | Comma delimited list of IPv6 static routes to route to the NIC and publish on uplink network
+boot.priority                        | integer | -                 | no       | no      | Boot priority for VMs (higher boots first)
+security.acls                        | string  | -                 | no       | no      | Comma separated list of Network ACLs to apply
+security.acls.default.ingress.action | string  | reject            | no       | no      | Action to use for ingress traffic that doesn't match any ACL rule
+security.acls.default.egress.action  | string  | reject            | no       | no      | Action to use for egress traffic that doesn't match any ACL rule
+security.acls.default.ingress.logged | boolean | false             | no       | no      | Whether to log ingress traffic that doesn't match any ACL rule
+security.acls.default.egress.logged  | boolean | false             | no       | no      | Whether to log egress traffic that doesn't match any ACL rule
 
 #### nic: physical
 

--- a/doc/network-acls.md
+++ b/doc/network-acls.md
@@ -11,13 +11,17 @@ The Instance NICs that have a particular ACL applied (either explicitly or impli
 logical group that can be referenced from other rules as a source or destination. This makes it possible to define
 rules for groups of instances without needing to maintain IP lists or create additional subnets.
 
-Network ACLs come with an implicit default rule (that defaults to `reject` unless `default.action` is set), so if
-traffic doesn't match one of the defined rules in an ACL then all other traffic is rejected.
+Once one or more ACLs are applied to a NIC (either explicitly or implicitly from the network) then a default reject
+rule is added to the NIC, so if traffic doesn't match one of the rules in the applied ACLs then it is rejected.
+
+This behaviour can be modified by using the network and NIC level `security.acls.default.ingress.action` and
+`security.acls.default.egress.action` settings. The NIC level settings will override the network level settings.
 
 Rules are defined for a particular direction (ingress or egress) in relation to the Instance NIC.
 Ingress rules apply to traffic going towards the NIC, and egress rules apply to traffic leaving the NIC.
 
-Rules are provided as lists, however the order of the rules in the list is not important and does not affect filtering.
+Rules are provided as lists, however the order of the rules in the list is not important and does not affect
+filtering. See [Rule ordering and priorities](#rule-ordering-and-priorities).
 
 Valid Network ACL names must:
 
@@ -36,14 +40,7 @@ name             | string     | yes      | Unique name of Network ACL in Project
 description      | string     | no       | Description of Network ACL
 ingress          | rule list  | no       | Ingress traffic rules
 egress           | rule list  | no       | Egress traffic rules
-config           | string set | no       | Config key/value pairs (in addition to `user.*` custom keys, see below)
-
-Config properties:
-
-Property         | Type       | Required | Description
-:--              | :--        | :--      | :--
-default.action   | string     | no       | What action to take for traffic hitting the default rule (default `reject`)
-default.logged   | boolean    | no       | Whether or not to log traffic hitting the default rule (default `false`)
+config           | string set | no       | Config key/value pairs (Only `user.*` custom keys supported)
 
 ACL rules have the following properties:
 
@@ -67,10 +64,13 @@ Rules cannot be explicitly ordered. However LXD will order the rules based on th
  - `drop`
  - `reject`
  - `allow`
- - Automatic default rule action for any unmatched traffic (defaults to `reject` if `default.action` not specified).
+ - Automatic default action for any unmatched traffic (defaults to `reject`).
 
 This means that multiple ACLs can be applied to a NIC without having to specify the combined rule ordering.
 As soon as one of the rules in the ACLs matches then that action is taken and no other rules are considered.
+
+The default reject action can be modified by using the network and NIC level `security.acls.default.ingress.action`
+and `security.acls.default.egress.action` settings. The NIC level settings will override the network level settings.
 
 ## Port group selectors
 

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -294,21 +294,25 @@ lxc ls
 +------+---------+---------------------+----------------------------------------------+-----------+-----------+
 ```
 
-Key                             | Type      | Condition             | Default                   | Description
-:--                             | :--       | :--                   | :--                       | :--
-bridge.hwaddr                   | string    | -                     | -                         | MAC address for the bridge
-bridge.mtu                      | integer   | -                     | 1442                      | Bridge MTU (default allows host to host geneve tunnels)
-dns.domain                      | string    | -                     | lxd                       | Domain to advertise to DHCP clients and use for DNS resolution
-dns.search                      | string    | -                     | -                         | Full comma separated domain search list, defaulting to `dns.domain` value
-ipv4.address                    | string    | standard mode         | auto (on create only)     | IPv4 address for the bridge (CIDR notation). Use "none" to turn off IPv4 or "auto" to generate a new random unused subnet
-ipv4.dhcp                       | boolean   | ipv4 address          | true                      | Whether to allocate addresses using DHCP
-ipv4.nat                        | boolean   | ipv4 address          | false                     | Whether to NAT (will default to true if unset and a random ipv4.address is generated)
-ipv6.address                    | string    | standard mode         | auto (on create only)     | IPv6 address for the bridge (CIDR notation). Use "none" to turn off IPv6 or "auto" to generate a new random unused subnet
-ipv6.dhcp                       | boolean   | ipv6 address          | true                      | Whether to provide additional network configuration over DHCP
-ipv6.dhcp.stateful              | boolean   | ipv6 dhcp             | false                     | Whether to allocate addresses using DHCP
-ipv6.nat                        | boolean   | ipv6 address          | false                     | Whether to NAT (will default to true if unset and a random ipv6.address is generated)
-network                         | string    | -                     | -                         | Uplink network to use for external network access
-security.acls                   | string    | -                     | -                         | Comma separated list of Network ACLs to apply to NICs connected to this network
+Key                                  | Type      | Condition             | Default                   | Description
+:--                                  | :--       | :--                   | :--                       | :--
+bridge.hwaddr                        | string    | -                     | -                         | MAC address for the bridge
+bridge.mtu                           | integer   | -                     | 1442                      | Bridge MTU (default allows host to host geneve tunnels)
+dns.domain                           | string    | -                     | lxd                       | Domain to advertise to DHCP clients and use for DNS resolution
+dns.search                           | string    | -                     | -                         | Full comma separated domain search list, defaulting to `dns.domain` value
+ipv4.address                         | string    | standard mode         | auto (on create only)     | IPv4 address for the bridge (CIDR notation). Use "none" to turn off IPv4 or "auto" to generate a new random unused subnet
+ipv4.dhcp                            | boolean   | ipv4 address          | true                      | Whether to allocate addresses using DHCP
+ipv4.nat                             | boolean   | ipv4 address          | false                     | Whether to NAT (will default to true if unset and a random ipv4.address is generated)
+ipv6.address                         | string    | standard mode         | auto (on create only)     | IPv6 address for the bridge (CIDR notation). Use "none" to turn off IPv6 or "auto" to generate a new random unused subnet
+ipv6.dhcp                            | boolean   | ipv6 address          | true                      | Whether to provide additional network configuration over DHCP
+ipv6.dhcp.stateful                   | boolean   | ipv6 dhcp             | false                     | Whether to allocate addresses using DHCP
+ipv6.nat                             | boolean   | ipv6 address          | false                     | Whether to NAT (will default to true if unset and a random ipv6.address is generated)
+network                              | string    | -                     | -                         | Uplink network to use for external network access
+security.acls                        | string    | -                     | -                         | Comma separated list of Network ACLs to apply to NICs connected to this network
+security.acls.default.ingress.action | string    | security.acls         | reject                    | Action to use for ingress traffic that doesn't match any ACL rule
+security.acls.default.egress.action  | string    | security.acls         | reject                    | Action to use for egress traffic that doesn't match any ACL rule
+security.acls.default.ingress.logged | boolean   | security.acls         | false                     | Whether to log ingress traffic that doesn't match any ACL rule
+security.acls.default.egress.logged  | boolean   | security.acls         | false                     | Whether to log egress traffic that doesn't match any ACL rule
 
 ## network: physical
 

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -397,7 +397,7 @@ definitions:
           type: string
         description: ACL configuration map (refer to doc/network-acls.md)
         example:
-          default.action: drop
+          user.mykey: foo
         type: object
         x-go-name: Config
       description:
@@ -453,7 +453,7 @@ definitions:
           type: string
         description: ACL configuration map (refer to doc/network-acls.md)
         example:
-          default.action: drop
+          user.mykey: foo
         type: object
         x-go-name: Config
       description:
@@ -539,7 +539,7 @@ definitions:
           type: string
         description: ACL configuration map (refer to doc/network-acls.md)
         example:
-          default.action: drop
+          user.mykey: foo
         type: object
         x-go-name: Config
       description:

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/lxc/lxd/lxd/instance"
+	"github.com/lxc/lxd/lxd/network/acl"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/validate"
 )
@@ -43,6 +44,14 @@ func nicValidationRules(requiredFields []string, optionalFields []string, instCo
 		"ipv4.routes.external":    validate.Optional(validate.IsNetworkV4List),
 		"ipv6.routes.external":    validate.Optional(validate.IsNetworkV6List),
 		"security.acls":           validate.IsAny,
+		"security.acls.default.ingress.action": validate.Optional(func(value string) error {
+			return validate.IsOneOf(value, acl.ValidActions)
+		}),
+		"security.acls.default.egress.action": validate.Optional(func(value string) error {
+			return validate.IsOneOf(value, acl.ValidActions)
+		}),
+		"security.acls.default.ingress.logged": validate.Optional(validate.IsBool),
+		"security.acls.default.egress.logged":  validate.Optional(validate.IsBool),
 	}
 
 	validators := map[string]func(value string) error{}

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -85,6 +85,10 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 		"ipv6.routes.external",
 		"boot.priority",
 		"security.acls",
+		"security.acls.default.ingress.action",
+		"security.acls.default.egress.action",
+		"security.acls.default.ingress.logged",
+		"security.acls.default.egress.logged",
 	}
 
 	// The NIC's network may be a non-default project, so lookup project and get network's project name.

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -30,9 +30,8 @@ type ovnNet interface {
 	network.Network
 
 	InstanceDevicePortValidateExternalRoutes(deviceInstance instance.Instance, deviceName string, externalRoutes []*net.IPNet) error
-	InstanceDevicePortConfigParse(deviceConfig map[string]string) (net.HardwareAddr, []net.IP, []*net.IPNet, []*net.IPNet, error)
-	InstanceDevicePortAdd(opts *network.OVNInstanceNICSetupOpts) (openvswitch.OVNSwitchPort, error)
-	InstanceDevicePortDelete(ovsExternalOVNPort openvswitch.OVNSwitchPort, opts *network.OVNInstanceNICOpts) error
+	InstanceDevicePortSetup(opts *network.OVNInstanceNICSetupOpts, securityACLsRemove []string) (openvswitch.OVNSwitchPort, error)
+	InstanceDevicePortDelete(ovsExternalOVNPort openvswitch.OVNSwitchPort, opts *network.OVNInstanceNICStopOpts) error
 	InstanceDevicePortDynamicIPs(instanceUUID string, deviceName string) ([]net.IP, error)
 }
 

--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -21,11 +21,16 @@ import (
 )
 
 // OVN ACL rule priorities.
-const ovnACLPrioritySwitchAllow = 10
-const ovnACLPriorityPortGroupDefaultReject = 0
-const ovnACLPriorityPortGroupAllow = 20
-const ovnACLPriorityPortGroupReject = 30
-const ovnACLPriorityPortGroupDrop = 40
+const ovnACLPriorityPortGroupDefaultAction = 0
+const ovnACLPriorityNICDefaultActionIngress = 100
+
+// ovnACLPriorityNICDefaultActionEgress needs to be >10 higher than ovnACLPriorityNICDefaultActionIngress so that
+// ingress reject rules (that OVN adds 10 to their priorities) don't prevent egress rules being tested first.
+const ovnACLPriorityNICDefaultActionEgress = 111
+const ovnACLPrioritySwitchAllow = 200
+const ovnACLPriorityPortGroupAllow = 300
+const ovnACLPriorityPortGroupReject = 400
+const ovnACLPriorityPortGroupDrop = 500
 
 // ovnACLPortGroupPrefix prefix used when naming ACL related port groups in OVN.
 const ovnACLPortGroupPrefix = "lxd_acl"
@@ -349,7 +354,7 @@ func ovnApplyToPortGroup(logger logger.Logger, client *openvswitch.OVN, aclInfo 
 	portGroupRules = append(portGroupRules, openvswitch.OVNACLRule{
 		Direction: "to-lport", // Always use this so that outport is available to Match.
 		Action:    defaultAction,
-		Priority:  ovnACLPriorityPortGroupDefaultReject, // Lowest priority to catch only unmatched traffic.
+		Priority:  ovnACLPriorityPortGroupDefaultAction, // Lowest priority to catch only unmatched traffic.
 		Match:     fmt.Sprintf("(inport == @%s || outport == @%s)", portGroupName, portGroupName),
 		Log:       defaultLogged,
 		LogName:   string(portGroupName),

--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -22,6 +22,7 @@ import (
 
 // OVN ACL rule priorities.
 const ovnACLPrioritySwitchAllow = 10
+const ovnACLPriorityPortGroupDefaultReject = 0
 const ovnACLPriorityPortGroupAllow = 20
 const ovnACLPriorityPortGroupReject = 30
 const ovnACLPriorityPortGroupDrop = 40
@@ -343,19 +344,12 @@ func ovnApplyToPortGroup(logger logger.Logger, client *openvswitch.OVN, aclInfo 
 
 	// Add default rule to port group ACL.
 	defaultAction := "reject"
-	if aclInfo.Config["default.action"] != "" {
-		defaultAction = aclInfo.Config["default.action"]
-	}
-
 	defaultLogged := false
-	if shared.IsTrue(aclInfo.Config["default.logged"]) {
-		defaultLogged = true
-	}
 
 	portGroupRules = append(portGroupRules, openvswitch.OVNACLRule{
 		Direction: "to-lport", // Always use this so that outport is available to Match.
 		Action:    defaultAction,
-		Priority:  0, // Lowest priority to catch only unmatched traffic.
+		Priority:  ovnACLPriorityPortGroupDefaultReject, // Lowest priority to catch only unmatched traffic.
 		Match:     fmt.Sprintf("(inport == @%s || outport == @%s)", portGroupName, portGroupName),
 		Log:       defaultLogged,
 		LogName:   string(portGroupName),

--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -348,7 +348,8 @@ func ovnApplyToPortGroup(logger logger.Logger, client *openvswitch.OVN, aclInfo 
 	}
 
 	// Add default rule to port group ACL.
-	defaultAction := "reject"
+	// This is a failsafe to drop unmatched traffic if the per-NIC default rule has unexpectedly not kicked in.
+	defaultAction := "drop"
 	defaultLogged := false
 
 	portGroupRules = append(portGroupRules, openvswitch.OVNACLRule{

--- a/lxd/network/acl/driver_common.go
+++ b/lxd/network/acl/driver_common.go
@@ -206,14 +206,7 @@ func (d *common) validateName(name string) error {
 
 // validateConfig checks the config and rules are valid.
 func (d *common) validateConfig(info *api.NetworkACLPut) error {
-	rules := map[string]func(value string) error{
-		"default.logged": validate.Optional(validate.IsBool),
-		"default.action": validate.Optional(func(value string) error {
-			return validate.IsOneOf(value, validActions)
-		}),
-	}
-
-	err := d.validateConfigMap(info.Config, rules)
+	err := d.validateConfigMap(info.Config, nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/acl/driver_common.go
+++ b/lxd/network/acl/driver_common.go
@@ -36,8 +36,8 @@ const ruleSubjectExternal = "@external"
 var ruleSubjectInternalAliases = []string{ruleSubjectInternal, "#internal"}
 var ruleSubjectExternalAliases = []string{ruleSubjectExternal, "#external"}
 
-// Define valid actions for rules.
-var validActions = []string{"allow", "drop", "reject"}
+// ValidActions defines valid actions for rules.
+var ValidActions = []string{"allow", "drop", "reject"}
 
 // common represents a Network ACL.
 type common struct {
@@ -295,8 +295,8 @@ func (d *common) validateConfigMap(config map[string]string, rules map[string]fu
 // validateRule validates the rule supplied.
 func (d *common) validateRule(direction ruleDirection, rule api.NetworkACLRule) error {
 	// Validate Action field (required).
-	if !shared.StringInSlice(rule.Action, validActions) {
-		return fmt.Errorf("Action must be one of: %s", strings.Join(validActions, ", "))
+	if !shared.StringInSlice(rule.Action, ValidActions) {
+		return fmt.Errorf("Action must be one of: %s", strings.Join(ValidActions, ", "))
 	}
 
 	// Validate State field (required).

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2339,7 +2339,7 @@ func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clientType re
 				n.logger.Debug("Applying ACL port group member change sets")
 				err = client.PortGroupMemberChange(addChangeSet, removeChangeSet)
 				if err != nil {
-					return errors.Wrapf(err, "Failed applying OVN port group member change sets for instance NICs")
+					return errors.Wrapf(err, "Failed applying OVN port group member change sets for instance NIC")
 				}
 			}
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2914,18 +2914,14 @@ func (n *ovn) InstanceDevicePortDelete(ovsExternalOVNPort openvswitch.OVNSwitchP
 		return errors.Wrapf(err, "Failed to load uplink network %q", n.config["network"])
 	}
 
-	err = client.LogicalSwitchPortDelete(instancePortName)
-	if err != nil {
-		return err
-	}
-
-	// Delete DNS records.
+	// Get DNS records.
 	dnsUUID, _, dnsIPs, err := client.LogicalSwitchPortGetDNS(instancePortName)
 	if err != nil {
 		return err
 	}
 
-	err = client.LogicalSwitchPortDeleteDNS(n.getIntSwitchName(), dnsUUID)
+	// Cleanup logical switch port and associated config.
+	err = client.LogicalSwitchPortCleanup(instancePortName, n.getIntSwitchName(), acl.OVNIntSwitchPortGroupName(n.ID()), dnsUUID)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -209,6 +209,14 @@ func (n *ovn) Validate(config map[string]string) error {
 		"dns.domain":         validate.IsAny,
 		"dns.search":         validate.IsAny,
 		"security.acls":      validate.IsAny,
+		"security.acls.default.ingress.action": validate.Optional(func(value string) error {
+			return validate.IsOneOf(value, acl.ValidActions)
+		}),
+		"security.acls.default.egress.action": validate.Optional(func(value string) error {
+			return validate.IsOneOf(value, acl.ValidActions)
+		}),
+		"security.acls.default.ingress.logged": validate.Optional(validate.IsBool),
+		"security.acls.default.egress.logged":  validate.Optional(validate.IsBool),
 
 		// Volatile keys populated automatically as needed.
 		ovnVolatileUplinkIPv4: validate.Optional(validate.IsNetworkAddressV4),

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -56,24 +56,20 @@ type ovnUplinkPortBridgeVars struct {
 	ovsEnd    string
 }
 
-// OVNInstanceNICOpts options for starting and stopping an OVN Instance NIC.
-type OVNInstanceNICOpts struct {
-	InstanceUUID   string
-	DeviceName     string
-	InternalRoutes []*net.IPNet
-	ExternalRoutes []*net.IPNet
-}
-
 // OVNInstanceNICSetupOpts options for starting an OVN Instance NIC.
 type OVNInstanceNICSetupOpts struct {
-	OVNInstanceNICOpts
+	InstanceUUID string
+	DeviceName   string
+	DeviceConfig deviceConfig.Device
+	UplinkConfig map[string]string
+	DNSName      string
+}
 
-	UplinkConfig       map[string]string
-	DNSName            string
-	MAC                net.HardwareAddr
-	IPs                []net.IP
-	SecurityACLs       []string
-	SecurityACLsRemove []string
+// OVNInstanceNICStopOpts options for stopping an OVN Instance NIC.
+type OVNInstanceNICStopOpts struct {
+	InstanceUUID string
+	DeviceName   string
+	DeviceConfig deviceConfig.Device
 }
 
 // ovn represents a LXD OVN network.

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -806,12 +806,17 @@ func (o *OVN) logicalSwitchDNSRecordsDelete(switchName OVNSwitch) error {
 
 // LogicalSwitchSetACLRules applies a set of rules to the specified logical switch. Any existing rules are removed.
 func (o *OVN) LogicalSwitchSetACLRules(switchName OVNSwitch, aclRules ...OVNACLRule) error {
+	// Remove any existing rules assigned to the entity.
+	args := []string{"clear", "logical_switch", string(switchName), "acls"}
+
 	// Add new rules.
 	externalIDs := map[string]string{
 		ovnExtIDLXDSwitch: string(switchName),
 	}
 
-	err := o.setACLRules("logical_switch", string(switchName), externalIDs, nil, aclRules...)
+	args = o.aclRuleAddAppendArgs(args, "logical_switch", string(switchName), externalIDs, nil, aclRules...)
+
+	_, err := o.nbctl(args...)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -506,8 +506,7 @@ func (o *OVN) logicalSwitchFindAssociatedPortGroups(switchName OVNSwitch) ([]OVN
 		return nil, err
 	}
 
-	output = strings.TrimSpace(output)
-	lines := util.SplitNTrimSpace(output, "\n", -1, true)
+	lines := util.SplitNTrimSpace(strings.TrimSpace(output), "\n", -1, true)
 	portGroups := make([]OVNPortGroup, 0, len(lines))
 
 	for _, line := range lines {
@@ -1307,8 +1306,7 @@ func (o *OVN) PortGroupListByProject(projectID int64) ([]OVNPortGroup, error) {
 		return nil, err
 	}
 
-	output = strings.TrimSpace(output)
-	lines := util.SplitNTrimSpace(output, "\n", -1, true)
+	lines := util.SplitNTrimSpace(strings.TrimSpace(output), "\n", -1, true)
 	portGroups := make([]OVNPortGroup, 0, len(lines))
 
 	for _, line := range lines {

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1115,12 +1115,25 @@ func (o *OVN) LogicalSwitchPortGetDNS(portName OVNSwitchPort) (OVNDNSUUID, strin
 	return OVNDNSUUID(dnsUUID), dnsName, ips, nil
 }
 
+// logicalSwitchPortDeleteDNSAppendArgs adds the command arguments to remove DNS records for a switch port.
+// Returns args with the commands added to it.
+func (o *OVN) logicalSwitchPortDeleteDNSAppendArgs(args []string, switchName OVNSwitch, dnsUUID OVNDNSUUID) []string {
+	if len(args) > 0 {
+		args = append(args, "--")
+	}
+
+	args = append(args,
+		"remove", "logical_switch", string(switchName), "dns_records", string(dnsUUID), "--",
+		"destroy", "dns", string(dnsUUID),
+	)
+
+	return args
+}
+
 // LogicalSwitchPortDeleteDNS removes DNS records for a switch port.
 func (o *OVN) LogicalSwitchPortDeleteDNS(switchName OVNSwitch, dnsUUID OVNDNSUUID) error {
 	// Remove DNS record association from switch, and remove DNS record entry itself.
-	_, err := o.nbctl(
-		"remove", "logical_switch", string(switchName), "dns_records", string(dnsUUID), "--",
-		"destroy", "dns", string(dnsUUID))
+	_, err := o.nbctl(o.logicalSwitchPortDeleteDNSAppendArgs(nil, switchName, dnsUUID)...)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -824,6 +824,21 @@ func (o *OVN) LogicalSwitchSetACLRules(switchName OVNSwitch, aclRules ...OVNACLR
 	return nil
 }
 
+// logicalSwitchPortACLRules returns the ACL rule UUIDs belonging to a logical switch port.
+func (o *OVN) logicalSwitchPortACLRules(portName OVNSwitchPort) ([]string, error) {
+	// Remove any existing rules assigned to the entity.
+	output, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--colum=_uuid", "find", "acl",
+		fmt.Sprintf("external_ids:%s=%s", ovnExtIDLXDSwitchPort, string(portName)),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	ruleUUIDs := util.SplitNTrimSpace(strings.TrimSpace(output), "\n", -1, true)
+
+	return ruleUUIDs, nil
+}
+
 // LogicalSwitchPorts returns a map of logical switch ports (name and UUID) for a switch.
 // Includes non-instance ports, such as the router port.
 func (o *OVN) LogicalSwitchPorts(switchName OVNSwitch) (map[OVNSwitchPort]OVNSwitchPortUUID, error) {

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1141,6 +1141,18 @@ func (o *OVN) LogicalSwitchPortDeleteDNS(switchName OVNSwitch, dnsUUID OVNDNSUUI
 	return nil
 }
 
+// logicalSwitchPortDeleteAppendArgs adds the commands to delete the specified logical switch port.
+// Returns args with the commands added to it.
+func (o *OVN) logicalSwitchPortDeleteAppendArgs(args []string, portName OVNSwitchPort) []string {
+	if len(args) > 0 {
+		args = append(args, "--")
+	}
+
+	args = append(args, "--if-exists", "lsp-del", string(portName))
+
+	return args
+}
+
 // LogicalSwitchPortDelete deletes a named logical switch port.
 func (o *OVN) LogicalSwitchPortDelete(portName OVNSwitchPort) error {
 	_, err := o.nbctl("--if-exists", "lsp-del", string(portName))

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1155,7 +1155,7 @@ func (o *OVN) logicalSwitchPortDeleteAppendArgs(args []string, portName OVNSwitc
 
 // LogicalSwitchPortDelete deletes a named logical switch port.
 func (o *OVN) LogicalSwitchPortDelete(portName OVNSwitchPort) error {
-	_, err := o.nbctl("--if-exists", "lsp-del", string(portName))
+	_, err := o.nbctl(o.logicalSwitchPortDeleteAppendArgs(nil, portName)...)
 	if err != nil {
 		return err
 	}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1355,12 +1355,17 @@ func (o *OVN) PortGroupMemberChange(addMembers map[OVNPortGroup][]OVNSwitchPortU
 
 // PortGroupSetACLRules applies a set of rules to the specified port group. Any existing rules are removed.
 func (o *OVN) PortGroupSetACLRules(portGroupName OVNPortGroup, matchReplace map[string]string, aclRules ...OVNACLRule) error {
+	// Remove any existing rules assigned to the entity.
+	args := []string{"clear", "port_group", string(portGroupName), "acls"}
+
 	// Add new rules.
 	externalIDs := map[string]string{
 		ovnExtIDLXDPortGroup: string(portGroupName),
 	}
 
-	err := o.setACLRules("port_group", string(portGroupName), externalIDs, matchReplace, aclRules...)
+	args = o.aclRuleAddAppendArgs(args, "port_group", string(portGroupName), externalIDs, matchReplace, aclRules...)
+
+	_, err := o.nbctl(args...)
 	if err != nil {
 		return err
 	}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -111,7 +111,7 @@ var patches = []patch{
 	{name: "storage_rename_custom_volume_add_project", stage: patchPreDaemonStorage, run: patchGenericStorage},
 	{name: "storage_lvm_skipactivation", stage: patchPostDaemonStorage, run: patchGenericStorage},
 	{name: "clustering_drop_database_role", stage: patchPostDaemonStorage, run: patchClusteringDropDatabaseRole},
-	{name: "network_clear_bridge_volatile_hwaddr", stage: patchPostDaemonStorage, run: patchNetworkCearBridgeVolatileHwaddr},
+	{name: "network_clear_bridge_volatile_hwaddr", stage: patchPostDaemonStorage, run: patchNetworkClearBridgeVolatileHwaddr},
 	{name: "move_backups_instances", stage: patchPostDaemonStorage, run: patchMoveBackupsInstances},
 	{name: "network_ovn_enable_nat", stage: patchPostDaemonStorage, run: patchNetworkOVNEnableNAT},
 	{name: "network_ovn_remove_routes", stage: patchPostDaemonStorage, run: patchNetworkOVNRemoveRoutes},
@@ -3850,8 +3850,8 @@ func patchClusteringDropDatabaseRole(name string, d *Daemon) error {
 	})
 }
 
-// patchNetworkCearBridgeVolatileHwaddr removes the unsupported `volatile.bridge.hwaddr` config key from networks.
-func patchNetworkCearBridgeVolatileHwaddr(name string, d *Daemon) error {
+// patchNetworkClearBridgeVolatileHwaddr removes the unsupported `volatile.bridge.hwaddr` config key from networks.
+func patchNetworkClearBridgeVolatileHwaddr(name string, d *Daemon) error {
 	// Use project.Default, as bridge networks don't support projects.
 	projectName := project.Default
 

--- a/shared/api/network_acl.go
+++ b/shared/api/network_acl.go
@@ -116,7 +116,7 @@ type NetworkACLPut struct {
 	Ingress []NetworkACLRule `json:"ingress" yaml:"ingress"`
 
 	// ACL configuration map (refer to doc/network-acls.md)
-	// Example: {"default.action": "drop"}
+	// Example: {"user.mykey": "foo"}
 	Config map[string]string `json:"config" yaml:"config"`
 }
 

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -262,6 +262,7 @@ var APIExtensions = []string{
 	"projects_images_auto_update",
 	"projects_restricted_cluster_target",
 	"images_default_architecture",
+	"network_ovn_acl_defaults",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Replaces them with new per-network and per-NIC settings:

- `security.acls.default.{in,e}gress.action` - can be `reject`, `drop` or `allow` (defaults to `reject` if not specified).
- `security.acls.default.{in,e}gress.logged` - can be `true` or `false` (defaults to `false` if not specified).

The NIC setting(s) will override the equivalent setting(s) on the network.

Fixes https://github.com/lxc/lxd/issues/8553
Fixes https://github.com/lxc/lxd/issues/8568

Also modifies the OVN ACL rule priority classes to work around an issue caused by OVN's addition of a +10 priority for TCP reject rules (https://github.com/ovn-org/ovn/commit/366ac0d89da7eb6cfac5f4e1245d34b8b9aabe7b) that was causing infinite reject packet generation due to overlapping priorities with the TCP RST|ACK allow rules.

**This will need network settings and ACL rules to be reapplied.**

Now we have the following rule priority classes (higher comes first):

```
- ovnACLPriorityPortGroupDefaultAction = 0 // Used for non-configurable failsafe drop rule.
- ovnACLPriorityNICDefaultActionIngress = 100
- ovnACLPriorityNICDefaultActionEgress = 111 // Process egress default rules before ingress default rules (this stops intra-network traffic from being handled by the destination port's default ingress rule first before evaluating the source port's egress default rule)
- ovnACLPrioritySwitchAllow = 200
- ovnACLPriorityPortGroupAllow = 300
- ovnACLPriorityPortGroupReject = 400
- ovnACLPriorityPortGroupDrop = 500
```

- [x] Add support for default rule config to NICs.
- [x] Add support for default rule config to Networks (to update active NICs).
- [x] Update CI tests (https://github.com/lxc/lxc-ci/pull/260).
- [x] Update design doc.