### PR TITLE
lxc/list: Improve filtering

### DIFF
--- a/lxc/list.go
+++ b/lxc/list.go
@@ -59,7 +59,6 @@ A key/value pair where the key is a shorthand. Multiple values must be delimited
   - type={instance type}
   - status={instance current lifecycle status}
   - architecture={instance architecture}
-  - name={instance name}
   - location={location name}
   - ipv4={ip or CIDR}
   - ipv6={ip or CIDR}
@@ -835,10 +834,6 @@ func (c *cmdList) matchByArchitecture(cInfo *api.Instance, query string) bool {
 	return strings.ToLower(cInfo.InstancePut.Architecture) == strings.ToLower(query)
 }
 
-func (c *cmdList) matchByName(cInfo *api.Instance, query string) bool {
-	return strings.ToLower(cInfo.Name) == strings.ToLower(query)
-}
-
 func (c *cmdList) matchByLocation(cInfo *api.Instance, query string) bool {
 	return strings.ToLower(cInfo.Location) == strings.ToLower(query)
 }
@@ -925,7 +920,6 @@ func (c *cmdList) mapShorthandFilters() {
 		"type":         c.matchByType,
 		"status":       c.matchByStatus,
 		"architecture": c.matchByArchitecture,
-		"name":         c.matchByName,
 		"location":     c.matchByLocation,
 		"ipv4":         c.matchByIPV4,
 		"ipv6":         c.matchByIPV6,

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -432,7 +432,24 @@ func (c *cmdList) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if len(filters) == 0 && needsData && d.HasExtension("container_full") {
+	// Check if we have any name based filters.
+	nameFilter := false
+	for _, filter := range filters {
+		// If not key=value syntax, it's a name filter.
+		if !strings.Contains(filter, "=") {
+			nameFilter = true
+			break
+		}
+
+		// If not straightforward key=value, assume name filter.
+		fields := strings.SplitN(filter, "=", 2)
+		if len(fields) != 2 {
+			nameFilter = true
+			break
+		}
+	}
+
+	if !nameFilter && needsData && d.HasExtension("container_full") {
 		// Using the GetInstancesFull shortcut
 		cts, err := d.GetInstancesFull(api.InstanceTypeAny)
 		if err != nil {

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -156,7 +156,7 @@ func (c *cmdList) dotPrefixMatch(short string, full string) bool {
 	return true
 }
 
-func (c *cmdList) shouldShow(filters []string, state *api.Instance) bool {
+func (c *cmdList) shouldShow(filters []string, inst *api.Instance) bool {
 	c.mapShorthandFilters()
 
 	for _, filter := range filters {
@@ -171,12 +171,12 @@ func (c *cmdList) shouldShow(filters []string, state *api.Instance) bool {
 				value = membs[1]
 			}
 
-			if c.evaluateShorthandFilter(key, value, state) {
+			if c.evaluateShorthandFilter(key, value, inst) {
 				continue
 			}
 
 			found := false
-			for configKey, configValue := range state.ExpandedConfig {
+			for configKey, configValue := range inst.ExpandedConfig {
 				if c.dotPrefixMatch(key, configKey) {
 					//try to test filter value as a regexp
 					regexpValue := value
@@ -200,7 +200,7 @@ func (c *cmdList) shouldShow(filters []string, state *api.Instance) bool {
 				}
 			}
 
-			if state.ExpandedConfig[key] == value {
+			if inst.ExpandedConfig[key] == value {
 				continue
 			}
 
@@ -214,11 +214,11 @@ func (c *cmdList) shouldShow(filters []string, state *api.Instance) bool {
 			}
 
 			r, err := regexp.Compile(regexpValue)
-			if err == nil && r.MatchString(state.Name) {
+			if err == nil && r.MatchString(inst.Name) {
 				continue
 			}
 
-			if !strings.HasPrefix(state.Name, filter) {
+			if !strings.HasPrefix(inst.Name, filter) {
 				return false
 			}
 		}
@@ -227,7 +227,7 @@ func (c *cmdList) shouldShow(filters []string, state *api.Instance) bool {
 	return true
 }
 
-func (c *cmdList) evaluateShorthandFilter(key string, value string, state *api.Instance) bool {
+func (c *cmdList) evaluateShorthandFilter(key string, value string, inst *api.Instance) bool {
 	const shorthandValueDelimiter = ","
 	shorthandFilterFunction, isShorthandFilter := c.shorthandFilters[strings.ToLower(key)]
 
@@ -235,7 +235,7 @@ func (c *cmdList) evaluateShorthandFilter(key string, value string, state *api.I
 		if strings.Contains(value, shorthandValueDelimiter) {
 			matched := false
 			for _, curValue := range strings.Split(value, shorthandValueDelimiter) {
-				if shorthandFilterFunction(state, curValue) {
+				if shorthandFilterFunction(inst, curValue) {
 					matched = true
 				}
 			}
@@ -243,7 +243,7 @@ func (c *cmdList) evaluateShorthandFilter(key string, value string, state *api.I
 			return matched
 		}
 
-		return shorthandFilterFunction(state, value)
+		return shorthandFilterFunction(inst, value)
 	}
 
 	return false

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -178,19 +178,20 @@ func (c *cmdList) shouldShow(filters []string, inst *api.Instance) bool {
 			found := false
 			for configKey, configValue := range inst.ExpandedConfig {
 				if c.dotPrefixMatch(key, configKey) {
-					//try to test filter value as a regexp
+					// Try to test filter value as a regexp.
 					regexpValue := value
 					if !(strings.Contains(value, "^") || strings.Contains(value, "$")) {
 						regexpValue = "^" + regexpValue + "$"
 					}
+
 					r, err := regexp.Compile(regexpValue)
-					//if not regexp compatible use original value
+					// If not regexp compatible use original value.
 					if err != nil {
 						if value == configValue {
 							found = true
 							break
 						} else {
-							// the property was found but didn't match
+							// The property was found but didn't match.
 							return false
 						}
 					} else if r.MatchString(configValue) {

--- a/lxc/list_test.go
+++ b/lxc/list_test.go
@@ -76,8 +76,8 @@ func TestShouldShow(t *testing.T) {
 		t.Error("user.blah=abc architecture=potato didn't match")
 	}
 
-	if !list.shouldShow([]string{"name=foo", "user.blah=abc"}, inst, nil, false) {
-		t.Error("user.blah=abc name=foo didn't match")
+	if !list.shouldShow([]string{"foo", "user.blah=abc"}, inst, nil, false) {
+		t.Error("user.blah=abc foo didn't match")
 	}
 
 	if list.shouldShow([]string{"image.os=temple-os", "user.blah=abc"}, inst, nil, false) {

--- a/lxc/list_test.go
+++ b/lxc/list_test.go
@@ -52,87 +52,87 @@ func TestShouldShow(t *testing.T) {
 		},
 	}
 
-	if !list.shouldShow([]string{"u.blah=abc"}, inst) {
+	if !list.shouldShow([]string{"u.blah=abc"}, inst, nil, false) {
 		t.Error("u.blah=abc didn't match")
 	}
 
-	if !list.shouldShow([]string{"user.blah=abc"}, inst) {
+	if !list.shouldShow([]string{"user.blah=abc"}, inst, nil, false) {
 		t.Error("user.blah=abc didn't match")
 	}
 
-	if !list.shouldShow([]string{"status=RUNNING", "user.blah=abc"}, inst) {
+	if !list.shouldShow([]string{"status=RUNNING", "user.blah=abc"}, inst, nil, false) {
 		t.Error("user.blah=abc status=RUNNING didn't match")
 	}
 
-	if !list.shouldShow([]string{"image.os=Debian", "user.blah=abc"}, inst) {
+	if !list.shouldShow([]string{"image.os=Debian", "user.blah=abc"}, inst, nil, false) {
 		t.Error("user.blah=abc os=debian didn't match")
 	}
 
-	if !list.shouldShow([]string{"location=mem-brain", "user.blah=abc"}, inst) {
+	if !list.shouldShow([]string{"location=mem-brain", "user.blah=abc"}, inst, nil, false) {
 		t.Error("user.blah=abc location=mem-brain didn't match")
 	}
 
-	if !list.shouldShow([]string{"architecture=potato", "user.blah=abc"}, inst) {
+	if !list.shouldShow([]string{"architecture=potato", "user.blah=abc"}, inst, nil, false) {
 		t.Error("user.blah=abc architecture=potato didn't match")
 	}
 
-	if !list.shouldShow([]string{"name=foo", "user.blah=abc"}, inst) {
+	if !list.shouldShow([]string{"name=foo", "user.blah=abc"}, inst, nil, false) {
 		t.Error("user.blah=abc name=foo didn't match")
 	}
 
-	if list.shouldShow([]string{"image.os=temple-os", "user.blah=abc"}, inst) {
+	if list.shouldShow([]string{"image.os=temple-os", "user.blah=abc"}, inst, nil, false) {
 		t.Error("user.blah=abc image.os=temple-os did match")
 	}
 
-	if list.shouldShow([]string{"status=RUNNING", "type=virtual-machine", "user.blah=abc"}, inst) {
+	if list.shouldShow([]string{"status=RUNNING", "type=virtual-machine", "user.blah=abc"}, inst, nil, false) {
 		t.Error("user.blah=abc status=RUNNING, type=virtual-machine did match ")
 	}
 
-	if list.shouldShow([]string{"status=FROZEN,STOPPED"}, inst) {
+	if list.shouldShow([]string{"status=FROZEN,STOPPED"}, inst, nil, false) {
 		t.Error("status=FROZEN,STOPPED did not match ")
 	}
 
-	if !list.shouldShow([]string{"status=RUNNING,STOPPED"}, inst) {
+	if !list.shouldShow([]string{"status=RUNNING,STOPPED"}, inst, nil, false) {
 		t.Error("status=RUNNING,STOPPED  did not match ")
 	}
 
-	if !list.shouldShow([]string{"type=container", "user.blah=abc"}, inst) {
+	if !list.shouldShow([]string{"type=container", "user.blah=abc"}, inst, nil, false) {
 		t.Error("user.blah=abc type=container didn't match")
 	}
 
-	if list.shouldShow([]string{"bar", "u.blah=abc"}, inst) {
+	if list.shouldShow([]string{"bar", "u.blah=abc"}, inst, nil, false) {
 		t.Errorf("name filter didn't work")
 	}
 
-	if list.shouldShow([]string{"bar", "u.blah=other"}, inst) {
+	if list.shouldShow([]string{"bar", "u.blah=other"}, inst, nil, false) {
 		t.Errorf("value filter didn't work")
 	}
 
-	if !list.shouldShow([]string{"ipv4=10.29.85.0/24"}, inst) {
+	if !list.shouldShow([]string{"ipv4=10.29.85.0/24"}, inst, nil, false) {
 		t.Errorf("net=10.29.85.0/24 filter didn't work")
 	}
 
-	if list.shouldShow([]string{"ipv4=10.29.85.0/32"}, inst) {
+	if list.shouldShow([]string{"ipv4=10.29.85.0/32"}, inst, nil, false) {
 		t.Errorf("net=10.29.85.0/32 filter did work but should not")
 	}
 
-	if !list.shouldShow([]string{"ipv4=10.29.85.156"}, inst) {
+	if !list.shouldShow([]string{"ipv4=10.29.85.156"}, inst, nil, false) {
 		t.Errorf("net=10.29.85.156 filter did not work")
 	}
 
-	if !list.shouldShow([]string{"ipv6=fd42:72a:89ac:e457:216:3eff:fe83:8301"}, inst) {
+	if !list.shouldShow([]string{"ipv6=fd42:72a:89ac:e457:216:3eff:fe83:8301"}, inst, nil, false) {
 		t.Errorf("net=fd42:72a:89ac:e457:216:3eff:fe83:8301 filter didn't work")
 	}
 
-	if list.shouldShow([]string{"ipv6=fd42:072a:89ac:e457:0216:3eff:fe83:ffff/128"}, inst) {
+	if list.shouldShow([]string{"ipv6=fd42:072a:89ac:e457:0216:3eff:fe83:ffff/128"}, inst, nil, false) {
 		t.Errorf("net=1net=fd42:072a:89ac:e457:0216:3eff:fe83:ffff/128 filter did work but should not")
 	}
 
-	if !list.shouldShow([]string{"ipv6=fd42:72a:89ac:e457:216:3eff:fe83:ffff/1"}, inst) {
+	if !list.shouldShow([]string{"ipv6=fd42:72a:89ac:e457:216:3eff:fe83:ffff/1"}, inst, nil, false) {
 		t.Errorf("net=fd42:72a:89ac:e457:216:3eff:fe83:ffff/1 filter filter didn't work")
 	}
 
-	if list.shouldShow([]string{"user.blah=abc", "status=stopped"}, inst) {
+	if list.shouldShow([]string{"user.blah=abc", "status=stopped"}, inst, nil, false) {
 		t.Error("user.blah=abc status=stopped did match even though container status is 'running'")
 	}
 }

--- a/lxc/list_test.go
+++ b/lxc/list_test.go
@@ -25,7 +25,7 @@ func TestDotPrefixMatch(t *testing.T) {
 
 func TestShouldShow(t *testing.T) {
 	list := cmdList{}
-	state := &api.Instance{
+	inst := &api.Instance{
 		Name: "foo",
 		ExpandedConfig: map[string]string{
 			"security.privileged": "1",
@@ -52,90 +52,89 @@ func TestShouldShow(t *testing.T) {
 		},
 	}
 
-	if !list.shouldShow([]string{"u.blah=abc"}, state) {
+	if !list.shouldShow([]string{"u.blah=abc"}, inst) {
 		t.Error("u.blah=abc didn't match")
 	}
 
-	if !list.shouldShow([]string{"user.blah=abc"}, state) {
+	if !list.shouldShow([]string{"user.blah=abc"}, inst) {
 		t.Error("user.blah=abc didn't match")
 	}
 
-	if !list.shouldShow([]string{"status=RUNNING", "user.blah=abc"}, state) {
+	if !list.shouldShow([]string{"status=RUNNING", "user.blah=abc"}, inst) {
 		t.Error("user.blah=abc status=RUNNING didn't match")
 	}
 
-	if !list.shouldShow([]string{"image.os=Debian", "user.blah=abc"}, state) {
+	if !list.shouldShow([]string{"image.os=Debian", "user.blah=abc"}, inst) {
 		t.Error("user.blah=abc os=debian didn't match")
 	}
 
-	if !list.shouldShow([]string{"location=mem-brain", "user.blah=abc"}, state) {
+	if !list.shouldShow([]string{"location=mem-brain", "user.blah=abc"}, inst) {
 		t.Error("user.blah=abc location=mem-brain didn't match")
 	}
 
-	if !list.shouldShow([]string{"architecture=potato", "user.blah=abc"}, state) {
+	if !list.shouldShow([]string{"architecture=potato", "user.blah=abc"}, inst) {
 		t.Error("user.blah=abc architecture=potato didn't match")
 	}
 
-	if !list.shouldShow([]string{"name=foo", "user.blah=abc"}, state) {
+	if !list.shouldShow([]string{"name=foo", "user.blah=abc"}, inst) {
 		t.Error("user.blah=abc name=foo didn't match")
 	}
 
-	if list.shouldShow([]string{"image.os=temple-os", "user.blah=abc"}, state) {
+	if list.shouldShow([]string{"image.os=temple-os", "user.blah=abc"}, inst) {
 		t.Error("user.blah=abc image.os=temple-os did match")
 	}
 
-	if list.shouldShow([]string{"status=RUNNING", "type=virtual-machine", "user.blah=abc"}, state) {
+	if list.shouldShow([]string{"status=RUNNING", "type=virtual-machine", "user.blah=abc"}, inst) {
 		t.Error("user.blah=abc status=RUNNING, type=virtual-machine did match ")
 	}
 
-	if list.shouldShow([]string{"status=FROZEN,STOPPED"}, state) {
+	if list.shouldShow([]string{"status=FROZEN,STOPPED"}, inst) {
 		t.Error("status=FROZEN,STOPPED did not match ")
 	}
 
-	if !list.shouldShow([]string{"status=RUNNING,STOPPED"}, state) {
+	if !list.shouldShow([]string{"status=RUNNING,STOPPED"}, inst) {
 		t.Error("status=RUNNING,STOPPED  did not match ")
 	}
 
-	if !list.shouldShow([]string{"type=container", "user.blah=abc"}, state) {
+	if !list.shouldShow([]string{"type=container", "user.blah=abc"}, inst) {
 		t.Error("user.blah=abc type=container didn't match")
 	}
 
-	if list.shouldShow([]string{"bar", "u.blah=abc"}, state) {
+	if list.shouldShow([]string{"bar", "u.blah=abc"}, inst) {
 		t.Errorf("name filter didn't work")
 	}
 
-	if list.shouldShow([]string{"bar", "u.blah=other"}, state) {
+	if list.shouldShow([]string{"bar", "u.blah=other"}, inst) {
 		t.Errorf("value filter didn't work")
 	}
 
-	if !list.shouldShow([]string{"ipv4=10.29.85.0/24"}, state) {
+	if !list.shouldShow([]string{"ipv4=10.29.85.0/24"}, inst) {
 		t.Errorf("net=10.29.85.0/24 filter didn't work")
 	}
 
-	if list.shouldShow([]string{"ipv4=10.29.85.0/32"}, state) {
+	if list.shouldShow([]string{"ipv4=10.29.85.0/32"}, inst) {
 		t.Errorf("net=10.29.85.0/32 filter did work but should not")
 	}
 
-	if !list.shouldShow([]string{"ipv4=10.29.85.156"}, state) {
+	if !list.shouldShow([]string{"ipv4=10.29.85.156"}, inst) {
 		t.Errorf("net=10.29.85.156 filter did not work")
 	}
 
-	if !list.shouldShow([]string{"ipv6=fd42:72a:89ac:e457:216:3eff:fe83:8301"}, state) {
+	if !list.shouldShow([]string{"ipv6=fd42:72a:89ac:e457:216:3eff:fe83:8301"}, inst) {
 		t.Errorf("net=fd42:72a:89ac:e457:216:3eff:fe83:8301 filter didn't work")
 	}
 
-	if list.shouldShow([]string{"ipv6=fd42:072a:89ac:e457:0216:3eff:fe83:ffff/128"}, state) {
+	if list.shouldShow([]string{"ipv6=fd42:072a:89ac:e457:0216:3eff:fe83:ffff/128"}, inst) {
 		t.Errorf("net=1net=fd42:072a:89ac:e457:0216:3eff:fe83:ffff/128 filter did work but should not")
 	}
 
-	if !list.shouldShow([]string{"ipv6=fd42:72a:89ac:e457:216:3eff:fe83:ffff/1"}, state) {
+	if !list.shouldShow([]string{"ipv6=fd42:72a:89ac:e457:216:3eff:fe83:ffff/1"}, inst) {
 		t.Errorf("net=fd42:72a:89ac:e457:216:3eff:fe83:ffff/1 filter filter didn't work")
 	}
 
-	if list.shouldShow([]string{"user.blah=abc", "status=stopped"}, state) {
+	if list.shouldShow([]string{"user.blah=abc", "status=stopped"}, inst) {
 		t.Error("user.blah=abc status=stopped did match even though container status is 'running'")
 	}
-
 }
 
 // Used by TestColumns and TestInvalidColumns

--- a/lxc/list_test.go
+++ b/lxc/list_test.go
@@ -38,17 +38,32 @@ func TestShouldShow(t *testing.T) {
 		Type:     "Container",
 		ExpandedDevices: map[string]map[string]string{
 			"eth0": {
-				"name":         "eth0",
-				"ipv4.address": "10.29.85.156",
-				"ipv6.address": "fd42:72a:89ac:e457:216:3eff:fe83:8301",
-				"type":         "nic",
-				"parent":       "lxdbr0",
-				"nictype":      "bridged",
+				"name":    "eth0",
+				"type":    "nic",
+				"parent":  "lxdbr0",
+				"nictype": "bridged",
 			},
 		},
 		InstancePut: api.InstancePut{
 			Architecture: "potato",
 			Description:  "Something which does something",
+		},
+	}
+
+	state := &api.InstanceState{
+		Network: map[string]api.InstanceStateNetwork{
+			"eth0": {
+				Addresses: []api.InstanceStateNetworkAddress{
+					{
+						Family:  "inet",
+						Address: "10.29.85.156",
+					},
+					{
+						Family:  "inet6",
+						Address: "fd42:72a:89ac:e457:216:3eff:fe83:8301",
+					},
+				},
+			},
 		},
 	}
 
@@ -108,27 +123,27 @@ func TestShouldShow(t *testing.T) {
 		t.Errorf("value filter didn't work")
 	}
 
-	if !list.shouldShow([]string{"ipv4=10.29.85.0/24"}, inst, nil, false) {
+	if !list.shouldShow([]string{"ipv4=10.29.85.0/24"}, inst, state, false) {
 		t.Errorf("net=10.29.85.0/24 filter didn't work")
 	}
 
-	if list.shouldShow([]string{"ipv4=10.29.85.0/32"}, inst, nil, false) {
+	if list.shouldShow([]string{"ipv4=10.29.85.0/32"}, inst, state, false) {
 		t.Errorf("net=10.29.85.0/32 filter did work but should not")
 	}
 
-	if !list.shouldShow([]string{"ipv4=10.29.85.156"}, inst, nil, false) {
+	if !list.shouldShow([]string{"ipv4=10.29.85.156"}, inst, state, false) {
 		t.Errorf("net=10.29.85.156 filter did not work")
 	}
 
-	if !list.shouldShow([]string{"ipv6=fd42:72a:89ac:e457:216:3eff:fe83:8301"}, inst, nil, false) {
+	if !list.shouldShow([]string{"ipv6=fd42:72a:89ac:e457:216:3eff:fe83:8301"}, inst, state, false) {
 		t.Errorf("net=fd42:72a:89ac:e457:216:3eff:fe83:8301 filter didn't work")
 	}
 
-	if list.shouldShow([]string{"ipv6=fd42:072a:89ac:e457:0216:3eff:fe83:ffff/128"}, inst, nil, false) {
+	if list.shouldShow([]string{"ipv6=fd42:072a:89ac:e457:0216:3eff:fe83:ffff/128"}, inst, state, false) {
 		t.Errorf("net=1net=fd42:072a:89ac:e457:0216:3eff:fe83:ffff/128 filter did work but should not")
 	}
 
-	if !list.shouldShow([]string{"ipv6=fd42:72a:89ac:e457:216:3eff:fe83:ffff/1"}, inst, nil, false) {
+	if !list.shouldShow([]string{"ipv6=fd42:72a:89ac:e457:216:3eff:fe83:ffff/1"}, inst, state, false) {
 		t.Errorf("net=fd42:72a:89ac:e457:216:3eff:fe83:ffff/1 filter filter didn't work")
 	}
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -513,7 +513,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
@@ -686,7 +686,7 @@ msgstr "automatisches Update: %s"
 msgid "Available projects:"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr " Prozessorauslastung:"
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -783,7 +783,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "ERSTELLT AM"
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr "ERSTELLT AM"
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -903,7 +903,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr "Spalten"
 
@@ -1143,13 +1143,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1380,7 +1380,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1453,7 +1453,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1606,7 +1606,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1669,7 +1669,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1789,11 +1789,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1934,12 +1934,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1954,17 +1954,17 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2012,11 +2012,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -2160,7 +2160,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2320,11 +2319,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2644,7 +2643,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2836,15 +2835,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -3296,7 +3295,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3308,7 +3307,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3320,7 +3319,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3763,7 +3762,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3985,7 +3984,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5120,7 +5119,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -345,7 +345,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -506,7 +506,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -579,7 +579,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "  Χρήση CPU:"
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -601,7 +601,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -648,7 +648,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -707,7 +707,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -927,13 +927,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1217,7 +1217,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1418,7 +1418,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1533,11 +1533,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1673,12 +1673,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1693,17 +1693,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1746,11 +1746,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1890,7 +1890,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2031,11 +2030,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2329,7 +2328,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2518,15 +2517,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2955,7 +2954,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2967,7 +2966,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2979,7 +2978,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3396,7 +3395,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3608,7 +3607,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4303,7 +4302,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -493,7 +493,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
@@ -655,7 +655,7 @@ msgstr "Auto actualización: %s"
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -729,7 +729,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "Uso de CPU:"
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "CREADO"
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr "CREADO EN"
 
@@ -790,7 +790,7 @@ msgstr "No se peude leer desde stdin: %s"
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -799,7 +799,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -859,7 +859,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr "Columnas"
 
@@ -1087,13 +1087,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1311,7 +1311,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1377,7 +1377,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1581,7 +1581,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1696,11 +1696,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1838,12 +1838,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1858,17 +1858,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1911,11 +1911,11 @@ msgstr "Cacheado: %s"
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -2057,7 +2057,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2198,11 +2197,11 @@ msgstr "Cacheado: %s"
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2501,7 +2500,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2688,15 +2687,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -3131,7 +3130,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3143,7 +3142,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3155,7 +3154,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3572,7 +3571,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3784,7 +3783,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4575,7 +4574,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -509,7 +509,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -681,7 +681,7 @@ msgstr "Mise à jour auto. : %s"
 msgid "Available projects:"
 msgstr "Rendre l'image publique"
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -755,7 +755,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "CPU utilisé :"
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -777,7 +777,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "CRÉÉ À"
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr "CRÉÉ À"
 
@@ -819,7 +819,7 @@ msgstr "Impossible de lire depuis stdin : %s"
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -827,7 +827,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -889,7 +889,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr "Colonnes"
 
@@ -1153,13 +1153,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1387,7 +1387,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr "ÉPHÉMÈRE"
 
@@ -1461,7 +1461,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1621,7 +1621,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 #, fuzzy
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Mode rapide (identique à --columns=nsacPt"
@@ -1683,7 +1683,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1806,11 +1806,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr "IPv4"
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr "IPv6"
 
@@ -1957,12 +1957,12 @@ msgstr "Schème d'URL invalide \"%s\" in \"%s\""
 msgid "Invalid certificate"
 msgstr "Certificat invalide"
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, fuzzy, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr "Clé de configuration invalide"
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1977,17 +1977,17 @@ msgstr "Cible invalide %s"
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2031,11 +2031,11 @@ msgstr "Créé : %s"
 msgid "Keep the image up to date after initial copy"
 msgstr "Garder l'image à jour après la copie initiale"
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -2179,7 +2179,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2380,11 +2379,11 @@ msgstr "Créé : %s"
 msgid "MANAGED"
 msgstr "GÉRÉ"
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2708,7 +2707,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2911,15 +2910,15 @@ msgstr "Surcharger le mode terminal (auto, interactif ou non-interactif)"
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr "PID"
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr "PROFILS"
 
@@ -3389,7 +3388,7 @@ msgstr ""
 msgid "SIZE"
 msgstr "TAILLE"
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr "INSTANTANÉS"
 
@@ -3401,7 +3400,7 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr "ÉTAT"
 
@@ -3414,7 +3413,7 @@ msgstr "STATIQUE"
 msgid "STATUS"
 msgstr "ÉTAT"
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
@@ -3868,7 +3867,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr "TYPE"
@@ -4093,7 +4092,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -5332,7 +5331,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -484,7 +484,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
@@ -646,7 +646,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -719,7 +719,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "Utilizzo CPU:"
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "CREATO IL"
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr "CREATO IL"
 
@@ -780,7 +780,7 @@ msgstr "Impossible leggere da stdin: %s"
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -788,7 +788,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -848,7 +848,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr "Colonne"
 
@@ -1075,13 +1075,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1300,7 +1300,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1367,7 +1367,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1511,7 +1511,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1571,7 +1571,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1686,11 +1686,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1828,12 +1828,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1848,17 +1848,17 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1902,11 +1902,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -2049,7 +2049,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2190,11 +2189,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2493,7 +2492,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2680,15 +2679,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -3124,7 +3123,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3136,7 +3135,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3148,7 +3147,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3567,7 +3566,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3780,7 +3779,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4574,7 +4573,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: 2021-02-02 15:21+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -487,7 +487,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -660,7 +660,7 @@ msgstr "自動更新: %s"
 msgid "Available projects:"
 msgstr "利用可能なプロジェクト:"
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr "BASE IMAGE"
 
@@ -735,7 +735,7 @@ msgstr "CONTENT TYPE"
 msgid "CPU (%s):"
 msgstr "CPU (%s):"
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr "CPU USAGE"
 
@@ -756,7 +756,7 @@ msgstr "CPUs (%s):"
 msgid "CREATED"
 msgstr "CREATED"
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr "CREATED AT"
 
@@ -796,7 +796,7 @@ msgstr "標準入力から読み込めません: %s"
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr "--fast と --columns は同時に指定できません"
 
@@ -804,7 +804,7 @@ msgstr "--fast と --columns は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
@@ -863,7 +863,7 @@ msgstr "クラスタメンバ名"
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr "カラムレイアウト"
 
@@ -1096,13 +1096,13 @@ msgstr "現在の VF 数: %d"
 msgid "DATABASE"
 msgstr "DATABASE"
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr "DISK USAGE"
 
@@ -1320,7 +1320,7 @@ msgstr "進捗情報を表示しません"
 msgid "Driver: %v (%v)"
 msgstr "ドライバ: %v (%v)"
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr "EPHEMERAL"
 
@@ -1390,7 +1390,7 @@ msgstr "ストレージボリュームの設定をYAMLで編集します"
 msgid "Edit trust configurations as YAML"
 msgstr "プロジェクト設定をYAMLで編集します"
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1558,7 +1558,7 @@ msgstr "エイリアス %s の削除に失敗しました"
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Fast モード (--columns=nsacPt と同じ)"
 
@@ -1632,7 +1632,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1748,11 +1748,11 @@ msgstr "IMAGES"
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr "IPV6"
 
@@ -1897,12 +1897,12 @@ msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
 msgid "Invalid certificate"
 msgstr "不正な証明書です"
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr "'%s' は正しくない設定項目 (key) です (%s 中の)"
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1918,19 +1918,19 @@ msgstr "不正なフォーマット %q"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 "'%s' は最大幅の値として不正です (-1 もしくは 0 もしくは正の整数でなくてはなり"
 "ません) ('%s' 中の)"
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr "'%s' は最大幅の値として不正です (整数でなくてはなりません) ('%s' 中の)"
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1974,11 +1974,11 @@ msgstr "IsSM: %s (%s)"
 msgid "Keep the image up to date after initial copy"
 msgstr "最初にコピーした後も常にイメージを最新の状態に保つ"
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr "LAST USED AT"
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr "LOCATION"
@@ -2150,7 +2150,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2379,11 +2378,11 @@ msgstr "MAD: %s (%s)"
 msgid "MANAGED"
 msgstr "MANAGED"
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr "MEMORY USAGE"
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr "MEMORY USAGE%"
@@ -2701,7 +2700,7 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2889,15 +2888,15 @@ msgstr "ターミナルモードを上書きします (auto, interactive, non-in
 msgid "PCI address: %v"
 msgstr "PCI アドレス: %v"
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr "PID"
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr "PROCESSES"
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr "PROFILES"
 
@@ -3335,7 +3334,7 @@ msgstr "すべてのインスタンスに対してコマンドを実行します
 msgid "SIZE"
 msgstr "SIZE"
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr "SNAPSHOTS"
 
@@ -3347,7 +3346,7 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr "STATE"
 
@@ -3359,7 +3358,7 @@ msgstr "STATIC"
 msgid "STATUS"
 msgstr "STATUS"
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr "STORAGE POOL"
 
@@ -3817,7 +3816,7 @@ msgstr "デフォルトのリモートを切り替えます"
 msgid "TARGET"
 msgstr "TARGET"
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr "TYPE"
@@ -4055,7 +4054,7 @@ msgstr "UUID: %v"
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
@@ -4820,7 +4819,7 @@ msgstr ""
 "lxc launch ubuntu:18.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成し、起動します"
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2021-03-29 14:33-0400\n"
+        "POT-Creation-Date: 2021-03-29 23:43-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -327,7 +327,7 @@ msgstr  ""
 msgid   "ALIASES"
 msgstr  ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid   "ARCHITECTURE"
 msgstr  ""
 
@@ -484,7 +484,7 @@ msgstr  ""
 msgid   "Available projects:"
 msgstr  ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid   "BASE IMAGE"
 msgstr  ""
 
@@ -556,7 +556,7 @@ msgstr  ""
 msgid   "CPU (%s):"
 msgstr  ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid   "CPU USAGE"
 msgstr  ""
 
@@ -577,7 +577,7 @@ msgstr  ""
 msgid   "CREATED"
 msgstr  ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid   "CREATED AT"
 msgstr  ""
 
@@ -616,7 +616,7 @@ msgstr  ""
 msgid   "Can't remove the default remote"
 msgstr  ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid   "Can't specify --fast with --columns"
 msgstr  ""
 
@@ -624,7 +624,7 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
@@ -673,7 +673,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid   "Columns"
 msgstr  ""
 
@@ -886,11 +886,11 @@ msgstr  ""
 msgid   "DATABASE"
 msgstr  ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621 lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid   "DESCRIPTION"
 msgstr  ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid   "DISK USAGE"
 msgstr  ""
 
@@ -1049,7 +1049,7 @@ msgstr  ""
 msgid   "Driver: %v (%v)"
 msgstr  ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid   "EPHEMERAL"
 msgstr  ""
 
@@ -1113,7 +1113,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1247,7 +1247,7 @@ msgstr  ""
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid   "Fast mode (same as --columns=nsacPt)"
 msgstr  ""
 
@@ -1299,7 +1299,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155 lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515 lxc/storage_volume.go:1195
+#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523 lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
@@ -1412,11 +1412,11 @@ msgstr  ""
 msgid   "IP ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid   "IPV4"
 msgstr  ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid   "IPV6"
 msgstr  ""
 
@@ -1549,12 +1549,12 @@ msgstr  ""
 msgid   "Invalid certificate"
 msgstr  ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid   "Invalid config key '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid   "Invalid config key column format (too many fields): '%s'"
 msgstr  ""
@@ -1569,17 +1569,17 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid   "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid   "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
@@ -1621,11 +1621,11 @@ msgstr  ""
 msgid   "Keep the image up to date after initial copy"
 msgstr  ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid   "LAST USED AT"
 msgstr  ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165 lxc/storage_volume.go:1278
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165 lxc/storage_volume.go:1278
 msgid   "LOCATION"
 msgstr  ""
 
@@ -1759,7 +1759,6 @@ msgid   "List instances\n"
         "  - type={instance type}\n"
         "  - status={instance current lifecycle status}\n"
         "  - architecture={instance architecture}\n"
-        "  - name={instance name}\n"
         "  - location={location name}\n"
         "  - ipv4={ip or CIDR}\n"
         "  - ipv6={ip or CIDR}\n"
@@ -1894,11 +1893,11 @@ msgstr  ""
 msgid   "MANAGED"
 msgstr  ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid   "MEMORY USAGE"
 msgstr  ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid   "MEMORY USAGE%"
 msgstr  ""
@@ -2164,7 +2163,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567 lxc/storage_volume.go:1270
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid   "NAME"
 msgstr  ""
 
@@ -2347,15 +2346,15 @@ msgstr  ""
 msgid   "PCI address: %v"
 msgstr  ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid   "PID"
 msgstr  ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid   "PROCESSES"
 msgstr  ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid   "PROFILES"
 msgstr  ""
 
@@ -2777,7 +2776,7 @@ msgstr  ""
 msgid   "SIZE"
 msgstr  ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid   "SNAPSHOTS"
 msgstr  ""
 
@@ -2789,7 +2788,7 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid   "STATE"
 msgstr  ""
 
@@ -2801,7 +2800,7 @@ msgstr  ""
 msgid   "STATUS"
 msgstr  ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid   "STORAGE POOL"
 msgstr  ""
 
@@ -3200,7 +3199,7 @@ msgstr  ""
 msgid   "TARGET"
 msgstr  ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895 lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895 lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid   "TYPE"
 msgstr  ""
 
@@ -3399,7 +3398,7 @@ msgstr  ""
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -4058,7 +4057,7 @@ msgid   "lxc launch ubuntu:18.04 u1\n"
         "    Create and start the instance with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid   "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
         "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", \"IPV6\" and \"MAC\" columns.\n"
         "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from instance configuration keys.\n"

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -480,7 +480,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
@@ -641,7 +641,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -714,7 +714,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -774,7 +774,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -782,7 +782,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -841,7 +841,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -1061,13 +1061,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1348,7 +1348,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1664,11 +1664,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1804,12 +1804,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1824,17 +1824,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1877,11 +1877,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -2021,7 +2021,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2162,11 +2161,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2458,7 +2457,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2645,15 +2644,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -3082,7 +3081,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3094,7 +3093,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3106,7 +3105,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3523,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3735,7 +3734,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4430,7 +4429,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -498,7 +498,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -659,7 +659,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -732,7 +732,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -753,7 +753,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -792,7 +792,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -800,7 +800,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -859,7 +859,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -1079,13 +1079,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1300,7 +1300,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1366,7 +1366,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1567,7 +1567,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1682,11 +1682,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1822,12 +1822,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1842,17 +1842,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1895,11 +1895,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -2039,7 +2039,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2180,11 +2179,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2476,7 +2475,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2663,15 +2662,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -3100,7 +3099,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3112,7 +3111,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3124,7 +3123,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3541,7 +3540,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3753,7 +3752,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4448,7 +4447,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -501,7 +501,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
@@ -672,7 +672,7 @@ msgstr "Atualização automática: %s"
 msgid "Available projects:"
 msgstr "Criar projetos"
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr "IMAGEM BASE"
 
@@ -745,7 +745,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "Utilização do CPU:"
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr "CPUs:"
 msgid "CREATED"
 msgstr "CRIADO"
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr "CRIADO EM"
 
@@ -806,7 +806,7 @@ msgstr "Não é possível ler stdin: %s"
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr "Não é possível especificar --fast com --columns"
 
@@ -814,7 +814,7 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
@@ -874,7 +874,7 @@ msgstr "Nome de membro do cluster"
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr "Colunas"
 
@@ -1113,13 +1113,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1343,7 +1343,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr "EFÊMERO"
 
@@ -1417,7 +1417,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1559,7 +1559,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1618,7 +1618,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1738,11 +1738,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr "IPV6"
 
@@ -1880,12 +1880,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1900,17 +1900,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1953,11 +1953,11 @@ msgstr "Em cache: %s"
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -2098,7 +2098,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2239,11 +2238,11 @@ msgstr "Em cache: %s"
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2545,7 +2544,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2732,15 +2731,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -3183,7 +3182,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3195,7 +3194,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3207,7 +3206,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3638,7 +3637,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3853,7 +3852,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4571,7 +4570,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: 2020-10-08 08:16+0000\n"
 "Last-Translator: Artem <KovalevArtem.ru@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -508,7 +508,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
@@ -673,7 +673,7 @@ msgstr "Авто-обновление: %s"
 msgid "Available projects:"
 msgstr "Доступные команды:"
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr " Использование ЦП:"
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "СОЗДАН"
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr "СОЗДАН"
 
@@ -808,7 +808,7 @@ msgstr "Невозможно прочитать из стандартного в
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -816,7 +816,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -876,7 +876,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr "Столбцы"
 
@@ -1107,13 +1107,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1336,7 +1336,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1404,7 +1404,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1551,7 +1551,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1610,7 +1610,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1725,11 +1725,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1870,12 +1870,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1890,17 +1890,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1943,11 +1943,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -2091,7 +2091,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2233,11 +2232,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2543,7 +2542,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2733,15 +2732,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -3178,7 +3177,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3190,7 +3189,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3202,7 +3201,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3627,7 +3626,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3839,7 +3838,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4922,7 +4921,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: 2020-11-05 02:45+0000\n"
 "Last-Translator: wdggg <wdggg7@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -396,7 +396,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -630,7 +630,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -651,7 +651,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -690,7 +690,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -698,7 +698,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -977,13 +977,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1198,7 +1198,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1264,7 +1264,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1406,7 +1406,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1465,7 +1465,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1580,11 +1580,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1720,12 +1720,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1740,17 +1740,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1793,11 +1793,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1937,7 +1937,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2078,11 +2077,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2374,7 +2373,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2561,15 +2560,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2998,7 +2997,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3010,7 +3009,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3022,7 +3021,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3439,7 +3438,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3651,7 +3650,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4346,7 +4345,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-03-29 14:33-0400\n"
+"POT-Creation-Date: 2021-03-29 23:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:467
+#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:472 lxc/list.go:473
+#: lxc/list.go:491 lxc/list.go:492
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:503
 msgid "CPU USAGE"
 msgstr ""
 
@@ -597,7 +597,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:488
 msgid "CREATED AT"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:490
+#: lxc/list.go:509
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:502 lxc/storage_volume.go:1282
+#: lxc/list.go:521 lxc/storage_volume.go:1282
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1010 lxc/list.go:131 lxc/storage_volume.go:1176
+#: lxc/image.go:1010 lxc/list.go:130 lxc/storage_volume.go:1176
 msgid "Columns"
 msgstr ""
 
@@ -923,13 +923,13 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:470 lxc/network.go:899
+#: lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899
 #: lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621
 #: lxc/project.go:465 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:490
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:752
+#: lxc/list.go:771
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1036 lxc/list.go:514 lxc/storage_volume.go:1293
+#: lxc/image.go:1036 lxc/list.go:533 lxc/storage_volume.go:1293
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:132
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 
 #: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
 #: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:132 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
+#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
 #: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:523
 #: lxc/storage.go:515 lxc/storage_volume.go:1195
 msgid "Format (csv|json|table|yaml)"
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:897
+#: lxc/list.go:484 lxc/network.go:897
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:466 lxc/network.go:898
+#: lxc/list.go:485 lxc/network.go:898
 msgid "IPV6"
 msgstr ""
 
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:546
+#: lxc/list.go:565
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:540
+#: lxc/list.go:559
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1686,17 +1686,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:565
+#: lxc/list.go:584
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:562
+#: lxc/list.go:581
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:553
+#: lxc/list.go:572
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1739,11 +1739,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:474
+#: lxc/list.go:493
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:498 lxc/network.go:973 lxc/operation.go:165
+#: lxc/list.go:517 lxc/network.go:973 lxc/operation.go:165
 #: lxc/storage_volume.go:1278
 msgid "LOCATION"
 msgstr ""
@@ -1883,7 +1883,6 @@ msgid ""
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
-"  - name={instance name}\n"
 "  - location={location name}\n"
 "  - ipv4={ip or CIDR}\n"
 "  - ipv6={ip or CIDR}\n"
@@ -2024,11 +2023,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:475
+#: lxc/list.go:494
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:476
+#: lxc/list.go:495
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2320,7 +2319,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:477 lxc/network.go:894 lxc/network_acl.go:140
+#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
 #: lxc/profile.go:620 lxc/project.go:460 lxc/remote.go:577 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
@@ -2507,15 +2506,15 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:479
+#: lxc/list.go:498
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:478
+#: lxc/list.go:497
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:480 lxc/project.go:462
+#: lxc/list.go:499 lxc/project.go:462
 msgid "PROFILES"
 msgstr ""
 
@@ -2944,7 +2943,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:481
+#: lxc/list.go:500
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2956,7 +2955,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:482 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -2968,7 +2967,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:487
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3385,7 +3384,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:483 lxc/network.go:895
+#: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 msgid "TYPE"
 msgstr ""
@@ -3597,7 +3596,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1043 lxc/list.go:528 lxc/storage_volume.go:1300
+#: lxc/image.go:1043 lxc/list.go:547 lxc/storage_volume.go:1300
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -4292,7 +4291,7 @@ msgid ""
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:120
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"


### PR DESCRIPTION
 - Removes duplicate filter (name=)
 - Cleanup list logic a bit
 - Make ipv4/ipv6 filters apply to current addresses instead of config
 - Optimize filtering to apply to InstanceFull too