### PR TITLE
Import: Maintain effective root disk config from backup.yaml when doing import

### DIFF
--- a/lxd/api_internal_test.go
+++ b/lxd/api_internal_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lxc/lxd/shared/api"
+)
+
+// Test that an instance with a local root disk device just gets its pool property modified.
+func TestInternalImportRootDevicePopulate_LocalDevice(t *testing.T) {
+	instancePoolName := "test"
+	localDevices := make(map[string]map[string]string, 0)
+
+	localRootDev := map[string]string{
+		"type": "disk",
+		"path": "/",
+		"pool": "oldpool",
+		"size": "15GB",
+	}
+
+	localDevices["root"] = localRootDev
+
+	internalImportRootDevicePopulate(instancePoolName, localDevices, nil, nil)
+
+	assert.Equal(t, instancePoolName, localDevices["root"]["pool"])
+	assert.Equal(t, localRootDev["type"], localDevices["root"]["type"])
+	assert.Equal(t, localRootDev["path"], localDevices["root"]["path"])
+	assert.Equal(t, localRootDev["size"], localDevices["root"]["size"])
+}
+
+// Test that an instance with no local root disk device but has a root disk from its old expanded profile devices,
+// that doesn't match the root disk in the new profiles, gets it added back as a local disk, with the pool property
+// modified.
+func TestInternalImportRootDevicePopulate_ExpandedDeviceProfileDeviceMismatch(t *testing.T) {
+	instancePoolName := "test"
+	localDevices := make(map[string]map[string]string, 0)
+	expandedDevices := make(map[string]map[string]string, 0)
+
+	expandedRootDev := map[string]string{
+		"type": "disk",
+		"path": "/",
+		"pool": "oldpool",
+		"size": "15GB",
+	}
+
+	expandedDevices["root"] = expandedRootDev
+
+	profiles := []api.Profile{
+		{
+			Name: "default",
+		},
+	}
+
+	internalImportRootDevicePopulate(instancePoolName, localDevices, expandedDevices, profiles)
+
+	assert.Equal(t, instancePoolName, localDevices["root"]["pool"])
+	assert.Equal(t, expandedRootDev["type"], localDevices["root"]["type"])
+	assert.Equal(t, expandedRootDev["path"], localDevices["root"]["path"])
+	assert.Equal(t, expandedRootDev["size"], localDevices["root"]["size"])
+}
+
+// Test that an instance with no local root disk device but has a root disk from its old expanded profile devices,
+// that matches the new profile root disk device (excluding pool name), and the new profile root disk matches the
+// target pool, then no local root disk device is added, and the instance will continue to use the profile root
+// disk device.
+func TestInternalImportRootDevicePopulate_ExpandedDeviceProfileDeviceMatch(t *testing.T) {
+	instancePoolName := "test"
+	localDevices := make(map[string]map[string]string, 0)
+	expandedDevices := make(map[string]map[string]string, 0)
+
+	expandedRootDev := map[string]string{
+		"type": "disk",
+		"path": "/",
+		"pool": "oldpool",
+		"size": "15GB",
+	}
+
+	expandedDevices["root"] = expandedRootDev
+
+	profiles := []api.Profile{
+		{
+			Name: "default",
+			ProfilePut: api.ProfilePut{
+				Devices: make(map[string]map[string]string, 0),
+			},
+		},
+	}
+
+	profiles[0].Devices["root"] = map[string]string{
+		"type": "disk",
+		"path": "/",
+		"pool": instancePoolName,
+		"size": "15GB",
+	}
+
+	internalImportRootDevicePopulate(instancePoolName, localDevices, expandedDevices, profiles)
+
+	assert.Equal(t, len(localDevices), 0)
+}
+
+// Test that for an instance with no local root disk device, if the new profile root disk device doesn't match the
+// target pool that the old expanded root device is added as a local root disk device (with the pool modified).
+func TestInternalImportRootDevicePopulate_ExpandedDeviceProfileDevicePoolMismatch(t *testing.T) {
+	instancePoolName := "test"
+	localDevices := make(map[string]map[string]string, 0)
+	expandedDevices := make(map[string]map[string]string, 0)
+
+	expandedRootDev := map[string]string{
+		"type": "disk",
+		"path": "/",
+		"pool": "oldpool",
+		"size": "15GB",
+	}
+
+	expandedDevices["root"] = expandedRootDev
+
+	profiles := []api.Profile{
+		{
+			Name: "default",
+			ProfilePut: api.ProfilePut{
+				Devices: make(map[string]map[string]string, 0),
+			},
+		},
+	}
+
+	profiles[0].Devices["root"] = map[string]string{
+		"type": "disk",
+		"path": "/",
+		"pool": "wrongpool",
+		"size": "15GB",
+	}
+
+	internalImportRootDevicePopulate(instancePoolName, localDevices, expandedDevices, profiles)
+
+	assert.Equal(t, instancePoolName, localDevices["root"]["pool"])
+	assert.Equal(t, expandedRootDev["type"], localDevices["root"]["type"])
+	assert.Equal(t, expandedRootDev["path"], localDevices["root"]["path"])
+	assert.Equal(t, expandedRootDev["size"], localDevices["root"]["size"])
+}
+
+// Test that if old config has no root disk device, and neither does new profiles, then a basic local root disk
+// device is added using the target pool.
+func TestInternalImportRootDevicePopulate_NoExistingRootDiskDevice(t *testing.T) {
+	instancePoolName := "test"
+	localDevices := make(map[string]map[string]string, 0)
+
+	internalImportRootDevicePopulate(instancePoolName, localDevices, nil, nil)
+
+	assert.Equal(t, instancePoolName, localDevices["root"]["pool"])
+	assert.Equal(t, "disk", localDevices["root"]["type"])
+	assert.Equal(t, "/", localDevices["root"]["path"])
+}
+
+// Test that if old config has no root disk device, and neither does new profiles, then a basic local root disk
+// device is added using the target pool, and if there is already a local device called "root", then this new root
+// disk device is added under an automatically generated name.
+func TestInternalImportRootDevicePopulate_NoExistingRootDiskDeviceNameConflict(t *testing.T) {
+	instancePoolName := "test"
+	localDevices := make(map[string]map[string]string, 0)
+
+	localConflictingRootDev := map[string]string{
+		"type":    "nic",
+		"nictype": "bridged",
+		"name":    "eth0",
+	}
+
+	localDevices["root"] = localConflictingRootDev // Conflicting device called "root".
+
+	internalImportRootDevicePopulate(instancePoolName, localDevices, nil, nil)
+
+	assert.Equal(t, instancePoolName, localDevices["root0"]["pool"])
+	assert.Equal(t, "disk", localDevices["root0"]["type"])
+	assert.Equal(t, "/", localDevices["root0"]["path"])
+}

--- a/lxd/db/profiles.go
+++ b/lxd/db/profiles.go
@@ -165,23 +165,25 @@ func (c *ClusterTx) getProfile(project, name string) (int64, *api.Profile, error
 }
 
 // GetProfiles returns the profiles with the given names in the given project.
-func (c *Cluster) GetProfiles(project string, names []string) ([]api.Profile, error) {
-	profiles := make([]api.Profile, len(names))
+func (c *Cluster) GetProfiles(projectName string, profileNames []string) ([]api.Profile, error) {
+	profiles := make([]api.Profile, len(profileNames))
 
 	err := c.Transaction(func(tx *ClusterTx) error {
-		enabled, err := tx.ProjectHasProfiles(project)
+		enabled, err := tx.ProjectHasProfiles(projectName)
 		if err != nil {
-			return errors.Wrap(err, "Check if project has profiles")
-		}
-		if !enabled {
-			project = "default"
+			return errors.Wrapf(err, "Failed checking if project %q has profiles", projectName)
 		}
 
-		for i, name := range names {
-			profile, err := tx.GetProfile(project, name)
+		if !enabled {
+			projectName = "default"
+		}
+
+		for i, profileName := range profileNames {
+			profile, err := tx.GetProfile(projectName, profileName)
 			if err != nil {
-				return errors.Wrapf(err, "Load profile %q", name)
+				return errors.Wrapf(err, "Failed loading profile %q", profileName)
 			}
+
 			profiles[i] = *ProfileToAPI(profile)
 		}
 

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -156,6 +156,19 @@ test_container_import() {
     lxc delete --force ctImport
     # FIXME: the daemon code should get rid of this leftover db entry
     lxd sql global "PRAGMA foreign_keys=ON; DELETE FROM storage_volumes WHERE name='ctImport/snap0'"
+
+    lxc init testimage ctImport
+    lxc snapshot ctImport
+    lxc start ctImport
+    lxd import ctImport --force
+    lxc config device show ctImport | grep '{}'
+
+    lxc config device override ctImport root size=11GB
+    lxd import ctImport --force
+    lxc config device show ctImport | grep 'size: 11GB'
+
+    lxc delete --force ctImport
+
   )
   # shellcheck disable=SC2031
   LXD_DIR=${LXD_DIR}


### PR DESCRIPTION
- If backup.yaml contains a local root disk device, always keep that (just update `pool` property to match target pool).
- If backup.yaml doesn't contain a local root disk device, and profile's expanded root disk pool doesn't match target pool, then add new local root disk device, setting `pool` to target pool, and inheriting any extra config from the expanded root disk device in backup.yaml.
- If backup.yaml doesn't contain a local root disk device, and profile's expanded root disk pool does match target pool, but profile's expanded disk config doesn't match expanded root disk device in backup.yaml (excluding `pool` property), then add new local root disk device, setting `pool` to target pool, and inheriting any extra config from the expanded root disk device in backup.yaml.
- If backup.yaml doesn't contain a local root disk device, and profile's expanded root disk pool does match target pool, and profile's expanded disk config does match expanded root disk device in backup.yaml (excluding `pool` property), then don't add local device, and instance will to use profile device.

- [x] Tests

Fixes https://github.com/lxc/lxd/issues/8619