### PR TITLE
cluster: Larger Timeout to find leader

### DIFF
--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -610,7 +610,7 @@ assign:
 		"Changing dqlite raft role",
 		log15.Ctx{"id": info.ID, "address": info.Address, "role": info.Role})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
 	client, err := client.FindLeader(ctx, gateway.NodeStore(), client.WithDialFunc(gateway.raftDial()))
@@ -935,7 +935,7 @@ func List(state *state.State, gateway *Gateway) ([]api.ClusterMember, error) {
 	store := gateway.NodeStore()
 	dial := gateway.DialFunc()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
 	cli, err := client.FindLeader(ctx, store, client.WithDialFunc(dial))

--- a/lxd/cluster/recover.go
+++ b/lxd/cluster/recover.go
@@ -108,7 +108,7 @@ func RemoveRaftNode(gateway *Gateway, address string) error {
 		return fmt.Errorf("No raft node with address %q", address)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 	client, err := client.FindLeader(
 		ctx, gateway.NodeStore(),


### PR DESCRIPTION
go-dqlite has an internal timeout of 5s when attempting to contact a
node. If the timeout of the parent context is not large enough, an
unreachable node might consume the whole time budget, and other,
possible reachable nodes will not be attempted anymore leading to
observed failures while in fact the cluster is healthy.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>