### PR TITLE
Storage: Only mount instance filesystem volumes in postHook for ZFS CreateVolumeFromBackup

### DIFF
--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -409,7 +409,8 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 
 	var postHook func(vol Volume) error
 
-	if vol.volType != VolumeTypeCustom {
+	// Only mount instance filesystem volumes for backup.yaml access.
+	if vol.volType != VolumeTypeCustom && vol.contentType != ContentTypeBlock {
 		// The import requires a mounted volume, so mount it and have it unmounted as a post hook.
 		err = d.MountVolume(vol, op)
 		if err != nil {


### PR DESCRIPTION
Otherwise calling MountVolume for an instance block volume will increment the filesystem volume mount ref counter again, as MountVolume would have already been called for the filesystem volume as part of the recursive call to CreateVolumeFromBackup for VM Block volumes above.

And as we don't use the post hook function from that function call, we'd end up leaving the filesystem volume of a block volume mounted due to the extra ref count.

Fixes #8649

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>