### PR TITLE
Network: OVN detect scenario where there are multiple DHCP option sets for a specific subnet

### DIFF
--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -484,9 +484,22 @@ func (o *OVN) LogicalSwitchDelete(switchName OVNSwitch) error {
 		return err
 	}
 
-	err = o.LogicalSwitchDHCPOptionsDelete(switchName)
+	// Remove any existing DHCP options associated to switch.
+	deleteDHCPRecords, err := o.LogicalSwitchDHCPOptionsGet(switchName)
 	if err != nil {
 		return err
+	}
+
+	if len(deleteDHCPRecords) > 0 {
+		deleteDHCPUUIDs := make([]OVNDHCPOptionsUUID, 0, len(deleteDHCPRecords))
+		for _, deleteDHCPRecord := range deleteDHCPRecords {
+			deleteDHCPUUIDs = append(deleteDHCPUUIDs, deleteDHCPRecord.UUID)
+		}
+
+		err = o.LogicalSwitchDHCPOptionsDelete(switchName, deleteDHCPUUIDs...)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = o.logicalSwitchDNSRecordsDelete(switchName)

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -696,19 +696,6 @@ func (o *OVN) LogicalSwitchDHCPv6OptionsSet(switchName OVNSwitch, uuid OVNDHCPOp
 	return nil
 }
 
-// LogicalSwitchDHCPOptionsGetID returns the UUID for DHCP options set associated to the logical switch and subnet.
-func (o *OVN) LogicalSwitchDHCPOptionsGetID(switchName OVNSwitch, subnet *net.IPNet) (OVNDHCPOptionsUUID, error) {
-	uuid, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--colum=_uuid", "find", "dhcp_options",
-		fmt.Sprintf("external_ids:%s=%s", ovnExtIDLXDSwitch, switchName),
-		fmt.Sprintf(`cidr="%s"`, subnet.String()), // Special quoting to support IPv6 subnets.
-	)
-	if err != nil {
-		return "", err
-	}
-
-	return OVNDHCPOptionsUUID(strings.TrimSpace(uuid)), nil
-}
-
 // LogicalSwitchDHCPOptionsGet retrieves the existing DHCP options defined for a logical switch.
 func (o *OVN) LogicalSwitchDHCPOptionsGet(switchName OVNSwitch) ([]OVNDHCPOptsSet, error) {
 	output, err := o.nbctl("--format=csv", "--no-headings", "--data=bare", "--colum=_uuid,cidr", "find", "dhcp_options",


### PR DESCRIPTION
Shouldn't happen (I suspect I had some left over entries from a partially deleted dev network), but this patch detects it with clear error.

Also reduces number of calls to ovn-nbctl in the process.