### PR TITLE
Cluster: Make heartbeat interval half of offline threshold

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -601,6 +601,7 @@ func doApi10Update(d *Daemon, req api.ServerPut, patch bool) response.Response {
 		if err != nil {
 			return errors.Wrap(err, "Failed to load cluster config")
 		}
+
 		if patch {
 			clusterChanged, err = newClusterConfig.Patch(req.Config)
 		} else {

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -788,5 +788,11 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		}
 	}
 
+	_, ok = clusterChanged["cluster.offline_threshold"]
+	if ok {
+		d.gateway.HeartbeatOfflineThreshold = clusterConfig.OfflineThreshold()
+		d.taskClusterHeartbeat.Reset()
+	}
+
 	return nil
 }

--- a/lxd/cluster/config.go
+++ b/lxd/cluster/config.go
@@ -279,6 +279,8 @@ func offlineThresholdDefault() string {
 }
 
 func offlineThresholdValidator(value string) error {
+	minThreshold := 10
+
 	// Ensure that the given value is greater than the heartbeat interval,
 	// which is the lower bound granularity of the offline check.
 	threshold, err := strconv.Atoi(value)
@@ -286,8 +288,8 @@ func offlineThresholdValidator(value string) error {
 		return fmt.Errorf("Offline threshold is not a number")
 	}
 
-	if threshold <= heartbeatInterval {
-		return fmt.Errorf("Value must be greater than '%d'", heartbeatInterval)
+	if threshold <= minThreshold {
+		return fmt.Errorf("Value must be greater than '%d'", minThreshold)
 	}
 
 	return nil

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -112,8 +112,9 @@ type Gateway struct {
 	upgradeTriggered bool
 
 	// Used for the heartbeat handler
-	Cluster           *db.Cluster
-	HeartbeatNodeHook func(*APIHeartbeat)
+	Cluster                   *db.Cluster
+	HeartbeatNodeHook         func(*APIHeartbeat)
+	HeartbeatOfflineThreshold time.Duration
 
 	// NodeStore wrapper.
 	store *dqliteNodeStore

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -388,9 +388,6 @@ func (g *Gateway) heartbeat(ctx context.Context, initialHeartbeat bool) {
 	logger.Debug("Completed heartbeat round", log.Ctx{"duration": duration})
 }
 
-// heartbeatInterval Number of seconds to wait between to heartbeat rounds.
-const heartbeatInterval = 10
-
 // HeartbeatNode performs a single heartbeat request against the node with the given address.
 func HeartbeatNode(taskCtx context.Context, address string, networkCert *shared.CertInfo, serverCert *shared.CertInfo, heartbeatData *APIHeartbeat) error {
 	logger.Debug("Sending heartbeat request", log.Ctx{"address": address})

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -202,7 +202,9 @@ func HeartbeatTask(gateway *Gateway) (task.Func, task.Schedule) {
 		}
 	}
 
-	schedule := task.Every(time.Duration(heartbeatInterval) * time.Second)
+	schedule := func() (time.Duration, error) {
+		return task.Every(gateway.heartbeatInterval())()
+	}
 
 	return heartbeatWrapper, schedule
 }

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -407,7 +407,7 @@ func HeartbeatNode(taskCtx context.Context, address string, networkCert *shared.
 	setDqliteVersionHeader(request)
 
 	// Use 1s later timeout to give HTTP client chance timeout with more useful info.
-	ctx, cancel := context.WithTimeout(context.Background(), timeout+time.Second)
+	ctx, cancel := context.WithTimeout(taskCtx, timeout+time.Second)
 	defer cancel()
 	request = request.WithContext(ctx)
 	request.Close = true // Immediately close the connection after the request is done

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -207,6 +207,16 @@ func HeartbeatTask(gateway *Gateway) (task.Func, task.Schedule) {
 	return heartbeatWrapper, schedule
 }
 
+// heartbeatInterval returns heartbeat interval to use.
+func (g *Gateway) heartbeatInterval() time.Duration {
+	threshold := g.HeartbeatOfflineThreshold
+	if threshold <= 0 {
+		threshold = db.DefaultOfflineThreshold
+	}
+
+	return threshold / 2
+}
+
 func (g *Gateway) heartbeat(ctx context.Context, initialHeartbeat bool) {
 	// Avoid concurent heartbeat loops.
 	// This is possible when both the task and the out of band heartbeat

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -282,7 +282,7 @@ func (g *Gateway) heartbeat(ctx context.Context, initialHeartbeat bool) {
 		hbState.Send(ctx, g.networkCert, g.serverCert(), localAddress, allNodes, false)
 
 		// We have the latest set of node states now, lets send that state set to all nodes.
-		hbState.Update(true, raftNodes, allNodes, offlineThreshold)
+		hbState.FullStateList = true
 		hbState.Send(ctx, g.networkCert, g.serverCert(), localAddress, allNodes, false)
 	} else {
 		hbState.Update(true, raftNodes, allNodes, offlineThreshold)

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -337,13 +337,12 @@ func (g *Gateway) heartbeat(ctx context.Context, initialHeartbeat bool) {
 
 	err = query.Retry(func() error {
 		return g.Cluster.Transaction(func(tx *db.ClusterTx) error {
-			hbTime := time.Now()
 			for _, node := range hbState.Members {
 				if !node.updated {
 					continue
 				}
 
-				err := tx.SetNodeHeartbeat(node.Address, hbTime)
+				err := tx.SetNodeHeartbeat(node.Address, node.LastHeartbeat)
 				if err != nil && errors.Cause(err) != db.ErrNoSuchObject {
 					return errors.Wrapf(err, "Failed updating heartbeat time for member %q", node.Address)
 				}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -84,7 +84,8 @@ type Daemon struct {
 	clusterTasks task.Group
 
 	// Indexes of tasks that need to be reset when their execution interval changes
-	taskPruneImages *task.Task
+	taskPruneImages      *task.Task
+	taskClusterHeartbeat *task.Task
 
 	// Stores startup time of daemon
 	startTime time.Time
@@ -1028,9 +1029,11 @@ func (d *Daemon) init() error {
 			// leader.
 			d.gateway.Cluster = d.cluster
 			taskFunc, taskSchedule := cluster.HeartbeatTask(d.gateway)
-			stop, _ := task.Start(d.ctx, taskFunc, taskSchedule)
+			hbGroup := task.Group{}
+			d.taskClusterHeartbeat = hbGroup.Add(taskFunc, taskSchedule)
+			hbGroup.Start(d.ctx)
 			d.gateway.WaitUpgradeNotification()
-			stop(time.Second)
+			hbGroup.Stop(time.Second)
 			d.gateway.Cluster = nil
 
 			d.cluster.Close()
@@ -1288,7 +1291,7 @@ func (d *Daemon) init() error {
 
 func (d *Daemon) startClusterTasks() {
 	// Heartbeats
-	d.clusterTasks.Add(cluster.HeartbeatTask(d.gateway))
+	d.taskClusterHeartbeat = d.clusterTasks.Add(cluster.HeartbeatTask(d.gateway))
 
 	// Events
 	d.clusterTasks.Add(cluster.Events(d.endpoints, d.cluster, d.serverCert, d.events.Forward))

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1205,6 +1205,8 @@ func (d *Daemon) init() error {
 		candidAPIURL, candidAPIKey, candidExpiry, candidDomains = config.CandidServer()
 		maasAPIURL, maasAPIKey = config.MAASController()
 		rbacAPIURL, rbacAPIKey, rbacExpiry, rbacAgentURL, rbacAgentUsername, rbacAgentPrivateKey, rbacAgentPublicKey = config.RBACServer()
+		d.gateway.HeartbeatOfflineThreshold = config.OfflineThreshold()
+
 		return nil
 	})
 	if err != nil {

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3633,7 +3633,8 @@ func autoSyncImages(ctx context.Context, d *Daemon) error {
 }
 
 func imageSyncBetweenNodes(d *Daemon, project string, fingerprint string) error {
-	logger.Info("Syncing image to members", log.Ctx{"fingerprint": fingerprint, "project": project})
+	logger.Info("Syncing image to members started", log.Ctx{"fingerprint": fingerprint, "project": project})
+	defer logger.Info("Syncing image to members finished", log.Ctx{"fingerprint": fingerprint, "project": project})
 
 	var desiredSyncNodeCount int64
 
@@ -3668,11 +3669,13 @@ func imageSyncBetweenNodes(d *Daemon, project string, fingerprint string) error 
 
 	// If none of the nodes have the image, there's nothing to sync.
 	if len(syncNodeAddresses) == 0 {
+		logger.Debug("No members have image, nothing to do", log.Ctx{"fingerprint": fingerprint, "project": project})
 		return nil
 	}
 
 	nodeCount := desiredSyncNodeCount - int64(len(syncNodeAddresses))
 	if nodeCount <= 0 {
+		logger.Debug("Sufficient members have image", log.Ctx{"fingerprint": fingerprint, "project": project, "desiredSyncCount": desiredSyncNodeCount, "syncedCount": len(syncNodeAddresses)})
 		return nil
 	}
 
@@ -3699,7 +3702,9 @@ func imageSyncBetweenNodes(d *Daemon, project string, fingerprint string) error 
 		if err != nil {
 			return errors.Wrap(err, "Failed to get nodes for the image synchronization")
 		}
+
 		if len(addresses) <= 0 {
+			logger.Debug("All members have image", log.Ctx{"fingerprint": fingerprint, "project": project})
 			return nil
 		}
 


### PR DESCRIPTION
Also:
- Use daemon context for heartbeat requests.
- Improve logging and error messages.

This improves test reliability, although we are still seeing a few intermittent failures (which @MathieuBordere believes is caused by https://github.com/canonical/raft/issues/203 in Dqlite). This would seem to make sense because the tests that fail now are all inspecting the `Database` column from `lxc cluster ls`, which indicates the Dqlite role, rather than failing on a LXD heartbeat related status check.