### PR TITLE
shared/logging: Support multiple custom handlers

### DIFF
--- a/shared/logging/log.go
+++ b/shared/logging/log.go
@@ -13,7 +13,7 @@ import (
 )
 
 // GetLogger returns a logger suitable for using as logger.Log.
-func GetLogger(syslog string, logfile string, verbose bool, debug bool, customHandler log.Handler) (logger.Logger, error) {
+func GetLogger(syslog string, logfile string, verbose bool, debug bool, customHandlers ...log.Handler) (logger.Logger, error) {
 	Log := log.New()
 
 	var handlers []log.Handler
@@ -72,8 +72,12 @@ func GetLogger(syslog string, logfile string, verbose bool, debug bool, customHa
 		)
 	}
 
-	if customHandler != nil {
-		handlers = append(handlers, customHandler)
+	for _, handler := range customHandlers {
+		if handler == nil {
+			continue
+		}
+
+		handlers = append(handlers, handler)
 	}
 
 	Log.SetHandler(log.MultiHandler(handlers...))


### PR DESCRIPTION
This adds support for multiple custom handlers.

For the upcoming warnings API, this is a simple way of receiving
any warnings/errors.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
