### PR TITLE
Network: Don't attempt to setup bridge ipv6 firewall when no ipv6.address

### DIFF
--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1992,7 +1992,9 @@ func (n *bridge) updateForkdnsServersFile(addresses []string) error {
 
 // hasIPv4Firewall indicates whether the network has IPv4 firewall enabled.
 func (n *bridge) hasIPv4Firewall() bool {
-	if n.config["ipv4.firewall"] == "" || shared.IsTrue(n.config["ipv4.firewall"]) {
+	// IPv4 firewall is only enabled if there is a bridge ipv4.address or fan mode, and ipv4.firewall enabled.
+	// When using fan bridge.mode, there can be an empty ipv4.address, so we assume it is active.
+	if (n.config["bridge.mode"] == "fan" || !shared.StringInSlice(n.config["ipv4.address"], []string{"", "none"})) && (n.config["ipv4.firewall"] == "" || shared.IsTrue(n.config["ipv4.firewall"])) {
 		return true
 	}
 
@@ -2001,7 +2003,8 @@ func (n *bridge) hasIPv4Firewall() bool {
 
 // hasIPv6Firewall indicates whether the network has IPv6 firewall enabled.
 func (n *bridge) hasIPv6Firewall() bool {
-	if n.config["ipv6.firewall"] == "" || shared.IsTrue(n.config["ipv6.firewall"]) {
+	// IPv6 firewall is only enabled if there is a bridge ipv6.address and ipv6.firewall enabled.
+	if !shared.StringInSlice(n.config["ipv6.address"], []string{"", "none"}) && (n.config["ipv6.firewall"] == "" || shared.IsTrue(n.config["ipv6.firewall"])) {
 		return true
 	}
 


### PR DESCRIPTION
So that `ipv6.address = ["", "none"]` implicitly disables `ipv6.firewall`.

Also applies similar logic for `ipv4.address` for `ipv4.firewall`, except that if `bridge.mode=fan` then we assume `ipv4.address` is enabled even if not set.

Fixes #8705

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>