### PR TITLE
Firewall: Revert "lxd/firewall/drivers/drivers/xtables: Don't check for existing rule in iptablesAdd"

### DIFF
--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -711,7 +711,16 @@ func (d Xtables) iptablesAdd(ipVersion uint, comment string, table string, metho
 
 	baseArgs := []string{"-w", "-t", table}
 
-	args := append(baseArgs, []string{method, chain}...)
+	// Check for an existing entry
+	args := append(baseArgs, []string{"-C", chain}...)
+	args = append(args, rule...)
+	args = append(args, "-m", "comment", "--comment", fmt.Sprintf("generated for %s", comment))
+	_, err = shared.RunCommand(cmd, args...)
+	if err == nil {
+		return nil
+	}
+
+	args = append(baseArgs, []string{method, chain}...)
 	args = append(args, rule...)
 	args = append(args, "-m", "comment", "--comment", fmt.Sprintf("generated for %s", comment))
 


### PR DESCRIPTION
This reverts commit 5ff5df309bdc2305d07fa2872589b0ad352d11e1.

Looks like the proxy device depends on this behaviour so will need to dig into more detail as to why, as I was depending on this behaviour for the xtables ACL driver.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>