### PR TITLE
lxd/instance/qmp: Switch to query-cpus-fast

### DIFF
--- a/lxd/instance/drivers/qmp/commands.go
+++ b/lxd/instance/drivers/qmp/commands.go
@@ -184,13 +184,13 @@ func (m *Monitor) GetCPUs() ([]int, error) {
 	// Prepare the response.
 	var resp struct {
 		Return []struct {
-			CPU int `json:"CPU"`
-			PID int `json:"thread_id"`
+			CPU int `json:"cpu-index"`
+			PID int `json:"thread-id"`
 		} `json:"return"`
 	}
 
 	// Query the consoles.
-	err := m.run("query-cpus", "", &resp)
+	err := m.run("query-cpus-fast", "", &resp)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Let's try migrating again, this time updating the struct to match the
renamed fields.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>