### PR TITLE
Cluster: Introduce server trusted certificate type

### DIFF
--- a/lxc/config_trust.go
+++ b/lxc/config_trust.go
@@ -112,7 +112,7 @@ func (c *cmdConfigTrustAdd) Run(cmd *cobra.Command, args []string) error {
 	cert := api.CertificatesPost{}
 	cert.Certificate = base64.StdEncoding.EncodeToString(x509Cert.Raw)
 	cert.Name = name
-	cert.Type = "client"
+	cert.Type = api.CertificateTypeClient
 	cert.Restricted = c.flagRestricted
 	if c.flagProjects != "" {
 		cert.Projects = strings.Split(c.flagProjects, ",")

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -433,7 +433,7 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 			req := api.CertificatesPost{
 				Password: c.flagPassword,
 			}
-			req.Type = "client"
+			req.Type = api.CertificateTypeClient
 
 			err = d.(lxd.InstanceServer).CreateCertificate(req)
 			if err != nil {

--- a/lxd-p2c/utils.go
+++ b/lxd-p2c/utils.go
@@ -153,7 +153,7 @@ func connectTarget(url string) (lxd.ContainerServer, error) {
 	req := api.CertificatesPost{
 		Password: string(pwd),
 	}
-	req.Type = "client"
+	req.Type = api.CertificateTypeClient
 
 	err = c.CreateCertificate(req)
 	if err != nil {

--- a/lxd/api_cluster_test.go
+++ b/lxd/api_cluster_test.go
@@ -644,7 +644,7 @@ func (f *clusterFixture) RegisterCertificate(daemon1, daemon2 *Daemon, name, pas
 		Certificate: certificate,
 	}
 	post.Name = fmt.Sprintf("lxd.cluster.%s", name)
-	post.Type = "client"
+	post.Type = api.CertificateTypeClient
 
 	client2 := f.ClientUnix(daemon2)
 	err = client2.CreateCertificate(post)

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -176,20 +176,20 @@ func updateCertificateCache(d *Daemon) {
 		return err
 	})
 	if err != nil {
-		logger.Infof("Error reading certificates from database: %s", err)
+		logger.Infof("Error reading certificates from database: %v", err)
 		return
 	}
 
 	for _, dbCert := range dbCerts {
 		certBlock, _ := pem.Decode([]byte(dbCert.Certificate))
 		if certBlock == nil {
-			logger.Infof("Error decoding certificate for %s: %s", dbCert.Name, err)
+			logger.Infof("Error decoding certificate for %q: %v", dbCert.Name, err)
 			continue
 		}
 
 		cert, err := x509.ParseCertificate(certBlock.Bytes)
 		if err != nil {
-			logger.Infof("Error reading certificate for %s: %s", dbCert.Name, err)
+			logger.Infof("Error reading certificate for %q: %v", dbCert.Name, err)
 			continue
 		}
 

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -370,7 +370,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 			Certificate: base64.StdEncoding.EncodeToString(cert.Raw),
 		}
 		req.Name = name
-		req.Type = "client"
+		req.Type = api.CertificateTypeClient
 
 		err = notifier(func(client lxd.InstanceServer) error {
 			return client.CreateCertificate(req)

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -298,8 +298,9 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 		return response.Forbidden(nil)
 	}
 
-	if req.Type != "client" {
-		return response.BadRequest(fmt.Errorf("Unknown request type %s", req.Type))
+	dbReqType, err := db.CertificateAPITypeToDBType(req.Type)
+	if err != nil {
+		return response.BadRequest(err)
 	}
 
 	// Extract the certificate
@@ -346,7 +347,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 		// Store the certificate in the cluster database
 		dbCert := db.Certificate{
 			Fingerprint: shared.CertFingerprint(cert),
-			Type:        1,
+			Type:        dbReqType,
 			Name:        name,
 			Certificate: string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})),
 			Restricted:  req.Restricted,
@@ -550,9 +551,13 @@ func certificatePatch(d *Daemon, r *http.Request) response.Response {
 }
 
 func doCertificateUpdate(d *Daemon, dbInfo db.Certificate, fingerprint string, req api.CertificatePut) response.Response {
-	// We only support client certificates for now.
-	if req.Type != "client" {
-		return response.BadRequest(fmt.Errorf("Unknown request type %s", req.Type))
+	reqDBType, err := db.CertificateAPITypeToDBType(req.Type)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	if reqDBType != dbInfo.Type {
+		return response.BadRequest(fmt.Errorf("Certificate type cannot be changed"))
 	}
 
 	// Convert to the database type.
@@ -568,7 +573,7 @@ func doCertificateUpdate(d *Daemon, dbInfo db.Certificate, fingerprint string, r
 	}
 
 	// Update the database record.
-	err := d.cluster.UpdateCertificate(fingerprint, cert)
+	err = d.cluster.UpdateCertificate(fingerprint, cert)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -273,14 +273,14 @@ func updateCertificateCache(d *Daemon) {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func certificatesPost(d *Daemon, r *http.Request) response.Response {
-	// Parse the request
+	// Parse the request.
 	req := api.CertificatesPost{}
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		return response.BadRequest(err)
 	}
 
-	// Access check
+	// Access check.
 	secret, err := cluster.ConfigGetString(d.cluster, "core.trust_password")
 	if err != nil {
 		return response.SmartError(err)
@@ -303,7 +303,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	// Extract the certificate
+	// Extract the certificate.
 	var cert *x509.Certificate
 	var name string
 	if req.Certificate != "" {
@@ -338,13 +338,13 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 	fingerprint := shared.CertFingerprint(cert)
 
 	if !isClusterNotification(r) {
-		// Check if we already have the certificate
+		// Check if we already have the certificate.
 		existingCert, _ := d.cluster.GetCertificate(fingerprint)
 		if existingCert != nil {
 			return response.BadRequest(fmt.Errorf("Certificate already in trust store"))
 		}
 
-		// Store the certificate in the cluster database
+		// Store the certificate in the cluster database.
 		dbCert := db.Certificate{
 			Fingerprint: shared.CertFingerprint(cert),
 			Type:        dbReqType,

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -193,7 +193,7 @@ func SetupTrust(cert, targetAddress, targetCert, targetPassword string) error {
 	}
 
 	post.Name = fmt.Sprintf("lxd.cluster.%s", fingerprint)
-	post.Type = "client"
+	post.Type = api.CertificateTypeClient
 
 	err = target.CreateCertificate(post)
 	if err != nil && err.Error() != "Certificate already in trust store" {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -352,8 +352,10 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, str
 		return false, "", "", err
 	}
 
+	trustedCerts := d.getTrustedCertificates()
+
 	for i := range r.TLS.PeerCertificates {
-		trusted, username := util.CheckTrustState(*r.TLS.PeerCertificates[i], d.clientCerts.Certificates, d.endpoints.NetworkCert(), trustCACertificates)
+		trusted, username := util.CheckTrustState(*r.TLS.PeerCertificates[i], trustedCerts[db.CertificateTypeClient], d.endpoints.NetworkCert(), trustCACertificates)
 		if trusted {
 			return true, username, "tls", nil
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -470,9 +470,13 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 
 				// Regular TLS clients.
 				if protocol == "tls" {
+					d.clientCerts.Lock.Lock()
+					certProjects := d.clientCerts.Projects
+					d.clientCerts.Lock.Unlock()
+
 					// Check if we have restrictions on the key.
-					if d.clientCerts != nil && d.clientCerts.Projects != nil {
-						projects, ok := d.clientCerts.Projects[username]
+					if certProjects != nil {
+						projects, ok := certProjects[username]
 						if ok {
 							ua.Admin = false
 							ua.Projects = map[string][]string{}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -258,6 +258,14 @@ func (d *Daemon) checkTrustedClient(r *http.Request) error {
 	return nil
 }
 
+// getTrustedCertificates returns trusted certificates key on DB type and fingerprint.
+func (d *Daemon) getTrustedCertificates() map[int]map[string]x509.Certificate {
+	d.clientCerts.Lock.Lock()
+	defer d.clientCerts.Lock.Unlock()
+
+	return d.clientCerts.Certificates
+}
+
 // Authenticate validates an incoming http Request
 // It will check over what protocol it came, what type of request it is and
 // will validate the TLS certificate or Macaroon.

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -270,9 +270,9 @@ func (d *Daemon) getTrustedCertificates() map[int]map[string]x509.Certificate {
 // It will check over what protocol it came, what type of request it is and
 // will validate the TLS certificate or Macaroon.
 //
-// This does not perform authorization, only validates authentication
+// This does not perform authorization, only validates authentication.
 func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, string, string, error) {
-	// Allow internal cluster traffic
+	// Allow internal cluster traffic.
 	if r.TLS != nil {
 		cert, _ := x509.ParseCertificate(d.endpoints.NetworkCert().KeyPair().Certificate[0])
 		clusterCerts := map[string]x509.Certificate{"0": *cert}
@@ -284,7 +284,7 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, str
 		}
 	}
 
-	// Local unix socket queries
+	// Local unix socket queries.
 	if r.RemoteAddr == "@" {
 		if w != nil {
 			conn := extractUnderlyingConn(w)
@@ -304,23 +304,23 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, str
 		return true, "", "unix", nil
 	}
 
-	// Devlxd unix socket credentials on main API
+	// Devlxd unix socket credentials on main API.
 	if r.RemoteAddr == "@devlxd" {
 		return false, "", "", fmt.Errorf("Main API query can't come from /dev/lxd socket")
 	}
 
-	// Cluster notification with wrong certificate
+	// Cluster notification with wrong certificate.
 	if isClusterNotification(r) {
 		return false, "", "", fmt.Errorf("Cluster notification isn't using cluster certificate")
 	}
 
-	// Bad query, no TLS found
+	// Bad query, no TLS found.
 	if r.TLS == nil {
 		return false, "", "", fmt.Errorf("Bad/missing TLS on network query")
 	}
 
 	if d.externalAuth != nil && r.Header.Get(httpbakery.BakeryProtocolHeader) != "" {
-		// Validate external authentication
+		// Validate external authentication.
 		ctx := httpbakery.ContextWithRequest(context.TODO(), r)
 		authChecker := d.externalAuth.bakery.Checker.Auth(httpbakery.RequestMacaroons(r)...)
 
@@ -331,20 +331,20 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, str
 
 		info, err := authChecker.Allow(ctx, ops...)
 		if err != nil {
-			// Bad macaroon
+			// Bad macaroon.
 			return false, "", "", err
 		}
 
 		if info != nil && info.Identity != nil {
-			// Valid identity macaroon found
+			// Valid identity macaroon found.
 			return true, info.Identity.Id(), "candid", nil
 		}
 
-		// Valid macaroon with no identity information
+		// Valid macaroon with no identity information.
 		return true, "", "candid", nil
 	}
 
-	// Validate normal TLS access
+	// Validate normal TLS access.
 	var err error
 
 	trustCACertificates, err := cluster.ConfigGetBool(d.cluster, "core.trust_ca_certificates")
@@ -361,7 +361,7 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, str
 		}
 	}
 
-	// Reject unauthorized
+	// Reject unauthorized.
 	return false, "", "", nil
 }
 

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -51,8 +51,7 @@ func CertificateAPITypeToDBType(apiType string) (int, error) {
 	return -1, fmt.Errorf("Invalid certificate type")
 }
 
-// Certificate is here to pass the certificates content
-// from the database around
+// Certificate is here to pass the certificates content from the database around.
 type Certificate struct {
 	ID          int
 	Fingerprint string `db:"primary=yes&comparison=like"`

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -4,6 +4,8 @@
 package db
 
 import (
+	"fmt"
+
 	"github.com/lxc/lxd/shared/api"
 )
 
@@ -31,6 +33,24 @@ import (
 //go:generate mapper method -p db -e certificate Delete
 //go:generate mapper method -p db -e certificate Update struct=Certificate
 
+// CertificateTypeClient indicates a client certificate type.
+const CertificateTypeClient = 1
+
+// CertificateTypeServer indicates a server certificate type.
+const CertificateTypeServer = 2
+
+// CertificateAPITypeToDBType converts an API type to the equivalent DB type.
+func CertificateAPITypeToDBType(apiType string) (int, error) {
+	switch apiType {
+	case api.CertificateTypeClient:
+		return CertificateTypeClient, nil
+	case api.CertificateTypeServer:
+		return CertificateTypeServer, nil
+	}
+
+	return -1, fmt.Errorf("Invalid certificate type")
+}
+
 // Certificate is here to pass the certificates content
 // from the database around
 type Certificate struct {
@@ -43,6 +63,18 @@ type Certificate struct {
 	Projects    []string
 }
 
+// ToAPIType returns the API equivalent type.
+func (cert *Certificate) ToAPIType() string {
+	switch cert.Type {
+	case CertificateTypeClient:
+		return api.CertificateTypeClient
+	case CertificateTypeServer:
+		return api.CertificateTypeServer
+	}
+
+	return api.CertificateTypeUnknown
+}
+
 // ToAPI converts the database Certificate struct to an api.Certificate entry.
 func (cert *Certificate) ToAPI() api.Certificate {
 	resp := api.Certificate{}
@@ -51,11 +83,7 @@ func (cert *Certificate) ToAPI() api.Certificate {
 	resp.Name = cert.Name
 	resp.Restricted = cert.Restricted
 	resp.Projects = cert.Projects
-	if cert.Type == 1 {
-		resp.Type = "client"
-	} else {
-		resp.Type = "unknown"
-	}
+	resp.Type = cert.ToAPIType()
 
 	return resp
 }

--- a/lxd/util/encryption.go
+++ b/lxd/util/encryption.go
@@ -71,6 +71,17 @@ func LoadClusterCert(dir string) (*shared.CertInfo, error) {
 	return cert, nil
 }
 
+// LoadServerCert reads the LXD server certificate from the given var dir.
+func LoadServerCert(dir string) (*shared.CertInfo, error) {
+	prefix := "server"
+	cert, err := shared.KeyPairAndCA(dir, prefix, shared.CertServer, true)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load TLS certificate")
+	}
+
+	return cert, nil
+}
+
 // WriteCert writes the given material to the appropriate certificate files in
 // the given LXD var directory.
 func WriteCert(dir, prefix string, cert, key, ca []byte) error {

--- a/shared/api/certificate.go
+++ b/shared/api/certificate.go
@@ -1,5 +1,14 @@
 package api
 
+// CertificateTypeClient indicates a client certificate type.
+const CertificateTypeClient = "client"
+
+// CertificateTypeServer indicates a server certificate type.
+const CertificateTypeServer = "server"
+
+// CertificateTypeUnknown indicates an unknown certificate type.
+const CertificateTypeUnknown = "unknown"
+
 // CertificatesPost represents the fields of a new LXD certificate
 //
 // swagger:model


### PR DESCRIPTION
- Add constants and helper functions for converting between API and DB type representations.
- Ensure locking is used when accessing cached certificates by way of getTrustedCertificates function.
- Store cached certificates keyed by type to allow retrieval of specific types only.
- Continues to authenticate access using only client certificate type (for now).
- Adds LoadServerCert for future use.