### PR TITLE
Cluster: Fix issues with heartbeats now that we are relying on them more for accurate timings

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1371,5 +1371,9 @@ This includes the following endpoints (see  [Restful API](rest-api.md) for detai
 Adds new `restricted.backups` and `restricted.snapshots` config keys to project which
 prevents the user from creation of backups and snapshots.
 
+## clustering\_join\_token
+Adds `POST /1.0/cluster/members` API endpoint for requesting a join token used when adding new cluster members
+without using the trust password.
+
 ## clustering\_description
 Adds an editable description to the cluster members.

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lxc/lxd/lxd/task"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -64,7 +65,7 @@ func eventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 		return nil
 	})
 	if err != nil {
-		logger.Warnf("Failed to get current cluster nodes: %v", err)
+		logger.Warn("Failed to get current cluster members", log.Ctx{"err": err})
 		return
 	}
 	if len(nodes) == 1 {
@@ -101,10 +102,10 @@ func eventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 
 		listener, err := eventsConnect(node.Address, endpoints.NetworkCert(), serverCert())
 		if err != nil {
-			logger.Warnf("Failed to get events from node %s: %v", node.Address, err)
+			logger.Warn("Failed to get events from member", log.Ctx{"address": node.Address, "err": err})
 			continue
 		}
-		logger.Debugf("Listening for events on node %s", node.Address)
+		logger.Debug("Listening for events on member", log.Ctx{"address": node.Address})
 		listener.AddHandler(nil, func(event api.Event) { f(node.ID, event) })
 
 		listenersLock.Lock()

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -241,7 +241,7 @@ func (g *Gateway) heartbeat(ctx context.Context, initialHeartbeat bool) {
 		return tx.ReplaceRaftNodes(raftNodes)
 	})
 	if err != nil {
-		logger.Warnf("Failed to replace local raft nodes: %v", err)
+		logger.Warn("Failed to replace local raft nodes", log.Ctx{"err": err})
 		return
 	}
 
@@ -268,7 +268,7 @@ func (g *Gateway) heartbeat(ctx context.Context, initialHeartbeat bool) {
 		return nil
 	})
 	if err != nil {
-		logger.Warnf("Failed to get current cluster nodes: %v", err)
+		logger.Warn("Failed to get current cluster members", log.Ctx{"err": err})
 		return
 	}
 

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -213,7 +213,12 @@ func (g *Gateway) heartbeat(ctx context.Context, initialHeartbeat bool) {
 	}
 
 	raftNodes, err := g.currentRaftNodes()
-	if err == ErrNotLeader {
+	if err != nil {
+		if errors.Cause(err) == ErrNotLeader {
+			return
+		}
+
+		logger.Error("Failed to get current raft members", log.Ctx{"err": err})
 		return
 	}
 

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -329,12 +329,13 @@ func (g *Gateway) heartbeat(ctx context.Context, initialHeartbeat bool) {
 	}
 
 	err = g.Cluster.Transaction(func(tx *db.ClusterTx) error {
+		hbTime := time.Now()
 		for _, node := range hbState.Members {
 			if !node.updated {
 				continue
 			}
 
-			err := tx.SetNodeHeartbeat(node.Address, time.Now())
+			err := tx.SetNodeHeartbeat(node.Address, hbTime)
 			if err != nil {
 				return err
 			}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1027,7 +1027,8 @@ func (d *Daemon) init() error {
 			// to run the heartbeat task, in case we are the raft
 			// leader.
 			d.gateway.Cluster = d.cluster
-			stop, _ := task.Start(cluster.HeartbeatTask(d.gateway))
+			taskFunc, taskSchedule := cluster.HeartbeatTask(d.gateway)
+			stop, _ := task.Start(d.ctx, taskFunc, taskSchedule)
 			d.gateway.WaitUpgradeNotification()
 			stop(time.Second)
 			d.gateway.Cluster = nil
@@ -1294,7 +1295,7 @@ func (d *Daemon) startClusterTasks() {
 	d.clusterTasks.Add(autoSyncImagesTask(d))
 
 	// Start all background tasks
-	d.clusterTasks.Start()
+	d.clusterTasks.Start(d.ctx)
 }
 
 func (d *Daemon) stopClusterTasks() {
@@ -1354,7 +1355,7 @@ func (d *Daemon) Ready() error {
 	}
 
 	// Start all background tasks
-	d.tasks.Start()
+	d.tasks.Start(d.ctx)
 
 	// Get daemon state struct
 	s := d.State()

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -788,9 +788,13 @@ func (c *ClusterTx) SetNodeHeartbeat(address string, heartbeat time.Time) error 
 	if err != nil {
 		return err
 	}
-	if n != 1 {
-		return fmt.Errorf("expected to update one row and not %d", n)
+
+	if n < 1 {
+		return ErrNoSuchObject
+	} else if n > 1 {
+		return fmt.Errorf("Expected to update one row and not %d", n)
 	}
+
 	return nil
 }
 

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -136,7 +136,7 @@ func (n NodeInfo) ToAPI(cluster *Cluster, node *Node) (*api.ClusterMember, error
 
 	if n.IsOffline(offlineThreshold) {
 		result.Status = "Offline"
-		result.Message = fmt.Sprintf("No heartbeat for %s", time.Now().Sub(n.Heartbeat))
+		result.Message = fmt.Sprintf("No heartbeat for %s (%s)", time.Now().Sub(n.Heartbeat), n.Heartbeat)
 	} else {
 		// Check if up to date.
 		n, err := util.CompareVersions(maxVersion, n.Version())

--- a/lxd/db/query/retry.go
+++ b/lxd/db/query/retry.go
@@ -26,7 +26,7 @@ func Retry(f func() error) error {
 		err = f()
 		if err != nil {
 			// No point in re-trying or logging a no-row error.
-			if err == sql.ErrNoRows {
+			if errors.Cause(err) == sql.ErrNoRows {
 				break
 			}
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3633,6 +3633,8 @@ func autoSyncImages(ctx context.Context, d *Daemon) error {
 }
 
 func imageSyncBetweenNodes(d *Daemon, project string, fingerprint string) error {
+	logger.Info("Syncing image to members", log.Ctx{"fingerprint": fingerprint, "project": project})
+
 	var desiredSyncNodeCount int64
 
 	err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
@@ -3717,6 +3719,7 @@ func imageSyncBetweenNodes(d *Daemon, project string, fingerprint string) error 
 			Type: image.Type,
 		}
 
+		logger.Info("Copying image to member", log.Ctx{"fingerprint": fingerprint, "address": targetNodeAddress, "project": project})
 		op, err := client.CopyImage(source, *image, &args)
 		if err != nil {
 			return errors.Wrap(err, "Failed to copy image")

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3569,6 +3569,10 @@ func autoSyncImagesTask(d *Daemon) (task.Func, task.Schedule) {
 
 		leader, err := d.gateway.LeaderAddress()
 		if err != nil {
+			if errors.Cause(err) == cluster.ErrNodeIsNotClustered {
+				return // No error if not clustered.
+			}
+
 			logger.Errorf("Failed to get leader node address: %v", err)
 			return
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3563,7 +3563,7 @@ func autoSyncImagesTask(d *Daemon) (task.Func, task.Schedule) {
 		// across the cluster, only leader node can launch the task, no others.
 		localAddress, err := node.ClusterAddress(d.db)
 		if err != nil {
-			logger.Errorf("Failed to get current node address: %v", err)
+			logger.Error("Failed to get current node address", log.Ctx{"err": err})
 			return
 		}
 
@@ -3573,7 +3573,7 @@ func autoSyncImagesTask(d *Daemon) (task.Func, task.Schedule) {
 				return // No error if not clustered.
 			}
 
-			logger.Errorf("Failed to get leader node address: %v", err)
+			logger.Error("Failed to get leader node address", log.Ctx{"err": err})
 			return
 		}
 

--- a/lxd/task/group.go
+++ b/lxd/task/group.go
@@ -34,14 +34,13 @@ func (g *Group) Add(f Func, schedule Schedule) *Task {
 }
 
 // Start all the tasks in the group.
-func (g *Group) Start() {
+func (g *Group) Start(ctx context.Context) {
 	// Lock access to the g.running and g.tasks map for the entirety of this function so that
 	// concurrent calls to Start() or Add(0) don't race. This ensures all tasks in this group
 	// are started based on a consistent snapshot of g.running and g.tasks.
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	ctx := context.Background()
 	ctx, g.cancel = context.WithCancel(ctx)
 	g.wg.Add(len(g.tasks))
 

--- a/lxd/task/group_test.go
+++ b/lxd/task/group_test.go
@@ -14,7 +14,7 @@ func TestGroup_Add(t *testing.T) {
 	ok := make(chan struct{})
 	f := func(context.Context) { close(ok) }
 	group.Add(f, task.Every(time.Second))
-	group.Start()
+	group.Start(context.Background())
 
 	assertRecv(t, ok)
 
@@ -33,7 +33,7 @@ func TestGroup_StopUngracefully(t *testing.T) {
 	}
 
 	group.Add(f, task.Every(time.Second))
-	group.Start()
+	group.Start(context.Background())
 
 	assertRecv(t, ok)
 

--- a/lxd/task/start.go
+++ b/lxd/task/start.go
@@ -1,6 +1,9 @@
 package task
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // Start a single task executing the given function with the given schedule.
 //
@@ -9,10 +12,10 @@ import "time"
 // the task gracefully within the given timeout and the second is a "reset"
 // function to reset the task's state. See Group.Stop() and Group.Reset() for
 // more details.
-func Start(f Func, schedule Schedule) (func(time.Duration) error, func()) {
+func Start(ctx context.Context, f Func, schedule Schedule) (func(time.Duration) error, func()) {
 	group := Group{}
 	task := group.Add(f, schedule)
-	group.Start()
+	group.Start(ctx)
 
 	stop := group.Stop
 	reset := task.Reset

--- a/lxd/task/task_test.go
+++ b/lxd/task/task_test.go
@@ -30,7 +30,7 @@ func TestTask_ExecutePeriodically(t *testing.T) {
 // again after the interval.
 func TestTask_Reset(t *testing.T) {
 	f, wait := newFunc(t, 3)
-	stop, reset := task.Start(f, task.Every(250*time.Millisecond))
+	stop, reset := task.Start(context.Background(), f, task.Every(250*time.Millisecond))
 	defer stop(time.Second)
 
 	wait(50 * time.Millisecond)  // First execution, immediately
@@ -124,7 +124,7 @@ func newFunc(t *testing.T, n int) (task.Func, func(time.Duration)) {
 // Convenience around task.Start which also makes sure that the stop function
 // of the task actually terminates.
 func startTask(t *testing.T, f task.Func, schedule task.Schedule) func() {
-	stop, _ := task.Start(f, schedule)
+	stop, _ := task.Start(context.Background(), f, schedule)
 	return func() {
 		assert.NoError(t, stop(time.Second))
 	}

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -121,7 +121,7 @@ test_clustering_membership() {
 
   # Shutdown a database node, and wait a few seconds so it will be
   # detected as down.
-  LXD_DIR="${LXD_ONE_DIR}" lxc config set cluster.offline_threshold 15
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set cluster.offline_threshold 11
   LXD_DIR="${LXD_THREE_DIR}" lxd shutdown
   sleep 18
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list
@@ -322,9 +322,9 @@ test_clustering_containers() {
 
   # Shutdown node 2, wait for it to be considered offline, and list
   # containers.
-  LXD_DIR="${LXD_THREE_DIR}" lxc config set cluster.offline_threshold 15
+  LXD_DIR="${LXD_THREE_DIR}" lxc config set cluster.offline_threshold 12
   LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
-  sleep 20
+  sleep 15
   LXD_DIR="${LXD_ONE_DIR}" lxc list | grep foo | grep -q ERROR
   LXD_DIR="${LXD_ONE_DIR}" lxc config set cluster.offline_threshold 20
 
@@ -572,9 +572,9 @@ test_clustering_storage() {
     LXD_DIR="${LXD_ONE_DIR}" lxc info bar | grep -q "backup (taken at"
 
     # Shutdown node 3, and wait for it to be considered offline.
-    LXD_DIR="${LXD_THREE_DIR}" lxc config set cluster.offline_threshold 15
+    LXD_DIR="${LXD_THREE_DIR}" lxc config set cluster.offline_threshold 12
     LXD_DIR="${LXD_THREE_DIR}" lxd shutdown
-    sleep 20
+    sleep 15
 
     # Move the container back to node2, even if node3 is offline
     LXD_DIR="${LXD_ONE_DIR}" lxc move bar --target node2
@@ -1940,7 +1940,7 @@ test_clustering_rebalance() {
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list | grep "node4" | grep -q "NO"
 
   # Kill the second node.
-  LXD_DIR="${LXD_ONE_DIR}" lxc config set cluster.offline_threshold 15
+  LXD_DIR="${LXD_ONE_DIR}" lxc config set cluster.offline_threshold 12
   kill -9 "$(cat "${LXD_TWO_DIR}/lxd.pid")"
 
   # Wait for the second node to be considered offline and be replaced by the

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -1572,7 +1572,8 @@ test_clustering_image_replication() {
 
   # Modify the container's rootfs and create a new image from the container
   lxc exec c1 -- touch /a
-  lxc stop c1 --force && lxc publish c1 --alias new-image
+  lxc stop c1 --force
+  lxc publish c1 --alias new-image
 
   fingerprint=$(LXD_DIR="${LXD_ONE_DIR}" lxc image info new-image | grep "Fingerprint:" | cut -f2 -d" ")
   [ -f "${LXD_ONE_DIR}/images/${fingerprint}" ] || false

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -1843,12 +1843,15 @@ test_clustering_handover() {
   ns4="${prefix}4"
   spawn_lxd_and_join_cluster "${ns4}" "${bridge}" "${cert}" 4 1 "${LXD_FOUR_DIR}"
 
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster list
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list | grep "node4" | grep -q "NO"
 
   # Shutdown the first node.
   LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
 
   # The fourth node has been promoted, while the first one demoted.
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster list
+  LXD_DIR="${LXD_THREE_DIR}" lxc cluster list
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list | grep "node4" | grep -q "YES"
   LXD_DIR="${LXD_THREE_DIR}" lxc cluster list | grep "node1" | grep -q "NO"
 
@@ -1937,6 +1940,7 @@ test_clustering_rebalance() {
   ns4="${prefix}4"
   spawn_lxd_and_join_cluster "${ns4}" "${bridge}" "${cert}" 4 1 "${LXD_FOUR_DIR}"
 
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster list
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list | grep "node4" | grep -q "NO"
 
   # Kill the second node.
@@ -2060,6 +2064,7 @@ test_clustering_remove_raft_node() {
   ! LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep -q "node2" || false
 
   # There are only 2 database nodes.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster list
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep "node1" | grep -q "YES"
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep "node3" | grep -q "YES"
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep "node4" | grep -q "NO"
@@ -2074,6 +2079,7 @@ test_clustering_remove_raft_node() {
   sleep 20
 
   # We're back to 3 database nodes.
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster list
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep "node1" | grep -q "YES"
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep "node3" | grep -q "YES"
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep "node4" | grep -q "YES"


### PR DESCRIPTION
In PR https://github.com/lxc/lxd/pull/8690 we reduced the amount of adhoc heartbeats that were generated by not forcefully reconnecting to cluster members when trying to get a list of cluster members and their statuses. This has highlighted some scenarios where the existing heartbeat logic was weak:

1. If a node was removed during a heartbeat round, then when we attempted to update the heartbeat time in the nodes table it would fail (as the row had been removed) - which failed the whole transaction meaning all nodes didn't have their heartbeat time updated for that round.
2. Sometimes the heartbeat transaction to update the nodes table would fail due to a write lock, have added retry mechanism.
3. Pass the daemon's context into the heartbeat task to allow clean cancellation on shutdown.

This also improves the logging in the heartbeat subsystem.

Also restores clustering_join_token API extension documentation, which was accidentally removed in https://github.com/lxc/lxd/pull/8743

Also reverts cluster handover test threshold changes as they did not improve the situation.