### PR TITLE
Instance: Reduce calls to getLxcState to reduce crashes and improve efficiency

### DIFF
--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -637,3 +637,8 @@ func (d *common) insertConfigkey(key string, value string) (string, error) {
 
 	return value, nil
 }
+
+// isRunningStatusCode returns if instance is running from status code.
+func (d *common) isRunningStatusCode(statusCode api.StatusCode) bool {
+	return statusCode != api.Error && statusCode != api.Stopped
+}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3135,14 +3135,7 @@ func (d *lxc) renderState(statusCode api.StatusCode) (*api.InstanceState, error)
 
 // RenderState renders just the running state of the instance.
 func (d *lxc) RenderState() (*api.InstanceState, error) {
-	cState, err := d.getLxcState()
-	if err != nil {
-		return nil, err
-	}
-
-	statusCode := lxcStatusCode(cState)
-
-	return d.renderState(statusCode)
+	return d.renderState(d.statusCode())
 }
 
 // Snapshot takes a new snapshot.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6370,8 +6370,7 @@ func (d *lxc) IsPrivileged() bool {
 
 // IsRunning returns if instance is running.
 func (d *lxc) IsRunning() bool {
-	state := d.State()
-	return state != "BROKEN" && state != "STOPPED"
+	return d.isRunningStatusCode(d.statusCode())
 }
 
 // InitPID returns PID of init process.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6441,13 +6441,19 @@ func (d *lxc) NextIdmap() (*idmap.IdmapSet, error) {
 	return idmap.JSONUnmarshal(jsonIdmap)
 }
 
-// State returns instance state.
-func (d *lxc) State() string {
+// statusCode returns instance status code.
+func (d *lxc) statusCode() api.StatusCode {
 	state, err := d.getLxcState()
 	if err != nil {
-		return api.Error.String()
+		return api.Error
 	}
-	return state.String()
+
+	return lxcStatusCode(state)
+}
+
+// State returns instance state.
+func (d *lxc) State() string {
+	return strings.ToUpper(d.statusCode().String())
 }
 
 // LogFilePath log file path.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3022,13 +3022,7 @@ func (d *lxc) Render(options ...func(response interface{}) error) (interface{}, 
 	// Prepare the ETag
 	etag := []interface{}{d.architecture, d.localConfig, d.localDevices, d.ephemeral, d.profiles}
 
-	// FIXME: Render shouldn't directly access the go-lxc struct
-	cState, err := d.getLxcState()
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "Get container stated")
-	}
-	statusCode := lxcStatusCode(cState)
-
+	statusCode := d.statusCode()
 	instState := api.Instance{
 		ExpandedConfig:  d.expandedConfig,
 		ExpandedDevices: d.expandedDevices.CloneNative(),

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3075,7 +3075,7 @@ func (d *lxc) RenderFull() (*api.InstanceFull, interface{}, error) {
 	ct := api.InstanceFull{Instance: *base.(*api.Instance)}
 
 	// Add the ContainerState
-	ct.State, err = d.RenderState()
+	ct.State, err = d.renderState(ct.StatusCode)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6350,7 +6350,7 @@ func (d *lxc) setNetworkPriority() error {
 
 // IsFrozen returns if instance is frozen.
 func (d *lxc) IsFrozen() bool {
-	return d.State() == "FROZEN"
+	return d.statusCode() == api.Frozen
 }
 
 // IsNesting returns if instance is nested.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4506,13 +4506,14 @@ func (d *qemu) Render(options ...func(response interface{}) error) (interface{},
 
 	// Prepare the ETag
 	etag := []interface{}{d.architecture, d.localConfig, d.localDevices, d.ephemeral, d.profiles}
+	statusCode := d.statusCode()
 
 	instState := api.Instance{
 		ExpandedConfig:  d.expandedConfig,
 		ExpandedDevices: d.expandedDevices.CloneNative(),
 		Name:            d.name,
-		Status:          d.statusCode().String(),
-		StatusCode:      d.statusCode(),
+		Status:          statusCode.String(),
+		StatusCode:      statusCode,
 		Location:        d.node,
 		Type:            d.Type().String(),
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4604,7 +4604,7 @@ func (d *qemu) RenderState() (*api.InstanceState, error) {
 	statusCode := d.statusCode()
 	pid, _ := d.pid()
 
-	if statusCode == api.Running {
+	if d.isRunningStatusCode(statusCode) {
 		// Try and get state info from agent.
 		status, err = d.agentGetState()
 		if err != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4554,7 +4554,7 @@ func (d *qemu) RenderFull() (*api.InstanceFull, interface{}, error) {
 	vmState := api.InstanceFull{Instance: *base.(*api.Instance)}
 
 	// Add the InstanceState.
-	vmState.State, err = d.RenderState()
+	vmState.State, err = d.renderState(vmState.StatusCode)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4745,7 +4745,7 @@ func (d *qemu) IsRunning() bool {
 
 // IsFrozen returns whether the instance frozen or not.
 func (d *qemu) IsFrozen() bool {
-	return d.State() == "FROZEN"
+	return d.statusCode() == api.Frozen
 }
 
 // DeviceEventHandler handles events occurring on the instance's devices.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4740,8 +4740,7 @@ func (d *qemu) agentGetState() (*api.InstanceState, error) {
 
 // IsRunning returns whether or not the instance is running.
 func (d *qemu) IsRunning() bool {
-	state := d.State()
-	return state != "STOPPED"
+	return d.isRunningStatusCode(d.statusCode())
 }
 
 // IsFrozen returns whether the instance frozen or not.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4597,12 +4597,11 @@ func (d *qemu) RenderFull() (*api.InstanceFull, interface{}, error) {
 	return &vmState, etag, nil
 }
 
-// RenderState returns just state info about the instance.
-func (d *qemu) RenderState() (*api.InstanceState, error) {
+// renderState returns just state info about the instance.
+func (d *qemu) renderState(statusCode api.StatusCode) (*api.InstanceState, error) {
 	var err error
 
 	status := &api.InstanceState{}
-	statusCode := d.statusCode()
 	pid, _ := d.pid()
 
 	if d.isRunningStatusCode(statusCode) {
@@ -4682,6 +4681,11 @@ func (d *qemu) RenderState() (*api.InstanceState, error) {
 	}
 
 	return status, nil
+}
+
+// RenderState returns just state info about the instance.
+func (d *qemu) RenderState() (*api.InstanceState, error) {
+	return d.renderState(d.statusCode())
 }
 
 // diskState gets disk usage info.

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -380,7 +380,7 @@ func instancesShutdown(s *state.State) error {
 		lastState := c.State()
 
 		// Stop the container
-		if lastState != "BROKEN" && lastState != "STOPPED" {
+		if lastState != "ERROR" && lastState != "STOPPED" {
 			// Determinate how long to wait for the instance to shutdown cleanly
 			var timeoutSeconds int
 			value, ok := c.ExpandedConfig()["boot.host_shutdown_timeout"]


### PR DESCRIPTION
There were several unnecessary calls to `getLxcState` which meant that doing:

```
while :; do lxc ls; done
```

With 2 containers would quickly crash LXD. 

This PR reduces the calls to `getLxcState` (which is the function that calls liblxc that triggers the crash mentioned in https://github.com/lxc/lxd/issues/8327), so it is more efficient and crashes less often, although it is still not a full fix. I suspect there is an issue in liblxc or Go but I've not been able to confirm that yet.

Also applies similar optimisation techniques to Qemu driver to reduce calls to QMP and align the two driver's behaviours.