### PR TITLE
lxd/images: Specify image type during distribution

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1671,6 +1671,7 @@ func distributeImage(ctx context.Context, d *Daemon, nodes []string, oldFingerpr
 
 		createArgs.MetaFile = metaFile
 		createArgs.MetaName = filepath.Base(imageMetaPath)
+		createArgs.Type = newImage.Type
 
 		if shared.PathExists(imageRootfsPath) {
 			rootfsFile, err := os.Open(imageRootfsPath)


### PR DESCRIPTION
I've run into a cluster where a bunch of VM images were incorrectly
recorded as container images. I believe that a combination of
auto-refresh and distribution is what caused the issue and that this
should fix it.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>