### PR TITLE
Device: Check bridge NIC's security.ipv6_filtering support before wiping existing rules

### DIFF
--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -123,7 +123,7 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 		return fmt.Errorf("Network is not ovnNet interface type")
 	}
 
-	d.network = ovnNet // Stored loaded instance for use by other functions.
+	d.network = ovnNet // Stored loaded network for use by other functions.
 	netConfig := d.network.Config()
 
 	if d.config["ipv4.address"] != "" {


### PR DESCRIPTION
That way we don't leave an empty ruleset on error when updating a NIC's config.