### PR TITLE
lxd: don't set device cgroup values for unpriv containers

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2061,6 +2061,9 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 		// Pass any cgroups rules into LXC.
 		if len(runConf.CGroups) > 0 {
 			for _, rule := range runConf.CGroups {
+				if strings.HasPrefix(rule.Key, "devices.") && (!d.isCurrentlyPrivileged() || d.state.OS.RunningInUserNS) {
+					continue
+				}
 				if d.state.OS.CGInfo.Layout == cgroup.CgroupsUnified {
 					err = lxcSetConfigItem(d.c, fmt.Sprintf("lxc.cgroup2.%s", rule.Key), rule.Value)
 				} else {


### PR DESCRIPTION
Fixes: #8608
Fixes: https://discuss.linuxcontainers.org/t/container-fails-to-start-properly-when-a-usb-device-is-attached-to-the-container-before-start-up
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>