### PR TITLE
Cluster: Clear config.Cluster.ClusterPassword after setting up trust during interactive init

### DIFF
--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -249,6 +249,10 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer) error
 				return errors.Wrap(err, "Failed to setup trust relationship with cluster")
 			}
 
+			// Now we have setup trust, don't send to server, othwerwise it will try and setup trust
+			// again and if using a one-time join token, will fail.
+			config.Cluster.ClusterPassword = ""
+
 			// Client parameters to connect to the target cluster node.
 			args := &lxd.ConnectionArgs{
 				TLSClientCert: string(serverCert.PublicKey()),


### PR DESCRIPTION
This avoids triggering a 2nd attempt at setting up trust in clusterPutJoin which would fail when using a single-use join token as a password. There's no need for a 2nd attempt at setting up trust when in interactive init with trust password.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>