### PR TITLE
vm/qemu: configure spice using -spice parameter

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1043,6 +1043,7 @@ func (d *qemu) Start(stateful bool) error {
 		"-no-user-config",
 		"-sandbox", "on,obsolete=deny,elevateprivileges=allow,spawn=deny,resourcecontrol=deny",
 		"-readconfig", confFile,
+		"-spice", d.spiceCmdlineConfig(),
 		"-pidfile", d.pidFilePath(),
 		"-D", d.LogFilePath(),
 	}
@@ -1572,6 +1573,10 @@ func (d *qemu) spicePath() string {
 	return filepath.Join(d.LogPath(), "qemu.spice")
 }
 
+func (d *qemu) spiceCmdlineConfig() string {
+	return fmt.Sprintf("unix=on,disable-ticketing=on,addr=%s", d.spicePath())
+}
+
 // generateConfigShare generates the config share directory that will be exported to the VM via
 // a 9P share. Due to the unknown size of templates inside the images this directory is created
 // inside the VM's config volume so that it can be restricted by quota.
@@ -2004,7 +2009,6 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 
 	err := qemuBase.Execute(sb, map[string]interface{}{
 		"architecture": d.architectureName,
-		"spicePath":    d.spicePath(),
 	})
 	if err != nil {
 		return "", err

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -44,12 +44,6 @@ strict = "on"
 # Console
 [chardev "console"]
 backend = "pty"
-
-# Graphical console
-[spice]
-unix = "on"
-addr = "{{.spicePath}}"
-disable-ticketing = "on"
 `))
 
 var qemuMemory = template.Must(template.New("qemuMemory").Parse(`


### PR DESCRIPTION
Since QEMU 5.2, if QEMU has its modules compiled as dynamic objects to
be dlopen(2)'d rather than statically compiled into the QEMU binary,
QEMU will not accept [spice] directives through -readconfig. This is a
known issue with QEMU but has been effectively marked as WONTFIX because
-readconfig has sort-of been soft-deprecated [1] [2] [3].

In the meantime, just switch to the -spice commandline since this
appears to only affect modules rather than core QEMU options.

[1]: https://bugs.launchpad.net/qemu/+bug/1910696
[2]: https://lists.gnu.org/archive/html/qemu-devel/2020-11/msg02934.html
[3]: https://bugzilla.suse.com/show_bug.cgi?id=1181549#c11

Fixes #8416
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>