### PR TITLE
Firewall: Switch to using network-specific NIC filtering chain in xtables driver

### DIFF
--- a/lxd/firewall/drivers/drivers_nftables.go
+++ b/lxd/firewall/drivers/drivers_nftables.go
@@ -303,16 +303,19 @@ func (d Nftables) NetworkSetup(networkName string, opts Opts) error {
 }
 
 // NetworkClear removes the LXD network related chains.
-func (d Nftables) NetworkClear(networkName string, ipVersion uint) error {
-	family, err := d.getIPFamily(ipVersion)
-	if err != nil {
-		return err
-	}
+// The delete argument has no effect for nftables driver.
+func (d Nftables) NetworkClear(networkName string, delete bool, ipVersions []uint) error {
+	for _, ipVersion := range ipVersions {
+		family, err := d.getIPFamily(ipVersion)
+		if err != nil {
+			return err
+		}
 
-	// Remove chains created by network rules.
-	err = d.removeChains([]string{family}, networkName, "fwd", "pstrt", "in", "out")
-	if err != nil {
-		return errors.Wrapf(err, "Failed clearing nftables rules for network %q", networkName)
+		// Remove chains created by network rules.
+		err = d.removeChains([]string{family}, networkName, "fwd", "pstrt", "in", "out")
+		if err != nil {
+			return errors.Wrapf(err, "Failed clearing nftables rules for network %q", networkName)
+		}
 	}
 
 	return nil

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -884,3 +884,29 @@ func (d Xtables) iptablesChainCreate(ipVersion uint, table string, chain string)
 
 	return nil
 }
+
+// iptablesChainDelete deletes a chain in a table.
+func (d Xtables) iptablesChainDelete(ipVersion uint, table string, chain string) error {
+	var cmd string
+	if ipVersion == 4 {
+		cmd = "iptables"
+	} else if ipVersion == 6 {
+		cmd = "ip6tables"
+	} else {
+		return fmt.Errorf("Invalid IP version")
+	}
+
+	// Attempt to flush rules from chain in table.
+	_, err := shared.RunCommand(cmd, "-t", table, "-F", chain)
+	if err != nil {
+		return errors.Wrapf(err, "Failed flushing %q chain %q in table %q", cmd, chain, table)
+	}
+
+	// Attempt to delete chain in table.
+	_, err = shared.RunCommand(cmd, "-t", table, "-X", chain)
+	if err != nil {
+		return errors.Wrapf(err, "Failed deleting %q chain %q in table %q", cmd, chain, table)
+	}
+
+	return nil
+}

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -628,12 +628,14 @@ func (d Xtables) generateFilterIptablesRules(parentName string, hostName string,
 	// correct source address and MAC at the IP & ethernet layers, but a fraudulent IP or MAC
 	// inside the ICMPv6 NDP packet.
 	if IPv6 != nil {
+		chain := fmt.Sprintf("%s_%s", iptablesChainNICFilterPrefix, parentName)
+
 		ipv6Hex := hex.EncodeToString(IPv6)
 		rules = append(rules,
 			// Prevent Neighbor Advertisement IP spoofing (prevents the instance redirecting traffic for IPs that are not its own).
-			[]string{"6", iptablesChainNICFilter, "-i", parentName, "-p", "ipv6-icmp", "-m", "physdev", "--physdev-in", hostName, "-m", "icmp6", "--icmpv6-type", "136", "-m", "string", "!", "--hex-string", fmt.Sprintf("|%s|", ipv6Hex), "--algo", "bm", "--from", "48", "--to", "64", "-j", "DROP"},
+			[]string{"6", chain, "-i", parentName, "-p", "ipv6-icmp", "-m", "physdev", "--physdev-in", hostName, "-m", "icmp6", "--icmpv6-type", "136", "-m", "string", "!", "--hex-string", fmt.Sprintf("|%s|", ipv6Hex), "--algo", "bm", "--from", "48", "--to", "64", "-j", "DROP"},
 			// Prevent Neighbor Advertisement MAC spoofing (prevents the instance poisoning the NDP cache of its neighbours with a MAC address that isn't its own).
-			[]string{"6", iptablesChainNICFilter, "-i", parentName, "-p", "ipv6-icmp", "-m", "physdev", "--physdev-in", hostName, "-m", "icmp6", "--icmpv6-type", "136", "-m", "string", "!", "--hex-string", fmt.Sprintf("|%s|", macHex), "--algo", "bm", "--from", "66", "--to", "72", "-j", "DROP"},
+			[]string{"6", chain, "-i", parentName, "-p", "ipv6-icmp", "-m", "physdev", "--physdev-in", hostName, "-m", "icmp6", "--icmpv6-type", "136", "-m", "string", "!", "--hex-string", fmt.Sprintf("|%s|", macHex), "--algo", "bm", "--from", "66", "--to", "72", "-j", "DROP"},
 		)
 	}
 

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -876,13 +876,8 @@ func (d Xtables) iptablesChainCreate(ipVersion uint, table string, chain string)
 		return fmt.Errorf("Invalid IP version")
 	}
 
-	_, err := exec.LookPath(cmd)
-	if err != nil {
-		return errors.Wrapf(err, "Failed creating %q chain %q in table %q", cmd, chain, table)
-	}
-
 	// Attempt to create chain in table.
-	_, err = shared.RunCommand(cmd, "-t", table, "-N", chain)
+	_, err := shared.RunCommand(cmd, "-t", table, "-N", chain)
 	if err != nil {
 		return errors.Wrapf(err, "Failed creating %q chain %q in table %q", cmd, chain, table)
 	}

--- a/lxd/firewall/firewall_interface.go
+++ b/lxd/firewall/firewall_interface.go
@@ -13,7 +13,7 @@ type Firewall interface {
 	Compat() (bool, error)
 
 	NetworkSetup(networkName string, opts drivers.Opts) error
-	NetworkClear(networkName string, ipVersion uint) error
+	NetworkClear(networkName string, delete bool, ipVersions []uint) error
 
 	InstanceSetupBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4 net.IP, IPv6 net.IP) error
 	InstanceClearBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4 net.IP, IPv6 net.IP) error

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -741,11 +741,22 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		}
 	}
 
-	// Remove any existing IPv4 firewall rules.
+	// Remove any existing firewall rules.
+	fwClearIPVersions := []uint{}
+
 	if usesIPv4Firewall(n.config) || usesIPv4Firewall(oldConfig) {
-		err = n.state.Firewall.NetworkClear(n.name, 4)
+		fwClearIPVersions = append(fwClearIPVersions, 4)
+	}
+
+	if usesIPv6Firewall(n.config) || usesIPv6Firewall(oldConfig) {
+		fwClearIPVersions = append(fwClearIPVersions, 6)
+	}
+
+	if len(fwClearIPVersions) > 0 {
+		n.logger.Debug("Clearing firewall")
+		err = n.state.Firewall.NetworkClear(n.name, false, fwClearIPVersions)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "Failed clearing firewall")
 		}
 	}
 
@@ -905,14 +916,6 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 
 		// Restore container specific IPv4 routes to interface.
 		n.applyBootRoutesV4(ctRoutes)
-	}
-
-	// Remove any existing IPv6 firewall rules.
-	if usesIPv6Firewall(n.config) || usesIPv6Firewall(oldConfig) {
-		err = n.state.Firewall.NetworkClear(n.name, 6)
-		if err != nil {
-			return err
-		}
 	}
 
 	// Snapshot container specific IPv6 routes (added with boot proto) before removing IPv6 addresses.

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1489,18 +1489,22 @@ func (n *bridge) Stop() error {
 		}
 	}
 
-	// Cleanup firewall rules.
+	// Fully clear firewall setup.
+	fwClearIPVersions := []uint{}
+
 	if usesIPv4Firewall(n.config) {
-		err := n.state.Firewall.NetworkClear(n.name, 4)
-		if err != nil {
-			return err
-		}
+		fwClearIPVersions = append(fwClearIPVersions, 4)
 	}
 
 	if usesIPv6Firewall(n.config) {
-		err := n.state.Firewall.NetworkClear(n.name, 6)
+		fwClearIPVersions = append(fwClearIPVersions, 6)
+	}
+
+	if len(fwClearIPVersions) > 0 {
+		n.logger.Debug("Deleting firewall")
+		err := n.state.Firewall.NetworkClear(n.name, true, fwClearIPVersions)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "Failed deleting firewall")
 		}
 	}
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1457,6 +1457,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 	}
 
 	// Setup firewall.
+	n.logger.Debug("Setting up firewall")
 	err = n.state.Firewall.NetworkSetup(n.name, fwOpts)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to setup firewall")


### PR DESCRIPTION
In https://github.com/lxc/lxd/pull/8637 we moved to using a separate chain for NIC security filtering rules so they took precedence over the default forwarding policy rules (when LXD was reloaded and the network config was reapplied).

Initially I used a single chain called `lxd_nic` that would contain the NIC rules for all `bridge` networks.
This meant that when an individual network was deleted we didn't need to remove the `lxd_nic` chain.

However with the forthcoming ACL support for bridge networks, we will need to introduce a per-network ACL rule chain, which will require support deleting the chain when the network is deleted.

As we are going to introduce this for ACLs, it makes sense to me to also use the same approach for NIC filtering rules, and switch to a per-network chain for these (before LXD is released with https://github.com/lxc/lxd/pull/8637). This will also be beneficial as xtables won't have to traverse through every NIC rule for all bridge networks, and only needs to consult the NIC rules for the particular network.

This modifies `NetworkClear()` to accept a list of ipVersions to clear up (so we can eventually achieve optimisations for the nftables driver by clearing all versions in a single exec call to nft), as well as a `delete` argument that will indicate to the `xtables` driver we need to delete the per-network chains.

Tested `lxd_container_devices_bridged_filtering` test on both iptables and nftables.
