### PR TITLE
Replace cluster.List with GetNodes

### DIFF
--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -15,10 +15,8 @@ import (
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
-	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
-	"github.com/lxc/lxd/shared/osarch"
 	"github.com/lxc/lxd/shared/version"
 	"github.com/pkg/errors"
 )
@@ -899,130 +897,6 @@ func Purge(cluster *db.Cluster, name string) error {
 		}
 		return nil
 	})
-}
-
-// List the nodes of the cluster.
-func List(state *state.State, gateway *Gateway) ([]api.ClusterMember, error) {
-	var err error
-	var nodes []db.NodeInfo
-	var offlineThreshold time.Duration
-	domains := map[string]string{}
-
-	err = state.Cluster.Transaction(func(tx *db.ClusterTx) error {
-		nodes, err = tx.GetNodes()
-		if err != nil {
-			return errors.Wrap(err, "Load nodes")
-		}
-
-		offlineThreshold, err = tx.GetNodeOfflineThreshold()
-		if err != nil {
-			return errors.Wrap(err, "Load offline threshold config")
-		}
-
-		nodesDomains, err := tx.GetNodesFailureDomains()
-		if err != nil {
-			return errors.Wrap(err, "Load nodes failure domains")
-		}
-
-		domainsNames, err := tx.GetFailureDomainsNames()
-		if err != nil {
-			return errors.Wrap(err, "Load failure domains names")
-		}
-
-		for _, node := range nodes {
-			domainID := nodesDomains[node.Address]
-			domains[node.Address] = domainsNames[domainID]
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	store := gateway.NodeStore()
-	dial := gateway.DialFunc()
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
-	cli, err := client.FindLeader(ctx, store, client.WithDialFunc(dial))
-	if err != nil {
-		return nil, err
-	}
-	defer cli.Close()
-
-	raftNodes, err := cli.Cluster(ctx)
-	if err != nil {
-		return nil, err
-	}
-	raftRoles := map[string]client.NodeRole{} // Address to role
-	for _, node := range raftNodes {
-		address, err := gateway.nodeAddress(node.Address)
-		if err != nil {
-			return nil, err
-		}
-		raftRoles[address] = node.Role
-	}
-
-	result := make([]api.ClusterMember, len(nodes))
-	now := time.Now()
-	version := nodes[0].Version()
-	for i, node := range nodes {
-		result[i].ServerName = node.Name
-		result[i].URL = fmt.Sprintf("https://%s", node.Address)
-		result[i].Database = raftRoles[node.Address] == db.RaftVoter
-		result[i].Roles = node.Roles
-		if result[i].Database {
-			result[i].Roles = append(result[i].Roles, string(db.ClusterRoleDatabase))
-		}
-		result[i].Architecture, err = osarch.ArchitectureName(node.Architecture)
-		if err != nil {
-			return nil, err
-		}
-		result[i].FailureDomain = domains[node.Address]
-
-		if node.IsOffline(offlineThreshold) {
-			result[i].Status = "Offline"
-			result[i].Message = fmt.Sprintf(
-				"no heartbeat for %s", now.Sub(node.Heartbeat))
-		} else {
-			result[i].Status = "Online"
-			result[i].Message = "fully operational"
-		}
-
-		n, err := util.CompareVersions(version, node.Version())
-		if err != nil {
-			result[i].Status = "Broken"
-			result[i].Message = "inconsistent version"
-			continue
-		}
-
-		if n == 1 {
-			// This node's version is lower, which means the
-			// version that the previous node in the loop has been
-			// upgraded.
-			version = node.Version()
-		}
-	}
-
-	// Update the state of online nodes that have been upgraded and whose
-	// schema is more recent than the rest of the nodes.
-	for i, node := range nodes {
-		if result[i].Status != "Online" {
-			continue
-		}
-		n, err := util.CompareVersions(version, node.Version())
-		if err != nil {
-			continue
-		}
-		if n == 2 {
-			result[i].Status = "Blocked"
-			result[i].Message = "waiting for other nodes to be upgraded"
-		}
-	}
-
-	return result, nil
 }
 
 // Count is a convenience for checking the current number of nodes in the

--- a/lxd/cluster/membership_test.go
+++ b/lxd/cluster/membership_test.go
@@ -328,15 +328,6 @@ func TestJoin(t *testing.T) {
 	assert.Equal(t, address, raftNodes[1].Address)
 	assert.Equal(t, db.RaftStandBy, raftNodes[1].Role)
 
-	// The List function returns all nodes in the cluster.
-	nodes, err := cluster.List(state, gateway)
-	require.NoError(t, err)
-	assert.Len(t, nodes, 2)
-	assert.Equal(t, "Online", nodes[0].Status)
-	assert.Equal(t, "Online", nodes[1].Status)
-	assert.True(t, nodes[0].Database)
-	assert.False(t, nodes[1].Database)
-
 	// The Count function returns the number of nodes.
 	count, err := cluster.Count(state)
 	require.NoError(t, err)

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -950,7 +950,7 @@ test_clustering_upgrade() {
   # The second daemon is blocked waiting for the other to be upgraded
   ! LXD_DIR="${LXD_TWO_DIR}" lxd waitready --timeout=5 || false
 
-  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node1 | grep -q "message: fully operational"
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node1 | grep -q "message: Fully operational"
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node2 | grep -q "message: waiting for other nodes to be upgraded"
 
   # Respawn the first node, so it matches the version the second node
@@ -981,9 +981,9 @@ test_clustering_upgrade() {
   # upgraded
   ! LXD_DIR="${LXD_TWO_DIR}" lxd waitready --timeout=5 || false
 
-  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node1 | grep -q "message: fully operational"
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node1 | grep -q "message: Fully operational"
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node2 | grep -q "message: waiting for other nodes to be upgraded"
-  LXD_DIR="${LXD_THREE_DIR}" lxc cluster show node3 | grep -q "message: fully operational"
+  LXD_DIR="${LXD_THREE_DIR}" lxc cluster show node3 | grep -q "message: Fully operational"
 
   # Respawn the first node and third node, so they match the version
   # the second node believes to have.
@@ -1219,7 +1219,7 @@ test_clustering_join_api() {
   op=$(curl --unix-socket "${LXD_TWO_DIR}/unix.socket" -X PUT "lxd/1.0/cluster" -d "{\"server_name\":\"node2\",\"enabled\":true,\"member_config\":[{\"entity\": \"storage-pool\",\"name\":\"data\",\"key\":\"source\",\"value\":\"\"}],\"server_address\":\"10.1.1.102:8443\",\"cluster_address\":\"10.1.1.101:8443\",\"cluster_certificate\":\"${cert}\",\"cluster_password\":\"sekret\"}" | jq -r .operation)
   curl --unix-socket "${LXD_TWO_DIR}/unix.socket" "lxd${op}/wait"
 
-  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node2 | grep -q "message: fully operational"
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node2 | grep -q "message: Fully operational"
 
   LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
   LXD_DIR="${LXD_ONE_DIR}" lxd shutdown


### PR DESCRIPTION
This will fix us constantly issuing heartbeats on simple API interactions and instead rely on the state we have in the database.
This should lead to faster API calls and less cross-cluster chatter.