### PR TITLE
lxd/lxd: Record requestor as part of lifecycle events

### DIFF
--- a/lxd-agent/exec.go
+++ b/lxd-agent/exec.go
@@ -121,7 +121,7 @@ func execPost(d *Daemon, r *http.Request) response.Response {
 
 	resources := map[string][]string{}
 
-	op, err := operations.OperationCreate(nil, "", operations.OperationClassWebsocket, db.OperationCommandExec, resources, ws.Metadata(), ws.Do, nil, ws.Connect)
+	op, err := operations.OperationCreate(nil, "", operations.OperationClassWebsocket, db.OperationCommandExec, resources, ws.Metadata(), ws.Do, nil, ws.Connect, r)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -277,13 +277,13 @@ func clusterPut(d *Daemon, r *http.Request) response.Response {
 	// cluster with this node as first node, or perform a request to join a
 	// given cluster.
 	if req.ClusterAddress == "" {
-		return clusterPutBootstrap(d, req)
+		return clusterPutBootstrap(d, r, req)
 	}
 
-	return clusterPutJoin(d, req)
+	return clusterPutJoin(d, r, req)
 }
 
-func clusterPutBootstrap(d *Daemon, req api.ClusterPut) response.Response {
+func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) response.Response {
 	run := func(op *operations.Operation) error {
 		// Start clustering tasks
 		d.startClusterTasks()
@@ -327,7 +327,7 @@ func clusterPutBootstrap(d *Daemon, req api.ClusterPut) response.Response {
 		return response.SmartError(err)
 	}
 
-	op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationClusterBootstrap, resources, nil, run, nil, nil)
+	op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationClusterBootstrap, resources, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -338,7 +338,7 @@ func clusterPutBootstrap(d *Daemon, req api.ClusterPut) response.Response {
 	return operations.OperationResponse(op)
 }
 
-func clusterPutJoin(d *Daemon, req api.ClusterPut) response.Response {
+func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Response {
 	// Make sure basic pre-conditions are met.
 	if len(req.ClusterCertificate) == 0 {
 		return response.BadRequest(fmt.Errorf("No target cluster member certificate provided"))
@@ -676,7 +676,7 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) response.Response {
 	resources := map[string][]string{}
 	resources["cluster"] = []string{}
 
-	op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationClusterJoin, resources, nil, run, nil, nil)
+	op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationClusterJoin, resources, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -1182,7 +1182,7 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 	resources := map[string][]string{}
 	resources["cluster"] = []string{}
 
-	op, err := operations.OperationCreate(d.State(), project.Default, operations.OperationClassToken, db.OperationClusterJoinToken, resources, meta, nil, nil, nil)
+	op, err := operations.OperationCreate(d.State(), project.Default, operations.OperationClassToken, db.OperationClusterJoinToken, resources, meta, nil, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -681,7 +681,7 @@ func projectPost(d *Daemon, r *http.Request) response.Response {
 		return nil
 	}
 
-	op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationProjectRename, nil, nil, run, nil, nil)
+	op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationProjectRename, nil, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -255,7 +255,7 @@ func pruneExpiredContainerBackupsTask(d *Daemon) (task.Func, task.Schedule) {
 			return pruneExpiredContainerBackups(ctx, d)
 		}
 
-		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationBackupsExpire, nil, nil, opRun, nil, nil)
+		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationBackupsExpire, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
 			logger.Error("Failed to start expired instance backups operation", log.Ctx{"err": err})
 			return

--- a/lxd/backup/backup_utils.go
+++ b/lxd/backup/backup_utils.go
@@ -43,5 +43,5 @@ func Lifecycle(s *state.State, inst Instance, name string, action string, ctx ma
 		u = fmt.Sprintf("%s?project=%s", u, url.QueryEscape(inst.Project()))
 	}
 
-	return s.Events.SendLifecycle(inst.Project(), fmt.Sprintf("%s-%s", prefix, action), u, ctx)
+	return s.Events.SendLifecycle(inst.Project(), fmt.Sprintf("%s-%s", prefix, action), u, ctx, nil)
 }

--- a/lxd/events/events.go
+++ b/lxd/events/events.go
@@ -60,12 +60,12 @@ func (s *Server) AddListener(group string, connection *websocket.Conn, messageTy
 }
 
 // SendLifecycle broadcasts a lifecycle event.
-func (s *Server) SendLifecycle(group, action, source string,
-	context map[string]interface{}) error {
+func (s *Server) SendLifecycle(group, action, source string, context map[string]interface{}, requestor *api.EventLifecycleRequestor) error {
 	s.Send(group, "lifecycle", api.EventLifecycle{
-		Action:  action,
-		Source:  source,
-		Context: context})
+		Action:    action,
+		Source:    source,
+		Context:   context,
+		Requestor: requestor})
 	return nil
 }
 

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -430,7 +430,7 @@ func autoCreateContainerSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 			return autoCreateContainerSnapshots(ctx, d, instances)
 		}
 
-		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationSnapshotCreate, nil, nil, opRun, nil, nil)
+		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationSnapshotCreate, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
 			logger.Error("Failed to start create snapshot operation", log.Ctx{"err": err})
 			return
@@ -537,7 +537,7 @@ func pruneExpiredContainerSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 			return pruneExpiredContainerSnapshots(ctx, d, expiredSnapshots)
 		}
 
-		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationSnapshotsExpire, nil, nil, opRun, nil, nil)
+		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationSnapshotsExpire, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
 			logger.Error("Failed to start expired instance snapshots operation", log.Ctx{"err": err})
 			return

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -612,7 +612,12 @@ func (d *common) lifecycle(action string, ctx map[string]interface{}) error {
 		u = fmt.Sprintf("%s?project=%s", u, url.QueryEscape(d.project))
 	}
 
-	return d.state.Events.SendLifecycle(d.project, fmt.Sprintf("%s-%s", prefix, action), u, ctx)
+	var requestor *api.EventLifecycleRequestor
+	if d.op != nil {
+		requestor = d.op.Requestor()
+	}
+
+	return d.state.Events.SendLifecycle(d.project, fmt.Sprintf("%s-%s", prefix, action), u, ctx, requestor)
 }
 
 // insertConfigkey function attempts to insert the instance config key into the database. If the insert fails

--- a/lxd/instance_backup.go
+++ b/lxd/instance_backup.go
@@ -322,7 +322,7 @@ func instanceBackupsPost(d *Daemon, r *http.Request) response.Response {
 	resources["backups"] = []string{req.Name}
 
 	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask,
-		db.OperationBackupCreate, resources, nil, backup, nil, nil)
+		db.OperationBackupCreate, resources, nil, backup, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -482,7 +482,7 @@ func instanceBackupPost(d *Daemon, r *http.Request) response.Response {
 	resources["containers"] = resources["instances"]
 
 	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask,
-		db.OperationBackupRename, resources, nil, rename, nil, nil)
+		db.OperationBackupRename, resources, nil, rename, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -554,7 +554,7 @@ func instanceBackupDelete(d *Daemon, r *http.Request) response.Response {
 	resources["container"] = []string{name}
 
 	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask,
-		db.OperationBackupRemove, resources, nil, remove, nil, nil)
+		db.OperationBackupRemove, resources, nil, remove, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -492,8 +492,7 @@ func instanceConsolePost(d *Daemon, r *http.Request) response.Response {
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassWebsocket, db.OperationConsoleShow,
-		resources, ws.Metadata(), ws.Do, nil, ws.Connect)
+	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassWebsocket, db.OperationConsoleShow, resources, ws.Metadata(), ws.Do, nil, ws.Connect, r)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/instance_delete.go
+++ b/lxd/instance_delete.go
@@ -75,7 +75,7 @@ func instanceDelete(d *Daemon, r *http.Request) response.Response {
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceDelete, resources, nil, rmct, nil, nil)
+	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceDelete, resources, nil, rmct, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -593,7 +593,7 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 			resources["containers"] = resources["instances"]
 		}
 
-		op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassWebsocket, db.OperationCommandExec, resources, ws.Metadata(), ws.Do, nil, ws.Connect)
+		op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassWebsocket, db.OperationCommandExec, resources, ws.Metadata(), ws.Do, nil, ws.Connect, r)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -664,7 +664,7 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationCommandExec, resources, nil, run, nil, nil)
+	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationCommandExec, resources, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/instance_instance_types.go
+++ b/lxd/instance_instance_types.go
@@ -92,7 +92,7 @@ func instanceRefreshTypesTask(d *Daemon) (task.Func, task.Schedule) {
 			}
 		}
 
-		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationInstanceTypesUpdate, nil, nil, opRun, nil, nil)
+		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationInstanceTypesUpdate, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
 			logger.Error("Failed to start instance types update operation", log.Ctx{"err": err})
 			return

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -224,7 +224,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 
 			resources := map[string][]string{}
 			resources["instances"] = []string{name}
-			op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceMigrate, resources, nil, run, nil, nil)
+			op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceMigrate, resources, nil, run, nil, nil, r)
 			if err != nil {
 				return response.InternalError(err)
 			}
@@ -260,7 +260,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 				return response.SmartError(err)
 			}
 			if pool.Driver == "ceph" {
-				return instancePostClusteringMigrateWithCeph(d, inst, projectName, name, req.Name, targetNode, instanceType)
+				return instancePostClusteringMigrateWithCeph(d, r, inst, projectName, name, req.Name, targetNode, instanceType)
 			}
 
 			// If this is not a ceph-based container, make sure
@@ -272,7 +272,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 				return response.SmartError(err)
 			}
 
-			return instancePostClusteringMigrate(d, inst, name, req.Name, targetNode)
+			return instancePostClusteringMigrate(d, r, inst, name, req.Name, targetNode)
 		}
 
 		instanceOnly := req.InstanceOnly || req.ContainerOnly
@@ -304,7 +304,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 				return response.InternalError(err)
 			}
 
-			op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceMigrate, resources, nil, run, nil, nil)
+			op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceMigrate, resources, nil, run, nil, nil, r)
 			if err != nil {
 				return response.InternalError(err)
 			}
@@ -313,7 +313,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Pull mode.
-		op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassWebsocket, db.OperationInstanceMigrate, resources, ws.Metadata(), run, cancel, ws.Connect)
+		op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassWebsocket, db.OperationInstanceMigrate, resources, ws.Metadata(), run, cancel, ws.Connect, r)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -338,7 +338,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceRename, resources, nil, run, nil, nil)
+	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceRename, resources, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -424,7 +424,7 @@ func instancePostPoolMigration(d *Daemon, inst instance.Instance, newName string
 }
 
 // Move a non-ceph container to another cluster node.
-func instancePostClusteringMigrate(d *Daemon, inst instance.Instance, oldName, newName, newNode string) response.Response {
+func instancePostClusteringMigrate(d *Daemon, r *http.Request, inst instance.Instance, oldName, newName, newNode string) response.Response {
 	var sourceAddress string
 	var targetAddress string
 
@@ -576,7 +576,7 @@ func instancePostClusteringMigrate(d *Daemon, inst instance.Instance, oldName, n
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(d.State(), inst.Project(), operations.OperationClassTask, db.OperationInstanceMigrate, resources, nil, run, nil, nil)
+	op, err := operations.OperationCreate(d.State(), inst.Project(), operations.OperationClassTask, db.OperationInstanceMigrate, resources, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -585,7 +585,7 @@ func instancePostClusteringMigrate(d *Daemon, inst instance.Instance, oldName, n
 }
 
 // Special case migrating a container backed by ceph across two cluster nodes.
-func instancePostClusteringMigrateWithCeph(d *Daemon, inst instance.Instance, projectName, oldName, newName, newNode string, instanceType instancetype.Type) response.Response {
+func instancePostClusteringMigrateWithCeph(d *Daemon, r *http.Request, inst instance.Instance, projectName, oldName, newName, newNode string, instanceType instancetype.Type) response.Response {
 	run := func(op *operations.Operation) error {
 		// If source node is online (i.e. we're serving the request on
 		// it, and c != nil), let's unmap the RBD volume locally
@@ -659,7 +659,7 @@ func instancePostClusteringMigrateWithCeph(d *Daemon, inst instance.Instance, pr
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceMigrate, resources, nil, run, nil, nil)
+	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceMigrate, resources, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/instance_put.go
+++ b/lxd/instance_put.go
@@ -142,7 +142,7 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, opType, resources, nil, do, nil, nil)
+	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, opType, resources, nil, do, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -295,7 +295,7 @@ func instanceSnapshotsPost(d *Daemon, r *http.Request) response.Response {
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationSnapshotCreate, resources, nil, snapshot, nil, nil)
+	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationSnapshotCreate, resources, nil, snapshot, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -336,7 +336,7 @@ func instanceSnapshotHandler(d *Daemon, r *http.Request) response.Response {
 	case "POST":
 		return snapshotPost(d, r, inst, containerName)
 	case "DELETE":
-		return snapshotDelete(d.State(), inst, snapshotName)
+		return snapshotDelete(d.State(), r, inst, snapshotName)
 	case "PUT":
 		return snapshotPut(d, r, inst, snapshotName)
 	case "PATCH":
@@ -484,8 +484,7 @@ func snapshotPut(d *Daemon, r *http.Request, snapInst instance.Instance, name st
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(d.State(), snapInst.Project(), operations.OperationClassTask, opType, resources, nil,
-		do, nil, nil)
+	op, err := operations.OperationCreate(d.State(), snapInst.Project(), operations.OperationClassTask, opType, resources, nil, do, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -648,7 +647,7 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 				return response.InternalError(err)
 			}
 
-			op, err := operations.OperationCreate(d.State(), snapInst.Project(), operations.OperationClassTask, db.OperationSnapshotTransfer, resources, nil, run, nil, nil)
+			op, err := operations.OperationCreate(d.State(), snapInst.Project(), operations.OperationClassTask, db.OperationSnapshotTransfer, resources, nil, run, nil, nil, r)
 			if err != nil {
 				return response.InternalError(err)
 			}
@@ -657,7 +656,7 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 		}
 
 		// Pull mode
-		op, err := operations.OperationCreate(d.State(), snapInst.Project(), operations.OperationClassWebsocket, db.OperationSnapshotTransfer, resources, ws.Metadata(), run, nil, ws.Connect)
+		op, err := operations.OperationCreate(d.State(), snapInst.Project(), operations.OperationClassWebsocket, db.OperationSnapshotTransfer, resources, ws.Metadata(), run, nil, ws.Connect, r)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -695,7 +694,7 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(d.State(), snapInst.Project(), operations.OperationClassTask, db.OperationSnapshotRename, resources, nil, rename, nil, nil)
+	op, err := operations.OperationCreate(d.State(), snapInst.Project(), operations.OperationClassTask, db.OperationSnapshotRename, resources, nil, rename, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -729,7 +728,7 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 //     $ref: "#/responses/Forbidden"
 //   "500":
 //     $ref: "#/responses/InternalServerError"
-func snapshotDelete(s *state.State, snapInst instance.Instance, name string) response.Response {
+func snapshotDelete(s *state.State, r *http.Request, snapInst instance.Instance, name string) response.Response {
 	remove := func(op *operations.Operation) error {
 		return snapInst.Delete(false)
 	}
@@ -741,7 +740,7 @@ func snapshotDelete(s *state.State, snapInst instance.Instance, name string) res
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(s, snapInst.Project(), operations.OperationClassTask, db.OperationSnapshotDelete, resources, nil, remove, nil, nil)
+	op, err := operations.OperationCreate(s, snapInst.Project(), operations.OperationClassTask, db.OperationSnapshotDelete, resources, nil, remove, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/instance_state.go
+++ b/lxd/instance_state.go
@@ -171,7 +171,7 @@ func instanceStatePut(d *Daemon, r *http.Request) response.Response {
 
 	resources := map[string][]string{}
 	resources["instances"] = []string{name}
-	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, opType, resources, nil, do, nil, nil)
+	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, opType, resources, nil, do, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -33,7 +33,7 @@ import (
 	"github.com/lxc/lxd/shared/osarch"
 )
 
-func createFromImage(d *Daemon, projectName string, req *api.InstancesPost) response.Response {
+func createFromImage(d *Daemon, r *http.Request, projectName string, req *api.InstancesPost) response.Response {
 	hash, err := instance.ResolveImage(d.State(), projectName, req.Source)
 	if err != nil {
 		return response.BadRequest(err)
@@ -132,7 +132,7 @@ func createFromImage(d *Daemon, projectName string, req *api.InstancesPost) resp
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceCreate, resources, nil, run, nil, nil)
+	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceCreate, resources, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -140,7 +140,7 @@ func createFromImage(d *Daemon, projectName string, req *api.InstancesPost) resp
 	return operations.OperationResponse(op)
 }
 
-func createFromNone(d *Daemon, projectName string, req *api.InstancesPost) response.Response {
+func createFromNone(d *Daemon, r *http.Request, projectName string, req *api.InstancesPost) response.Response {
 	dbType, err := instancetype.New(string(req.Type))
 	if err != nil {
 		return response.BadRequest(err)
@@ -177,7 +177,7 @@ func createFromNone(d *Daemon, projectName string, req *api.InstancesPost) respo
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceCreate, resources, nil, run, nil, nil)
+	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceCreate, resources, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -185,7 +185,7 @@ func createFromNone(d *Daemon, projectName string, req *api.InstancesPost) respo
 	return operations.OperationResponse(op)
 }
 
-func createFromMigration(d *Daemon, projectName string, req *api.InstancesPost) response.Response {
+func createFromMigration(d *Daemon, r *http.Request, projectName string, req *api.InstancesPost) response.Response {
 	// Validate migration mode.
 	if req.Source.Mode != "pull" && req.Source.Mode != "push" {
 		return response.NotImplemented(fmt.Errorf("Mode '%s' not implemented", req.Source.Mode))
@@ -384,12 +384,12 @@ func createFromMigration(d *Daemon, projectName string, req *api.InstancesPost) 
 
 	var op *operations.Operation
 	if push {
-		op, err = operations.OperationCreate(d.State(), projectName, operations.OperationClassWebsocket, db.OperationInstanceCreate, resources, sink.Metadata(), run, nil, sink.Connect)
+		op, err = operations.OperationCreate(d.State(), projectName, operations.OperationClassWebsocket, db.OperationInstanceCreate, resources, sink.Metadata(), run, nil, sink.Connect, r)
 		if err != nil {
 			return response.InternalError(err)
 		}
 	} else {
-		op, err = operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceCreate, resources, nil, run, nil, nil)
+		op, err = operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, db.OperationInstanceCreate, resources, nil, run, nil, nil, r)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -399,7 +399,7 @@ func createFromMigration(d *Daemon, projectName string, req *api.InstancesPost) 
 	return operations.OperationResponse(op)
 }
 
-func createFromCopy(d *Daemon, projectName string, req *api.InstancesPost) response.Response {
+func createFromCopy(d *Daemon, r *http.Request, projectName string, req *api.InstancesPost) response.Response {
 	if req.Source.Source == "" {
 		return response.BadRequest(fmt.Errorf("Must specify a source instance"))
 	}
@@ -568,7 +568,7 @@ func createFromCopy(d *Daemon, projectName string, req *api.InstancesPost) respo
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(d.State(), targetProject, operations.OperationClassTask, db.OperationInstanceCreate, resources, nil, run, nil, nil)
+	op, err := operations.OperationCreate(d.State(), targetProject, operations.OperationClassTask, db.OperationInstanceCreate, resources, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -576,7 +576,7 @@ func createFromCopy(d *Daemon, projectName string, req *api.InstancesPost) respo
 	return operations.OperationResponse(op)
 }
 
-func createFromBackup(d *Daemon, projectName string, data io.Reader, pool string, instanceName string) response.Response {
+func createFromBackup(d *Daemon, r *http.Request, projectName string, data io.Reader, pool string, instanceName string) response.Response {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -746,7 +746,7 @@ func createFromBackup(d *Daemon, projectName string, data io.Reader, pool string
 	resources["instances"] = []string{bInfo.Name}
 	resources["containers"] = resources["instances"]
 
-	op, err := operations.OperationCreate(d.State(), bInfo.Project, operations.OperationClassTask, db.OperationBackupRestore, resources, nil, run, nil, nil)
+	op, err := operations.OperationCreate(d.State(), bInfo.Project, operations.OperationClassTask, db.OperationBackupRestore, resources, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -805,7 +805,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 
 	// If we're getting binary content, process separately
 	if r.Header.Get("Content-Type") == "application/octet-stream" {
-		return createFromBackup(d, targetProject, r.Body, r.Header.Get("X-LXD-pool"), r.Header.Get("X-LXD-name"))
+		return createFromBackup(d, r, targetProject, r.Body, r.Header.Get("X-LXD-pool"), r.Header.Get("X-LXD-name"))
 	}
 
 	// Parse the request
@@ -994,13 +994,13 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 
 	switch req.Source.Type {
 	case "image":
-		return createFromImage(d, targetProject, &req)
+		return createFromImage(d, r, targetProject, &req)
 	case "none":
-		return createFromNone(d, targetProject, &req)
+		return createFromNone(d, r, targetProject, &req)
 	case "migration":
-		return createFromMigration(d, targetProject, &req)
+		return createFromMigration(d, r, targetProject, &req)
 	case "copy":
-		return createFromCopy(d, targetProject, &req)
+		return createFromCopy(d, r, targetProject, &req)
 	default:
 		return response.BadRequest(fmt.Errorf("Unknown source type %s", req.Source.Type))
 	}
@@ -1145,5 +1145,5 @@ func clusterCopyContainerInternal(d *Daemon, source instance.Instance, projectNa
 	req.Source.Project = ""
 
 	// Run the migration
-	return createFromMigration(d, projectName, req)
+	return createFromMigration(d, nil, projectName, req)
 }

--- a/lxd/instances_put.go
+++ b/lxd/instances_put.go
@@ -251,7 +251,7 @@ func instancesPut(d *Daemon, r *http.Request) response.Response {
 
 	resources := map[string][]string{}
 	resources["instances"] = names
-	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, opType, resources, nil, do, nil, nil)
+	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassTask, opType, resources, nil, do, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/logging.go
+++ b/lxd/logging.go
@@ -28,7 +28,7 @@ func expireLogsTask(state *state.State) (task.Func, task.Schedule) {
 			return expireLogs(ctx, state)
 		}
 
-		op, err := operations.OperationCreate(state, "", operations.OperationClassTask, db.OperationLogsExpire, nil, nil, opRun, nil, nil)
+		op, err := operations.OperationCreate(state, "", operations.OperationClassTask, db.OperationLogsExpire, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
 			logger.Error("Failed to start log expiry operation", log.Ctx{"err": err})
 			return

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -569,6 +569,7 @@ func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operati
 					closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
 					return c.WriteMessage(websocket.CloseMessage, closeMsg)
 				},
+				nil,
 			)
 			if err != nil {
 				os.RemoveAll(checkpointDir)

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -402,7 +402,7 @@ func (n *common) lifecycle(action string, ctx map[string]interface{}) error {
 		u = fmt.Sprintf("%s?project=%s", u, url.QueryEscape(n.project))
 	}
 
-	return n.state.Events.SendLifecycle(n.project, fmt.Sprintf("%s-%s", prefix, action), u, ctx)
+	return n.state.Events.SendLifecycle(n.project, fmt.Sprintf("%s-%s", prefix, action), u, ctx, nil)
 }
 
 // notifyDependentNetworks allows any dependent networks to apply changes to themselves when this network changes.

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -238,7 +238,7 @@ func storagePoolVolumesTypePost(d *Daemon, r *http.Request) response.Response {
 
 	// If we're getting binary content, process separately.
 	if r.Header.Get("Content-Type") == "application/octet-stream" {
-		return createStoragePoolVolumeFromBackup(d, projectParam(r), projectName, r.Body, poolName, r.Header.Get("X-LXD-name"))
+		return createStoragePoolVolumeFromBackup(d, r, projectParam(r), projectName, r.Body, poolName, r.Header.Get("X-LXD-name"))
 	}
 
 	req := api.StorageVolumesPost{}
@@ -300,17 +300,17 @@ func storagePoolVolumesTypePost(d *Daemon, r *http.Request) response.Response {
 
 	switch req.Source.Type {
 	case "":
-		return doVolumeCreateOrCopy(d, projectParam(r), projectName, poolName, &req)
+		return doVolumeCreateOrCopy(d, r, projectParam(r), projectName, poolName, &req)
 	case "copy":
-		return doVolumeCreateOrCopy(d, projectParam(r), projectName, poolName, &req)
+		return doVolumeCreateOrCopy(d, r, projectParam(r), projectName, poolName, &req)
 	case "migration":
-		return doVolumeMigration(d, projectParam(r), projectName, poolName, &req)
+		return doVolumeMigration(d, r, projectParam(r), projectName, poolName, &req)
 	default:
 		return response.BadRequest(fmt.Errorf("Unknown source type %q", req.Source.Type))
 	}
 }
 
-func doVolumeCreateOrCopy(d *Daemon, requestProjectName string, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {
+func doVolumeCreateOrCopy(d *Daemon, r *http.Request, requestProjectName string, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {
 	var run func(op *operations.Operation) error
 
 	pool, err := storagePools.GetPoolByName(d.State(), poolName)
@@ -347,7 +347,7 @@ func doVolumeCreateOrCopy(d *Daemon, requestProjectName string, projectName stri
 	}
 
 	// Volume copy operations potentially take a long time, so run as an async operation.
-	op, err := operations.OperationCreate(d.State(), requestProjectName, operations.OperationClassTask, db.OperationVolumeCopy, nil, nil, run, nil, nil)
+	op, err := operations.OperationCreate(d.State(), requestProjectName, operations.OperationClassTask, db.OperationVolumeCopy, nil, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -420,17 +420,17 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 
 	switch req.Source.Type {
 	case "":
-		return doVolumeCreateOrCopy(d, projectParam(r), projectName, poolName, &req)
+		return doVolumeCreateOrCopy(d, r, projectParam(r), projectName, poolName, &req)
 	case "copy":
-		return doVolumeCreateOrCopy(d, projectParam(r), projectName, poolName, &req)
+		return doVolumeCreateOrCopy(d, r, projectParam(r), projectName, poolName, &req)
 	case "migration":
-		return doVolumeMigration(d, projectParam(r), projectName, poolName, &req)
+		return doVolumeMigration(d, r, projectParam(r), projectName, poolName, &req)
 	default:
 		return response.BadRequest(fmt.Errorf("Unknown source type %q", req.Source.Type))
 	}
 }
 
-func doVolumeMigration(d *Daemon, requestProjectName string, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {
+func doVolumeMigration(d *Daemon, r *http.Request, requestProjectName string, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {
 	// Validate migration mode
 	if req.Source.Mode != "pull" && req.Source.Mode != "push" {
 		return response.NotImplemented(fmt.Errorf("Mode '%s' not implemented", req.Source.Mode))
@@ -495,12 +495,12 @@ func doVolumeMigration(d *Daemon, requestProjectName string, projectName string,
 
 	var op *operations.Operation
 	if push {
-		op, err = operations.OperationCreate(d.State(), requestProjectName, operations.OperationClassWebsocket, db.OperationVolumeCreate, resources, sink.Metadata(), run, nil, sink.Connect)
+		op, err = operations.OperationCreate(d.State(), requestProjectName, operations.OperationClassWebsocket, db.OperationVolumeCreate, resources, sink.Metadata(), run, nil, sink.Connect, r)
 		if err != nil {
 			return response.InternalError(err)
 		}
 	} else {
-		op, err = operations.OperationCreate(d.State(), requestProjectName, operations.OperationClassTask, db.OperationVolumeCopy, resources, nil, run, nil, nil)
+		op, err = operations.OperationCreate(d.State(), requestProjectName, operations.OperationClassTask, db.OperationVolumeCopy, resources, nil, run, nil, nil, r)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -580,7 +580,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 
 	// This is a migration request so send back requested secrets.
 	if req.Migration {
-		return storagePoolVolumeTypePostMigration(d.State(), projectParam(r), projectName, srcPoolName, volumeName, req)
+		return storagePoolVolumeTypePostMigration(d.State(), r, projectParam(r), projectName, srcPoolName, volumeName, req)
 	}
 
 	// Retrieve ID of the storage pool (and check if the storage pool exists).
@@ -648,11 +648,11 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Otherwise this is a move request.
-	return storagePoolVolumeTypePostMove(d, srcPoolName, projectParam(r), projectName, vol, req)
+	return storagePoolVolumeTypePostMove(d, r, srcPoolName, projectParam(r), projectName, vol, req)
 }
 
 // storagePoolVolumeTypePostMigration handles volume migration type POST requests.
-func storagePoolVolumeTypePostMigration(state *state.State, requestProjectName string, projectName string, poolName string, volumeName string, req api.StorageVolumePost) response.Response {
+func storagePoolVolumeTypePostMigration(state *state.State, r *http.Request, requestProjectName string, projectName string, poolName string, volumeName string, req api.StorageVolumePost) response.Response {
 	ws, err := newStorageMigrationSource(req.VolumeOnly)
 	if err != nil {
 		return response.InternalError(err)
@@ -672,7 +672,7 @@ func storagePoolVolumeTypePostMigration(state *state.State, requestProjectName s
 			return response.InternalError(err)
 		}
 
-		op, err := operations.OperationCreate(state, requestProjectName, operations.OperationClassTask, db.OperationVolumeMigrate, resources, nil, run, nil, nil)
+		op, err := operations.OperationCreate(state, requestProjectName, operations.OperationClassTask, db.OperationVolumeMigrate, resources, nil, run, nil, nil, r)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -681,7 +681,7 @@ func storagePoolVolumeTypePostMigration(state *state.State, requestProjectName s
 	}
 
 	// Pull mode
-	op, err := operations.OperationCreate(state, requestProjectName, operations.OperationClassWebsocket, db.OperationVolumeMigrate, resources, ws.Metadata(), run, nil, ws.Connect)
+	op, err := operations.OperationCreate(state, requestProjectName, operations.OperationClassWebsocket, db.OperationVolumeMigrate, resources, ws.Metadata(), run, nil, ws.Connect, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -718,7 +718,7 @@ func storagePoolVolumeTypePostRename(d *Daemon, poolName string, projectName str
 }
 
 // storagePoolVolumeTypePostMove handles volume move type POST requests.
-func storagePoolVolumeTypePostMove(d *Daemon, poolName string, requestProjectName string, projectName string, vol *api.StorageVolume, req api.StorageVolumePost) response.Response {
+func storagePoolVolumeTypePostMove(d *Daemon, r *http.Request, poolName string, requestProjectName string, projectName string, vol *api.StorageVolume, req api.StorageVolumePost) response.Response {
 	newVol := *vol
 	newVol.Name = req.Name
 
@@ -759,7 +759,7 @@ func storagePoolVolumeTypePostMove(d *Daemon, poolName string, requestProjectNam
 		return nil
 	}
 
-	op, err := operations.OperationCreate(d.State(), requestProjectName, operations.OperationClassTask, db.OperationVolumeMove, nil, nil, run, nil, nil)
+	op, err := operations.OperationCreate(d.State(), requestProjectName, operations.OperationClassTask, db.OperationVolumeMove, nil, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -1129,7 +1129,7 @@ func storagePoolVolumeDelete(d *Daemon, r *http.Request) response.Response {
 	return response.EmptySyncResponse
 }
 
-func createStoragePoolVolumeFromBackup(d *Daemon, requestProjectName string, projectName string, data io.Reader, pool string, volName string) response.Response {
+func createStoragePoolVolumeFromBackup(d *Daemon, r *http.Request, requestProjectName string, projectName string, data io.Reader, pool string, volName string) response.Response {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -1265,7 +1265,7 @@ func createStoragePoolVolumeFromBackup(d *Daemon, requestProjectName string, pro
 	resources := map[string][]string{}
 	resources["storage_volumes"] = []string{bInfo.Name}
 
-	op, err := operations.OperationCreate(d.State(), requestProjectName, operations.OperationClassTask, db.OperationCustomVolumeBackupRestore, resources, nil, run, nil, nil)
+	op, err := operations.OperationCreate(d.State(), requestProjectName, operations.OperationClassTask, db.OperationCustomVolumeBackupRestore, resources, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -250,8 +250,7 @@ func storagePoolVolumeTypeCustomBackupsPost(d *Daemon, r *http.Request) response
 	resources["storage_volumes"] = []string{volumeName}
 	resources["backups"] = []string{req.Name}
 
-	op, err := operations.OperationCreate(d.State(), projectParam(r), operations.OperationClassTask,
-		db.OperationCustomVolumeBackupCreate, resources, nil, backup, nil, nil)
+	op, err := operations.OperationCreate(d.State(), projectParam(r), operations.OperationClassTask, db.OperationCustomVolumeBackupCreate, resources, nil, backup, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -373,8 +372,7 @@ func storagePoolVolumeTypeCustomBackupPost(d *Daemon, r *http.Request) response.
 	resources := map[string][]string{}
 	resources["volume"] = []string{volumeName}
 
-	op, err := operations.OperationCreate(d.State(), projectParam(r), operations.OperationClassTask,
-		db.OperationCustomVolumeBackupRename, resources, nil, rename, nil, nil)
+	op, err := operations.OperationCreate(d.State(), projectParam(r), operations.OperationClassTask, db.OperationCustomVolumeBackupRename, resources, nil, rename, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -437,8 +435,7 @@ func storagePoolVolumeTypeCustomBackupDelete(d *Daemon, r *http.Request) respons
 	resources := map[string][]string{}
 	resources["volume"] = []string{volumeName}
 
-	op, err := operations.OperationCreate(d.State(), projectParam(r), operations.OperationClassTask,
-		db.OperationCustomVolumeBackupRemove, resources, nil, remove, nil, nil)
+	op, err := operations.OperationCreate(d.State(), projectParam(r), operations.OperationClassTask, db.OperationCustomVolumeBackupRemove, resources, nil, remove, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -167,7 +167,7 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 	resources := map[string][]string{}
 	resources["storage_volumes"] = []string{volumeName}
 
-	op, err := operations.OperationCreate(d.State(), projectParam(r), operations.OperationClassTask, db.OperationVolumeSnapshotCreate, resources, nil, snapshot, nil, nil)
+	op, err := operations.OperationCreate(d.State(), projectParam(r), operations.OperationClassTask, db.OperationVolumeSnapshotCreate, resources, nil, snapshot, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -322,7 +322,7 @@ func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Resp
 	resources := map[string][]string{}
 	resources["storage_volume_snapshots"] = []string{volumeName}
 
-	op, err := operations.OperationCreate(d.State(), projectParam(r), operations.OperationClassTask, db.OperationVolumeSnapshotDelete, resources, nil, snapshotRename, nil, nil)
+	op, err := operations.OperationCreate(d.State(), projectParam(r), operations.OperationClassTask, db.OperationVolumeSnapshotDelete, resources, nil, snapshotRename, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -627,7 +627,7 @@ func storagePoolVolumeSnapshotTypeDelete(d *Daemon, r *http.Request) response.Re
 	resources := map[string][]string{}
 	resources["storage_volume_snapshots"] = []string{volumeName}
 
-	op, err := operations.OperationCreate(d.State(), projectParam(r), operations.OperationClassTask, db.OperationVolumeSnapshotDelete, resources, nil, snapshotDelete, nil, nil)
+	op, err := operations.OperationCreate(d.State(), projectParam(r), operations.OperationClassTask, db.OperationVolumeSnapshotDelete, resources, nil, snapshotDelete, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -652,7 +652,7 @@ func pruneExpireCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) 
 			return pruneExpiredCustomVolumeSnapshots(ctx, d, expiredSnapshots)
 		}
 
-		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationCustomVolumeSnapshotsExpire, nil, nil, opRun, nil, nil)
+		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationCustomVolumeSnapshotsExpire, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
 			logger.Error("Failed to start expired custom volume snapshots operation", log.Ctx{"err": err})
 			return
@@ -814,7 +814,7 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 			return nil
 		}
 
-		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationVolumeSnapshotCreate, nil, nil, opRun, nil, nil)
+		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationVolumeSnapshotCreate, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
 			logger.Error("Failed to start create volume snapshot operation", log.Ctx{"err": err})
 			return

--- a/lxd/warnings.go
+++ b/lxd/warnings.go
@@ -398,7 +398,7 @@ func pruneResolvedWarningsTask(d *Daemon) (task.Func, task.Schedule) {
 			return pruneResolvedWarnings(ctx, d)
 		}
 
-		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationWarningsPruneResolved, nil, nil, opRun, nil, nil)
+		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationWarningsPruneResolved, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
 			logger.Error("Failed to start prune resolved warnings operation", log.Ctx{"err": err})
 			return

--- a/shared/api/event.go
+++ b/shared/api/event.go
@@ -98,4 +98,15 @@ type EventLifecycle struct {
 	Action  string                 `yaml:"action" json:"action"`
 	Source  string                 `yaml:"source" json:"source"`
 	Context map[string]interface{} `yaml:"context,omitempty" json:"context,omitempty"`
+
+	// API extension: event_lifecycle_requestor
+	Requestor *EventLifecycleRequestor `yaml:"requestor,omitempty" json:"requestor,omitempty"`
+}
+
+// EventLifecycleRequestor represents the initial requestor for an event
+//
+// API extension: event_lifecycle_requestor
+type EventLifecycleRequestor struct {
+	Username string `yaml:"username" json:"username"`
+	Protocol string `yaml:"protocol" json:"protocol"`
 }


### PR DESCRIPTION
I'm sorry. I accidentially closed the original pull request, and can't reopen it -> https://github.com/lxc/lxd/pull/8695.

maybe resolves #8011 

I'm aware tthat some attributes on Requestor are duplicate in EventLifecycle. I'm not entirely shure which attributes are relevant. I probably should implement pragmatic solution instead flexibility thats not really needed here. I also got lost pressings buttons on golang : ) 
 
Signed-off-by: Sascha Bast <sash@mischkonsum.org>