### PR TITLE
Firewall: Changes nftables to use a single inet table rather than separate ip and ip6 tables

### DIFF
--- a/lxd/firewall/drivers/drivers_nftables_templates.go
+++ b/lxd/firewall/drivers/drivers_nftables_templates.go
@@ -13,18 +13,29 @@ table {{.family}} {{.namespace}} {
 var nftablesNetForwardingPolicy = template.Must(template.New("nftablesNetForwardingPolicy").Parse(`
 chain fwd{{.chainSeparator}}{{.networkName}} {
 	type filter hook forward priority 0; policy accept;
-	oifname "{{.networkName}}" {{.action}}
-	iifname "{{.networkName}}" {{.action}}
+
+	{{if .ip4Action -}}
+	ip version 4 oifname "{{.networkName}}" {{.ip4Action}}
+	ip version 4 iifname "{{.networkName}}" {{.ip4Action}}
+	{{- end}}
+
+	{{if .ip6Action -}}
+	ip6 version 6 oifname "{{.networkName}}" {{.ip6Action}}
+	ip6 version 6 iifname "{{.networkName}}" {{.ip6Action}}
+	{{- end}}
 }
 `))
 
 var nftablesNetOutboundNAT = template.Must(template.New("nftablesNetOutboundNAT").Parse(`
 chain pstrt{{.chainSeparator}}{{.networkName}} {
 	type nat hook postrouting priority 100; policy accept;
-	{{if .srcIP -}}
-	{{.family}} saddr {{.subnet}} {{.family}} daddr != {{.subnet}} snat {{.srcIP}}
+
+	{{- range $ipFamily, $config := .rules}}
+	{{if $config.SNATAddress -}}
+	{{$ipFamily}} saddr {{$config.Subnet}} {{$ipFamily}} daddr != {{$config.Subnet}} snat {{$config.SNATAddress}}
 	{{else -}}
-	{{.family}} saddr {{.subnet}} {{.family}} daddr != {{.subnet}} masquerade
+	{{$ipFamily}} saddr {{$config.Subnet}} {{$ipFamily}} daddr != {{$config.Subnet}} masquerade
+	{{- end}}
 	{{- end}}
 }
 `))
@@ -32,23 +43,31 @@ chain pstrt{{.chainSeparator}}{{.networkName}} {
 var nftablesNetDHCPDNS = template.Must(template.New("nftablesNetDHCPDNS").Parse(`
 chain in{{.chainSeparator}}{{.networkName}} {
 	type filter hook input priority 0; policy accept;
+
 	iifname "{{.networkName}}" tcp dport 53 accept
 	iifname "{{.networkName}}" udp dport 53 accept
-	{{if eq .family "ip" -}}
-	iifname "{{.networkName}}" udp dport 67 accept
+
+	{{- range .ipFamilies}}
+	{{if eq . "ip" -}}
+	iifname "{{$.networkName}}" udp dport 67 accept
 	{{else -}}
-	iifname "{{.networkName}}" udp dport 547 accept
+	iifname "{{$.networkName}}" udp dport 547 accept
+	{{- end}}
 	{{- end}}
 }
 
 chain out{{.chainSeparator}}{{.networkName}} {
 	type filter hook output priority 0; policy accept;
+
 	oifname "{{.networkName}}" tcp sport 53 accept
 	oifname "{{.networkName}}" udp sport 53 accept
-	{{if eq .family "ip" -}}
-	oifname "{{.networkName}}" udp sport 67 accept
+
+	{{- range .ipFamilies}}
+	{{if eq . "ip" -}}
+	oifname "{{$.networkName}}" udp sport 67 accept
 	{{else -}}
-	oifname "{{.networkName}}" udp sport 547 accept
+	oifname "{{$.networkName}}" udp sport 547 accept
+	{{- end}}
 	{{- end}}
 }
 `))
@@ -57,21 +76,21 @@ var nftablesNetProxyNAT = template.Must(template.New("nftablesNetProxyNAT").Pars
 chain prert{{.chainSeparator}}{{.deviceLabel}} {
 	type nat hook prerouting priority -100; policy accept;
 	{{- range .rules}}
-	{{.family}} daddr {{.listenHost}} {{.connType}} dport {{.listenPort}} dnat to {{.connectDest}}
+	{{.ipFamily}} daddr {{.listenHost}} {{.connType}} dport {{.listenPort}} dnat to {{.connectDest}}
 	{{- end}}
 }
 
 chain out{{.chainSeparator}}{{.deviceLabel}} {
 	type nat hook output priority -100; policy accept;
 	{{- range .rules}}
-	{{.family}} daddr {{.listenHost}} {{.connType}} dport {{.listenPort}} dnat to {{.connectDest}}
+	{{.ipFamily}} daddr {{.listenHost}} {{.connType}} dport {{.listenPort}} dnat to {{.connectDest}}
 	{{- end}}
 }
 
 chain pstrt{{.chainSeparator}}{{.deviceLabel}} {
 	type nat hook postrouting priority 100; policy accept;
 	{{- range .rules}}
-	{{.family}} saddr {{.connectHost}} {{.family}} daddr {{.connectHost}} {{.connType}} dport {{.connectPort}} masquerade
+	{{.ipFamily}} saddr {{.connectHost}} {{.ipFamily}} daddr {{.connectHost}} {{.connType}} dport {{.connectPort}} masquerade
 	{{- end}}
 }
 `))

--- a/test/suites/container_devices_proxy.sh
+++ b/test/suites/container_devices_proxy.sh
@@ -164,16 +164,16 @@ container_devices_proxy_tcp() {
   if [ "$firewallDriver" = "xtables" ]; then
     [ "$(iptables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 0 ]
   else
-    ! nft -nn list chain ip lxd prert.nattest.validNAT
-    ! nft -nn list chain ip lxd out.nattest.validNAT
+    ! nft -nn list chain inet lxd prert.nattest.validNAT
+    ! nft -nn list chain inet lxd out.nattest.validNAT
   fi
 
   lxc config device add nattest validNAT proxy listen="tcp:127.0.0.1:1234" connect="tcp:${v4_addr}:1234" bind=host
   if [ "$firewallDriver" = "xtables" ]; then
     [ "$(iptables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 0 ]
   else
-    ! nft -nn list chain ip lxd prert.nattest.validNAT
-    ! nft -nn list chain ip lxd out.nattest.validNAT
+    ! nft -nn list chain inet lxd prert.nattest.validNAT
+    ! nft -nn list chain inet lxd out.nattest.validNAT
   fi
 
   # enable NAT
@@ -181,52 +181,52 @@ container_devices_proxy_tcp() {
   if [ "$firewallDriver" = "xtables" ]; then
     [ "$(iptables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 3 ]
   else
-      [ "$(nft -nn list chain ip lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat to ${v4_addr}:1234")" -eq 1 ]
-      [ "$(nft -nn list chain ip lxd out.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat to ${v4_addr}:1234")" -eq 1 ]
+      [ "$(nft -nn list chain inet lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat ip to ${v4_addr}:1234")" -eq 1 ]
+      [ "$(nft -nn list chain inet lxd out.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat ip to ${v4_addr}:1234")" -eq 1 ]
   fi
 
   lxc config device remove nattest validNAT
   if [ "$firewallDriver" = "xtables" ]; then
     [ "$(iptables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 0 ]
   else
-    ! nft -nn list chain ip lxd prert.nattest.validNAT
-    ! nft -nn list chain ip lxd out.nattest.validNAT
+    ! nft -nn list chain inet lxd prert.nattest.validNAT
+    ! nft -nn list chain inet lxd out.nattest.validNAT
   fi
 
   lxc config device add nattest validNAT proxy listen="tcp:127.0.0.1:1234-1235" connect="tcp:${v4_addr}:1234" bind=host nat=true
   if [ "$firewallDriver" = "xtables" ]; then
     [ "$(iptables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 5 ]
   else
-      [ "$(nft -nn list chain ip lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat to ${v4_addr}:1234")" -eq 1 ]
-      [ "$(nft -nn list chain ip lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1235 dnat to ${v4_addr}:1234")" -eq 1 ]
-      [ "$(nft -nn list chain ip lxd out.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat to ${v4_addr}:1234")" -eq 1 ]
-      [ "$(nft -nn list chain ip lxd out.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1235 dnat to ${v4_addr}:1234")" -eq 1 ]
+      [ "$(nft -nn list chain inet lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat ip to ${v4_addr}:1234")" -eq 1 ]
+      [ "$(nft -nn list chain inet lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1235 dnat ip to ${v4_addr}:1234")" -eq 1 ]
+      [ "$(nft -nn list chain inet lxd out.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat ip to ${v4_addr}:1234")" -eq 1 ]
+      [ "$(nft -nn list chain inet lxd out.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1235 dnat ip to ${v4_addr}:1234")" -eq 1 ]
   fi
 
   lxc config device remove nattest validNAT
   if [ "$firewallDriver" = "xtables" ]; then
     [ "$(iptables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 0 ]
   else
-    ! nft -nn list chain ip lxd prert.nattest.validNAT
-    ! nft -nn list chain ip lxd out.nattest.validNAT
+    ! nft -nn list chain inet lxd prert.nattest.validNAT
+    ! nft -nn list chain inet lxd out.nattest.validNAT
   fi
 
   lxc config device add nattest validNAT proxy listen="tcp:127.0.0.1:1234-1235" connect="tcp:${v4_addr}:1234-1235" bind=host nat=true
   if [ "$firewallDriver" = "xtables" ]; then
     [ "$(iptables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 6 ]
   else
-      [ "$(nft -nn list chain ip lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat to ${v4_addr}:1234")" -eq 1 ]
-      [ "$(nft -nn list chain ip lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1235 dnat to ${v4_addr}:1235")" -eq 1 ]
-      [ "$(nft -nn list chain ip lxd out.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat to ${v4_addr}:1234")" -eq 1 ]
-      [ "$(nft -nn list chain ip lxd out.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1235 dnat to ${v4_addr}:1235")" -eq 1 ]
+      [ "$(nft -nn list chain inet lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat ip to ${v4_addr}:1234")" -eq 1 ]
+      [ "$(nft -nn list chain inet lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1235 dnat ip to ${v4_addr}:1235")" -eq 1 ]
+      [ "$(nft -nn list chain inet lxd out.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat ip to ${v4_addr}:1234")" -eq 1 ]
+      [ "$(nft -nn list chain inet lxd out.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1235 dnat ip to ${v4_addr}:1235")" -eq 1 ]
   fi
 
   lxc config device remove nattest validNAT
   if [ "$firewallDriver" = "xtables" ]; then
     [ "$(iptables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 0 ]
   else
-    ! nft -nn list chain ip lxd prert.nattest.validNAT
-    ! nft -nn list chain ip lxd out.nattest.validNAT
+    ! nft -nn list chain inet lxd prert.nattest.validNAT
+    ! nft -nn list chain inet lxd out.nattest.validNAT
   fi
 
   # IPv6 test
@@ -234,16 +234,16 @@ container_devices_proxy_tcp() {
   if [ "$firewallDriver" = "xtables" ]; then
     [ "$(ip6tables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 3 ]
   else
-      [ "$(nft -nn list chain ip6 lxd prert.nattest.validNAT | grep -c "ip6 daddr ::1 tcp dport 1234 dnat to \[${v6_addr}\]:1234")" -eq 1 ]
-      [ "$(nft -nn list chain ip6 lxd out.nattest.validNAT | grep -c "ip6 daddr ::1 tcp dport 1234 dnat to \[${v6_addr}\]:1234")" -eq 1 ]
+      [ "$(nft -nn list chain inet lxd prert.nattest.validNAT | grep -c "ip6 daddr ::1 tcp dport 1234 dnat ip6 to \[${v6_addr}\]:1234")" -eq 1 ]
+      [ "$(nft -nn list chain inet lxd out.nattest.validNAT | grep -c "ip6 daddr ::1 tcp dport 1234 dnat ip6 to \[${v6_addr}\]:1234")" -eq 1 ]
   fi
 
   lxc config device unset nattest validNAT nat
   if [ "$firewallDriver" = "xtables" ]; then
     [ "$(ip6tables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 0 ]
   else
-    ! nft -nn list chain ip6 lxd prert.nattest.validNAT
-    ! nft -nn list chain ip6 lxd out.nattest.validNAT
+    ! nft -nn list chain inet lxd prert.nattest.validNAT
+    ! nft -nn list chain inet lxd out.nattest.validNAT
   fi
 
   lxc config device remove nattest validNAT
@@ -253,16 +253,16 @@ container_devices_proxy_tcp() {
   if [ "$firewallDriver" = "xtables" ]; then
     [ "$(iptables -w -t nat -S | grep -c "generated for LXD container nattest (invalidNAT)")" -eq 0 ]
   else
-    ! nft -nn list chain ip lxd prert.nattest.invalidNAT
-    ! nft -nn list chain ip lxd out.nattest.invalidNAT
+    ! nft -nn list chain inet lxd prert.nattest.invalidNAT
+    ! nft -nn list chain inet lxd out.nattest.invalidNAT
   fi
 
   lxc delete -f nattest
   if [ "$firewallDriver" = "xtables" ]; then
     [ "$(iptables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 0 ]
   else
-    ! nft -nn list chain ip lxd prert.nattest.validNAT
-    ! nft -nn list chain ip lxd out.nattest.validNAT
+    ! nft -nn list chain inet lxd prert.nattest.validNAT
+    ! nft -nn list chain inet lxd out.nattest.validNAT
   fi
 
   lxc network delete lxdt$$


### PR DESCRIPTION
The inet table is described here: https://wiki.nftables.org/wiki-nftables/index.php/Nftables_families#inet

> Tables of this family see both IPv4 and IPv6 traffic/packets, simplifying dual stack support.

> Within a table of inet family, both IPv4 and IPv6 packets traverse the same rules. Rules for IPv4 packets don't affect IPv6 packets. Rules for both L3 protocols affect both. 

The rationale behind this is to simplify the forthcoming ACL rules that will be added as a single chain with mixed IP4/IPv6 rules, rather than needing to separate or duplicate them over two chains in two tables.

This also makes it easier to reason about where LXD is putting its rules, and can result in rule amount reduction by being able to use the same rule for both IPv4 and IPv6 traffic.

I've ensure that the cleanup functions still remove rules from the old ip and ip6 tables, as well as the new inet table, to ensure that old rules get removed for running instances and existing networks.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>