### PR TITLE
Network: Handle non-uuid OVS system-ids for OVN networks

### DIFF
--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -934,9 +934,9 @@ func (o *OVN) LogicalSwitchPortDynamicIPs(portName OVNSwitchPort) ([]net.IP, err
 		return []net.IP{}, nil
 	}
 
-	dynamicAddressesRaw, err = strconv.Unquote(dynamicAddressesRaw)
+	dynamicAddressesRaw, err = unquote(dynamicAddressesRaw)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "Failed unquoting")
 	}
 
 	dynamicAddresses := strings.Split(strings.TrimSpace(dynamicAddressesRaw), " ")

--- a/lxd/network/openvswitch/ovs.go
+++ b/lxd/network/openvswitch/ovs.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
-	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/pkg/errors"
 
 	"github.com/lxc/lxd/lxd/ip"
 	"github.com/lxc/lxd/shared"
@@ -183,9 +184,9 @@ func (o *OVS) ChassisID() (string, error) {
 	}
 
 	chassisID = strings.TrimSpace(chassisID)
-	chassisID, err = strconv.Unquote(chassisID)
+	chassisID, err = unquote(chassisID)
 	if err != nil {
-		return "", err
+		return "", errors.Wrapf(err, "Failed unquoting")
 	}
 
 	return chassisID, nil
@@ -203,9 +204,9 @@ func (o *OVS) OVNEncapIP() (net.IP, error) {
 	}
 
 	encapIPStr = strings.TrimSpace(encapIPStr)
-	encapIPStr, err = strconv.Unquote(encapIPStr)
+	encapIPStr, err = unquote(encapIPStr)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "Failed unquoting")
 	}
 
 	encapIP := net.ParseIP(encapIPStr)
@@ -232,9 +233,9 @@ func (o *OVS) OVNBridgeMappings(bridgeName string) ([]string, error) {
 		return []string{}, nil
 	}
 
-	mappings, err = strconv.Unquote(mappings)
+	mappings, err = unquote(mappings)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "Failed unquoting")
 	}
 
 	return strings.SplitN(mappings, ",", -1), nil

--- a/lxd/network/openvswitch/shared.go
+++ b/lxd/network/openvswitch/shared.go
@@ -1,0 +1,16 @@
+package openvswitch
+
+import (
+	"strconv"
+	"strings"
+)
+
+// unquote passes s through strconv.Unquote if the first character is a ", otherwise returns s unmodified.
+// This is useful as openvswitch's tools can sometimes return values double quoted if they start with a number.
+func unquote(s string) (string, error) {
+	if strings.HasPrefix(s, `"`) {
+		return strconv.Unquote(s)
+	}
+
+	return s, nil
+}


### PR DESCRIPTION
OVS tools dynamically change the quoting they use based on whether the value starts with a number or not.

When the OVS system-id doesn't start with a number it doesn't get quoted which upset the strconv.Unquote() function being used our parser. So now we detect this scenario and return the value unprocessed if it doesn't start with a `"`.

Fixes https://discuss.linuxcontainers.org/t/error-creating-ovn-network/11034