### PR TITLE
Revert "lxd/instance/qemu: Move to query-cpus-fast"

### DIFF
--- a/lxd/instance/drivers/qmp/commands.go
+++ b/lxd/instance/drivers/qmp/commands.go
@@ -190,7 +190,7 @@ func (m *Monitor) GetCPUs() ([]int, error) {
 	}
 
 	// Query the consoles.
-	err := m.run("query-cpus-fast", "", &resp)
+	err := m.run("query-cpus", "", &resp)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
query-cpus-fast breaks our ability to pin the various PIDs as those
aren't returned.

This reverts commit 200288b76c3fa129ac8cf30aad6bed954bf9d655.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>