### PR TITLE
Storage: Remove duplicated attempts to unmap in DeleteVolume

### DIFF
--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2015,7 +2015,17 @@ test_clustering_remove_raft_node() {
   kill -9 "$(cat "${LXD_TWO_DIR}/lxd.pid")"
 
   # Remove the second node from the database but not from the raft configuration.
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "DELETE FROM nodes WHERE address = '10.1.1.102:8443'"
+  retries=10
+  while [ "${retries}" != "0" ]; do
+    LXD_DIR="${LXD_ONE_DIR}" lxd sql global "DELETE FROM nodes WHERE address = '10.1.1.102:8443'" && break
+    sleep 0.5
+    retries=$((retries-1))
+  done
+
+  if [ "${retries}" -eq 0 ]; then
+      echo "Failed to remove node from database"
+      return 1
+  fi
 
   # The node does not appear anymore in the cluster list.
   ! LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep -q "node2" || false


### PR DESCRIPTION
I cannot see a reason why we were ignoring the unmount volume errors (which would also return unmap errors https://github.com/lxc/lxd/blob/master/lxd/storage/drivers/driver_ceph_volumes.go#L1053-L1058 and https://github.com/lxc/lxd/blob/master/lxd/storage/drivers/driver_ceph_volumes.go#L1072-L1089), as if the volume is mounted or mapped and cannot be unmounted/unmapped, then it cannot be deleted as I understand.

Also adds a retry for a `test_clustering_remove_raft_node` test to make it more reliable in the face of DB locking.