### PR TITLE
Image: Add image locks when downloading images

### DIFF
--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -127,20 +127,20 @@ func (d *Daemon) ImageDownload(op *operations.Operation, server string, protocol
 		// Check if the image is available locally or it's on another node.
 		nodeAddress, err := d.State().Cluster.LocateImage(imgInfo.Fingerprint)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Locate image %q in the cluster", imgInfo.Fingerprint)
+			return nil, errors.Wrapf(err, "Failed locating image %q in the cluster", imgInfo.Fingerprint)
 		}
 
 		if nodeAddress != "" {
 			// The image is available from another node, let's try to import it.
 			err = instanceImageTransfer(d, project, imgInfo.Fingerprint, nodeAddress)
 			if err != nil {
-				return nil, errors.Wrapf(err, "Failed transferring image")
+				return nil, errors.Wrapf(err, "Failed transferring image %q from %q", imgInfo.Fingerprint, nodeAddress)
 			}
 
 			// As the image record already exists in the project, just add the node ID to the image.
 			err = d.cluster.AddImageToLocalNode(project, imgInfo.Fingerprint)
 			if err != nil {
-				return nil, errors.Wrapf(err, "Failed adding image to local node")
+				return nil, errors.Wrapf(err, "Failed adding transferred image %q to local cluster member", imgInfo.Fingerprint)
 			}
 		}
 	} else if err == db.ErrNoSuchObject {

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -98,6 +98,10 @@ func (d *Daemon) ImageDownload(op *operations.Operation, server string, protocol
 		}
 	}
 
+	// Ensure we are the only ones operating on this image.
+	unlock := d.imageDownloadLock(fp)
+	defer unlock()
+
 	// If auto-update is on and we're being given the image by
 	// alias, try to use a locally cached image matching the given
 	// server/protocol/alias, regardless of whether it's stale or

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -112,13 +112,13 @@ func instanceCreateFromImage(d *Daemon, args db.InstanceArgs, hash string, op *o
 		// The image is available from another node, let's try to import it.
 		err = instanceImageTransfer(d, args.Project, img.Fingerprint, nodeAddress)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Failed transferring image")
+			return nil, errors.Wrapf(err, "Failed transferring image %q from %q", img.Fingerprint, nodeAddress)
 		}
 
 		// As the image record already exists in the project, just add the node ID to the image.
 		err = d.cluster.AddImageToLocalNode(args.Project, img.Fingerprint)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Failed adding image to local node")
+			return nil, errors.Wrapf(err, "Failed adding transferred image %q to local cluster member", img.Fingerprint)
 		}
 	}
 

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -109,17 +109,24 @@ func instanceCreateFromImage(d *Daemon, args db.InstanceArgs, hash string, op *o
 	}
 
 	if nodeAddress != "" {
+		// Ensure we are the only ones operating on this image.
+		unlock := d.imageDownloadLock(img.Fingerprint)
+
 		// The image is available from another node, let's try to import it.
 		err = instanceImageTransfer(d, args.Project, img.Fingerprint, nodeAddress)
 		if err != nil {
+			unlock()
 			return nil, errors.Wrapf(err, "Failed transferring image %q from %q", img.Fingerprint, nodeAddress)
 		}
 
 		// As the image record already exists in the project, just add the node ID to the image.
 		err = d.cluster.AddImageToLocalNode(args.Project, img.Fingerprint)
 		if err != nil {
+			unlock()
 			return nil, errors.Wrapf(err, "Failed adding transferred image %q to local cluster member", img.Fingerprint)
 		}
+
+		unlock()
 	}
 
 	// Set the "image.*" keys.


### PR DESCRIPTION
This fixes a race condition when transferring an image that exists on another cluster member, but does not exist on the local member.

If two or more instances are created at the same time, then one or more of them would fail with an error:

```
lxc config set cluster.images_minimal_replica=1
lxc init images:ubuntu/focal csrc --target=v1
lxc init images:ubuntu/focal c1 --target=v2 &
lxc init images:ubuntu/focal c2 --target=v2
Creating c1
Creating c2
Error: Failed instance creation: Failed adding image to local node: UNIQUE constraint failed: images_nodes.image_id, images_nodes.node_id
```