### PR TITLE
Cluster: Add join token

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ update-schema:
 
 .PHONY: update-api
 update-api:
-	go get -v -x github.com/go-swagger/go-swagger/cmd/swagger
+	GO111MODULE=on go get -v -x github.com/go-swagger/go-swagger/cmd/swagger
 	swagger generate spec -o doc/rest-api.yaml -w ./lxd -m
 
 .PHONY: debug

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -313,6 +313,7 @@ type InstanceServer interface {
 	GetClusterMember(name string) (member *api.ClusterMember, ETag string, err error)
 	UpdateClusterMember(name string, member api.ClusterMemberPut, ETag string) (err error)
 	RenameClusterMember(name string, member api.ClusterMemberPost) (err error)
+	CreateClusterMember(member api.ClusterMembersPost) (op Operation, err error)
 
 	// Warning functions
 	GetWarningUUIDs() (uuids []string, err error)

--- a/client/lxd_cluster.go
+++ b/client/lxd_cluster.go
@@ -149,3 +149,17 @@ func (r *ProtocolLXD) RenameClusterMember(name string, member api.ClusterMemberP
 
 	return nil
 }
+
+// CreateClusterMember generates a join token to add a cluster member.
+func (r *ProtocolLXD) CreateClusterMember(member api.ClusterMembersPost) (Operation, error) {
+	if !r.HasExtension("clustering_join_token") {
+		return nil, fmt.Errorf("The server is missing the required \"clustering_join_token\" API extension")
+	}
+
+	op, _, err := r.queryOperation("POST", "/cluster/members", member, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return op, nil
+}

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1370,3 +1370,7 @@ This includes the following endpoints (see  [Restful API](rest-api.md) for detai
 ## projects\_restricted\_backups\_and\_snapshots
 Adds new `restricted.backups` and `restricted.snapshots` config keys to project which
 prevents the user from creation of backups and snapshots.
+
+## clustering\_join\_token
+Adds `POST /1.0/cluster/members` API endpoint for requesting a join token used when adding new cluster members
+without using the trust password.

--- a/doc/clustering.md
+++ b/doc/clustering.md
@@ -43,13 +43,31 @@ nodes should be brand new LXD servers, or alternatively you should
 clear their contents before joining, since any existing data on them
 will be lost.
 
-To add an additional node, run `lxd init` and answer `yes` to the question
-about whether to use clustering. Choose a node name that is different from
-the one chosen for the bootstrap node or any other nodes you have joined so
-far. Then pick an IP or DNS address for the node and answer `yes` to the
-question about whether you're joining an existing cluster. Pick an address
-of an existing node in the cluster and check the fingerprint that gets
-printed.
+There are two ways to add a member to an existing cluster; using the trust password or using a join token.
+A join token for a new member is generated in advance on the existing cluster using the command:
+
+```
+lxc cluster add <new member name>
+```
+
+This will return a single-use join token which can then be used in the join token question stage of `lxd init`.
+The join token contains the addresses of the existing online members, as well as a single-use secret and the
+fingerprint of the cluster certificate. This reduces the amount of questions you have to answer during `lxd init`
+as the join token can be used to answer these questions automatically.
+
+Alternatively you can use the trust password instead of using a join token.
+
+To add an additional node, run `lxd init` and answer `yes` to the question about whether to use clustering.
+Choose a node name that is different from the one chosen for the bootstrap node or any other nodes you have joined
+so far. Then pick an IP or DNS address for the node and answer `yes` to the question about whether you're joining
+an existing cluster.
+
+If you have a join token then answer `yes` to the question that asks if you have a join token and then copy it in
+when it asks for it.
+
+If you do not have a join token, but have a trust password instead then, then answer `no` to the question that asks
+if you have a join token. Then pick an address of an existing node in the cluster and check the fingerprint that
+gets printed matches the cluster certificate of the existing members.
 
 ### Preseed
 

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -217,6 +217,35 @@ definitions:
       the cluster is required to provide when joining.
     type: object
     x-go-package: github.com/lxc/lxd/shared/api
+  ClusterMemberJoinToken:
+    properties:
+      addresses:
+        description: The addresses of existing online cluster members
+        example:
+        - 10.98.30.229:8443
+        items:
+          type: string
+        type: array
+        x-go-name: Addresses
+      fingerprint:
+        description: The fingerprint of the network certificate
+        example: 57bb0ff4340b5bb28517e062023101adf788c37846dc8b619eb2c3cb4ef29436
+        type: string
+        x-go-name: Fingerprint
+      secret:
+        description: The random join secret.
+        example: 2b2284d44db32675923fe0d2020477e0e9be11801ff70c435e032b97028c35cd
+        type: string
+        x-go-name: Secret
+      server_name:
+        description: The name of the new cluster member
+        example: lxd02
+        type: string
+        x-go-name: ServerName
+    title: ClusterMemberJoinToken represents the fields contained within an encoded
+      cluster member join token.
+    type: object
+    x-go-package: github.com/lxc/lxd/shared/api
   ClusterMemberPost:
     properties:
       server_name:
@@ -244,6 +273,17 @@ definitions:
           type: string
         type: array
         x-go-name: Roles
+    type: object
+    x-go-package: github.com/lxc/lxd/shared/api
+  ClusterMembersPost:
+    properties:
+      server_name:
+        description: The name of the new cluster member
+        example: lxd02
+        type: string
+        x-go-name: ServerName
+    title: ClusterMembersPost represents the fields required to request a join token
+      to add a member to the cluster.
     type: object
     x-go-package: github.com/lxc/lxd/shared/api
   ClusterPut:
@@ -4210,6 +4250,32 @@ paths:
         "500":
           $ref: '#/responses/InternalServerError'
       summary: Get the cluster members
+      tags:
+      - cluster
+    post:
+      consumes:
+      - application/json
+      description: Requests a join token to add a cluster member.
+      operationId: cluster_members_post
+      parameters:
+      - description: Cluster member add request
+        in: body
+        name: cluster
+        required: true
+        schema:
+          $ref: '#/definitions/ClusterMembersPost'
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/Operation'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "403":
+          $ref: '#/responses/Forbidden'
+        "500":
+          $ref: '#/responses/InternalServerError'
+      summary: Request a join token
       tags:
       - cluster
   /1.0/cluster/members/{name}:

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -59,6 +59,10 @@ func (c *cmdCluster) Command() *cobra.Command {
 	cmdClusterAdd := cmdClusterAdd{global: c.global, cluster: c}
 	cmd.AddCommand(cmdClusterAdd.Command())
 
+	// List tokens
+	cmdClusterListTokens := cmdClusterListTokens{global: c.global, cluster: c}
+	cmd.AddCommand(cmdClusterListTokens.Command())
+
 	return cmd
 }
 
@@ -582,4 +586,104 @@ func (c *cmdClusterAdd) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// List Tokens.
+type cmdClusterListTokens struct {
+	global  *cmdGlobal
+	cluster *cmdCluster
+
+	flagFormat string
+}
+
+func (c *cmdClusterListTokens) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("list-tokens", i18n.G("[<remote>:]"))
+	cmd.Short = i18n.G("List all active cluster member join tokens")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`List all active cluster member join tokens`))
+	cmd.Flags().StringVar(&c.flagFormat, "format", "table", i18n.G("Format (csv|json|table|yaml)")+"``")
+
+	cmd.RunE = c.Run
+
+	return cmd
+}
+
+func (c *cmdClusterListTokens) Run(cmd *cobra.Command, args []string) error {
+	// Sanity checks.
+	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
+	if exit {
+		return err
+	}
+
+	// Parse remote.
+	remote := ""
+	if len(args) == 1 {
+		remote = args[0]
+	}
+
+	resources, err := c.global.ParseServers(remote)
+	if err != nil {
+		return err
+	}
+
+	resource := resources[0]
+
+	// Check if clustered.
+	cluster, _, err := resource.server.GetCluster()
+	if err != nil {
+		return err
+	}
+
+	if !cluster.Enabled {
+		return fmt.Errorf(i18n.G("LXD server isn't part of a cluster"))
+	}
+
+	// Get the cluster member join tokens.
+	ops, err := resource.server.GetOperations()
+	if err != nil {
+		return err
+	}
+
+	// Convert the join token operation into encoded form for display.
+	type displayToken struct {
+		ServerName string
+		Token      string
+	}
+
+	displayTokens := make([]displayToken, 0)
+
+	for _, op := range ops {
+		if op.Class != api.OperationClassToken {
+			continue
+		}
+
+		if op.StatusCode != api.Running {
+			continue // Tokens are single use, so if cancelled but not deleted yet its not available.
+		}
+
+		joinToken, err := clusterJoinTokenOperationToAPI(&op)
+		if err != nil {
+			continue // Operation is not a valid cluster member join token operation.
+		}
+
+		displayTokens = append(displayTokens, displayToken{
+			ServerName: joinToken.ServerName,
+			Token:      joinToken.String(),
+		})
+	}
+
+	// Render the table.
+	data := [][]string{}
+	for _, token := range displayTokens {
+		line := []string{token.ServerName, token.Token}
+		data = append(data, line)
+	}
+	sort.Sort(byName(data))
+
+	header := []string{
+		i18n.G("NAME"),
+		i18n.G("TOKEN"),
+	}
+
+	return utils.RenderTable(c.flagFormat, header, data, displayTokens)
 }

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -528,6 +528,46 @@ func (c *cmdClusterEdit) Run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func clusterJoinTokenOperationToAPI(op *api.Operation) (*api.ClusterMemberJoinToken, error) {
+	serverName, ok := op.Metadata["serverName"].(string)
+	if !ok {
+		return nil, fmt.Errorf("Operation serverName is type %T not string", op.Metadata["serverName"])
+	}
+
+	secret, ok := op.Metadata["secret"].(string)
+	if !ok {
+		return nil, fmt.Errorf("Operation secret is type %T not string", op.Metadata["secret"])
+	}
+
+	fingerprint, ok := op.Metadata["fingerprint"].(string)
+	if !ok {
+		return nil, fmt.Errorf("Operation fingerprint is type %T not string", op.Metadata["fingerprint"])
+	}
+
+	addresses, ok := op.Metadata["addresses"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Operation addresses is type %T not []interface{}", op.Metadata["addresses"])
+	}
+
+	joinToken := api.ClusterMemberJoinToken{
+		ServerName:  serverName,
+		Secret:      secret,
+		Fingerprint: fingerprint,
+		Addresses:   make([]string, 0, len(addresses)),
+	}
+
+	for i, address := range addresses {
+		addressString, ok := address.(string)
+		if !ok {
+			return nil, fmt.Errorf("Operation address index %d is type %T not string", i, address)
+		}
+
+		joinToken.Addresses = append(joinToken.Addresses, addressString)
+	}
+
+	return &joinToken, nil
+}
+
 // Add
 type cmdClusterAdd struct {
 	global  *cmdGlobal

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -55,6 +55,10 @@ func (c *cmdCluster) Command() *cobra.Command {
 	clusterEditCmd := cmdClusterEdit{global: c.global, cluster: c}
 	cmd.AddCommand(clusterEditCmd.Command())
 
+	// Add
+	cmdClusterAdd := cmdClusterAdd{global: c.global, cluster: c}
+	cmd.AddCommand(cmdClusterAdd.Command())
+
 	return cmd
 }
 
@@ -515,6 +519,66 @@ func (c *cmdClusterEdit) Run(cmd *cobra.Command, args []string) error {
 			continue
 		}
 		break
+	}
+
+	return nil
+}
+
+// Add
+type cmdClusterAdd struct {
+	global  *cmdGlobal
+	cluster *cmdCluster
+}
+
+func (c *cmdClusterAdd) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("add", i18n.G("[<remote>:]<member>"))
+	cmd.Aliases = []string{"rm"}
+	cmd.Short = i18n.G("Request a join token for adding a cluster member")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`Request a join token for adding a cluster member`))
+
+	cmd.RunE = c.Run
+
+	return cmd
+}
+
+func (c *cmdClusterAdd) Run(cmd *cobra.Command, args []string) error {
+	// Sanity checks.
+	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	if exit {
+		return err
+	}
+
+	// Parse remote.
+	resources, err := c.global.ParseServers(args[0])
+	if err != nil {
+		return err
+	}
+
+	resource := resources[0]
+
+	if resource.name == "" {
+		return fmt.Errorf(i18n.G("Missing cluster member name"))
+	}
+
+	// Request the join token.
+	member := api.ClusterMembersPost{
+		ServerName: resource.name,
+	}
+
+	op, err := resource.server.CreateClusterMember(member)
+	if err != nil {
+		return err
+	}
+
+	if !c.global.flagQuiet {
+		opAPI := op.Get()
+		joinToken, err := clusterJoinTokenOperationToAPI(&opAPI)
+		if err != nil {
+			return errors.Wrapf(err, "Failed converting token operation to join token")
+		}
+
+		fmt.Printf(i18n.G("Member %s join token: %s")+"\n", resource.name, joinToken.String())
 	}
 
 	return nil

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/rbac"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/util"
@@ -271,6 +272,82 @@ func updateCertificateCacheFromLocal(d *Daemon, networkCert *shared.CertInfo) er
 	d.clientCerts.Lock.Unlock()
 
 	return nil
+}
+
+// clusterMemberJoinTokenDecode decodes a base64 and JSON encode join token.
+func clusterMemberJoinTokenDecode(input string) (*api.ClusterMemberJoinToken, error) {
+	joinTokenJSON, err := base64.StdEncoding.DecodeString(input)
+	if err != nil {
+		return nil, err
+	}
+
+	var j api.ClusterMemberJoinToken
+	err = json.Unmarshal(joinTokenJSON, &j)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(j.Addresses) < 1 {
+		return nil, fmt.Errorf("No cluster member addresses in join token")
+	}
+
+	if j.Secret == "" {
+		return nil, fmt.Errorf("No secret in join token")
+	}
+
+	if j.Fingerprint == "" {
+		return nil, fmt.Errorf("No certificate fingerprint in join token")
+	}
+
+	return &j, nil
+}
+
+// clusterMemberJoinTokenValid searches for cluster join token that matches the joint token provided.
+// Returns matching operation if found and cancels the operation, otherwise returns nil.
+func clusterMemberJoinTokenValid(d *Daemon, projectName string, joinToken *api.ClusterMemberJoinToken) (*api.Operation, error) {
+	ops, err := operationsGetByType(d, projectName, db.OperationClusterJoinToken)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed getting cluster join token operations")
+	}
+
+	var foundOp *api.Operation
+	for _, op := range ops {
+		if op.StatusCode != api.Running {
+			continue // Tokens are single use, so if cancelled but not deleted yet its not available.
+		}
+
+		if op.Resources == nil {
+			continue
+		}
+
+		opSecret, ok := op.Metadata["secret"]
+		if !ok {
+			continue
+		}
+
+		opServerName, ok := op.Metadata["serverName"]
+		if !ok {
+			continue
+		}
+
+		if opServerName == joinToken.ServerName && opSecret == joinToken.Secret {
+			foundOp = op
+			break
+		}
+	}
+
+	if foundOp != nil {
+		// Token is single-use, so cancel it now.
+		err = operationCancel(d, projectName, foundOp)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to cancel operation")
+		}
+
+		return foundOp, nil
+	}
+
+	// No operation found.
+	return nil, nil
 }
 
 // swagger:operation POST /1.0/certificates?public certificates certificates_post_untrusted

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1760,7 +1760,7 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat) {
 				if role != db.RaftSpare {
 					isDegraded = true
 				}
-				logger.Warnf("Excluding offline node from refresh: %+v", node)
+				logger.Warn("Excluding offline member from refresh", log.Ctx{"address": node.Address, "ID": node.ID, "raftID": node.RaftID, "lastHeartbeat": node.LastHeartbeat})
 				delete(heartbeatData.Members, i)
 			}
 			switch role {

--- a/lxd/db/operations.go
+++ b/lxd/db/operations.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/pkg/errors"
+
+	"github.com/lxc/lxd/lxd/db/query"
 )
 
 // Operation holds information about a single LXD operation running on a node

--- a/lxd/db/operations_types.go
+++ b/lxd/db/operations_types.go
@@ -61,6 +61,7 @@ const (
 	OperationCustomVolumeBackupRename
 	OperationCustomVolumeBackupRestore
 	OperationWarningsPruneResolved
+	OperationClusterJoinToken
 )
 
 // Description return a human-readable description of the operation type.

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -149,38 +149,88 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer) error
 		if cli.AskBool("Are you joining an existing cluster? (yes/no) [default=no]: ", "no") {
 			// Existing cluster
 			config.Cluster.ServerAddress = serverAddress
-			for {
-				// Cluster URL
-				clusterAddress := cli.AskString("IP address or FQDN of an existing cluster node: ", "", nil)
-				_, _, err := net.SplitHostPort(clusterAddress)
-				if err != nil {
-					clusterAddress = fmt.Sprintf("%s:%d", clusterAddress, shared.DefaultPort)
-				}
-				config.Cluster.ClusterAddress = clusterAddress
-
-				// Cluster certificate
-				cert, err := shared.GetRemoteCertificate(fmt.Sprintf("https://%s", config.Cluster.ClusterAddress), version.UserAgent)
-				if err != nil {
-					fmt.Printf("Error connecting to existing cluster node: %v\n", err)
-					continue
-				}
-
-				certDigest := shared.CertFingerprint(cert)
-				fmt.Printf("Cluster fingerprint: %s\n", certDigest)
-				fmt.Printf("You can validate this fingerprint by running \"lxc info\" locally on an existing node.\n")
-				if !cli.AskBool("Is this the correct fingerprint? (yes/no) [default=no]: ", "no") {
-					return fmt.Errorf("User aborted configuration")
-				}
-				config.Cluster.ClusterCertificate = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
-
-				// Cluster password
-				config.Cluster.ClusterPassword = cli.AskPasswordOnce("Cluster trust password: ")
-				break
-			}
 
 			// Root is required to access the certificate files
 			if os.Geteuid() != 0 {
 				return fmt.Errorf("Joining an existing cluster requires root privileges")
+			}
+
+			if cli.AskBool("Do you have a join token? (yes/no) [default=no]: ", "no") {
+				var joinToken *api.ClusterMemberJoinToken
+				validJoinToken := func(input string) error {
+					j, err := clusterMemberJoinTokenDecode(input)
+					if err != nil {
+						return errors.Wrapf(err, "Invalid join token")
+					}
+
+					joinToken = j // Store valid decoded join token
+					return nil
+				}
+
+				rawJoinToken := cli.AskString("Please provide join token: ", "", validJoinToken)
+
+				if joinToken.ServerName != config.Cluster.ServerName {
+					return fmt.Errorf("Server name does not match the one specified in join token")
+				}
+
+				for _, clusterAddress := range joinToken.Addresses {
+					// Cluster URL
+					_, _, err := net.SplitHostPort(clusterAddress)
+					if err != nil {
+						clusterAddress = fmt.Sprintf("%s:%d", clusterAddress, shared.DefaultPort)
+					}
+					config.Cluster.ClusterAddress = clusterAddress
+
+					// Cluster certificate
+					cert, err := shared.GetRemoteCertificate(fmt.Sprintf("https://%s", config.Cluster.ClusterAddress), version.UserAgent)
+					if err != nil {
+						fmt.Printf("Error connecting to existing cluster node %q: %v\n", clusterAddress, err)
+						continue
+					}
+
+					certDigest := shared.CertFingerprint(cert)
+					if joinToken.Fingerprint != certDigest {
+						return fmt.Errorf("Certificate fingerprint mismatch between join token and cluster member %q", clusterAddress)
+					}
+
+					config.Cluster.ClusterCertificate = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
+				}
+
+				if config.Cluster.ClusterCertificate == "" {
+					return fmt.Errorf("Unable to connect to any of the cluster members specified in join token")
+				}
+
+				// Raw join token used as cluster password so it can be validated.
+				config.Cluster.ClusterPassword = rawJoinToken
+			} else {
+				for {
+					// Cluster URL
+					clusterAddress := cli.AskString("IP address or FQDN of an existing cluster node: ", "", nil)
+					_, _, err := net.SplitHostPort(clusterAddress)
+					if err != nil {
+						clusterAddress = fmt.Sprintf("%s:%d", clusterAddress, shared.DefaultPort)
+					}
+					config.Cluster.ClusterAddress = clusterAddress
+
+					// Cluster certificate
+					cert, err := shared.GetRemoteCertificate(fmt.Sprintf("https://%s", config.Cluster.ClusterAddress), version.UserAgent)
+					if err != nil {
+						fmt.Printf("Error connecting to existing cluster node: %v\n", err)
+						continue
+					}
+
+					certDigest := shared.CertFingerprint(cert)
+					fmt.Printf("Cluster fingerprint: %s\n", certDigest)
+					fmt.Printf("You can validate this fingerprint by running \"lxc info\" locally on an existing node.\n")
+					if !cli.AskBool("Is this the correct fingerprint? (yes/no) [default=no]: ", "no") {
+						return fmt.Errorf("User aborted configuration")
+					}
+					config.Cluster.ClusterCertificate = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
+
+					// Cluster password
+					config.Cluster.ClusterPassword = cli.AskPasswordOnce("Cluster trust password: ")
+					break
+				}
 			}
 
 			// Confirm wiping

--- a/lxd/node/raft_test.go
+++ b/lxd/node/raft_test.go
@@ -26,7 +26,7 @@ func TestDetermineRaftNode(t *testing.T) {
 			&db.RaftNode{ID: 1},
 		},
 		{
-			`cluster.https_address set and and no raft_nodes rows`,
+			`cluster.https_address set and no raft_nodes rows`,
 			"1.2.3.4:8443",
 			[]string{},
 			&db.RaftNode{ID: 1},

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -39,9 +39,9 @@ const (
 
 func (t OperationClass) String() string {
 	return map[OperationClass]string{
-		OperationClassTask:      "task",
-		OperationClassWebsocket: "websocket",
-		OperationClassToken:     "token",
+		OperationClassTask:      api.OperationClassTask,
+		OperationClassWebsocket: api.OperationClassWebsocket,
+		OperationClassToken:     api.OperationClassToken,
 	}[t]
 }
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -346,7 +346,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -513,7 +513,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -949,7 +949,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -1150,7 +1150,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1239,14 +1239,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1388,7 +1388,7 @@ msgstr " Prozessorauslastung:"
 msgid "Disks:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1415,7 +1415,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -1480,11 +1480,11 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1590,7 +1590,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr "Fingerabdruck: %s\n"
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1669,7 +1669,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1693,11 +1693,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -2072,7 +2072,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2104,7 +2104,12 @@ msgstr ""
 msgid "List aliases"
 msgstr "Aliasse:\n"
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+#, fuzzy
+msgid "List all active cluster member join tokens"
+msgstr "der Name des Ursprung Containers muss angegeben werden"
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2404,7 +2409,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2549,12 +2554,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, fuzzy, c-format
+msgid "Member %s join token: %s"
+msgstr "Profil %s wurde auf %s angewandt\n"
+
+#: lxc/cluster.go:329
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -2592,7 +2602,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2724,9 +2734,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2980,7 +2990,7 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -3238,7 +3248,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3274,7 +3284,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3328,6 +3338,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3405,7 +3419,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3604,7 +3618,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3864,6 +3878,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -4068,7 +4086,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -4176,7 +4194,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4278,10 +4296,10 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 #, fuzzy
 msgid "[<remote>:]"
 msgstr ""
@@ -4315,7 +4333,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -4424,7 +4442,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr ""
@@ -4685,7 +4703,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -4694,7 +4712,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -5151,7 +5169,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5422,7 +5440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -199,7 +199,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -345,7 +345,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -713,7 +713,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,7 +934,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1018,14 +1018,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1159,7 +1159,7 @@ msgstr "  Χρήση CPU:"
 msgid "Disks:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1186,7 +1186,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1244,11 +1244,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1345,7 +1345,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1418,7 +1418,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1442,11 +1442,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1806,7 +1806,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1837,7 +1837,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2113,7 +2117,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2242,12 +2246,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2286,7 +2295,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2406,9 +2415,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2658,7 +2667,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2907,7 +2916,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2939,7 +2948,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2988,6 +2997,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3061,7 +3074,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3251,7 +3264,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3494,6 +3507,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3688,7 +3705,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3790,7 +3807,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3872,10 +3889,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3891,7 +3908,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3943,7 +3960,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4067,11 +4084,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4326,7 +4343,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4592,7 +4609,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -342,7 +342,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -493,7 +493,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -1094,7 +1094,7 @@ msgstr "Creando el contenedor"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1179,14 +1179,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1319,7 +1319,7 @@ msgstr "Uso del disco:"
 msgid "Disks:"
 msgstr "Uso del disco:"
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1346,7 +1346,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1404,11 +1404,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1507,7 +1507,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Exporting the image: %s"
 msgstr "Exportando la imagen: %s"
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1565,7 +1565,7 @@ msgstr "Huella dactilar: %s"
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1581,7 +1581,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1605,11 +1605,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1971,7 +1971,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2003,7 +2003,12 @@ msgstr ""
 msgid "List aliases"
 msgstr "Aliases:"
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+#, fuzzy
+msgid "List all active cluster member join tokens"
+msgstr "Nombre del Miembro del Cluster"
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2282,7 +2287,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2412,12 +2417,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Perfil %s creado"
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2455,7 +2465,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Nombre del Miembro del Cluster"
@@ -2580,9 +2590,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2830,7 +2840,7 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -3082,7 +3092,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3114,7 +3124,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3164,6 +3174,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3239,7 +3253,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3429,7 +3443,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3672,6 +3686,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3866,7 +3884,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3968,7 +3986,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4052,10 +4070,10 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4075,7 +4093,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4140,7 +4158,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4293,12 +4311,12 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4601,7 +4619,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4867,7 +4885,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -345,7 +345,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -509,7 +509,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -895,7 +895,7 @@ msgstr "Afficher la version du client"
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -1160,7 +1160,7 @@ msgstr "Création du conteneur"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1253,14 +1253,14 @@ msgstr "Récupération de l'image : %s"
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1396,7 +1396,7 @@ msgstr "  Disque utilisé :"
 msgid "Disks:"
 msgstr "  Disque utilisé :"
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 #, fuzzy
 msgid "Don't require user confirmation for using --force"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -1424,7 +1424,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -1490,11 +1490,11 @@ msgstr "Clé de configuration invalide"
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1606,7 +1606,7 @@ msgstr "Import de l'image : %s"
 msgid "Exporting the image: %s"
 msgstr "Import de l'image : %s"
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1667,7 +1667,7 @@ msgstr "Empreinte : %s"
 msgid "Force pseudo-terminal allocation"
 msgstr "Forcer l'allocation d'un pseudo-terminal"
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1685,7 +1685,7 @@ msgstr "Forcer la suppression des conteneurs arrêtés"
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1709,11 +1709,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -2094,7 +2094,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2126,7 +2126,12 @@ msgstr ""
 msgid "List aliases"
 msgstr "Alias :"
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+#, fuzzy
+msgid "List all active cluster member join tokens"
+msgstr "Vous devez fournir le nom d'un conteneur pour : "
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2467,7 +2472,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2610,12 +2615,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Profils : %s"
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, fuzzy, c-format
+msgid "Member %s join token: %s"
+msgstr "Profil %s ajouté à %s"
+
+#: lxc/cluster.go:329
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -2656,7 +2666,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr "Empreinte du certificat : %s"
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2791,9 +2801,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr "NOM"
 
@@ -3059,7 +3069,7 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -3319,7 +3329,7 @@ msgstr "Serveur distant : %s"
 msgid "Remove %s (yes/no): "
 msgstr "Supprimer %s (oui/non) : "
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3355,7 +3365,7 @@ msgstr "Création du conteneur"
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3408,6 +3418,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3502,7 +3516,7 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr "ÉTAT"
 
@@ -3705,7 +3719,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3973,6 +3987,10 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -4180,7 +4198,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr "URL"
 
@@ -4291,7 +4309,7 @@ msgstr "Publié : %s"
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 #, fuzzy
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
@@ -4390,10 +4408,10 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "Serveur distant : %s"
@@ -4430,7 +4448,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -4551,7 +4569,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr ""
@@ -4860,7 +4878,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -4872,7 +4890,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -5360,7 +5378,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5648,7 +5666,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr "oui"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -335,7 +335,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -484,7 +484,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
@@ -854,7 +854,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -891,7 +891,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -1082,7 +1082,7 @@ msgstr "Creazione del container in corso"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1168,14 +1168,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1308,7 +1308,7 @@ msgstr "Utilizzo disco:"
 msgid "Disks:"
 msgstr "Utilizzo disco:"
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1394,11 +1394,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1497,7 +1497,7 @@ msgstr "Creazione del container in corso"
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1555,7 +1555,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1595,11 +1595,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1962,7 +1962,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1994,7 +1994,12 @@ msgstr ""
 msgid "List aliases"
 msgstr "Alias:"
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+#, fuzzy
+msgid "List all active cluster member join tokens"
+msgstr "Il nome del container è: %s"
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2274,7 +2279,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2407,12 +2412,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2449,7 +2459,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Il nome del container è: %s"
@@ -2573,9 +2583,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2824,7 +2834,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -3075,7 +3085,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3108,7 +3118,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3158,6 +3168,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3233,7 +3247,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3423,7 +3437,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3668,6 +3682,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3863,7 +3881,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3966,7 +3984,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4052,10 +4070,10 @@ msgstr "Creazione del container in corso"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "Creazione del container in corso"
@@ -4075,7 +4093,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "Creazione del container in corso"
@@ -4140,7 +4158,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr "Creazione del container in corso"
@@ -4293,12 +4311,12 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr "Creazione del container in corso"
@@ -4601,7 +4619,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4867,7 +4885,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr "si"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: 2021-02-02 15:21+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -335,7 +335,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -487,7 +487,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -869,7 +869,7 @@ msgstr "クライアントバージョン: %s\n"
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
@@ -910,7 +910,7 @@ msgstr "新しいプロジェクトに適用するキー/値の設定"
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -1103,7 +1103,7 @@ msgstr "インスタンスを作成中"
 msgid "Current number of VFs: %d"
 msgstr "現在の VF 数: %d"
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr "DATABASE"
 
@@ -1190,14 +1190,14 @@ msgstr "イメージを削除します"
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1330,7 +1330,7 @@ msgstr "ディスク:"
 msgid "Disks:"
 msgstr "ディスク:"
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr "--force を使う際にユーザーの確認を必要としない"
 
@@ -1359,7 +1359,7 @@ msgstr ""
 "ファイル転送のサーバ側の初期処理はキャンセルできません（強制的に中断するには"
 "あと2回行ってください）"
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
@@ -1420,12 +1420,12 @@ msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 "'%s' 中のカラムエントリが空です (カラムの指定に空文字列が指定されています)"
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 "クラスタリングで動作していないLXDサーバ上でクラスタリングを有効にします"
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1546,7 +1546,7 @@ msgstr "バックアップのエクスポート中: %s"
 msgid "Exporting the image: %s"
 msgstr "イメージのエクスポート中: %s"
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr "FAILURE DOMAIN"
 
@@ -1603,7 +1603,7 @@ msgstr "証明書のフィンガープリント: %s"
 msgid "Force pseudo-terminal allocation"
 msgstr "強制的に擬似端末を割り当てます"
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr "degraded 状態であっても強制的にメンバを削除します"
 
@@ -1619,7 +1619,7 @@ msgstr "稼働中のインスタンスを強制的に削除します"
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1658,11 +1658,11 @@ msgstr ""
 "\n"
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr "フォーマット (csv|json|table|yaml)"
@@ -2039,7 +2039,7 @@ msgstr ""
 "LXD は spicy か remote-viewer がインストールされている場合は自動的にどちらか"
 "を使います。"
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
 
@@ -2070,7 +2070,12 @@ msgstr "DHCP のリースを一覧表示します"
 msgid "List aliases"
 msgstr "エイリアスを一覧表示します"
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+#, fuzzy
+msgid "List all active cluster member join tokens"
+msgstr "クラスタのメンバをすべて一覧表示します"
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr "クラスタのメンバをすべて一覧表示します"
 
@@ -2491,7 +2496,7 @@ msgstr "MEMORY USAGE"
 msgid "MEMORY USAGE%"
 msgstr "MEMORY USAGE%"
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr "MESSAGE"
 
@@ -2640,12 +2645,17 @@ msgstr "VF の最大数: %d"
 msgid "Mdev profiles:"
 msgstr "Mdevプロファイル:"
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, fuzzy, c-format
+msgid "Member %s join token: %s"
+msgstr "メンバ名 %s を %s に変更しました"
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr "メンバ %s が削除されました"
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
@@ -2683,7 +2693,7 @@ msgstr "表示するログメッセージの最小レベル"
 msgid "Missing certificate fingerprint"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
 
@@ -2809,9 +2819,9 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr "NAME"
 
@@ -3060,7 +3070,7 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -3310,7 +3320,7 @@ msgstr "リムーバブルディスク: %v"
 msgid "Remove %s (yes/no): "
 msgstr "%s を消去しますか (yes/no): "
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr "クラスタからメンバを削除します"
 
@@ -3343,7 +3353,7 @@ msgstr "インスタンスからプロファイルを削除します"
 msgid "Remove trusted clients"
 msgstr "信頼済みクライアントを削除します"
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr "クラスタメンバの名前を変更します"
 
@@ -3395,6 +3405,11 @@ msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しまし�
 #, c-format
 msgid "Render: %s (%s)"
 msgstr "レンダー: %s (%s)"
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+#, fuzzy
+msgid "Request a join token for adding a cluster member"
+msgstr "クラスタメンバの詳細を表示します"
 
 #: lxc/delete.go:36
 msgid "Require user confirmation"
@@ -3473,7 +3488,7 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr "STATE"
 
@@ -3701,7 +3716,7 @@ msgstr "詳細な情報を出力します"
 msgid "Show content of instance file templates"
 msgstr "インスタンスのファイルテンプレートの内容を表示します"
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr "クラスタメンバの詳細を表示します"
 
@@ -3947,6 +3962,10 @@ msgstr "デフォルトのリモートを切り替えます"
 msgid "TARGET"
 msgstr "TARGET"
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -4166,7 +4185,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr "URL"
 
@@ -4273,7 +4292,7 @@ msgstr "使用済: %v"
 msgid "User ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
@@ -4360,10 +4379,10 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
 
@@ -4379,7 +4398,7 @@ msgstr "[<remote>:] <cert>"
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr "[<remote>:] <hostname|fingerprint>"
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr "[<remote>:] <name>"
 
@@ -4437,7 +4456,7 @@ msgstr "[<remote>:]<alias> <fingerprint>"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "[<remote>:]<alias> <new-name>"
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr "[<remote>:]<cluster member>"
 
@@ -4565,11 +4584,11 @@ msgid ""
 msgstr ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr "[<remote>:]<member>"
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr "[<remote>:]<member> <new-name>"
 
@@ -4834,7 +4853,7 @@ msgstr ""
 "lxc alias rename list my-list\n"
 "    エイリアス名 \"list\" を \"my-list\" に変更します。"
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5212,7 +5231,7 @@ msgstr "ストレージを使用中の"
 msgid "y"
 msgstr "y"
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr "yes"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2021-05-04 16:56-0400\n"
+        "POT-Creation-Date: 2021-05-05 09:29+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -185,7 +185,7 @@ msgid   "### This is a YAML representation of the project.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid   "### This is a yaml representation of the cluster member.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
@@ -327,7 +327,7 @@ msgstr  ""
 msgid   "ALIASES"
 msgstr  ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid   "ARCHITECTURE"
 msgstr  ""
 
@@ -677,7 +677,7 @@ msgstr  ""
 msgid   "Cluster member name"
 msgstr  ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid   "Clustering enabled"
 msgstr  ""
 
@@ -712,7 +712,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328 lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431 lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498 lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941 lxc/storage_volume.go:971
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328 lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431 lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498 lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941 lxc/storage_volume.go:971
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -890,7 +890,7 @@ msgstr  ""
 msgid   "Current number of VFs: %d"
 msgstr  ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid   "DATABASE"
 msgstr  ""
 
@@ -970,7 +970,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154 lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422 lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52 lxc/config_metadata.go:174 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:73 lxc/config_trust.go:135 lxc/config_trust.go:247 lxc/config_trust.go:325 lxc/config_trust.go:368 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605 lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235 lxc/storage_volume.go:322 lxc/storage_volume.go:484 lxc/storage_volume.go:563 lxc/storage_volume.go:639 lxc/storage_volume.go:721 lxc/storage_volume.go:802 lxc/storage_volume.go:1002 lxc/storage_volume.go:1090 lxc/storage_volume.go:1177 lxc/storage_volume.go:1361 lxc/storage_volume.go:1392 lxc/storage_volume.go:1505 lxc/storage_volume.go:1581 lxc/storage_volume.go:1680 lxc/storage_volume.go:1714 lxc/storage_volume.go:1812 lxc/storage_volume.go:1879 lxc/storage_volume.go:2020 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:67 lxc/warning.go:247 lxc/warning.go:288 lxc/warning.go:342
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162 lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430 lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52 lxc/config_metadata.go:174 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:73 lxc/config_trust.go:135 lxc/config_trust.go:247 lxc/config_trust.go:325 lxc/config_trust.go:368 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605 lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235 lxc/storage_volume.go:322 lxc/storage_volume.go:484 lxc/storage_volume.go:563 lxc/storage_volume.go:639 lxc/storage_volume.go:721 lxc/storage_volume.go:802 lxc/storage_volume.go:1002 lxc/storage_volume.go:1090 lxc/storage_volume.go:1177 lxc/storage_volume.go:1361 lxc/storage_volume.go:1392 lxc/storage_volume.go:1505 lxc/storage_volume.go:1581 lxc/storage_volume.go:1680 lxc/storage_volume.go:1714 lxc/storage_volume.go:1812 lxc/storage_volume.go:1879 lxc/storage_volume.go:2020 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:67 lxc/warning.go:247 lxc/warning.go:288 lxc/warning.go:342
 msgid   "Description"
 msgstr  ""
 
@@ -1052,7 +1052,7 @@ msgstr  ""
 msgid   "Disks:"
 msgstr  ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid   "Don't require user confirmation for using --force"
 msgstr  ""
 
@@ -1077,7 +1077,7 @@ msgstr  ""
 msgid   "Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"
 msgstr  ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
@@ -1134,11 +1134,11 @@ msgstr  ""
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid   "Enable clustering on a single non-clustered LXD server"
 msgstr  ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid   "Enable clustering on a single non-clustered LXD server\n"
         "\n"
         "  This command turns a non-clustered LXD server into the first member of a new\n"
@@ -1228,7 +1228,7 @@ msgstr  ""
 msgid   "Exporting the image: %s"
 msgstr  ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid   "FAILURE DOMAIN"
 msgstr  ""
 
@@ -1284,7 +1284,7 @@ msgstr  ""
 msgid   "Force pseudo-terminal allocation"
 msgstr  ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid   "Force removing a member, even if degraded"
 msgstr  ""
 
@@ -1300,7 +1300,7 @@ msgstr  ""
 msgid   "Force using the local unix socket"
 msgstr  ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid   "Forcefully removing a server from the cluster should only be done as a last\n"
         "resort.\n"
@@ -1319,7 +1319,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515 lxc/storage_volume.go:1195 lxc/warning.go:89
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644 lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515 lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
@@ -1673,7 +1673,7 @@ msgstr  ""
 msgid   "LXD automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid   "LXD server isn't part of a cluster"
 msgstr  ""
 
@@ -1704,7 +1704,11 @@ msgstr  ""
 msgid   "List aliases"
 msgstr  ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid   "List all active cluster member join tokens"
+msgstr  ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid   "List all the cluster members"
 msgstr  ""
 
@@ -1968,7 +1972,7 @@ msgstr  ""
 msgid   "MEMORY USAGE%"
 msgstr  ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid   "MESSAGE"
 msgstr  ""
 
@@ -2094,12 +2098,17 @@ msgstr  ""
 msgid   "Mdev profiles:"
 msgstr  ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid   "Member %s join token: %s"
+msgstr  ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid   "Member %s removed"
 msgstr  ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid   "Member %s renamed to %s"
 msgstr  ""
@@ -2136,7 +2145,7 @@ msgstr  ""
 msgid   "Missing certificate fingerprint"
 msgstr  ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid   "Missing cluster member name"
 msgstr  ""
 
@@ -2233,7 +2242,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid   "NAME"
 msgstr  ""
 
@@ -2479,7 +2488,7 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660 lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310 lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660 lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310 lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid   "Press enter to open the editor again"
 msgstr  ""
 
@@ -2724,7 +2733,7 @@ msgstr  ""
 msgid   "Remove %s (yes/no): "
 msgstr  ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid   "Remove a member from the cluster"
 msgstr  ""
 
@@ -2756,7 +2765,7 @@ msgstr  ""
 msgid   "Remove trusted clients"
 msgstr  ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid   "Rename a cluster member"
 msgstr  ""
 
@@ -2804,6 +2813,10 @@ msgstr  ""
 #: lxc/info.go:120
 #, c-format
 msgid   "Render: %s (%s)"
+msgstr  ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid   "Request a join token for adding a cluster member"
 msgstr  ""
 
 #: lxc/delete.go:36
@@ -2875,7 +2888,7 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid   "STATE"
 msgstr  ""
 
@@ -3047,7 +3060,7 @@ msgstr  ""
 msgid   "Show content of instance file templates"
 msgstr  ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid   "Show details of a cluster member"
 msgstr  ""
 
@@ -3290,6 +3303,10 @@ msgstr  ""
 msgid   "TARGET"
 msgstr  ""
 
+#: lxc/cluster.go:721
+msgid   "TOKEN"
+msgstr  ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895 lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269 lxc/warning.go:210
 msgid   "TYPE"
 msgstr  ""
@@ -3471,7 +3488,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid   "URL"
 msgstr  ""
 
@@ -3570,7 +3587,7 @@ msgstr  ""
 msgid   "User ID to run the command as (default 0)"
 msgstr  ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid   "User aborted delete operation"
 msgstr  ""
 
@@ -3647,7 +3664,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr  ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20 lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244 lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20 lxc/warning.go:64
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -3663,7 +3680,7 @@ msgstr  ""
 msgid   "[<remote>:] <hostname|fingerprint>"
 msgstr  ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid   "[<remote>:] <name>"
 msgstr  ""
 
@@ -3715,7 +3732,7 @@ msgstr  ""
 msgid   "[<remote>:]<alias> <new-name>"
 msgstr  ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid   "[<remote>:]<cluster member>"
 msgstr  ""
 
@@ -3835,11 +3852,11 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr  ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid   "[<remote>:]<member>"
 msgstr  ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid   "[<remote>:]<member> <new-name>"
 msgstr  ""
 
@@ -4084,7 +4101,7 @@ msgid   "lxc alias rename list my-list\n"
         "    Rename existing alias \"list\" to \"my-list\"."
 msgstr  ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid   "lxc cluster edit <cluster member> < member.yaml\n"
         "    Update a cluster member using the content of member.yaml"
 msgstr  ""
@@ -4313,7 +4330,7 @@ msgstr  ""
 msgid   "y"
 msgstr  ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896 lxc/image.go:1079
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896 lxc/image.go:1079
 msgid   "yes"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -334,7 +334,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -480,7 +480,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
@@ -847,7 +847,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -884,7 +884,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -1068,7 +1068,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1152,14 +1152,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1290,7 +1290,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1317,7 +1317,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1375,11 +1375,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1476,7 +1476,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1573,11 +1573,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1937,7 +1937,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1968,7 +1968,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2244,7 +2248,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2373,12 +2377,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2415,7 +2424,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2535,9 +2544,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2785,7 +2794,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -3034,7 +3043,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3066,7 +3075,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3115,6 +3124,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3188,7 +3201,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3378,7 +3391,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3621,6 +3634,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3815,7 +3832,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3917,7 +3934,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3999,10 +4016,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -4018,7 +4035,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4070,7 +4087,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4194,11 +4211,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4453,7 +4470,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4719,7 +4736,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -352,7 +352,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -498,7 +498,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -902,7 +902,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -1086,7 +1086,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1170,14 +1170,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1393,11 +1393,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1494,7 +1494,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1551,7 +1551,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1567,7 +1567,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1591,11 +1591,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1986,7 +1986,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2262,7 +2266,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2391,12 +2395,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2433,7 +2442,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2553,9 +2562,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2803,7 +2812,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -3052,7 +3061,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3084,7 +3093,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3133,6 +3142,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3206,7 +3219,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3396,7 +3409,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3639,6 +3652,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3833,7 +3850,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3935,7 +3952,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4017,10 +4034,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -4036,7 +4053,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4088,7 +4105,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4212,11 +4229,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4471,7 +4488,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4737,7 +4754,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -346,7 +346,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -501,7 +501,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
@@ -880,7 +880,7 @@ msgstr "Versão do cliente: %s\n"
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
@@ -925,7 +925,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -1120,7 +1120,7 @@ msgstr "Criando %s"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1210,14 +1210,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1352,7 +1352,7 @@ msgstr "Uso de disco:"
 msgid "Disks:"
 msgstr "Uso de disco:"
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1379,7 +1379,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -1445,11 +1445,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1603,7 +1603,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr "Forçar alocação de pseudo-terminal"
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1619,7 +1619,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1643,11 +1643,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -2014,7 +2014,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2045,7 +2045,12 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+#, fuzzy
+msgid "List all active cluster member join tokens"
+msgstr "Nome de membro do cluster"
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2322,7 +2327,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2459,12 +2464,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Copiar perfis"
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2502,7 +2512,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Nome de membro do cluster"
@@ -2624,9 +2634,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2874,7 +2884,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -3128,7 +3138,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3162,7 +3172,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3212,6 +3222,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3291,7 +3305,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3487,7 +3501,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3738,6 +3752,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3935,7 +3953,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -4043,7 +4061,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4125,10 +4143,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -4145,7 +4163,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4203,7 +4221,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4332,11 +4350,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4597,7 +4615,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4863,7 +4881,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr "sim"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: 2020-10-08 08:16+0000\n"
 "Last-Translator: Artem <KovalevArtem.ru@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -348,7 +348,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -508,7 +508,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
@@ -882,7 +882,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -1114,7 +1114,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1202,14 +1202,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1344,7 +1344,7 @@ msgstr " Использование диска:"
 msgid "Disks:"
 msgstr " Использование диска:"
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1371,7 +1371,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1431,11 +1431,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1537,7 +1537,7 @@ msgstr "Копирование образа: %s"
 msgid "Exporting the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1594,7 +1594,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1610,7 +1610,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1634,11 +1634,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2035,7 +2035,12 @@ msgstr ""
 msgid "List aliases"
 msgstr "Псевдонимы:"
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+#, fuzzy
+msgid "List all active cluster member join tokens"
+msgstr "Копирование образа: %s"
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2317,7 +2322,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2453,12 +2458,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2497,7 +2507,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Копирование образа: %s"
@@ -2623,9 +2633,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2876,7 +2886,7 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -3126,7 +3136,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3159,7 +3169,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3211,6 +3221,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3287,7 +3301,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3478,7 +3492,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3728,6 +3742,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3922,7 +3940,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -4024,7 +4042,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4114,10 +4132,10 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 #, fuzzy
 msgid "[<remote>:]"
 msgstr ""
@@ -4149,7 +4167,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -4253,7 +4271,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr ""
@@ -4497,7 +4515,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -4505,7 +4523,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -4952,7 +4970,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5218,7 +5236,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr "да"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: 2020-11-05 02:45+0000\n"
 "Last-Translator: wdggg <wdggg7@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -396,7 +396,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -800,7 +800,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -984,7 +984,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1068,14 +1068,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1206,7 +1206,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1233,7 +1233,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1291,11 +1291,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1392,7 +1392,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1449,7 +1449,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1465,7 +1465,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1489,11 +1489,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1853,7 +1853,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1884,7 +1884,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2160,7 +2164,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2289,12 +2293,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2331,7 +2340,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2451,9 +2460,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2701,7 +2710,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2950,7 +2959,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2982,7 +2991,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3031,6 +3040,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3104,7 +3117,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3294,7 +3307,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3537,6 +3550,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3731,7 +3748,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3833,7 +3850,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3915,10 +3932,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3934,7 +3951,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3986,7 +4003,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4110,11 +4127,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4369,7 +4386,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4635,7 +4652,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-04 16:56-0400\n"
+"POT-Creation-Date: 2021-05-05 09:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:442
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:137 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:145 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:408
+#: lxc/cluster.go:416
 msgid "Clustering enabled"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:503 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:511 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:213 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:134
+#: lxc/cluster.go:142
 msgid "DATABASE"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:74 lxc/cluster.go:154
-#: lxc/cluster.go:204 lxc/cluster.go:254 lxc/cluster.go:337 lxc/cluster.go:422
-#: lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452
-#: lxc/config.go:610 lxc/config.go:734 lxc/config_device.go:24
-#: lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265
-#: lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520
-#: lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:52
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:162
+#: lxc/cluster.go:212 lxc/cluster.go:262 lxc/cluster.go:345 lxc/cluster.go:430
+#: lxc/cluster.go:582 lxc/cluster.go:643 lxc/config.go:30 lxc/config.go:89
+#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:734
+#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
+#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
+#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
+#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
 #: lxc/config_metadata.go:174 lxc/config_template.go:28
 #: lxc/config_template.go:65 lxc/config_template.go:108
 #: lxc/config_template.go:150 lxc/config_template.go:236
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:259
+#: lxc/cluster.go:267
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:421 lxc/cluster.go:422
+#: lxc/cluster.go:429 lxc/cluster.go:430
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1237,11 +1237,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:336
+#: lxc/cluster.go:344
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:337
+#: lxc/cluster.go:345
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:138
+#: lxc/cluster.go:146
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:258
+#: lxc/cluster.go:266
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:266
+#: lxc/cluster.go:274
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1435,11 +1435,11 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:76 lxc/config_template.go:238
-#: lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155
-#: lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91
-#: lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391
-#: lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:644
+#: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
+#: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
+#: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1799,7 +1799,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:110
+#: lxc/cluster.go:118 lxc/cluster.go:678
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1830,7 +1830,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:73 lxc/cluster.go:74
+#: lxc/cluster.go:642 lxc/cluster.go:643
+msgid "List all active cluster member join tokens"
+msgstr ""
+
+#: lxc/cluster.go:81 lxc/cluster.go:82
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:136
+#: lxc/cluster.go:144
 msgid "MESSAGE"
 msgstr ""
 
@@ -2235,12 +2239,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:321
+#: lxc/cluster.go:625
+#, c-format
+msgid "Member %s join token: %s"
+msgstr ""
+
+#: lxc/cluster.go:329
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:234
+#: lxc/cluster.go:242
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:455
+#: lxc/cluster.go:463 lxc/cluster.go:605
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2397,9 +2406,9 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:132 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140
-#: lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
-#: lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:720 lxc/list.go:496 lxc/network.go:894
+#: lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465
+#: lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:504 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:512 lxc/config_trust.go:214 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again"
@@ -2896,7 +2905,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:253 lxc/cluster.go:254
+#: lxc/cluster.go:261 lxc/cluster.go:262
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2928,7 +2937,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:203 lxc/cluster.go:204
+#: lxc/cluster.go:211 lxc/cluster.go:212
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2977,6 +2986,10 @@ msgstr ""
 #: lxc/info.go:120
 #, c-format
 msgid "Render: %s (%s)"
+msgstr ""
+
+#: lxc/cluster.go:581 lxc/cluster.go:582
+msgid "Request a join token for adding a cluster member"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -3050,7 +3063,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:135 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:143 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3240,7 +3253,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:153 lxc/cluster.go:154
+#: lxc/cluster.go:161 lxc/cluster.go:162
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3483,6 +3496,10 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/cluster.go:721
+msgid "TOKEN"
+msgstr ""
+
 #: lxc/image.go:1028 lxc/image_alias.go:233 lxc/list.go:502 lxc/network.go:895
 #: lxc/network.go:970 lxc/operation.go:159 lxc/storage_volume.go:1269
 #: lxc/warning.go:210
@@ -3677,7 +3694,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:133 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:583
 msgid "URL"
 msgstr ""
 
@@ -3779,7 +3796,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:285 lxc/delete.go:48
+#: lxc/cluster.go:293 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3861,10 +3878,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:71 lxc/config_trust.go:244 lxc/monitor.go:28
-#: lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99
-#: lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20
-#: lxc/warning.go:64
+#: lxc/cluster.go:79 lxc/cluster.go:641 lxc/config_trust.go:244
+#: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
+#: lxc/version.go:20 lxc/warning.go:64
 msgid "[<remote>:]"
 msgstr ""
 
@@ -3880,7 +3897,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:335
+#: lxc/cluster.go:343
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3932,7 +3949,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:420
+#: lxc/cluster.go:428
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4056,11 +4073,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:152 lxc/cluster.go:251
+#: lxc/cluster.go:160 lxc/cluster.go:259 lxc/cluster.go:579
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:201
+#: lxc/cluster.go:209
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4315,7 +4332,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:424
+#: lxc/cluster.go:432
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4581,7 +4598,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:284 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:292 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/shared/api/cluster.go
+++ b/shared/api/cluster.go
@@ -1,5 +1,10 @@
 package api
 
+import (
+	"encoding/base64"
+	"encoding/json"
+)
+
 // Cluster represents high-level information about a LXD cluster.
 //
 // swagger:model
@@ -92,6 +97,39 @@ type ClusterMembersPost struct {
 	// The name of the new cluster member
 	// Example: lxd02
 	ServerName string `json:"server_name" yaml:"server_name"`
+}
+
+// ClusterMemberJoinToken represents the fields contained within an encoded cluster member join token.
+//
+// swagger:model
+//
+// API extension: clustering_join_token
+type ClusterMemberJoinToken struct {
+	// The name of the new cluster member
+	// Example: lxd02
+	ServerName string `json:"server_name" yaml:"server_name"`
+
+	// The fingerprint of the network certificate
+	// Example: 57bb0ff4340b5bb28517e062023101adf788c37846dc8b619eb2c3cb4ef29436
+	Fingerprint string `json:"fingerprint" yaml:"fingerprint"`
+
+	// The addresses of existing online cluster members
+	// Example: ["10.98.30.229:8443"]
+	Addresses []string `json:"addresses" yaml:"addresses"`
+
+	// The random join secret.
+	// Example: 2b2284d44db32675923fe0d2020477e0e9be11801ff70c435e032b97028c35cd
+	Secret string `json:"secret" yaml:"secret"`
+}
+
+// String encodes the cluster member join token as JSON and then Base64.
+func (t *ClusterMemberJoinToken) String() string {
+	joinTokenJSON, err := json.Marshal(t)
+	if err != nil {
+		return ""
+	}
+
+	return base64.StdEncoding.EncodeToString(joinTokenJSON)
 }
 
 // ClusterMemberPost represents the fields required to rename a LXD node.

--- a/shared/api/cluster.go
+++ b/shared/api/cluster.go
@@ -83,6 +83,17 @@ type ClusterPut struct {
 	ClusterPassword string `json:"cluster_password" yaml:"cluster_password"`
 }
 
+// ClusterMembersPost represents the fields required to request a join token to add a member to the cluster.
+//
+// swagger:model
+//
+// API extension: clustering_join_token
+type ClusterMembersPost struct {
+	// The name of the new cluster member
+	// Example: lxd02
+	ServerName string `json:"server_name" yaml:"server_name"`
+}
+
 // ClusterMemberPost represents the fields required to rename a LXD node.
 //
 // swagger:model

--- a/shared/api/operation.go
+++ b/shared/api/operation.go
@@ -4,6 +4,15 @@ import (
 	"time"
 )
 
+// OperationClassTask represents the Task OperationClass
+const OperationClassTask = "task"
+
+// OperationClassWebsocket represents the Websocket OperationClass
+const OperationClassWebsocket = "websocket"
+
+// OperationClassToken represents the Token OperationClass
+const OperationClassToken = "token"
+
 // Operation represents a LXD background operation
 //
 // swagger:model

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -269,6 +269,7 @@ var APIExtensions = []string{
 	"network_bridge_acl",
 	"warnings",
 	"projects_restricted_backups_and_snapshots",
+	"clustering_join_token",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/includes/clustering.sh
+++ b/test/includes/clustering.sh
@@ -222,6 +222,7 @@ spawn_lxd_and_join_cluster() {
   fi
 
   echo "==> Spawn additional cluster node in ${ns} with storage driver ${driver}"
+  secret="${LXD_SECRET:-"sekret"}"
 
   LXD_NETNS="${ns}" spawn_lxd "${LXD_DIR}" false
   (
@@ -240,7 +241,7 @@ cluster:
   server_address: 10.1.1.10${index}:${port}
   cluster_address: 10.1.1.10${target}:8443
   cluster_certificate: "$cert"
-  cluster_password: sekret
+  cluster_password: ${secret}
   member_config:
 EOF
     # Declare the pool only if the driver is not ceph, because

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -121,7 +121,7 @@ test_clustering_membership() {
 
   # Shutdown a database node, and wait a few seconds so it will be
   # detected as down.
-  LXD_DIR="${LXD_ONE_DIR}" lxc config set cluster.offline_threshold 11
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set cluster.offline_threshold 15
   LXD_DIR="${LXD_THREE_DIR}" lxd shutdown
   sleep 18
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list
@@ -322,9 +322,9 @@ test_clustering_containers() {
 
   # Shutdown node 2, wait for it to be considered offline, and list
   # containers.
-  LXD_DIR="${LXD_THREE_DIR}" lxc config set cluster.offline_threshold 12
+  LXD_DIR="${LXD_THREE_DIR}" lxc config set cluster.offline_threshold 15
   LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
-  sleep 15
+  sleep 20
   LXD_DIR="${LXD_ONE_DIR}" lxc list | grep foo | grep -q ERROR
   LXD_DIR="${LXD_ONE_DIR}" lxc config set cluster.offline_threshold 20
 
@@ -572,9 +572,9 @@ test_clustering_storage() {
     LXD_DIR="${LXD_ONE_DIR}" lxc info bar | grep -q "backup (taken at"
 
     # Shutdown node 3, and wait for it to be considered offline.
-    LXD_DIR="${LXD_THREE_DIR}" lxc config set cluster.offline_threshold 12
+    LXD_DIR="${LXD_THREE_DIR}" lxc config set cluster.offline_threshold 15
     LXD_DIR="${LXD_THREE_DIR}" lxd shutdown
-    sleep 15
+    sleep 20
 
     # Move the container back to node2, even if node3 is offline
     LXD_DIR="${LXD_ONE_DIR}" lxc move bar --target node2
@@ -1940,7 +1940,7 @@ test_clustering_rebalance() {
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list | grep "node4" | grep -q "NO"
 
   # Kill the second node.
-  LXD_DIR="${LXD_ONE_DIR}" lxc config set cluster.offline_threshold 12
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set cluster.offline_threshold 15
   kill -9 "$(cat "${LXD_TWO_DIR}/lxd.pid")"
 
   # Wait for the second node to be considered offline and be replaced by the


### PR DESCRIPTION
This PR adds the ability to use one-time join tokens when adding new members to an existing cluster, which avoids the need to use the trust password.

- Adds `lxc cluster add` command that will create a cluster member add operation and output a join token for use with `lxd init`.
- Adds a join token question step to `lxd init`, and if supplied with a join token, will be used to automatically answer the target cluster address question, validate the network certificate and provide the one-time join token trust password (for adding the new member's certificate to the cluster trust store). The LXD server will also validate that the join token's secret matches a "running" join token operation with the same server name.
- Adds `lxc cluster list-tokens` command that uses the `/1.0/operations` endpoint to show the available join tokens (those that are in status "running").