### PR TITLE
Firewall: Only add multiple proxy masquerade hairpin NAT rules if connect port range used

### DIFF
--- a/lxd/firewall/drivers/drivers_nftables.go
+++ b/lxd/firewall/drivers/drivers_nftables.go
@@ -435,14 +435,15 @@ func (d Nftables) InstanceSetupProxyNAT(projectName string, instanceName string,
 		}
 
 		rules = append(rules, map[string]interface{}{
-			"family":      "inet",
-			"ipFamily":    ipFamily,
-			"connType":    listen.ConnType,
-			"listenHost":  listenHost,
-			"listenPort":  listenPort,
-			"connectDest": connectDest,
-			"connectHost": connectHost,
-			"connectPort": connectPort,
+			"family":        "inet",
+			"ipFamily":      ipFamily,
+			"connType":      listen.ConnType,
+			"listenHost":    listenHost,
+			"listenPort":    listenPort,
+			"connectDest":   connectDest,
+			"connectHost":   connectHost,
+			"connectPort":   connectPort,
+			"addHairpinNat": connectIndex == i, // Only add >1 hairpin NAT rules if connect range used.
 		})
 	}
 

--- a/lxd/firewall/drivers/drivers_nftables_templates.go
+++ b/lxd/firewall/drivers/drivers_nftables_templates.go
@@ -90,7 +90,9 @@ chain out{{.chainSeparator}}{{.deviceLabel}} {
 chain pstrt{{.chainSeparator}}{{.deviceLabel}} {
 	type nat hook postrouting priority 100; policy accept;
 	{{- range .rules}}
+	{{if .addHairpinNat}}
 	{{.ipFamily}} saddr {{.connectHost}} {{.ipFamily}} daddr {{.connectHost}} {{.connType}} dport {{.connectPort}} masquerade
+	{{- end}}
 	{{- end}}
 }
 `))

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -528,11 +528,13 @@ func (d Xtables) InstanceSetupProxyNAT(projectName string, instanceName string, 
 			return err
 		}
 
-		// instance <-> instance.
-		// Requires instance's bridge port has hairpin mode enabled when br_netfilter is loaded.
-		err = d.iptablesPrepend(ipVersion, comment, "nat", "POSTROUTING", "-p", listen.ConnType, "--source", connectHost, "--destination", connectHost, "--dport", connectPort, "-j", "MASQUERADE")
-		if err != nil {
-			return err
+		if connectIndex == i {
+			// instance <-> instance.
+			// Requires instance's bridge port has hairpin mode enabled when br_netfilter is loaded.
+			err = d.iptablesPrepend(ipVersion, comment, "nat", "POSTROUTING", "-p", listen.ConnType, "--source", connectHost, "--destination", connectHost, "--dport", connectPort, "-j", "MASQUERADE")
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -713,16 +713,7 @@ func (d Xtables) iptablesAdd(ipVersion uint, comment string, table string, metho
 
 	baseArgs := []string{"-w", "-t", table}
 
-	// Check for an existing entry
-	args := append(baseArgs, []string{"-C", chain}...)
-	args = append(args, rule...)
-	args = append(args, "-m", "comment", "--comment", fmt.Sprintf("generated for %s", comment))
-	_, err = shared.RunCommand(cmd, args...)
-	if err == nil {
-		return nil
-	}
-
-	args = append(baseArgs, []string{method, chain}...)
+	args := append(baseArgs, []string{method, chain}...)
 	args = append(args, rule...)
 	args = append(args, "-m", "comment", "--comment", fmt.Sprintf("generated for %s", comment))
 


### PR DESCRIPTION
If a proxy device used a listen port range but no connect port range in NAT mode, i.e:

```
p1:
    listen: tcp:192.168.1.200:80-81
    connect: tcp:10.105.189.2:80
    nat: "true"
    type: proxy
```

Then we were incorrectly adding multiple identical hairpin masquerade NAT rules for the same connect port.
This wasn't causing any problems, but is inefficient, so now we only add multiple rules if there are multiple connect ports being used, e.g.

```
p1:
    listen: tcp:192.168.1.200:80-81
    connect: tcp:10.105.189.2:80-81
    nat: "true"
    type: proxy
```

This also allows us to remove the duplicate rule detection in the `iptables` driver when adding new rules, which speeds up adding new rules, and allows the forthcoming ACL functionality to add duplicate rules (at a higher priority) when adding baseline DNS/DHCP rules that are independent from the rules being added by the `ipv{n}.firewall` options.