### PR TITLE
Network: Firewall interface refactor

### DIFF
--- a/lxd/firewall/drivers/drivers_consts.go
+++ b/lxd/firewall/drivers/drivers_consts.go
@@ -1,7 +1,30 @@
 package drivers
 
+import "net"
+
 // FilterIPv6All used to indicate to firewall package to filter all IPv6 traffic.
 const FilterIPv6All = "::"
 
 // FilterIPv4All used to indicate to firewall package to filter all IPv4 traffic.
 const FilterIPv4All = "0.0.0.0"
+
+// FeatureOpts specify how firewall features are setup.
+type FeatureOpts struct {
+	DHCPDNSAccess   bool // Add rules to allow DHCP and DNS access.
+	ForwardingAllow bool // Add rules to allow IP forwarding. Blocked if false.
+}
+
+// SNATOpts specify how SNAT rules are setup.
+type SNATOpts struct {
+	Append      bool       // Append rules (has no effect if driver doesn't support it).
+	Subnet      *net.IPNet // Subnet of source network used to identify candidate traffic.
+	SNATAddress net.IP     // SNAT IP address to use. If nil then MASQUERADE is used.
+}
+
+// Opts for setting up the firewall.
+type Opts struct {
+	FeaturesV4 *FeatureOpts // Enable IPv4 firewall with specified options. Off if not provided.
+	FeaturesV6 *FeatureOpts // Enable IPv6 firewall with specified options. Off if not provided.
+	SNATV4     *SNATOpts    // Enable IPv4 SNAT with specified options. Off if not provided.
+	SNATV6     *SNATOpts    // Enable IPv6 SNAT with specified options. Off if not provided.
+}

--- a/lxd/firewall/firewall_interface.go
+++ b/lxd/firewall/firewall_interface.go
@@ -4,6 +4,7 @@ import (
 	"net"
 
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
+	drivers "github.com/lxc/lxd/lxd/firewall/drivers"
 )
 
 // Firewall represents a LXD firewall.
@@ -11,10 +12,7 @@ type Firewall interface {
 	String() string
 	Compat() (bool, error)
 
-	NetworkSetupForwardingPolicy(networkName string, ipVersion uint, allow bool) error
-	NetworkSetupOutboundNAT(networkName string, subnet *net.IPNet, srcIP net.IP, append bool) error
-	NetworkSetupDHCPDNSAccess(networkName string, ipVersion uint) error
-	NetworkSetupDHCPv4Checksum(networkName string) error
+	NetworkSetup(networkName string, opts drivers.Opts) error
 	NetworkClear(networkName string, ipVersion uint) error
 
 	InstanceSetupBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4 net.IP, IPv6 net.IP) error


### PR DESCRIPTION
Simplify `Firewall` interface so that there is only 1 `NetworkSetup` function rather than per-feature setup functions.

This will allow each driver to apply the requested config in a predictable order and in the most efficient way allowed by each driver  (these will be delivered in separate PRs). 