### PR TITLE
Operations: Updates imageValidSecret to check across all cluster members not just local operations

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -172,7 +172,7 @@ func ConnectLXDUnix(path string, args *ConnectionArgs) (InstanceServer, error) {
 //
 // Unless the remote server is trusted by the system CA, the remote certificate must be provided (TLSServerCert).
 func ConnectPublicLXD(url string, args *ConnectionArgs) (ImageServer, error) {
-	logger.Debugf("Connecting to a remote public LXD over HTTPs")
+	logger.Debugf("Connecting to a remote public LXD over HTTPS")
 
 	// Cleanup URL
 	url = strings.TrimSuffix(url, "/")

--- a/lxd/db/operations.go
+++ b/lxd/db/operations.go
@@ -5,6 +5,7 @@ package db
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/pkg/errors"
@@ -41,6 +42,50 @@ SELECT DISTINCT nodes.address
  WHERE projects.name = ? OR operations.project_id IS NULL
 `
 	return query.SelectStrings(c.tx, stmt, project)
+}
+
+// GetOnlineNodesWithRunningOperationsOfType returns a list of online nodes that have running operations of type.
+func (c *ClusterTx) GetOnlineNodesWithRunningOperationsOfType(projectName string, opType OperationType) ([]string, error) {
+	var addresses []string
+
+	offlineThreshold, err := c.GetNodeOfflineThreshold()
+	if err != nil {
+		return nil, err
+	}
+
+	stmt := `
+SELECT DISTINCT nodes.address, nodes.heartbeat
+  FROM operations
+  LEFT OUTER JOIN projects ON projects.id = operations.project_id
+  JOIN nodes ON nodes.id = operations.node_id
+ WHERE (projects.name = ? OR operations.project_id IS NULL) AND type = ?
+`
+	rows, err := c.tx.Query(stmt, projectName, opType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var address string
+		var heartbeat time.Time
+
+		err := rows.Scan(&address, &heartbeat)
+		if err != nil {
+			return nil, err
+		}
+
+		if nodeIsOffline(offlineThreshold, heartbeat) {
+			continue
+		}
+
+		addresses = append(addresses, address)
+	}
+	if rows.Err() != nil {
+		return nil, err
+	}
+
+	return query.SelectStrings(c.tx, stmt, projectName)
 }
 
 // GetOperationWithID returns the operation with the given ID.

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3715,7 +3715,7 @@ func imageSyncBetweenNodes(d *Daemon, project string, fingerprint string) error 
 	return nil
 }
 
-func createTokenResponse(d *Daemon, project, fingerprint string, metadata shared.Jmap) response.Response {
+func createTokenResponse(d *Daemon, projectName string, fingerprint string, metadata shared.Jmap) response.Response {
 	secret, err := shared.RandomCryptoString()
 	if err != nil {
 		return response.InternalError(err)
@@ -3732,7 +3732,7 @@ func createTokenResponse(d *Daemon, project, fingerprint string, metadata shared
 	resources := map[string][]string{}
 	resources["images"] = []string{fingerprint}
 
-	op, err := operations.OperationCreate(d.State(), project, operations.OperationClassToken, db.OperationImageToken, resources, meta, nil, nil, nil)
+	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassToken, db.OperationImageToken, resources, meta, nil, nil, nil)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2272,34 +2272,46 @@ func doImageGet(db *db.Cluster, project, fingerprint string, public bool) (*api.
 	return imgInfo, nil
 }
 
-func imageValidSecret(fingerprint string, secret string) (*operations.Operation, bool) {
-	for _, op := range operations.Clone() {
-		if op.Resources() == nil {
+// imageValidSecret searches for an ImageToken operation running on any member in the default project that has an
+// images resource matching the specified fingerprint and the metadata secret field matches the specified secret.
+// If an operation is found it is returned and the operation is cancelled. Otherwise nil is returned if not found.
+func imageValidSecret(d *Daemon, projectName string, fingerprint string, secret string) (*api.Operation, error) {
+	ops, err := operationsGetByType(d, projectName, db.OperationImageToken)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed getting image token operations")
+	}
+
+	for _, op := range ops {
+		if op.Resources == nil {
 			continue
 		}
 
-		opImages, ok := op.Resources()["images"]
+		opImages, ok := op.Resources["images"]
 		if !ok {
 			continue
 		}
 
-		if !shared.StringInSlice(fingerprint, opImages) {
+		if !shared.StringInSlice(fmt.Sprintf("/1.0/images/%s", fingerprint), opImages) {
 			continue
 		}
 
-		opSecret, ok := op.Metadata()["secret"]
+		opSecret, ok := op.Metadata["secret"]
 		if !ok {
 			continue
 		}
 
 		if opSecret == secret {
-			// Token is single-use, so cancel it now
-			op.Cancel()
-			return op, true
+			// Token is single-use, so cancel it now.
+			err = operationCancel(d, projectName, op)
+			if err != nil {
+				return nil, errors.Wrapf(err, "Failed to cancel operation")
+			}
+
+			return op, nil
 		}
 	}
 
-	return nil, false
+	return nil, nil
 }
 
 // swagger:operation GET /1.0/images/{fingerprint}?public images image_get_untrusted

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -431,6 +431,7 @@ func (op *Operation) mayCancel() bool {
 }
 
 // Render renders the operation structure.
+// Returns URL of operation and operation info.
 func (op *Operation) Render() (string, *api.Operation, error) {
 	// Setup the resource URLs
 	resources := op.resources


### PR DESCRIPTION
Optimises process by only querying the remote members that are online and have running operations of the desired type (`OperationImageToken`).