### PR TITLE
Images: Improve download error messages

### DIFF
--- a/client/simplestreams_images.go
+++ b/client/simplestreams_images.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -42,7 +44,7 @@ func (r *ProtocolSimpleStreams) GetImageFingerprints() ([]string, error) {
 func (r *ProtocolSimpleStreams) GetImage(fingerprint string) (*api.Image, string, error) {
 	image, err := r.ssClient.GetImage(fingerprint)
 	if err != nil {
-		return nil, "", err
+		return nil, "", errors.Wrapf(err, "Failed getting image")
 	}
 
 	return image, "", err

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -70,13 +70,13 @@ func (d *Daemon) ImageDownload(op *operations.Operation, server string, protocol
 			// Setup LXD client
 			remote, err = lxd.ConnectPublicLXD(server, args)
 			if err != nil {
-				return nil, err
+				return nil, errors.Wrapf(err, "Failed to connect to LXD server %q", server)
 			}
 		} else {
 			// Setup simplestreams client
 			remote, err = lxd.ConnectSimpleStreams(server, args)
 			if err != nil {
-				return nil, err
+				return nil, errors.Wrapf(err, "Failed to connect to simple streams server %q", server)
 			}
 		}
 
@@ -91,7 +91,7 @@ func (d *Daemon) ImageDownload(op *operations.Operation, server string, protocol
 			// Expand partial fingerprints
 			info, _, err = remote.GetImage(fp)
 			if err != nil {
-				return nil, err
+				return nil, errors.Wrapf(err, "Failed getting remote image info")
 			}
 
 			fp = info.Fingerprint

--- a/test/godeps.list
+++ b/test/godeps.list
@@ -8,6 +8,7 @@ github.com/lxc/lxd/shared/ioprogress
 github.com/lxc/lxd/shared/logger
 github.com/lxc/lxd/shared/simplestreams
 github.com/lxc/lxd/shared/units
+github.com/pkg/errors
 gopkg.in/juju/environschema.v1/form
 gopkg.in/macaroon-bakery.v2/bakery
 gopkg.in/macaroon-bakery.v2/httpbakery


### PR DESCRIPTION
These changes allowed me to track down the affected URL generating the `unexpected end of JSON input` error when downloading images.