### PR TITLE
Cluster: Generate a new cluster certificate when bootstrapping a cluster

### DIFF
--- a/lxc-to-lxd/main_migrate_test.go
+++ b/lxc-to-lxd/main_migrate_test.go
@@ -235,6 +235,10 @@ func TestConvertNetworkConfig(t *testing.T) {
 		}
 
 		err = c.Destroy()
+		if err != nil && strings.Contains(err.Error(), string(liblxc.ErrNotDefined)) {
+			continue
+		}
+
 		require.NoError(t, err)
 	}
 }

--- a/lxd/util/encryption.go
+++ b/lxd/util/encryption.go
@@ -42,6 +42,7 @@ func PasswordCheck(secret string, password string) error {
 // LoadCert reads the LXD server certificate from the given var dir.
 //
 // If a cluster certificate is found it will be loaded instead.
+// If neither a server or cluster certfificate exists, a new server certificate will be generated.
 func LoadCert(dir string) (*shared.CertInfo, error) {
 	prefix := "server"
 	if shared.PathExists(filepath.Join(dir, "cluster.crt")) {

--- a/lxd/util/encryption.go
+++ b/lxd/util/encryption.go
@@ -57,6 +57,20 @@ func LoadCert(dir string) (*shared.CertInfo, error) {
 	return cert, nil
 }
 
+// LoadClusterCert reads the LXD cluster certificate from the given var dir.
+//
+// If a cluster certificate doesn't exist, a new one is generated.
+func LoadClusterCert(dir string) (*shared.CertInfo, error) {
+	prefix := "cluster"
+
+	cert, err := shared.KeyPairAndCA(dir, prefix, shared.CertServer, true)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load cluster TLS certificate")
+	}
+
+	return cert, nil
+}
+
 // WriteCert writes the given material to the appropriate certificate files in
 // the given LXD var directory.
 func WriteCert(dir, prefix string, cert, key, ca []byte) error {

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -51,7 +51,7 @@ test_clustering_membership() {
   spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
 
   # Add a newline at the end of each line. YAML as weird rules..
-  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   # Spawn a second node
   setup_clustering_netns 2
@@ -169,7 +169,7 @@ test_clustering_containers() {
   spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
 
   # Add a newline at the end of each line. YAML as weird rules..
-  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   # Spawn a second node
   setup_clustering_netns 2
@@ -353,7 +353,7 @@ test_clustering_storage() {
   LXD_DIR="${LXD_ONE_DIR}" lxc storage list | grep data | grep -q CREATED
 
   # Add a newline at the end of each line. YAML as weird rules..
-  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   # Spawn a second node
   setup_clustering_netns 2
@@ -778,7 +778,7 @@ test_clustering_network() {
   LXD_DIR="${LXD_ONE_DIR}" lxc network list | grep "${bridge}" | grep -q CREATED
 
   # Add a newline at the end of each line. YAML as weird rules..
-  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   # Spawn a second node
   setup_clustering_netns 2
@@ -932,7 +932,7 @@ test_clustering_upgrade() {
   spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
 
   # Add a newline at the end of each line. YAML as weird rules..
-  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   # Spawn a second node
   setup_clustering_netns 2
@@ -1031,7 +1031,7 @@ test_clustering_upgrade_large() {
   spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
 
   # Add a newline at the end of each line. YAML as weird rules..
-  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   for i in $(seq 2 "${N}"); do
     setup_clustering_netns "${i}"
@@ -1083,7 +1083,7 @@ test_clustering_publish() {
   spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
 
   # Add a newline at the end of each line. YAML as weird rules..
-  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   # Spawn a second node
   setup_clustering_netns 2
@@ -1135,7 +1135,7 @@ test_clustering_profiles() {
   spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
 
   # Add a newline at the end of each line. YAML as weird rules..
-  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   # Spawn a second node
   setup_clustering_netns 2
@@ -1208,7 +1208,7 @@ test_clustering_join_api() {
   ns1="${prefix}1"
   spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
 
-  cert=$(sed ':a;N;$!ba;s/\n/\\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   setup_clustering_netns 2
   LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
@@ -1249,7 +1249,7 @@ test_clustering_shutdown_nodes() {
   spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
 
   # Add a newline at the end of each line. YAML as weird rules..
-  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   # Spawn a second node
   setup_clustering_netns 2
@@ -1318,7 +1318,7 @@ test_clustering_projects() {
   spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
 
   # Add a newline at the end of each line. YAML as weird rules..
-  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   # Spawn a second node
   setup_clustering_netns 2
@@ -1395,7 +1395,7 @@ test_clustering_address() {
   lxc storage list cluster: | grep -q data
 
   # Add a newline at the end of each line. YAML as weird rules..
-  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   # Spawn a second node using a custom cluster port
   setup_clustering_netns 2
@@ -1461,7 +1461,7 @@ test_clustering_image_replication() {
   spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
 
   # Add a newline at the end of each line. YAML as weird rules..
-  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   # Spawn a second node
   setup_clustering_netns 2
@@ -1709,7 +1709,7 @@ test_clustering_recover() {
   spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
 
   # Add a newline at the end of each line. YAML as weird rules..
-  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   # Spawn a second node
   setup_clustering_netns 2
@@ -1791,7 +1791,7 @@ test_clustering_handover() {
   spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
 
   # Add a newline at the end of each line. YAML as weird rules..
-  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   # Spawn a second node
   setup_clustering_netns 2
@@ -1885,7 +1885,7 @@ test_clustering_rebalance() {
   spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
 
   # Add a newline at the end of each line. YAML as weird rules..
-  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   # Spawn a second node
   setup_clustering_netns 2
@@ -1971,7 +1971,7 @@ test_clustering_remove_raft_node() {
   spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
 
   # Add a newline at the end of each line. YAML as weird rules..
-  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   # Spawn a second node
   setup_clustering_netns 2
@@ -2085,7 +2085,7 @@ test_clustering_failure_domains() {
   spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
 
   # Add a newline at the end of each line. YAML as weird rules..
-  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   # Spawn a second node
   setup_clustering_netns 2
@@ -2202,7 +2202,7 @@ test_clustering_image_refresh() {
   LXD_DIR="${LXD_ONE_DIR}" lxc storage list | grep data | grep -q CREATED
 
   # Add a newline at the end of each line. YAML as weird rules..
-  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/cluster.crt")
 
   # Spawn a second node
   setup_clustering_netns 2


### PR DESCRIPTION
Rather than re-using the existing first-member server certificate.