### PR TITLE
lxd/instance/qemu: Disable net vectors on ccw

### DIFF
--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -476,7 +476,9 @@ netdev = "lxd_{{.devName}}"
 mac = "{{.devHwaddr}}"
 {{ if ne .vectors 0 -}}
 mq = "on"
+{{- if eq .bus "pci" "pcie"}}
 vectors = "{{.vectors}}"
+{{- end}}
 {{- end}}
 bootindex = "{{.bootIndex}}"
 {{if .multifunction -}}


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>