### PR TITLE
Network: Allow single IP in ACL source & destination subjects

### DIFF
--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -710,16 +710,7 @@ func (d Xtables) iptablesAdd(ipVersion uint, comment string, table string, metho
 
 	baseArgs := []string{"-w", "-t", table}
 
-	// Check for an existing entry
-	args := append(baseArgs, []string{"-C", chain}...)
-	args = append(args, rule...)
-	args = append(args, "-m", "comment", "--comment", fmt.Sprintf("generated for %s", comment))
-	_, err = shared.RunCommand(cmd, args...)
-	if err == nil {
-		return nil
-	}
-
-	args = append(baseArgs, []string{method, chain}...)
+	args := append(baseArgs, []string{method, chain}...)
 	args = append(args, rule...)
 	args = append(args, "-m", "comment", "--comment", fmt.Sprintf("generated for %s", comment))
 

--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -517,8 +517,13 @@ func ovnRuleSubjectToOVNACLMatch(direction string, aclNameIDs map[string]int64, 
 				return "", false, fmt.Errorf("Invalid IP range %q", subjectCriterion)
 			}
 		} else {
-			ip, _, err := net.ParseCIDR(subjectCriterion)
-			if err == nil {
+			// Try parsing subject as single IP or CIDR.
+			ip := net.ParseIP(subjectCriterion)
+			if ip == nil {
+				ip, _, _ = net.ParseCIDR(subjectCriterion)
+			}
+
+			if ip != nil {
 				protocol := "ip4"
 				if ip.To4() == nil {
 					protocol = "ip6"

--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -913,7 +913,7 @@ func OVNPortGroupInstanceNICSchedule(portUUID openvswitch.OVNSwitchPortUUID, cha
 }
 
 // OVNApplyInstanceNICDefaultRules applies instance NIC default rules to per-network port group.
-func OVNApplyInstanceNICDefaultRules(client *openvswitch.OVN, switchPortGroup openvswitch.OVNPortGroup, logName string, nicPortName openvswitch.OVNSwitchPort, ingressAction string, ingressLogged bool, egressAction string, egressLogged bool) error {
+func OVNApplyInstanceNICDefaultRules(client *openvswitch.OVN, switchPortGroup openvswitch.OVNPortGroup, logPrefix string, nicPortName openvswitch.OVNSwitchPort, ingressAction string, ingressLogged bool, egressAction string, egressLogged bool) error {
 	if !shared.StringInSlice(ingressAction, ValidActions) {
 		return fmt.Errorf("Invalid ingress action %q", ingressAction)
 	}
@@ -927,7 +927,7 @@ func OVNApplyInstanceNICDefaultRules(client *openvswitch.OVN, switchPortGroup op
 			Direction: "to-lport",
 			Action:    egressAction,
 			Log:       egressLogged,
-			LogName:   fmt.Sprintf("%s-egress", logName), // Max 63 chars.
+			LogName:   fmt.Sprintf("%s-egress", logPrefix), // Max 63 chars.
 			Priority:  ovnACLPriorityNICDefaultActionEgress,
 			Match:     fmt.Sprintf(`inport == "%s"`, nicPortName), // From NIC.
 		},
@@ -935,7 +935,7 @@ func OVNApplyInstanceNICDefaultRules(client *openvswitch.OVN, switchPortGroup op
 			Direction: "to-lport",
 			Action:    ingressAction,
 			Log:       ingressLogged,
-			LogName:   fmt.Sprintf("%s-ingress", logName), // Max 63 chars.
+			LogName:   fmt.Sprintf("%s-ingress", logPrefix), // Max 63 chars.
 			Priority:  ovnACLPriorityNICDefaultActionIngress,
 			Match:     fmt.Sprintf(`outport == "%s"`, nicPortName), // To NIC.
 		},

--- a/lxd/network/acl/driver_common.go
+++ b/lxd/network/acl/driver_common.go
@@ -311,22 +311,17 @@ func (d *common) validateRule(direction ruleDirection, rule api.NetworkACLRule) 
 		return errors.Wrapf(err, "Failed getting network ACLs for security ACL subject validation")
 	}
 
-	allowedSubjectNames := make([]string, 0, len(acls)+2)
-	allowedSubjectNames = append(allowedSubjectNames, ruleSubjectInternalAliases...)
-	allowedSubjectNames = append(allowedSubjectNames, ruleSubjectExternalAliases...)
+	validSubjectNames := make([]string, 0, len(acls)+2)
+	validSubjectNames = append(validSubjectNames, ruleSubjectInternalAliases...)
+	validSubjectNames = append(validSubjectNames, ruleSubjectExternalAliases...)
 
 	for aclName := range acls {
-		allowedSubjectNames = append(allowedSubjectNames, aclName)
+		validSubjectNames = append(validSubjectNames, aclName)
 	}
 
 	// Validate Source field.
 	if rule.Source != "" {
-		var validSubjects []string
-		if direction == ruleDirectionIngress {
-			validSubjects = allowedSubjectNames // Names are only allowed in ingress rule sources.
-		}
-
-		err := d.validateRuleSubjects(util.SplitNTrimSpace(rule.Source, ",", -1, false), validSubjects)
+		err := d.validateRuleSubjects("Source", direction, util.SplitNTrimSpace(rule.Source, ",", -1, false), validSubjectNames)
 		if err != nil {
 			return errors.Wrapf(err, "Invalid Source")
 		}
@@ -334,12 +329,7 @@ func (d *common) validateRule(direction ruleDirection, rule api.NetworkACLRule) 
 
 	// Validate Destination field.
 	if rule.Destination != "" {
-		var validSubjects []string
-		if direction == ruleDirectionEgress {
-			validSubjects = allowedSubjectNames // Names are only allowed in egress rule destinations.
-		}
-
-		err := d.validateRuleSubjects(util.SplitNTrimSpace(rule.Destination, ",", -1, false), validSubjects)
+		err := d.validateRuleSubjects("Destination", direction, util.SplitNTrimSpace(rule.Destination, ",", -1, false), validSubjectNames)
 		if err != nil {
 			return errors.Wrapf(err, "Invalid Destination")
 		}
@@ -424,14 +414,20 @@ func (d *common) validateRule(direction ruleDirection, rule api.NetworkACLRule) 
 }
 
 // validateRuleSubjects checks that the source or destination subjects for a rule are valid.
-// Accepts an allowedNames list of allowed ACL or special classifier names.
-func (d *common) validateRuleSubjects(subjects []string, allowedNames []string) error {
+// Accepts a validSubjectNames list of valid ACL or special classifier names.
+func (d *common) validateRuleSubjects(fieldName string, direction ruleDirection, subjects []string, validSubjectNames []string) error {
+	// Check if named subjects are allowed in field/direction combination.
+	allowSubjectNames := false
+	if (fieldName == "Source" && direction == ruleDirectionIngress) || (fieldName == "Destination" && direction == ruleDirectionEgress) {
+		allowSubjectNames = true
+	}
+
 	checks := []func(s string) error{
 		validate.IsNetworkAddressCIDR,
 		validate.IsNetworkRange,
 	}
 
-	validSubject := func(subject string, allowedNames []string) error {
+	validSubject := func(subject string) error {
 		// Check if it is one of the network IP types.
 		for _, c := range checks {
 			err := c(subject)
@@ -441,10 +437,14 @@ func (d *common) validateRuleSubjects(subjects []string, allowedNames []string) 
 			}
 		}
 
-		// Check if it is one of the allowed names.
-		for _, n := range allowedNames {
+		// Check if it is one of the valid subject names.
+		for _, n := range validSubjectNames {
 			if subject == n {
-				return nil // Found valid subject.
+				if allowSubjectNames {
+					return nil // Found valid subject.
+				}
+
+				return fmt.Errorf("Named subjects not allowed in %q for %q rules", fieldName, direction)
 			}
 		}
 
@@ -452,7 +452,7 @@ func (d *common) validateRuleSubjects(subjects []string, allowedNames []string) 
 	}
 
 	for _, s := range subjects {
-		err := validSubject(s, allowedNames)
+		err := validSubject(s)
 		if err != nil {
 			return err
 		}

--- a/lxd/network/acl/driver_common.go
+++ b/lxd/network/acl/driver_common.go
@@ -423,6 +423,7 @@ func (d *common) validateRuleSubjects(fieldName string, direction ruleDirection,
 	}
 
 	checks := []func(s string) error{
+		validate.IsNetworkAddress,
 		validate.IsNetworkAddressCIDR,
 		validate.IsNetworkRange,
 	}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2376,8 +2376,8 @@ func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clientType re
 						ingressAction, ingressLogged := n.instanceDeviceACLDefaults(nicConfig, "ingress")
 						egressAction, egressLogged := n.instanceDeviceACLDefaults(nicConfig, "egress")
 
-						logName := fmt.Sprintf("%s-%s", inst.Config["volatile.uuid"], nicName)
-						err = acl.OVNApplyInstanceNICDefaultRules(client, acl.OVNIntSwitchPortGroupName(n.ID()), logName, instancePortName, ingressAction, ingressLogged, egressAction, egressLogged)
+						logPrefix := fmt.Sprintf("%s-%s", inst.Config["volatile.uuid"], nicName)
+						err = acl.OVNApplyInstanceNICDefaultRules(client, acl.OVNIntSwitchPortGroupName(n.ID()), logPrefix, instancePortName, ingressAction, ingressLogged, egressAction, egressLogged)
 						if err != nil {
 							return errors.Wrapf(err, "Failed applying OVN default ACL rules for instance NIC")
 						}
@@ -2900,8 +2900,8 @@ func (n *ovn) InstanceDevicePortSetup(opts *OVNInstanceNICSetupOpts, securityACL
 		ingressAction, ingressLogged := n.instanceDeviceACLDefaults(opts.DeviceConfig, "ingress")
 		egressAction, egressLogged := n.instanceDeviceACLDefaults(opts.DeviceConfig, "egress")
 
-		logName := fmt.Sprintf("%s-%s", opts.InstanceUUID, opts.DeviceName)
-		err = acl.OVNApplyInstanceNICDefaultRules(client, acl.OVNIntSwitchPortGroupName(n.ID()), logName, instancePortName, ingressAction, ingressLogged, egressAction, egressLogged)
+		logPrefix := fmt.Sprintf("%s-%s", opts.InstanceUUID, opts.DeviceName)
+		err = acl.OVNApplyInstanceNICDefaultRules(client, acl.OVNIntSwitchPortGroupName(n.ID()), logPrefix, instancePortName, ingressAction, ingressLogged, egressAction, egressLogged)
 		if err != nil {
 			return "", errors.Wrapf(err, "Failed applying OVN default ACL rules for instance NIC")
 		}

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -535,6 +535,20 @@ func IsNetworkPortRange(value string) error {
 		}
 	}
 
+	startPort, err := strconv.ParseUint(ports[0], 10, 32)
+	if err != nil {
+		return fmt.Errorf("Invalid start port number %q", value)
+	}
+
+	endPort, err := strconv.ParseUint(ports[1], 10, 32)
+	if err != nil {
+		return fmt.Errorf("Invalid port number %q", value)
+	}
+
+	if startPort >= endPort {
+		return fmt.Errorf("Start port %d must be lower than end port %d", startPort, endPort)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Also improve error message returned when named subject is used in an invalid scenario.

Also lands some miscellaneous firewall related changes from the ongoing xtables/nftables branch that are not directly related to it.