### PR TITLE
Assorted bugfixes

### DIFF
--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -1543,7 +1543,7 @@ func (c *cmdStorageVolumeSet) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get the storage volume entry
-	vol, etag, err := resource.server.GetStoragePoolVolume(resource.name, volType, volName)
+	vol, etag, err := client.GetStoragePoolVolume(resource.name, volType, volName)
 	if err != nil {
 		return err
 	}
@@ -1748,7 +1748,7 @@ func (c *cmdStorageVolumeSnapshot) Run(cmd *cobra.Command, args []string) error 
 	}
 
 	// Check if the requested storage volume actually exists
-	_, _, err = resource.server.GetStoragePoolVolume(resource.name, volType, volName)
+	_, _, err = client.GetStoragePoolVolume(resource.name, volType, volName)
 	if err != nil {
 		return err
 	}
@@ -1832,7 +1832,7 @@ func (c *cmdStorageVolumeRestore) Run(cmd *cobra.Command, args []string) error {
 	client := resource.server
 
 	// Check if the requested storage volume actually exists
-	_, _, err = resource.server.GetStoragePoolVolume(resource.name, "custom", args[1])
+	_, _, err = client.GetStoragePoolVolume(resource.name, "custom", args[1])
 	if err != nil {
 		return err
 	}

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -1717,6 +1717,7 @@ func (c *cmdStorageVolumeSnapshot) Command() *cobra.Command {
 	cmd.RunE = c.Run
 	cmd.Flags().BoolVar(&c.flagNoExpiry, "no-expiry", false, i18n.G("Ignore any configured auto-expiry for the storage volume"))
 	cmd.Flags().BoolVar(&c.flagReuse, "reuse", false, i18n.G("If the snapshot name already exists, delete and create a new one"))
+	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
 	return cmd
 }
@@ -1740,6 +1741,11 @@ func (c *cmdStorageVolumeSnapshot) Run(cmd *cobra.Command, args []string) error 
 	}
 
 	client := resource.server
+
+	// Use the provided target.
+	if c.storage.flagTarget != "" {
+		client = client.UseTarget(c.storage.flagTarget)
+	}
 
 	// Parse the input
 	volName, volType := c.storageVolume.parseVolume("custom", args[1])
@@ -1805,6 +1811,7 @@ func (c *cmdStorageVolumeRestore) Command() *cobra.Command {
 	cmd.Short = i18n.G("Restore storage volume snapshots")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Restore storage volume snapshots`))
+	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
 	cmd.RunE = c.Run
 
@@ -1830,6 +1837,11 @@ func (c *cmdStorageVolumeRestore) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	client := resource.server
+
+	// Use the provided target.
+	if c.storage.flagTarget != "" {
+		client = client.UseTarget(c.storage.flagTarget)
+	}
 
 	// Check if the requested storage volume actually exists
 	_, _, err = client.GetStoragePoolVolume(resource.name, "custom", args[1])
@@ -1871,6 +1883,7 @@ func (c *cmdStorageVolumeExport) Command() *cobra.Command {
 	cmd.Flags().BoolVar(&c.flagOptimizedStorage, "optimized-storage", false,
 		i18n.G("Use storage driver optimized format (can only be restored on a similar pool)"))
 	cmd.Flags().StringVar(&c.flagCompressionAlgorithm, "compression", "", i18n.G("Define a compression algorithm: for backup or none")+"``")
+	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.Run
 
 	return cmd
@@ -1894,6 +1907,11 @@ func (c *cmdStorageVolumeExport) Run(cmd *cobra.Command, args []string) error {
 	d, err := conf.GetInstanceServer(remote)
 	if err != nil {
 		return err
+	}
+
+	// Use the provided target.
+	if c.storage.flagTarget != "" {
+		d = d.UseTarget(c.storage.flagTarget)
 	}
 
 	volumeOnly := c.flagVolumeOnly
@@ -2004,6 +2022,7 @@ func (c *cmdStorageVolumeImport) Command() *cobra.Command {
 	cmd.Example = cli.FormatSection("", i18n.G(
 		`lxc storage volume import default backup0.tar.gz
 		Create a new custom volume using backup0.tar.gz as the source.`))
+	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.Run
 
 	return cmd
@@ -2027,6 +2046,11 @@ func (c *cmdStorageVolumeImport) Run(cmd *cobra.Command, args []string) error {
 	d, err := conf.GetInstanceServer(remote)
 	if err != nil {
 		return err
+	}
+
+	// Use the provided target.
+	if c.storage.flagTarget != "" {
+		d = d.UseTarget(c.storage.flagTarget)
 	}
 
 	file, err := os.Open(shared.HostPathFollow(args[1]))

--- a/lxd/endpoints/endpoints.go
+++ b/lxd/endpoints/endpoints.go
@@ -239,9 +239,16 @@ func (e *Endpoints) up(config *Config) error {
 			logger.Infof("Starting cluster handler:")
 			e.serveHTTP(cluster)
 		} else if networkAddressErr != nil {
-			logger.Error("Cannot listen on https socket, skipping...", log.Ctx{"err": networkAddressErr})
-		}
+			logger.Error("Cannot currently listen on https socket, re-trying once in 30s...", log.Ctx{"err": networkAddressErr})
 
+			go func() {
+				time.Sleep(30 * time.Second)
+				err := e.NetworkUpdateAddress(config.NetworkAddress)
+				if err != nil {
+					logger.Error("Still unable to listen on https socket", log.Ctx{"err": err})
+				}
+			}()
+		}
 	}
 
 	if config.DebugAddress != "" {

--- a/lxd/instance/drivers/qmp/commands.go
+++ b/lxd/instance/drivers/qmp/commands.go
@@ -190,7 +190,7 @@ func (m *Monitor) GetCPUs() ([]int, error) {
 	}
 
 	// Query the consoles.
-	err := m.run("query-cpus", "", &resp)
+	err := m.run("query-cpus-fast", "", &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -56,13 +56,6 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 	// Get the name of the volume.
 	volumeName := mux.Vars(r)["name"]
 
-	// Parse the request.
-	req := api.StorageVolumeSnapshotsPost{}
-	err := json.NewDecoder(r.Body).Decode(&req)
-	if err != nil {
-		return response.BadRequest(err)
-	}
-
 	// Convert the volume type name to our internal integer representation.
 	volumeType, err := storagePools.VolumeTypeNameToDBType(volumeTypeName)
 	if err != nil {
@@ -74,9 +67,28 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
+	// Get the project name.
 	projectName, err := project.StorageVolumeProject(d.State().Cluster, projectParam(r), volumeType)
 	if err != nil {
 		return response.SmartError(err)
+	}
+
+	// Forward if needed.
+	resp := forwardedResponseIfTargetIsRemote(d, r)
+	if resp != nil {
+		return resp
+	}
+
+	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, volumeName, volumeType)
+	if resp != nil {
+		return resp
+	}
+
+	// Parse the request.
+	req := api.StorageVolumeSnapshotsPost{}
+	err = json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return response.BadRequest(err)
 	}
 
 	// Get a snapshot name.
@@ -107,16 +119,6 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 		return response.SmartError(err)
 	}
 
-	resp := forwardedResponseIfTargetIsRemote(d, r)
-	if resp != nil {
-		return resp
-	}
-
-	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, volumeName, volumeType)
-	if resp != nil {
-		return resp
-	}
-
 	// Ensure that the snapshot doesn't already exist.
 	_, _, err = d.cluster.GetLocalStoragePoolVolume(projectName, fmt.Sprintf("%s/%s", volumeName, req.Name), volumeType, poolID)
 	if err != db.ErrNoSuchObject {
@@ -133,8 +135,8 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 		return response.SmartError(err)
 	}
 
+	// Fill in the expiry.
 	var expiry time.Time
-
 	if req.ExpiresAt != nil {
 		expiry = *req.ExpiresAt
 	} else {
@@ -144,6 +146,7 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 		}
 	}
 
+	// Create the snapshot.
 	snapshot := func(op *operations.Operation) error {
 		pool, err := storagePools.GetPoolByName(d.State(), poolName)
 		if err != nil {
@@ -204,6 +207,7 @@ func storagePoolVolumeSnapshotsTypeGet(d *Daemon, r *http.Request) response.Resp
 		return response.SmartError(err)
 	}
 
+	// Prepare the response.
 	resultString := []string{}
 	resultMap := []*api.StorageVolumeSnapshot{}
 	for _, volume := range volumes {
@@ -252,10 +256,38 @@ func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Resp
 	// Get the name of the storage volume.
 	snapshotName := mux.Vars(r)["snapshotName"]
 
-	req := api.StorageVolumeSnapshotPost{}
+	// Convert the volume type name to our internal integer representation.
+	volumeType, err := storagePools.VolumeTypeNameToDBType(volumeTypeName)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	// Check that the storage volume type is valid.
+	if volumeType != db.StoragePoolVolumeTypeCustom {
+		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
+	}
+
+	// Get the project name.
+	projectName, err := project.StorageVolumeProject(d.State().Cluster, projectParam(r), volumeType)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	// Forward if needed.
+	resp := forwardedResponseIfTargetIsRemote(d, r)
+	if resp != nil {
+		return resp
+	}
+
+	fullSnapshotName := fmt.Sprintf("%s/%s", volumeName, snapshotName)
+	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, volumeName, volumeType)
+	if resp != nil {
+		return resp
+	}
 
 	// Parse the request.
-	err := json.NewDecoder(r.Body).Decode(&req)
+	req := api.StorageVolumeSnapshotPost{}
+	err = json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -269,33 +301,7 @@ func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Resp
 		return response.BadRequest(fmt.Errorf("Storage volume names may not contain slashes"))
 	}
 
-	// Convert the volume type name to our internal integer representation.
-	volumeType, err := storagePools.VolumeTypeNameToDBType(volumeTypeName)
-	if err != nil {
-		return response.BadRequest(err)
-	}
-
-	// Check that the storage volume type is valid.
-	if volumeType != db.StoragePoolVolumeTypeCustom {
-		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
-	}
-
-	projectName, err := project.StorageVolumeProject(d.State().Cluster, projectParam(r), volumeType)
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	resp := forwardedResponseIfTargetIsRemote(d, r)
-	if resp != nil {
-		return resp
-	}
-
-	fullSnapshotName := fmt.Sprintf("%s/%s", volumeName, snapshotName)
-	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, fullSnapshotName, volumeType)
-	if resp != nil {
-		return resp
-	}
-
+	// Rename the snapshot.
 	snapshotRename := func(op *operations.Operation) error {
 		pool, err := storagePools.GetPoolByName(d.State(), poolName)
 		if err != nil {
@@ -336,25 +342,28 @@ func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Respo
 		return response.BadRequest(err)
 	}
 
+	// Get the project name.
 	projectName, err := project.StorageVolumeProject(d.State().Cluster, projectParam(r), volumeType)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
+	// Forward if needed.
 	resp := forwardedResponseIfTargetIsRemote(d, r)
 	if resp != nil {
 		return resp
-	}
-
-	poolID, _, _, err := d.cluster.GetStoragePool(poolName)
-	if err != nil {
-		return response.SmartError(err)
 	}
 
 	fullSnapshotName := fmt.Sprintf("%s/%s", volumeName, snapshotName)
 	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, fullSnapshotName, volumeType)
 	if resp != nil {
 		return resp
+	}
+
+	// Get the snapshot.
+	poolID, _, _, err := d.cluster.GetStoragePool(poolName)
+	if err != nil {
+		return response.SmartError(err)
 	}
 
 	volID, volume, err := d.cluster.GetLocalStoragePoolVolume(projectName, fullSnapshotName, volumeType, poolID)
@@ -399,25 +408,28 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 		return response.BadRequest(err)
 	}
 
+	// Get the project name.
 	projectName, err := project.StorageVolumeProject(d.State().Cluster, projectParam(r), volumeType)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
+	// Forward if needed.
 	resp := forwardedResponseIfTargetIsRemote(d, r)
 	if resp != nil {
 		return resp
-	}
-
-	poolID, _, _, err := d.cluster.GetStoragePool(poolName)
-	if err != nil {
-		return response.SmartError(err)
 	}
 
 	fullSnapshotName := fmt.Sprintf("%s/%s", volumeName, snapshotName)
 	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, fullSnapshotName, volumeType)
 	if resp != nil {
 		return resp
+	}
+
+	// Get the snapshot.
+	poolID, _, _, err := d.cluster.GetStoragePool(poolName)
+	if err != nil {
+		return response.SmartError(err)
 	}
 
 	volID, vol, err := d.cluster.GetLocalStoragePoolVolume(projectName, fullSnapshotName, volumeType, poolID)
@@ -468,25 +480,28 @@ func storagePoolVolumeSnapshotTypePatch(d *Daemon, r *http.Request) response.Res
 		return response.BadRequest(err)
 	}
 
+	// Get the project name.
 	projectName, err := project.StorageVolumeProject(d.State().Cluster, projectParam(r), volumeType)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
+	// Forward if needed.
 	resp := forwardedResponseIfTargetIsRemote(d, r)
 	if resp != nil {
 		return resp
-	}
-
-	poolID, _, _, err := d.cluster.GetStoragePool(poolName)
-	if err != nil {
-		return response.SmartError(err)
 	}
 
 	fullSnapshotName := fmt.Sprintf("%s/%s", volumeName, snapshotName)
 	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, fullSnapshotName, volumeType)
 	if resp != nil {
 		return resp
+	}
+
+	// Get the snapshot.
+	poolID, _, _, err := d.cluster.GetStoragePool(poolName)
+	if err != nil {
+		return response.SmartError(err)
 	}
 
 	volID, vol, err := d.cluster.GetLocalStoragePoolVolume(projectName, fullSnapshotName, volumeType, poolID)
@@ -574,11 +589,13 @@ func storagePoolVolumeSnapshotTypeDelete(d *Daemon, r *http.Request) response.Re
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
+	// Get the project name.
 	projectName, err := project.StorageVolumeProject(d.State().Cluster, projectParam(r), volumeType)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
+	// Forward if needed.
 	resp := forwardedResponseIfTargetIsRemote(d, r)
 	if resp != nil {
 		return resp


### PR DESCRIPTION
Just went through a bunch of our open bugs and fixed them :)

This started with the storage volume target issues in the client, then fixed a few more commands, then fixed the server side of those commands, then fixed the snapshot increment bug and finished with the pool deletion.

I then looked into the endpoint binding issue and found a reasonable way to re-try bind failures.

And while looking into QMP and QEMU 6.0 for #8416 I came across the deprecation of query-cpus and so switched us to query-cpus-fast.