### PR TITLE
Cluster: Use per-member server certs

### DIFF
--- a/doc/clustering.md
+++ b/doc/clustering.md
@@ -96,7 +96,7 @@ node.
 
 Be sure to include the address and certificate of the target bootstrap node. To
 create a YAML-compatible entry for the ``cluster_certificate`` key you can use a
-command like `sed ':a;N;$!ba;s/\n/\n\n/g' /var/lib/lxd/server.crt`, which you
+command like `sed ':a;N;$!ba;s/\n/\n\n/g' /var/lib/lxd/cluster.crt`, which you
 have to run on the bootstrap node.
 
 For example:

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -64,7 +64,7 @@ func restServer(d *Daemon) *http.Server {
 		response.SyncResponse(true, []string{"/1.0"}).Render(w)
 	})
 
-	for endpoint, f := range d.gateway.HandlerFuncs(d.NodeRefreshTask) {
+	for endpoint, f := range d.gateway.HandlerFuncs(d.NodeRefreshTask, d.getTrustedCertificates) {
 		mux.HandleFunc(endpoint, f)
 	}
 

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -618,7 +618,7 @@ func doApi10Update(d *Daemon, req api.ServerPut, patch bool) response.Response {
 	}
 
 	// Notify the other nodes about changes
-	notifier, err := cluster.NewNotifier(s, d.endpoints.NetworkCert(), cluster.NotifyAlive)
+	notifier, err := cluster.NewNotifier(s, d.endpoints.NetworkCert(), d.serverCert(), cluster.NotifyAlive)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1428,6 +1428,11 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(errors.Wrap(err, "Failed to remove member from database"))
 	}
 
+	// Refresh the trusted certificate cache now that the member certificate has been removed.
+	// We do not need to notify the other members here because the next heartbeat will trigger member change
+	// detection and updateCertificateCache is called as part of that.
+	updateCertificateCache(d)
+
 	err = rebalanceMemberRoles(d)
 	if err != nil {
 		logger.Warnf("Failed to rebalance dqlite nodes: %v", err)

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -701,14 +701,15 @@ func clusterPutDisable(d *Daemon) response.Response {
 			return response.InternalError(err)
 		}
 	}
-	cert, err := util.LoadCert(d.os.VarDir)
+
+	networkCert, err := util.LoadCert(d.os.VarDir)
 	if err != nil {
 		return response.InternalError(errors.Wrap(err, "Failed to parse member certificate"))
 	}
 
 	// Reset the cluster database and make it local to this node.
-	d.endpoints.NetworkUpdateCert(cert)
-	err = d.gateway.Reset(cert)
+	d.endpoints.NetworkUpdateCert(networkCert)
+	err = d.gateway.Reset(networkCert)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1343,7 +1343,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 	}
 	if localAddress != leader {
 		logger.Debugf("Redirect member delete request to %s", leader)
-		client, err := cluster.Connect(leader, d.endpoints.NetworkCert(), false)
+		client, err := cluster.Connect(leader, d.endpoints.NetworkCert(), d.serverCert(), false)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -1377,8 +1377,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 	if force != 1 {
 		// Try to gracefully delete all networks and storage pools on it.
 		// Delete all networks on this node
-		cert := d.endpoints.NetworkCert()
-		client, err := cluster.Connect(address, cert, true)
+		client, err := cluster.Connect(address, d.endpoints.NetworkCert(), d.serverCert(), true)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -1440,8 +1439,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 
 	if force != 1 {
 		// Try to gracefully reset the database on the node.
-		cert := d.endpoints.NetworkCert()
-		client, err := cluster.Connect(address, cert, true)
+		client, err := cluster.Connect(address, d.endpoints.NetworkCert(), d.serverCert(), true)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -1611,7 +1609,7 @@ again:
 			continue
 		}
 
-		if cluster.HasConnectivity(d.endpoints.NetworkCert(), address) {
+		if cluster.HasConnectivity(d.endpoints.NetworkCert(), d.serverCert(), address) {
 			break
 		}
 
@@ -1664,8 +1662,7 @@ func changeMemberRole(d *Daemon, address string, nodes []db.RaftNode) error {
 		})
 	}
 
-	cert := d.endpoints.NetworkCert()
-	client, err := cluster.Connect(address, cert, true)
+	client, err := cluster.Connect(address, d.endpoints.NetworkCert(), d.serverCert(), true)
 	if err != nil {
 		return err
 	}
@@ -1721,8 +1718,7 @@ findLeader:
 		goto findLeader
 	}
 
-	cert := d.endpoints.NetworkCert()
-	client, err := cluster.Connect(leader, cert, true)
+	client, err := cluster.Connect(leader, d.endpoints.NetworkCert(), d.serverCert(), true)
 	if err != nil {
 		return err
 	}

--- a/lxd/api_cluster_test.go
+++ b/lxd/api_cluster_test.go
@@ -643,7 +643,7 @@ func (f *clusterFixture) RegisterCertificate(daemon1, daemon2 *Daemon, name, pas
 		Password:    password,
 		Certificate: certificate,
 	}
-	post.Name = fmt.Sprintf("lxd.cluster.%s", name)
+	post.Name = name
 	post.Type = api.CertificateTypeClient
 
 	client2 := f.ClientUnix(daemon2)

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -629,20 +629,16 @@ func doCertificateUpdate(d *Daemon, dbInfo db.Certificate, fingerprint string, r
 			return response.BadRequest(err)
 		}
 
-		if reqDBType != dbInfo.Type {
-			return response.BadRequest(fmt.Errorf("Certificate type cannot be changed"))
-		}
-
 		// Convert to the database type.
 		cert := db.Certificate{
 			// Read-only fields.
 			Certificate: dbInfo.Certificate,
 			Fingerprint: dbInfo.Fingerprint,
-			Type:        dbInfo.Type,
 
 			Restricted: req.Restricted,
 			Projects:   req.Projects,
 			Name:       req.Name,
+			Type:       reqDBType,
 		}
 
 		// Update the database record.

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -409,7 +409,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 		// Check if we already have the certificate.
 		existingCert, _ := d.cluster.GetCertificate(fingerprint)
 		if existingCert != nil {
-			return response.BadRequest(fmt.Errorf("Certificate already in trust store"))
+			return response.BadRequest(cluster.ErrCertificateExists)
 		}
 
 		// Store the certificate in the cluster database.
@@ -433,8 +433,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Notify other nodes about the new certificate.
-		notifier, err := cluster.NewNotifier(
-			d.State(), d.endpoints.NetworkCert(), cluster.NotifyAlive)
+		notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), d.serverCert(), cluster.NotifyAlive)
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -21,10 +21,9 @@ import (
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/version"
-
-	log "github.com/lxc/lxd/shared/log15"
 )
 
 type certificateCache struct {

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -164,17 +164,20 @@ func certificatesGet(d *Daemon, r *http.Request) response.Response {
 }
 
 func updateCertificateCache(d *Daemon) {
+	logger.Debug("Refreshing trusted certificate cache")
+
 	newCerts := map[int]map[string]x509.Certificate{}
 	newProjects := map[string][]string{}
 
 	var dbCerts []db.Certificate
+	var localCerts []db.Certificate
 	var err error
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
 		dbCerts, err = tx.GetCertificates(db.CertificateFilter{})
 		return err
 	})
 	if err != nil {
-		logger.Infof("Error reading certificates from database: %v", err)
+		logger.Warn("Failed reading certificates from global database", log.Ctx{"err": err})
 		return
 	}
 
@@ -185,20 +188,36 @@ func updateCertificateCache(d *Daemon) {
 
 		certBlock, _ := pem.Decode([]byte(dbCert.Certificate))
 		if certBlock == nil {
-			logger.Infof("Error decoding certificate for %q: %v", dbCert.Name, err)
+			logger.Warn("Failed decoding certificate", log.Ctx{"name": dbCert.Name, "err": err})
 			continue
 		}
 
 		cert, err := x509.ParseCertificate(certBlock.Bytes)
 		if err != nil {
-			logger.Infof("Error reading certificate for %q: %v", dbCert.Name, err)
+			logger.Warn("Failed parsing certificate", log.Ctx{"name": dbCert.Name, "err": err})
 			continue
 		}
 
 		newCerts[dbCert.Type][shared.CertFingerprint(cert)] = *cert
+
 		if dbCert.Restricted {
 			newProjects[shared.CertFingerprint(cert)] = dbCert.Projects
 		}
+
+		// Add server certs to list of certificates to store in local database to allow cluster restart.
+		if dbCert.Type == db.CertificateTypeServer {
+			localCerts = append(localCerts, dbCert)
+		}
+	}
+
+	// Write out the server certs to the local database to allow the cluster to restart.
+	err = d.db.Transaction(func(tx *db.NodeTx) error {
+		return tx.ReplaceCertificates(localCerts)
+	})
+	if err != nil {
+		logger.Warn("Failed writing certificates to local database", log.Ctx{"err": err})
+		// Don't return here, as we still should update the in-memory cache to allow the cluster to
+		// continue functioning, and hopefully the write will succeed on next update.
 	}
 
 	d.clientCerts.Lock.Lock()

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -15,6 +15,7 @@ import (
 
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/rbac"
 	"github.com/lxc/lxd/lxd/response"
@@ -557,8 +558,10 @@ func certificatePut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
+	clientType := request.UserAgentClientType(r.Header.Get("User-Agent"))
+
 	// Apply the update.
-	return doCertificateUpdate(d, *oldEntry, fingerprint, req)
+	return doCertificateUpdate(d, *oldEntry, fingerprint, req, clientType)
 }
 
 // swagger:operation PATCH /1.0/certificates/{fingerprint} certificates certificate_patch
@@ -614,40 +617,57 @@ func certificatePatch(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	return doCertificateUpdate(d, *oldEntry, fingerprint, req.Writable())
+	clientType := request.UserAgentClientType(r.Header.Get("User-Agent"))
+
+	return doCertificateUpdate(d, *oldEntry, fingerprint, req.Writable(), clientType)
 }
 
-func doCertificateUpdate(d *Daemon, dbInfo db.Certificate, fingerprint string, req api.CertificatePut) response.Response {
-	reqDBType, err := db.CertificateAPITypeToDBType(req.Type)
-	if err != nil {
-		return response.BadRequest(err)
-	}
+func doCertificateUpdate(d *Daemon, dbInfo db.Certificate, fingerprint string, req api.CertificatePut, clientType request.ClientType) response.Response {
+	if clientType == request.ClientTypeNormal {
+		reqDBType, err := db.CertificateAPITypeToDBType(req.Type)
+		if err != nil {
+			return response.BadRequest(err)
+		}
 
-	if reqDBType != dbInfo.Type {
-		return response.BadRequest(fmt.Errorf("Certificate type cannot be changed"))
-	}
+		if reqDBType != dbInfo.Type {
+			return response.BadRequest(fmt.Errorf("Certificate type cannot be changed"))
+		}
 
-	// Convert to the database type.
-	cert := db.Certificate{
-		// Read-only fields.
-		Certificate: dbInfo.Certificate,
-		Fingerprint: dbInfo.Fingerprint,
-		Type:        dbInfo.Type,
+		// Convert to the database type.
+		cert := db.Certificate{
+			// Read-only fields.
+			Certificate: dbInfo.Certificate,
+			Fingerprint: dbInfo.Fingerprint,
+			Type:        dbInfo.Type,
 
-		Restricted: req.Restricted,
-		Projects:   req.Projects,
-		Name:       req.Name,
-	}
+			Restricted: req.Restricted,
+			Projects:   req.Projects,
+			Name:       req.Name,
+		}
 
-	// Update the database record.
-	err = d.cluster.UpdateCertificate(fingerprint, cert)
-	if err != nil {
-		return response.SmartError(err)
-	}
+		// Update the database record.
+		err = d.cluster.UpdateCertificate(fingerprint, cert)
+		if err != nil {
+			return response.SmartError(err)
+		}
 
-	err = d.cluster.UpdateCertificateProjects(dbInfo.ID, cert.Projects)
-	if err != nil {
-		return response.SmartError(err)
+		err = d.cluster.UpdateCertificateProjects(dbInfo.ID, cert.Projects)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		// Notify other nodes about the new certificate.
+		notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), d.serverCert(), cluster.NotifyAlive)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		err = notifier(func(client lxd.InstanceServer) error {
+			return client.UpdateCertificate(dbInfo.Fingerprint, req, "")
+		})
+		if err != nil {
+			return response.SmartError(err)
+		}
 	}
 
 	// Reload the cache.

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -226,6 +226,52 @@ func updateCertificateCache(d *Daemon) {
 	d.clientCerts.Lock.Unlock()
 }
 
+// updateCertificateCacheFromLocal loads trusted server certificates from local database into memory.
+// If no local trusted server certificates available and is clustered, then loads network certificate into trusted
+// certificates cache.
+func updateCertificateCacheFromLocal(d *Daemon, networkCert *shared.CertInfo) error {
+	logger.Debug("Refreshing local trusted certificate cache")
+
+	newCerts := map[int]map[string]x509.Certificate{}
+
+	var dbCerts []db.Certificate
+	var err error
+
+	err = d.db.Transaction(func(tx *db.NodeTx) error {
+		dbCerts, err = tx.GetCertificates()
+		return err
+	})
+	if err != nil {
+		return errors.Wrapf(err, "Failed reading certificates from local database")
+	}
+
+	for _, dbCert := range dbCerts {
+		if _, found := newCerts[dbCert.Type]; !found {
+			newCerts[dbCert.Type] = make(map[string]x509.Certificate)
+		}
+
+		certBlock, _ := pem.Decode([]byte(dbCert.Certificate))
+		if certBlock == nil {
+			logger.Warn("Failed decoding certificate", log.Ctx{"name": dbCert.Name, "err": err})
+			continue
+		}
+
+		cert, err := x509.ParseCertificate(certBlock.Bytes)
+		if err != nil {
+			logger.Warn("Failed parsing certificate", log.Ctx{"name": dbCert.Name, "err": err})
+			continue
+		}
+
+		newCerts[dbCert.Type][shared.CertFingerprint(cert)] = *cert
+	}
+
+	d.clientCerts.Lock.Lock()
+	d.clientCerts.Certificates = newCerts
+	d.clientCerts.Lock.Unlock()
+
+	return nil
+}
+
 // swagger:operation POST /1.0/certificates?public certificates certificates_post_untrusted
 //
 // Add a trusted certificate

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -273,8 +273,8 @@ func generateTrustCertificate(serverCert *shared.CertInfo, serverName string) (*
 }
 
 // HasConnectivity probes the member with the given address for connectivity.
-func HasConnectivity(cert *shared.CertInfo, address string) bool {
-	config, err := tlsClientConfig(cert)
+func HasConnectivity(networkCert *shared.CertInfo, serverCert *shared.CertInfo, address string) bool {
+	config, err := tlsClientConfig(networkCert, serverCert)
 	if err != nil {
 		return false
 	}

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -21,6 +21,9 @@ import (
 	"github.com/lxc/lxd/shared/version"
 )
 
+// ErrCertificateExists indicates that a certificate already exists.
+var ErrCertificateExists error = fmt.Errorf("Certificate already in trust store")
+
 // Connect is a convenience around lxd.ConnectLXD that configures the client
 // with the correct parameters for node-to-node communication.
 //

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -22,14 +22,14 @@ var listenersLock sync.Mutex
 // get notified about events.
 //
 // Whenever an event is received the given callback is invoked.
-func Events(endpoints *endpoints.Endpoints, cluster *db.Cluster, f func(int64, api.Event)) (task.Func, task.Schedule) {
+func Events(endpoints *endpoints.Endpoints, cluster *db.Cluster, serverCert func() *shared.CertInfo, f func(int64, api.Event)) (task.Func, task.Schedule) {
 	// Update our pool of event listeners. Since database queries are
 	// blocking, we spawn the actual logic in a goroutine, to abort
 	// immediately when we receive the stop signal.
 	update := func(ctx context.Context) {
 		ch := make(chan struct{})
 		go func() {
-			eventsUpdateListeners(endpoints, cluster, f)
+			eventsUpdateListeners(endpoints, cluster, serverCert, f)
 			ch <- struct{}{}
 		}()
 		select {
@@ -43,7 +43,7 @@ func Events(endpoints *endpoints.Endpoints, cluster *db.Cluster, f func(int64, a
 	return update, schedule
 }
 
-func eventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, f func(int64, api.Event)) {
+func eventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, serverCert func() *shared.CertInfo, f func(int64, api.Event)) {
 	// Get the current cluster nodes.
 	var nodes []db.NodeInfo
 	var offlineThreshold time.Duration
@@ -99,7 +99,7 @@ func eventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 		}
 		listenersLock.Unlock()
 
-		listener, err := eventsConnect(node.Address, endpoints.NetworkCert())
+		listener, err := eventsConnect(node.Address, endpoints.NetworkCert(), serverCert())
 		if err != nil {
 			logger.Warnf("Failed to get events from node %s: %v", node.Address, err)
 			continue
@@ -123,8 +123,8 @@ func eventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 }
 
 // Establish a client connection to get events from the given node.
-func eventsConnect(address string, cert *shared.CertInfo) (*lxd.EventListener, error) {
-	client, err := Connect(address, cert, true)
+func eventsConnect(address string, networkCert *shared.CertInfo, serverCert *shared.CertInfo) (*lxd.EventListener, error) {
+	client, err := Connect(address, networkCert, serverCert, true)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -649,7 +649,7 @@ func (g *Gateway) LeaderAddress() (string, error) {
 
 	// If this isn't a raft node, contact a raft node and ask for the
 	// address of the current leader.
-	config, err := tlsClientConfig(g.cert)
+	config, err := tlsClientConfig(g.networkCert, g.serverCert())
 	if err != nil {
 		return "", err
 	}
@@ -933,7 +933,7 @@ func (g *Gateway) nodeAddress(raftAddress string) (string, error) {
 }
 
 func dqliteNetworkDial(ctx context.Context, addr string, g *Gateway) (net.Conn, error) {
-	config, err := tlsClientConfig(g.cert)
+	config, err := tlsClientConfig(g.networkCert, g.serverCert())
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -488,7 +488,7 @@ func (g *Gateway) TransferLeadership() error {
 		if err != nil {
 			return err
 		}
-		if !HasConnectivity(g.cert, address) {
+		if !HasConnectivity(g.networkCert, g.serverCert(), address) {
 			continue
 		}
 		id = server.ID

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -145,12 +145,12 @@ func setDqliteVersionHeader(request *http.Request) {
 // These handlers might return 404, either because this LXD node is a
 // non-clustered node not available over the network or because it is not a
 // database node part of the dqlite cluster.
-func (g *Gateway) HandlerFuncs(nodeRefreshTask func(*APIHeartbeat)) map[string]http.HandlerFunc {
+func (g *Gateway) HandlerFuncs(nodeRefreshTask func(*APIHeartbeat), trustedCerts func() map[int]map[string]x509.Certificate) map[string]http.HandlerFunc {
 	database := func(w http.ResponseWriter, r *http.Request) {
 		g.lock.RLock()
 		defer g.lock.RUnlock()
 
-		if !tlsCheckCert(r, g.cert) {
+		if !tlsCheckCert(r, g.networkCert, g.serverCert(), trustedCerts()) {
 			http.Error(w, "403 invalid client certificate", http.StatusForbidden)
 			return
 		}

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -590,7 +590,7 @@ func (g *Gateway) getClient() (*client.Client, error) {
 // the given certificate.
 //
 // This is used when disabling clustering on a node.
-func (g *Gateway) Reset(cert *shared.CertInfo) error {
+func (g *Gateway) Reset(networkCert *shared.CertInfo) error {
 	err := g.Shutdown()
 	if err != nil {
 		return err
@@ -605,7 +605,8 @@ func (g *Gateway) Reset(cert *shared.CertInfo) error {
 	if err != nil {
 		return err
 	}
-	g.cert = cert
+	g.networkCert = networkCert
+
 	return g.init(false)
 }
 

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -726,7 +726,7 @@ func (g *Gateway) init(bootstrap bool) error {
 	logger.Debugf("Initializing database gateway")
 	g.stopCh = make(chan struct{}, 0)
 
-	info, err := loadInfo(g.db, g.cert)
+	info, err := loadInfo(g.db, g.networkCert)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create raft factory")
 	}

--- a/lxd/cluster/gateway_export_test.go
+++ b/lxd/cluster/gateway_export_test.go
@@ -10,9 +10,14 @@ func (g *Gateway) IsLeader() (bool, error) {
 	return g.isLeader()
 }
 
-// Cert returns the gateway's internal TLS certificate information.
-func (g *Gateway) Cert() *shared.CertInfo {
-	return g.cert
+// ServerCert returns the gateway's internal TLS server certificate information.
+func (g *Gateway) ServerCert() *shared.CertInfo {
+	return g.networkCert
+}
+
+// NetworkCert returns the gateway's internal TLS NetworkCert certificate information.
+func (g *Gateway) NetworkCert() *shared.CertInfo {
+	return g.networkCert
 }
 
 // RaftNodes returns the nodes currently part of the raft cluster.

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -940,18 +940,24 @@ func Purge(cluster *db.Cluster, name string) error {
 		// Get the node (if it doesn't exists an error is returned).
 		node, err := tx.GetNodeByName(name)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get node %s", name)
+			return errors.Wrapf(err, "Failed to get member %q", name)
 		}
 
 		err = tx.ClearNode(node.ID)
 		if err != nil {
-			return errors.Wrapf(err, "failed to clear node %s", name)
+			return errors.Wrapf(err, "Failed to clear member %q", name)
 		}
 
 		err = tx.RemoveNode(node.ID)
 		if err != nil {
-			return errors.Wrapf(err, "failed to remove node %s", name)
+			return errors.Wrapf(err, "Failed to remove member %q", name)
 		}
+
+		err = tx.DeleteCertificateByNameAndType(name, db.CertificateTypeServer)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to remove member %q certificate from trust store", name)
+		}
+
 		return nil
 	})
 }

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -911,7 +911,7 @@ func newRolesChanges(state *state.State, gateway *Gateway, nodes []db.RaftNode) 
 	cluster := map[client.NodeInfo]*client.NodeMetadata{}
 
 	for _, node := range nodes {
-		if HasConnectivity(gateway.cert, node.Address) {
+		if HasConnectivity(gateway.networkCert, gateway.serverCert(), node.Address) {
 			cluster[node] = &client.NodeMetadata{
 				FailureDomain: domains[node.Address],
 			}

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -517,9 +517,8 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 	return nil
 }
 
-// Attempt to send a heartbeat to all other nodes to notify them of a new or
-// changed member.
-func notifyNodesUpdate(raftNodes []db.RaftNode, id uint64, cert *shared.CertInfo) {
+// Attempt to send a heartbeat to all other nodes to notify them of a new or changed member.
+func notifyNodesUpdate(raftNodes []db.RaftNode, id uint64, networkCert *shared.CertInfo, serverCert *shared.CertInfo) {
 	// Generate partial heartbeat request containing just a raft node list.
 	hbState := &APIHeartbeat{}
 	hbState.Time = time.Now().UTC()
@@ -534,7 +533,7 @@ func notifyNodesUpdate(raftNodes []db.RaftNode, id uint64, cert *shared.CertInfo
 		if node.ID == id {
 			continue
 		}
-		go HeartbeatNode(context.Background(), node.Address, cert, hbState)
+		go HeartbeatNode(context.Background(), node.Address, networkCert, serverCert, hbState)
 	}
 }
 
@@ -760,7 +759,7 @@ assign:
 	}
 
 	// Generate partial heartbeat request containing just a raft node list.
-	notifyNodesUpdate(nodes, info.ID, gateway.cert)
+	notifyNodesUpdate(nodes, info.ID, gateway.networkCert, gateway.serverCert())
 
 	return nil
 }

--- a/lxd/cluster/membership_test.go
+++ b/lxd/cluster/membership_test.go
@@ -1,6 +1,7 @@
 package cluster_test
 
 import (
+	"crypto/x509"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -69,8 +70,9 @@ func TestBootstrap_UnmetPreconditions(t *testing.T) {
 
 			c.setup(&membershipFixtures{t: t, state: state})
 
-			cert := shared.TestingKeyPair()
-			gateway := newGateway(t, state.Node, cert)
+			serverCert := shared.TestingKeyPair()
+			state.ServerCert = func() *shared.CertInfo { return serverCert }
+			gateway := newGateway(t, state.Node, serverCert, serverCert)
 			defer gateway.Shutdown()
 
 			err := cluster.Bootstrap(state, gateway, "buzz")
@@ -83,12 +85,13 @@ func TestBootstrap(t *testing.T) {
 	state, cleanup := state.NewTestState(t)
 	defer cleanup()
 
-	cert := shared.TestingKeyPair()
-	gateway := newGateway(t, state.Node, cert)
+	serverCert := shared.TestingKeyPair()
+	gateway := newGateway(t, state.Node, serverCert, serverCert)
+	state.ServerCert = func() *shared.CertInfo { return serverCert }
 	defer gateway.Shutdown()
 
 	mux := http.NewServeMux()
-	server := newServer(cert, mux)
+	server := newServer(serverCert, mux)
 	defer server.Close()
 
 	address := server.Listener.Addr().String()
@@ -123,8 +126,12 @@ func TestBootstrap(t *testing.T) {
 	// The cluster certificate is in place.
 	assert.True(t, shared.PathExists(filepath.Join(state.OS.VarDir, "cluster.crt")))
 
+	trustedCerts := func() map[int]map[string]x509.Certificate {
+		return nil
+	}
+
 	// The dqlite driver is now exposed over the network.
-	for path, handler := range gateway.HandlerFuncs(nil) {
+	for path, handler := range gateway.HandlerFuncs(nil, trustedCerts) {
 		mux.HandleFunc(path, handler)
 	}
 
@@ -201,8 +208,8 @@ func TestAccept_UnmetPreconditions(t *testing.T) {
 			state, cleanup := state.NewTestState(t)
 			defer cleanup()
 
-			cert := shared.TestingKeyPair()
-			gateway := newGateway(t, state.Node, cert)
+			serverCert := shared.TestingKeyPair()
+			gateway := newGateway(t, state.Node, serverCert, serverCert)
 			defer gateway.Shutdown()
 
 			c.setup(&membershipFixtures{t: t, state: state})
@@ -218,8 +225,8 @@ func TestAccept(t *testing.T) {
 	state, cleanup := state.NewTestState(t)
 	defer cleanup()
 
-	cert := shared.TestingKeyPair()
-	gateway := newGateway(t, state.Node, cert)
+	serverCert := shared.TestingKeyPair()
+	gateway := newGateway(t, state.Node, serverCert, serverCert)
 	defer gateway.Shutdown()
 
 	f := &membershipFixtures{t: t, state: state}
@@ -246,10 +253,21 @@ func TestJoin(t *testing.T) {
 	targetState, cleanup := state.NewTestState(t)
 	defer cleanup()
 
-	targetGateway := newGateway(t, targetState.Node, targetCert)
+	targetGateway := newGateway(t, targetState.Node, targetCert, targetCert)
 	defer targetGateway.Shutdown()
 
-	for path, handler := range targetGateway.HandlerFuncs(nil) {
+	altServerCert := shared.TestingAltKeyPair()
+	trustedAltServerCert, _ := x509.ParseCertificate(altServerCert.KeyPair().Certificate[0])
+
+	trustedCerts := func() map[int]map[string]x509.Certificate {
+		return map[int]map[string]x509.Certificate{
+			db.CertificateTypeServer: {
+				altServerCert.Fingerprint(): *trustedAltServerCert,
+			},
+		}
+	}
+
+	for path, handler := range targetGateway.HandlerFuncs(nil, trustedCerts) {
 		targetMux.HandleFunc(path, handler)
 	}
 
@@ -261,10 +279,8 @@ func TestJoin(t *testing.T) {
 	targetDialFunc := targetGateway.DialFunc()
 
 	var err error
-	targetState.Cluster, err = db.OpenCluster(
-		"db.bin", targetStore, targetAddress, "/unused/db/dir",
-		10*time.Second, nil,
-		driver.WithDialFunc(targetDialFunc))
+	targetState.Cluster, err = db.OpenCluster("db.bin", targetStore, targetAddress, "/unused/db/dir", 10*time.Second, nil, driver.WithDialFunc(targetDialFunc))
+	targetState.ServerCert = func() *shared.CertInfo { return targetCert }
 	require.NoError(t, err)
 
 	targetF := &membershipFixtures{t: t, state: targetState}
@@ -283,12 +299,11 @@ func TestJoin(t *testing.T) {
 	state, cleanup := state.NewTestState(t)
 	defer cleanup()
 
-	cert := shared.TestingAltKeyPair()
-	gateway := newGateway(t, state.Node, cert)
+	gateway := newGateway(t, state.Node, targetCert, altServerCert)
 
 	defer gateway.Shutdown()
 
-	for path, handler := range gateway.HandlerFuncs(nil) {
+	for path, handler := range gateway.HandlerFuncs(nil, trustedCerts) {
 		mux.HandleFunc(path, handler)
 	}
 
@@ -299,9 +314,7 @@ func TestJoin(t *testing.T) {
 	store := gateway.NodeStore()
 	dialFunc := gateway.DialFunc()
 
-	state.Cluster, err = db.OpenCluster(
-		"db.bin", store, address, "/unused/db/dir", 5*time.Second, nil,
-		driver.WithDialFunc(dialFunc))
+	state.Cluster, err = db.OpenCluster("db.bin", store, address, "/unused/db/dir", 5*time.Second, nil, driver.WithDialFunc(dialFunc))
 	require.NoError(t, err)
 
 	f := &membershipFixtures{t: t, state: state}
@@ -313,7 +326,7 @@ func TestJoin(t *testing.T) {
 	require.NoError(t, err)
 
 	// Actually join the cluster.
-	err = cluster.Join(state, gateway, targetCert, "rusp", raftNodes)
+	err = cluster.Join(state, gateway, targetCert, altServerCert, "rusp", raftNodes)
 	require.NoError(t, err)
 
 	// The leader now returns an updated list of raft nodes.

--- a/lxd/cluster/notify.go
+++ b/lxd/cluster/notify.go
@@ -32,7 +32,7 @@ const (
 
 // NewNotifier builds a Notifier that can be used to notify other peers using
 // the given policy.
-func NewNotifier(state *state.State, cert *shared.CertInfo, policy NotifierPolicy) (Notifier, error) {
+func NewNotifier(state *state.State, networkCert *shared.CertInfo, serverCert *shared.CertInfo, policy NotifierPolicy) (Notifier, error) {
 	address, err := node.ClusterAddress(state.Node)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch node address")
@@ -73,7 +73,7 @@ func NewNotifier(state *state.State, cert *shared.CertInfo, policy NotifierPolic
 			// enough, let's try to connect to the node, just in
 			// case the heartbeat is lagging behind for some reason
 			// and the node is actually up.
-			if !HasConnectivity(cert, node.Address) {
+			if !HasConnectivity(networkCert, serverCert, node.Address) {
 				switch policy {
 				case NotifyAll:
 					return nil, fmt.Errorf("peer node %s is down", node.Address)
@@ -94,7 +94,7 @@ func NewNotifier(state *state.State, cert *shared.CertInfo, policy NotifierPolic
 			logger.Debugf("Notify node %s of state changes", address)
 			go func(i int, address string) {
 				defer wg.Done()
-				client, err := Connect(address, cert, true)
+				client, err := Connect(address, networkCert, serverCert, true)
 				if err != nil {
 					errs[i] = errors.Wrapf(err, "failed to connect to peer %s", address)
 					return

--- a/lxd/cluster/notify_test.go
+++ b/lxd/cluster/notify_test.go
@@ -29,7 +29,7 @@ func TestNewNotifier(t *testing.T) {
 	f := notifyFixtures{t: t, state: state}
 	defer f.Nodes(cert, 3)()
 
-	notifier, err := cluster.NewNotifier(state, cert, cluster.NotifyAll)
+	notifier, err := cluster.NewNotifier(state, cert, cert, cluster.NotifyAll)
 	require.NoError(t, err)
 
 	peers := make(chan string, 2)
@@ -66,7 +66,7 @@ func TestNewNotify_NotifyAllError(t *testing.T) {
 	defer f.Nodes(cert, 3)()
 
 	f.Down(1)
-	notifier, err := cluster.NewNotifier(state, cert, cluster.NotifyAll)
+	notifier, err := cluster.NewNotifier(state, cert, cert, cluster.NotifyAll)
 	assert.Nil(t, notifier)
 	require.Error(t, err)
 	assert.Regexp(t, "peer node .+ is down", err.Error())
@@ -84,7 +84,7 @@ func TestNewNotify_NotifyAlive(t *testing.T) {
 	defer f.Nodes(cert, 3)()
 
 	f.Down(1)
-	notifier, err := cluster.NewNotifier(state, cert, cluster.NotifyAlive)
+	notifier, err := cluster.NewNotifier(state, cert, cert, cluster.NotifyAlive)
 	assert.NoError(t, err)
 
 	i := 0

--- a/lxd/cluster/upgrade.go
+++ b/lxd/cluster/upgrade.go
@@ -21,8 +21,8 @@ import (
 // cluster that any possible pending database update has been applied, and any
 // nodes which was waiting for this node to be upgraded should re-check if it's
 // okay to move forward.
-func NotifyUpgradeCompleted(state *state.State, cert *shared.CertInfo) error {
-	notifier, err := NewNotifier(state, cert, NotifyTryAll)
+func NotifyUpgradeCompleted(state *state.State, networkCert *shared.CertInfo, serverCert *shared.CertInfo) error {
+	notifier, err := NewNotifier(state, networkCert, serverCert, NotifyTryAll)
 	if err != nil {
 		return err
 	}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1036,7 +1036,7 @@ func (d *Daemon) init() error {
 	d.firewall = firewall.New()
 	logger.Infof("Firewall loaded driver %q", d.firewall)
 
-	err = cluster.NotifyUpgradeCompleted(d.State(), networkCert, d.serverCert)
+	err = cluster.NotifyUpgradeCompleted(d.State(), networkCert, d.serverCert())
 	if err != nil {
 		// Ignore the error, since it's not fatal for this particular
 		// node. In most cases it just means that some nodes are

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1239,7 +1239,7 @@ func (d *Daemon) startClusterTasks() {
 	d.clusterTasks.Add(cluster.HeartbeatTask(d.gateway))
 
 	// Events
-	d.clusterTasks.Add(cluster.Events(d.endpoints, d.cluster, d.events.Forward))
+	d.clusterTasks.Add(cluster.Events(d.endpoints, d.cluster, d.serverCert, d.events.Forward))
 
 	// Auto-sync images across the cluster (hourly)
 	d.clusterTasks.Add(autoSyncImagesTask(d))

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -106,6 +106,9 @@ type Daemon struct {
 	clusterMembershipMutex   sync.RWMutex
 	clusterMembershipClosing bool // Prevent further rebalances
 
+	serverCert    func() *shared.CertInfo
+	serverCertInt *shared.CertInfo // Do not use this directly, use servertCert func.
+
 	ctx    context.Context
 	cancel context.CancelFunc
 }
@@ -162,7 +165,7 @@ func newDaemon(config *DaemonConfig, os *sys.OS) *Daemon {
 	devlxdEvents := events.NewServer(daemon.Debug, daemon.Verbose)
 	ctx, cancel := context.WithCancel(context.Background())
 
-	return &Daemon{
+	d := &Daemon{
 		clientCerts:  &certificateCache{},
 		config:       config,
 		devlxdEvents: devlxdEvents,
@@ -174,6 +177,10 @@ func newDaemon(config *DaemonConfig, os *sys.OS) *Daemon {
 		ctx:          ctx,
 		cancel:       cancel,
 	}
+
+	d.serverCert = func() *shared.CertInfo { return d.serverCertInt }
+
+	return d
 }
 
 // defaultDaemonConfig returns a DaemonConfig object with default values.

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -398,7 +398,7 @@ func (d *Daemon) State() *state.State {
 	// If the daemon is shutting down, the context will be cancelled.
 	// This information will be available throughout the code, and can be used to prevent new
 	// operations from starting during shutdown.
-	return state.NewState(d.ctx, d.db, d.cluster, d.maas, d.os, d.endpoints, d.events, d.devlxdEvents, d.firewall, d.proxy, d.serverCert)
+	return state.NewState(d.ctx, d.db, d.cluster, d.maas, d.os, d.endpoints, d.events, d.devlxdEvents, d.firewall, d.proxy, d.serverCert, func() { updateCertificateCache(d) })
 }
 
 // UnixSocket returns the full path to the unix.socket file that this daemon is

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -279,12 +279,12 @@ func (d *Daemon) getTrustedCertificates() map[int]map[string]x509.Certificate {
 //
 // This does not perform authorization, only validates authentication.
 func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, string, string, error) {
-	// Allow internal cluster traffic.
+	trustedCerts := d.getTrustedCertificates()
+
+	// Allow internal cluster traffic by checking against the trusted certfificates.
 	if r.TLS != nil {
-		cert, _ := x509.ParseCertificate(d.endpoints.NetworkCert().KeyPair().Certificate[0])
-		clusterCerts := map[string]x509.Certificate{"0": *cert}
-		for i := range r.TLS.PeerCertificates {
-			trusted, _ := util.CheckTrustState(*r.TLS.PeerCertificates[i], clusterCerts, nil, false)
+		for _, i := range r.TLS.PeerCertificates {
+			trusted, _ := util.CheckTrustState(*i, trustedCerts[db.CertificateTypeServer], d.endpoints.NetworkCert(), false)
 			if trusted {
 				return true, "", "cluster", nil
 			}
@@ -318,7 +318,7 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, str
 
 	// Cluster notification with wrong certificate.
 	if isClusterNotification(r) {
-		return false, "", "", fmt.Errorf("Cluster notification isn't using cluster certificate")
+		return false, "", "", fmt.Errorf("Cluster notification isn't using trusted server certificate")
 	}
 
 	// Bad query, no TLS found.
@@ -352,17 +352,13 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, str
 	}
 
 	// Validate normal TLS access.
-	var err error
-
 	trustCACertificates, err := cluster.ConfigGetBool(d.cluster, "core.trust_ca_certificates")
 	if err != nil {
 		return false, "", "", err
 	}
 
-	trustedCerts := d.getTrustedCertificates()
-
-	for i := range r.TLS.PeerCertificates {
-		trusted, username := util.CheckTrustState(*r.TLS.PeerCertificates[i], trustedCerts[db.CertificateTypeClient], d.endpoints.NetworkCert(), trustCACertificates)
+	for _, i := range r.TLS.PeerCertificates {
+		trusted, username := util.CheckTrustState(*i, trustedCerts[db.CertificateTypeClient], d.endpoints.NetworkCert(), trustCACertificates)
 		if trusted {
 			return true, username, "tls", nil
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -875,10 +875,43 @@ func (d *Daemon) init() error {
 		return err
 	}
 
-	/* Setup server certificate */
-	certInfo, err := util.LoadCert(d.os.VarDir)
+	/* Setup network endpoint certificate */
+	networkCert, err := util.LoadCert(d.os.VarDir)
 	if err != nil {
 		return err
+	}
+
+	/* Setup server certificate */
+	serverCert, err := util.LoadServerCert(d.os.VarDir)
+	if err != nil {
+		return err
+	}
+
+	// Load cached local trusted certificates before starting listener and cluster database.
+	err = updateCertificateCacheFromLocal(d, networkCert)
+	if err != nil {
+		return err
+	}
+
+	clustered, err := cluster.Enabled(d.db)
+	if err != nil {
+		return errors.Wrapf(err, "Failed checking if clustered")
+	}
+
+	// Detect if clustered, but not yet upgraded to per-server client certificates.
+	if clustered && len(d.clientCerts.Certificates[db.CertificateTypeServer]) < 1 {
+		// If the cluster has not yet upgraded to per-server client certificates (by running patch
+		// patchClusteringServerCertTrust) then temporarily use the network (cluster) certificate as client
+		// certificate, and cause us to trust it for use as client certificate from the other members.
+		logger.Warnf("No local trusted server certificates found, falling back to trusting network certificate")
+		logger.Infof("Set client certificate to network certificate %v", networkCert.Fingerprint())
+		d.serverCertInt = networkCert
+
+	} else {
+		// If standalone or the local trusted certificates table is populated with server certificates then
+		// use our local server certificate as client certificate for intra-cluster communication.
+		logger.Infof("Set client certificate to server certificate %v", serverCert.Fingerprint())
+		d.serverCertInt = serverCert
 	}
 
 	/* Setup dqlite */
@@ -888,7 +921,8 @@ func (d *Daemon) init() error {
 	}
 	d.gateway, err = cluster.NewGateway(
 		d.db,
-		certInfo,
+		networkCert,
+		d.serverCert,
 		cluster.Latency(d.config.RaftLatency),
 		cluster.LogLevel(clusterLogLevel))
 	if err != nil {
@@ -930,7 +964,7 @@ func (d *Daemon) init() error {
 	config := &endpoints.Config{
 		Dir:                  d.os.VarDir,
 		UnixSocket:           d.UnixSocket(),
-		Cert:                 certInfo,
+		Cert:                 networkCert,
 		RestServer:           restServer(d),
 		DevLxdServer:         devLxdServer(d),
 		LocalUnixSocketGroup: d.config.Group,
@@ -939,11 +973,6 @@ func (d *Daemon) init() error {
 		DebugAddress:         debugAddress,
 	}
 	d.endpoints, err = endpoints.Up(config)
-	if err != nil {
-		return err
-	}
-
-	clustered, err := cluster.Enabled(d.db)
 	if err != nil {
 		return err
 	}
@@ -1011,7 +1040,7 @@ func (d *Daemon) init() error {
 	d.firewall = firewall.New()
 	logger.Infof("Firewall loaded driver %q", d.firewall)
 
-	err = cluster.NotifyUpgradeCompleted(d.State(), certInfo)
+	err = cluster.NotifyUpgradeCompleted(d.State(), networkCert, d.serverCert)
 	if err != nil {
 		// Ignore the error, since it's not fatal for this particular
 		// node. In most cases it just means that some nodes are

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1728,6 +1728,9 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat) {
 
 		nodeListChanged := d.hasNodeListChanged(heartbeatData)
 		if nodeListChanged {
+			logger.Debug("Member list has changed")
+			updateCertificateCache(d)
+
 			err := networkUpdateForkdnsServersTask(d.State(), heartbeatData)
 			if err != nil {
 				logger.Errorf("Error refreshing forkdns: %v", err)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -402,7 +402,7 @@ func (d *Daemon) State() *state.State {
 	// If the daemon is shutting down, the context will be cancelled.
 	// This information will be available throughout the code, and can be used to prevent new
 	// operations from starting during shutdown.
-	return state.NewState(d.ctx, d.db, d.cluster, d.maas, d.os, d.endpoints, d.events, d.devlxdEvents, d.firewall, d.proxy)
+	return state.NewState(d.ctx, d.db, d.cluster, d.maas, d.os, d.endpoints, d.events, d.devlxdEvents, d.firewall, d.proxy, d.serverCert)
 }
 
 // UnixSocket returns the full path to the unix.socket file that this daemon is

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -220,3 +220,27 @@ func (n *NodeTx) GetCertificates() ([]Certificate, error) {
 
 	return certs, nil
 }
+
+// ReplaceCertificates removes all existing certificates from the local certificates table and replaces them with
+// the ones provided.
+func (n *NodeTx) ReplaceCertificates(certs []Certificate) error {
+	_, err := n.tx.Exec("DELETE FROM certificates")
+	if err != nil {
+		return err
+	}
+
+	stmt, err := n.tx.Prepare("INSERT INTO certificates (fingerprint, type, name, certificate) VALUES(?,?,?,?)")
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	for _, cert := range certs {
+		_, err = stmt.Exec(cert.Fingerprint, cert.Type, cert.Name, cert.Certificate)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -6,6 +6,7 @@ package db
 import (
 	"fmt"
 
+	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared/api"
 )
 
@@ -176,4 +177,46 @@ func (c *Cluster) UpdateCertificateProjects(id int, projects []string) error {
 		return tx.UpdateCertificateProjects(id, projects)
 	})
 	return err
+}
+
+// GetCertificates returns all available local certificates.
+func (n *NodeTx) GetCertificates() ([]Certificate, error) {
+	dbCerts := []struct {
+		fingerprint string
+		certType    int
+		name        string
+		certificate string
+	}{}
+	dest := func(i int) []interface{} {
+		dbCerts = append(dbCerts, struct {
+			fingerprint string
+			certType    int
+			name        string
+			certificate string
+		}{})
+		return []interface{}{&dbCerts[i].fingerprint, &dbCerts[i].certType, &dbCerts[i].name, &dbCerts[i].certificate}
+	}
+
+	stmt, err := n.tx.Prepare("SELECT fingerprint, type, name, certificate FROM certificates")
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+
+	err = query.SelectObjects(stmt, dest)
+	if err != nil {
+		return nil, err
+	}
+
+	certs := make([]Certificate, 0, len(dbCerts))
+	for _, dbCert := range dbCerts {
+		certs = append(certs, Certificate{
+			Fingerprint: dbCert.fingerprint,
+			Type:        dbCert.certType,
+			Name:        dbCert.name,
+			Certificate: dbCert.certificate,
+		})
+	}
+
+	return certs, nil
 }

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -114,6 +114,12 @@ func (c *ClusterTx) UpdateCertificateProjects(id int, projects []string) error {
 	return nil
 }
 
+// DeleteCertificateByNameAndType deletes the certificate(s) matching the given name and certificate type.
+func (c *ClusterTx) DeleteCertificateByNameAndType(name string, certType int) error {
+	_, err := c.tx.Exec("DELETE FROM certificates WHERE name = ? and type = ?", name, certType)
+	return err
+}
+
 // CertificateFilter can be used to filter results yielded by GetCertInfos
 type CertificateFilter struct {
 	Fingerprint string // Matched with LIKE

--- a/lxd/db/node/schema.go
+++ b/lxd/db/node/schema.go
@@ -6,6 +6,14 @@ package node
 // modify the database schema, please add a new schema update to update.go
 // and the run 'make update-schema'.
 const freshSchema = `
+CREATE TABLE certificates (
+	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+	fingerprint TEXT NOT NULL,
+	type INTEGER NOT NULL,
+	name TEXT NOT NULL,
+	certificate TEXT NOT NULL,
+	UNIQUE (fingerprint)
+);
 CREATE TABLE config (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     key VARCHAR(255) NOT NULL,
@@ -25,5 +33,5 @@ CREATE TABLE raft_nodes (
     UNIQUE (address)
 );
 
-INSERT INTO schema (version, updated_at) VALUES (40, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (41, strftime("%s"))
 `

--- a/lxd/db/node/update.go
+++ b/lxd/db/node/update.go
@@ -97,6 +97,7 @@ var updates = map[int]schema.Update{
 	38: updateFromV37,
 	39: updateFromV38,
 	40: updateFromV39,
+	41: updateFromV40,
 }
 
 // UpdateFromPreClustering is the last schema version where clustering support
@@ -104,6 +105,21 @@ var updates = map[int]schema.Update{
 const UpdateFromPreClustering = 36
 
 // Schema updates begin here
+
+func updateFromV40(tx *sql.Tx) error {
+	stmt := `
+CREATE TABLE certificates (
+	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+	fingerprint TEXT NOT NULL,
+	type INTEGER NOT NULL,
+	name TEXT NOT NULL,
+	certificate TEXT NOT NULL,
+	UNIQUE (fingerprint)
+);
+`
+	_, err := tx.Exec(stmt)
+	return err
+}
 
 // Fix the address of the bootstrap node being set to "0" in the raft_nodes
 // table.

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1610,7 +1610,7 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 			return errors.Wrapf(err, "Failed to retrieve information about cluster member with address %q", nodeAddress)
 		}
 
-		client, err := cluster.Connect(nodeAddress, d.endpoints.NetworkCert(), true)
+		client, err := cluster.Connect(nodeAddress, d.endpoints.NetworkCert(), d.serverCert(), true)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to connect to %q for image synchronization", nodeAddress)
 		}
@@ -3201,8 +3201,7 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 	}
 	if address != "" {
 		// Forward the request to the other node
-		cert := d.endpoints.NetworkCert()
-		client, err := cluster.Connect(address, cert, false)
+		client, err := cluster.Connect(address, d.endpoints.NetworkCert(), d.serverCert(), false)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -3649,7 +3648,7 @@ func imageSyncBetweenNodes(d *Daemon, project string, fingerprint string) error 
 	// Pick a random node from that slice as the source.
 	syncNodeAddress := syncNodeAddresses[rand.Intn(len(syncNodeAddresses))]
 
-	source, err := cluster.Connect(syncNodeAddress, d.endpoints.NetworkCert(), true)
+	source, err := cluster.Connect(syncNodeAddress, d.endpoints.NetworkCert(), d.serverCert(), true)
 	if err != nil {
 		return errors.Wrap(err, "Failed to connect to source node for image synchronization")
 	}
@@ -3676,7 +3675,7 @@ func imageSyncBetweenNodes(d *Daemon, project string, fingerprint string) error 
 		// Pick a random node from that slice as the target.
 		targetNodeAddress := addresses[rand.Intn(len(addresses))]
 
-		client, err := cluster.Connect(targetNodeAddress, d.endpoints.NetworkCert(), true)
+		client, err := cluster.Connect(targetNodeAddress, d.endpoints.NetworkCert(), d.serverCert(), true)
 		if err != nil {
 			return errors.Wrap(err, "Failed to connect node for image synchronization")
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2166,7 +2166,7 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Notify the other nodes about the removed image so they can remove it from disk too.
-			notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), cluster.NotifyAll)
+			notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), d.serverCert(), cluster.NotifyAll)
 			if err != nil {
 				return err
 			}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -62,7 +62,7 @@ func instanceCreateAsEmpty(d *Daemon, args db.InstanceArgs) (instance.Instance, 
 // instanceImageTransfer transfers an image from another cluster node.
 func instanceImageTransfer(d *Daemon, projectName string, hash string, nodeAddress string) error {
 	logger.Debugf("Transferring image %q from node %q", hash, nodeAddress)
-	client, err := cluster.Connect(nodeAddress, d.endpoints.NetworkCert(), false)
+	client, err := cluster.Connect(nodeAddress, d.endpoints.NetworkCert(), d.serverCert(), false)
 	if err != nil {
 		return err
 	}

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -386,8 +386,7 @@ func instanceConsolePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Forward the request if the container is remote.
-	cert := d.endpoints.NetworkCert()
-	client, err := cluster.ConnectIfInstanceIsRemote(d.cluster, projectName, name, cert, instanceType)
+	client, err := cluster.ConnectIfInstanceIsRemote(d.cluster, projectName, name, d.endpoints.NetworkCert(), d.serverCert(), instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -429,8 +429,7 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Forward the request if the container is remote.
-	cert := d.endpoints.NetworkCert()
-	client, err := cluster.ConnectIfInstanceIsRemote(d.cluster, projectName, name, cert, instanceType)
+	client, err := cluster.ConnectIfInstanceIsRemote(d.cluster, projectName, name, d.endpoints.NetworkCert(), d.serverCert(), instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -388,8 +388,6 @@ func instancePostPoolMigration(d *Daemon, inst instance.Instance, newName string
 
 // Move a non-ceph container to another cluster node.
 func instancePostClusteringMigrate(d *Daemon, inst instance.Instance, oldName, newName, newNode string) response.Response {
-	cert := d.endpoints.NetworkCert()
-
 	var sourceAddress string
 	var targetAddress string
 
@@ -419,14 +417,14 @@ func instancePostClusteringMigrate(d *Daemon, inst instance.Instance, oldName, n
 
 	run := func(op *operations.Operation) error {
 		// Connect to the source host, i.e. ourselves (the node the instance is running on).
-		source, err := cluster.Connect(sourceAddress, cert, true)
+		source, err := cluster.Connect(sourceAddress, d.endpoints.NetworkCert(), d.serverCert(), true)
 		if err != nil {
 			return errors.Wrap(err, "Failed to connect to source server")
 		}
 		source = source.UseProject(inst.Project())
 
 		// Connect to the destination host, i.e. the node to migrate the container to.
-		dest, err := cluster.Connect(targetAddress, cert, false)
+		dest, err := cluster.Connect(targetAddress, d.endpoints.NetworkCert(), d.serverCert(), false)
 		if err != nil {
 			return errors.Wrap(err, "Failed to connect to destination server")
 		}
@@ -594,8 +592,7 @@ func instancePostClusteringMigrateWithCeph(d *Daemon, inst instance.Instance, pr
 		}
 
 		// Create the container mount point on the target node
-		cert := d.endpoints.NetworkCert()
-		client, err := cluster.ConnectIfInstanceIsRemote(d.cluster, projectName, newName, cert, instanceType)
+		client, err := cluster.ConnectIfInstanceIsRemote(d.cluster, projectName, newName, d.endpoints.NetworkCert(), d.serverCert(), instanceType)
 		if err != nil {
 			return errors.Wrap(err, "Failed to connect to target node")
 		}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -828,8 +828,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			return response.SmartError(err)
 		}
 		if address != "" {
-			cert := d.endpoints.NetworkCert()
-			client, err := cluster.Connect(address, cert, false)
+			client, err := cluster.Connect(address, d.endpoints.NetworkCert(), d.serverCert(), false)
 			if err != nil {
 				return response.SmartError(err)
 			}
@@ -1035,7 +1034,7 @@ func clusterCopyContainerInternal(d *Daemon, source instance.Instance, projectNa
 	}
 
 	// Connect to the container source
-	client, err := cluster.Connect(nodeAddress, d.endpoints.NetworkCert(), false)
+	client, err := cluster.Connect(nodeAddress, d.endpoints.NetworkCert(), d.serverCert(), false)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instances_put.go
+++ b/lxd/instances_put.go
@@ -168,7 +168,7 @@ func instancesPut(d *Daemon, r *http.Request) response.Response {
 		failuresLock := sync.Mutex{}
 		wgAction := sync.WaitGroup{}
 
-		cert := d.endpoints.NetworkCert()
+		networkCert := d.endpoints.NetworkCert()
 		for _, node := range nodes {
 			wgAction.Add(1)
 			go func(node db.NodeInfo) {
@@ -186,7 +186,7 @@ func instancesPut(d *Daemon, r *http.Request) response.Response {
 				}
 
 				// Connect to the remote server.
-				client, err := cluster.Connect(node.Address, cert, true)
+				client, err := cluster.Connect(node.Address, networkCert, d.serverCert(), true)
 				if err != nil {
 					failuresLock.Lock()
 					failures[node.Name] = err

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -175,7 +175,7 @@ func (c *cmdInit) availableStorageDrivers(poolType string) []string {
 	}
 
 	// Get info for supported drivers.
-	s := state.NewState(nil, nil, nil, nil, sys.DefaultOS(), nil, nil, nil, nil, nil)
+	s := state.NewState(nil, nil, nil, nil, sys.DefaultOS(), nil, nil, nil, nil, nil, nil, func() {})
 	supportedDrivers := storageDrivers.SupportedDrivers(s)
 
 	drivers := make([]string, 0, len(supportedDrivers))

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -189,22 +189,20 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer) error
 			}
 
 			// Connect to existing cluster
-			cert, err := util.LoadCert(shared.VarPath(""))
+			serverCert, err := util.LoadServerCert(shared.VarPath(""))
 			if err != nil {
 				return err
 			}
 
-			err = cluster.SetupTrust(string(cert.PublicKey()),
-				config.Cluster.ClusterAddress,
-				string(config.Cluster.ClusterCertificate), config.Cluster.ClusterPassword)
+			err = cluster.SetupTrust(serverCert, serverName, config.Cluster.ClusterAddress, config.Cluster.ClusterCertificate, config.Cluster.ClusterPassword)
 			if err != nil {
 				return errors.Wrap(err, "Failed to setup trust relationship with cluster")
 			}
 
 			// Client parameters to connect to the target cluster node.
 			args := &lxd.ConnectionArgs{
-				TLSClientCert: string(cert.PublicKey()),
-				TLSClientKey:  string(cert.PrivateKey()),
+				TLSClientCert: string(serverCert.PublicKey()),
+				TLSClientKey:  string(serverCert.PrivateKey()),
 				TLSServerCert: string(config.Cluster.ClusterCertificate),
 				UserAgent:     version.UserAgent,
 			}

--- a/lxd/network/acl/driver_common.go
+++ b/lxd/network/acl/driver_common.go
@@ -685,7 +685,7 @@ func (d *common) Update(config *api.NetworkACLPut, clientType request.ClientType
 	// Apply ACL changes to non-OVN networks on cluster members.
 	if clientType == request.ClientTypeNormal && len(aclNets) > 0 {
 		// Notify all other nodes to update the network if no target specified.
-		notifier, err := cluster.NewNotifier(d.state, d.state.Endpoints.NetworkCert(), cluster.NotifyAll)
+		notifier, err := cluster.NewNotifier(d.state, d.state.Endpoints.NetworkCert(), d.state.ServerCert(), cluster.NotifyAll)
 		if err != nil {
 			return err
 		}

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1725,14 +1725,14 @@ func (n *bridge) HandleHeartbeat(heartbeatData *cluster.APIHeartbeat) error {
 
 	n.logger.Info("Refreshing forkdns peers")
 
-	cert := n.state.Endpoints.NetworkCert()
+	networkCert := n.state.Endpoints.NetworkCert()
 	for _, node := range heartbeatData.Members {
 		if node.Address == localAddress {
 			// No need to query ourselves.
 			continue
 		}
 
-		client, err := cluster.Connect(node.Address, cert, true)
+		client, err := cluster.Connect(node.Address, networkCert, n.state.ServerCert(), true)
 		if err != nil {
 			return err
 		}

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -244,7 +244,7 @@ func (n *common) update(applyNetwork api.NetworkPut, targetNode string, clientTy
 	if clientType != request.ClientTypeNotifier {
 		if targetNode == "" {
 			// Notify all other nodes to update the network if no target specified.
-			notifier, err := cluster.NewNotifier(n.state, n.state.Endpoints.NetworkCert(), cluster.NotifyAll)
+			notifier, err := cluster.NewNotifier(n.state, n.state.Endpoints.NetworkCert(), n.state.ServerCert(), cluster.NotifyAll)
 			if err != nil {
 				return err
 			}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -546,7 +546,7 @@ func networksPostCluster(d *Daemon, projectName string, netInfo *api.Network, re
 	}
 
 	// Create notifier for other nodes to create the network.
-	notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), cluster.NotifyAll)
+	notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), d.serverCert(), cluster.NotifyAll)
 	if err != nil {
 		return err
 	}
@@ -892,7 +892,7 @@ func networkDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 	if clustered {
-		notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), cluster.NotifyAll)
+		notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), d.serverCert(), cluster.NotifyAll)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -1429,7 +1429,7 @@ func networkLeasesGet(d *Daemon, r *http.Request) response.Response {
 
 	// Collect leases from other servers.
 	if !isClusterNotification(r) {
-		notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), cluster.NotifyAlive)
+		notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), d.serverCert(), cluster.NotifyAlive)
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -21,6 +21,8 @@ func networkAutoAttach(cluster *db.Cluster, devName string) error {
 
 // networkUpdateForkdnsServersTask runs every 30s and refreshes the forkdns servers list.
 func networkUpdateForkdnsServersTask(s *state.State, heartbeatData *cluster.APIHeartbeat) error {
+	logger.Debug("Refreshing forkdns servers")
+
 	// Use project.Default here as forkdns (fan bridge) networks don't support projects.
 	projectName := project.Default
 

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -187,8 +187,7 @@ func operationGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	cert := d.endpoints.NetworkCert()
-	client, err := cluster.Connect(address, cert, false)
+	client, err := cluster.Connect(address, d.endpoints.NetworkCert(), d.serverCert(), false)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -254,8 +253,7 @@ func operationDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	cert := d.endpoints.NetworkCert()
-	client, err := cluster.Connect(address, cert, false)
+	client, err := cluster.Connect(address, d.endpoints.NetworkCert(), d.serverCert(), false)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -472,14 +470,14 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
-	cert := d.endpoints.NetworkCert()
+	networkCert := d.endpoints.NetworkCert()
 	for _, node := range nodes {
 		if node == localAddress {
 			continue
 		}
 
 		// Connect to the remote server
-		client, err := cluster.Connect(node, cert, true)
+		client, err := cluster.Connect(node, networkCert, d.serverCert(), true)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -651,8 +649,7 @@ func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	cert := d.endpoints.NetworkCert()
-	client, err := cluster.Connect(address, cert, false)
+	client, err := cluster.Connect(address, d.endpoints.NetworkCert(), d.serverCert(), false)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -786,8 +783,7 @@ func operationWebsocketGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	cert := d.endpoints.NetworkCert()
-	client, err := cluster.Connect(address, cert, false)
+	client, err := cluster.Connect(address, d.endpoints.NetworkCert(), d.serverCert(), false)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -28,6 +28,7 @@ import (
 	driver "github.com/lxc/lxd/lxd/storage"
 	storagePools "github.com/lxc/lxd/lxd/storage"
 	storageDrivers "github.com/lxc/lxd/lxd/storage/drivers"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	log "github.com/lxc/lxd/shared/log15"
@@ -120,6 +121,7 @@ var patches = []patch{
 	{name: "vm_rename_uuid_key", stage: patchPostDaemonStorage, run: patchVMRenameUUIDKey},
 	{name: "db_nodes_autoinc", stage: patchPreDaemonStorage, run: patchDBNodesAutoInc},
 	{name: "network_acl_remove_defaults", stage: patchPostDaemonStorage, run: patchNetworkACLRemoveDefaults},
+	{name: "clustering_server_cert_trust", stage: patchPreDaemonStorage, run: patchClusteringServerCertTrust},
 }
 
 type patch struct {
@@ -183,6 +185,101 @@ func patchesApply(d *Daemon, stage patchStage) error {
 }
 
 // Patches begin here
+
+func patchClusteringServerCertTrust(name string, d *Daemon) error {
+	clustered, err := cluster.Enabled(d.db)
+	if err != nil {
+		return err
+	}
+
+	if !clustered {
+		return nil
+	}
+
+	var serverName string
+	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
+		serverName, err = tx.GetLocalNodeName()
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	// Add our server cert to DB trust store.
+	serverCert, err := util.LoadServerCert(d.os.VarDir)
+	if err != nil {
+		return err
+	}
+	// Update our own entry in the nodes table.
+	logger.Infof("Adding local server certificate to global trust store for %q patch", name)
+	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
+		return cluster.EnsureServerCertificateTrusted(serverName, serverCert, tx)
+	})
+	if err != nil {
+		return err
+	}
+	logger.Infof("Added local server certificate to global trust store for %q patch", name)
+
+	// Check all other members have done the same.
+	for {
+		var err error
+		var dbCerts []db.Certificate
+		err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
+			dbCerts, err = tx.GetCertificates(db.CertificateFilter{})
+			return err
+		})
+		if err != nil {
+			return err
+		}
+
+		trustedServerCerts := make(map[string]*db.Certificate)
+
+		for _, c := range dbCerts {
+			if c.Type == db.CertificateTypeServer {
+				trustedServerCerts[c.Name] = &c
+			}
+		}
+
+		var nodes []db.NodeInfo
+		err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
+			nodes, err = tx.GetNodes()
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+
+		missingCerts := false
+		for _, n := range nodes {
+			if _, found := trustedServerCerts[n.Name]; !found {
+				logger.Warnf("Missing trusted server certificate for cluster member %q", n.Name)
+				missingCerts = true
+				break
+			}
+		}
+
+		if missingCerts {
+			logger.Warnf("Waiting for %q patch to be applied on all cluster members", name)
+			time.Sleep(time.Second)
+			continue
+		}
+
+		logger.Infof("Trusted server certificates found in trust store for all cluster members")
+		break
+	}
+
+	// Now switch to using our server certificate for intra-cluster communication and load the trusted server
+	// certificates for the other members into the in-memory trusted cache.
+	logger.Infof("Set client certificate to server certificate %v", serverCert.Fingerprint())
+	d.serverCertInt = serverCert
+	updateCertificateCache(d)
+
+	return nil
+}
 
 // patchNetworkACLRemoveDefaults removes the "default.action" and "default.logged" settings from network ACLs.
 // It was decided that the user experience of having the default actions at the ACL level was confusing when using

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -420,7 +420,7 @@ func profilePut(d *Daemon, r *http.Request) response.Response {
 
 	if err == nil && !isClusterNotification(r) {
 		// Notify all other nodes. If a node is down, it will be ignored.
-		notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), cluster.NotifyAlive)
+		notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), d.serverCert(), cluster.NotifyAlive)
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/lxd/response.go
+++ b/lxd/response.go
@@ -25,8 +25,7 @@ func forwardedResponseIfTargetIsRemote(d *Daemon, request *http.Request) respons
 
 	if address != "" {
 		// Forward the response.
-		cert := d.endpoints.NetworkCert()
-		client, err := cluster.Connect(address, cert, false)
+		client, err := cluster.Connect(address, d.endpoints.NetworkCert(), d.serverCert(), false)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -40,8 +39,7 @@ func forwardedResponseIfTargetIsRemote(d *Daemon, request *http.Request) respons
 // the container with the given name. If the container is local, nothing gets
 // done and nil is returned.
 func forwardedResponseIfInstanceIsRemote(d *Daemon, r *http.Request, project, name string, instanceType instancetype.Type) (response.Response, error) {
-	cert := d.endpoints.NetworkCert()
-	client, err := cluster.ConnectIfInstanceIsRemote(d.cluster, project, name, cert, instanceType)
+	client, err := cluster.ConnectIfInstanceIsRemote(d.cluster, project, name, d.endpoints.NetworkCert(), d.serverCert(), instanceType)
 	if err != nil {
 		return nil, err
 	}
@@ -63,8 +61,7 @@ func forwardedResponseIfVolumeIsRemote(d *Daemon, r *http.Request, poolName stri
 		return nil
 	}
 
-	cert := d.endpoints.NetworkCert()
-	client, err := cluster.ConnectIfVolumeIsRemote(d.State(), poolName, projectName, volumeName, volumeType, cert)
+	client, err := cluster.ConnectIfVolumeIsRemote(d.State(), poolName, projectName, volumeName, volumeType, d.endpoints.NetworkCert(), d.serverCert())
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/state/state.go
+++ b/lxd/state/state.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lxc/lxd/lxd/firewall"
 	"github.com/lxc/lxd/lxd/maas"
 	"github.com/lxc/lxd/lxd/sys"
+	"github.com/lxc/lxd/shared"
 )
 
 // State is a gateway to the two main stateful components of LXD, the database
@@ -41,22 +42,28 @@ type State struct {
 	// Firewall instance
 	Firewall firewall.Firewall
 
+	// Server certificate
+	ServerCert             func() *shared.CertInfo
+	UpdateCertificateCache func()
+
 	Context context.Context
 }
 
 // NewState returns a new State object with the given database and operating
 // system components.
-func NewState(ctx context.Context, node *db.Node, cluster *db.Cluster, maas *maas.Controller, os *sys.OS, endpoints *endpoints.Endpoints, events *events.Server, devlxdEvents *events.Server, firewall firewall.Firewall, proxy func(req *http.Request) (*url.URL, error)) *State {
+func NewState(ctx context.Context, node *db.Node, cluster *db.Cluster, maas *maas.Controller, os *sys.OS, endpoints *endpoints.Endpoints, events *events.Server, devlxdEvents *events.Server, firewall firewall.Firewall, proxy func(req *http.Request) (*url.URL, error), serverCert func() *shared.CertInfo, updateCertificateCache func()) *State {
 	return &State{
-		Node:         node,
-		Cluster:      cluster,
-		MAAS:         maas,
-		OS:           os,
-		Endpoints:    endpoints,
-		DevlxdEvents: devlxdEvents,
-		Events:       events,
-		Firewall:     firewall,
-		Proxy:        proxy,
-		Context:      ctx,
+		Node:                   node,
+		Cluster:                cluster,
+		MAAS:                   maas,
+		OS:                     os,
+		Endpoints:              endpoints,
+		DevlxdEvents:           devlxdEvents,
+		Events:                 events,
+		Firewall:               firewall,
+		Proxy:                  proxy,
+		Context:                ctx,
+		ServerCert:             serverCert,
+		UpdateCertificateCache: updateCertificateCache,
 	}
 }

--- a/lxd/state/testing.go
+++ b/lxd/state/testing.go
@@ -28,7 +28,7 @@ func NewTestState(t *testing.T) (*State, func()) {
 		osCleanup()
 	}
 
-	state := NewState(context.TODO(), node, cluster, nil, os, nil, nil, nil, firewall.New(), nil)
+	state := NewState(context.TODO(), node, cluster, nil, os, nil, nil, nil, firewall.New(), nil, nil, func() {})
 
 	return state, cleanup
 }

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -297,7 +297,7 @@ func storagePoolsPostCluster(d *Daemon, pool *api.StoragePool, req api.StoragePo
 	}
 
 	// Create notifier for other nodes to create the storage pool.
-	notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), cluster.NotifyAll)
+	notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), d.serverCert(), cluster.NotifyAll)
 	if err != nil {
 		return err
 	}
@@ -536,8 +536,7 @@ func doStoragePoolUpdate(d *Daemon, pool storagePools.Pool, req api.StoragePoolP
 
 	// Notify the other nodes, unless this is itself a notification.
 	if clustered && clientType != request.ClientTypeNotifier && targetNode == "" {
-		cert := d.endpoints.NetworkCert()
-		notifier, err := cluster.NewNotifier(d.State(), cert, cluster.NotifyAll)
+		notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), d.serverCert(), cluster.NotifyAll)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -594,7 +593,7 @@ func storagePoolDelete(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Get the cluster notifier
-		notifier, err = cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), cluster.NotifyAll)
+		notifier, err = cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), d.serverCert(), cluster.NotifyAll)
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -136,18 +136,18 @@ type ContextAwareRequest interface {
 // CheckTrustState checks whether the given client certificate is trusted
 // (i.e. it has a valid time span and it belongs to the given list of trusted
 // certificates).
-func CheckTrustState(cert x509.Certificate, trustedCerts map[string]x509.Certificate, certInfo *shared.CertInfo, trustCACertificates bool) (bool, string) {
+func CheckTrustState(cert x509.Certificate, trustedCerts map[string]x509.Certificate, networkCert *shared.CertInfo, trustCACertificates bool) (bool, string) {
 	// Extra validity check (should have been caught by TLS stack)
 	if time.Now().Before(cert.NotBefore) || time.Now().After(cert.NotAfter) {
 		return false, ""
 	}
 
-	if certInfo != nil && trustCACertificates {
-		ca := certInfo.CA()
+	if networkCert != nil && trustCACertificates {
+		ca := networkCert.CA()
 
 		if ca != nil && cert.CheckSignatureFrom(ca) == nil {
 			// Check whether the certificate has been revoked.
-			crl := certInfo.CRL()
+			crl := networkCert.CRL()
 
 			if crl != nil {
 				for _, revoked := range crl.TBSCertList.RevokedCertificates {
@@ -165,7 +165,7 @@ func CheckTrustState(cert x509.Certificate, trustedCerts map[string]x509.Certifi
 	// Check whether client certificate is in trust store.
 	for k, v := range trustedCerts {
 		if bytes.Compare(cert.Raw, v.Raw) == 0 {
-			logger.Debug("Found cert", log.Ctx{"name": k})
+			logger.Debug("Matched trusted cert", log.Ctx{"fingerprint": k, "subject": v.Subject})
 			return true, k
 		}
 	}

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -127,8 +127,12 @@ test_clustering_membership() {
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster show node3 | grep -q "status: Offline"
 
-  # Gracefully remove a node.
+  # Gracefully remove a node and check trust certificate is removed.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep node4
+  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'SELECT name FROM certificates WHERE type = 2' | grep node4
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster remove node4
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep node4 || false
+  ! LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'SELECT name FROM certificates WHERE type = 2' | grep node4 || false
 
   # The node isn't clustered anymore.
   ! LXD_DIR="${LXD_FOUR_DIR}" lxc cluster list || false

--- a/test/suites/database.sh
+++ b/test/suites/database.sh
@@ -23,7 +23,7 @@ EOF
   spawn_lxd "${LXD_MIGRATE_DIR}" true
 
   # Assert there are enough tables.
-  expected_tables=5
+  expected_tables=6
   tables=$(sqlite3 "${MIGRATE_DB}" ".dump" | grep -c "CREATE TABLE")
   [ "${tables}" -eq "${expected_tables}" ] || { echo "FAIL: Wrong number of tables after database migration. Found: ${tables}, expected ${expected_tables}"; false; }
 


### PR DESCRIPTION
- Introduces concept of `servertCert` and `networkCert` to represent the certificate used for each server's client certificate when making intra-cluster requests, and the certificate used when exposing the API onto the network respectively.
- Notifies other cluster members when a trusted certificate is updated or deleted, to allow their local trusted certificate caches to be refreshed.
- Requires and ensures that trusted server certificates are stored with a name of `<server name>` and a type of `server`. This is the server certificate for a cluster member can be found, and that they are trusted correctly as server certificates.
- Adds a `certificates` table to the local DB which caches the server type certificates from the global DB, to allow the LXD daemon to re-establish a connection to the cluster when starting up.
- Detects if the local `certificates` table is empty, and if so switches to pre-server-cert mode, that uses the network certificate for both the client certificate and the trusted certificate for incoming requests. This allows the cluster communication to be established allowing the per-server certificate patch to run,
- Adds a patch that will wait add the server certificate to the global trust store, and wait until all other cluster members have done the same. Once this is completed, the LXD daemon will load the trusted certificates into its cache and switch to using its own server certificate for intra-cluster communication.
- When a member is removed from the cluster, any trusted server certificates matching the member's name are removed from the database and the cached trusted certificates are refreshed. This ensures that once a member is removed it can no longer access the cluster.
- Updates the heartbeat handler to refresh cached trusted certificates from the global DB when the member list changes (added or removed) to ensure that we only trust active members in the cluster.
