### PR TITLE
Cluster: Cancel ongoing heartbeat and restart round when notification heartbeat comes from non-leader member

### DIFF
--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -404,7 +404,7 @@ func (g *Gateway) DialFunc() client.DialFunc {
 		// trigger a full heartbeat now: it will be a no-op if we aren't
 		// actually leaders.
 		logger.Debug("Triggering an out of schedule hearbeat", log.Ctx{"address": address})
-		go g.heartbeat(g.ctx, true)
+		go g.heartbeat(g.ctx, hearbeatInitial)
 
 		return conn, nil
 	}

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -115,6 +115,8 @@ type Gateway struct {
 	Cluster                   *db.Cluster
 	HeartbeatNodeHook         func(*APIHeartbeat)
 	HeartbeatOfflineThreshold time.Duration
+	heartbeatCancel           context.CancelFunc
+	heartbeatCancelLock       sync.Mutex
 
 	// NodeStore wrapper.
 	store *dqliteNodeStore

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -199,7 +199,7 @@ func HeartbeatTask(gateway *Gateway) (task.Func, task.Schedule) {
 	heartbeatWrapper := func(ctx context.Context) {
 		ch := make(chan struct{})
 		go func() {
-			gateway.heartbeat(ctx, false)
+			gateway.heartbeat(ctx, hearbeatNormal)
 			ch <- struct{}{}
 		}()
 		select {

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -19,6 +19,14 @@ import (
 	"github.com/pkg/errors"
 )
 
+type heartbeatMode int
+
+const (
+	hearbeatNormal heartbeatMode = iota
+	hearbeatImmediate
+	hearbeatInitial
+)
+
 // APIHeartbeatMember contains specific cluster node info.
 type APIHeartbeatMember struct {
 	ID            int64     // ID field value in nodes table.

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -419,7 +419,7 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 	}
 
 	// Update last leader heartbeat time so next time a full node state list can be sent (if not this time).
-	logger.Debug("Completed heartbeat round", log.Ctx{"duration": duration})
+	logger.Debug("Completed heartbeat round", log.Ctx{"duration": duration, "address": localAddress})
 }
 
 // HeartbeatNode performs a single heartbeat request against the node with the given address.

--- a/lxd/cluster/heartbeat_test.go
+++ b/lxd/cluster/heartbeat_test.go
@@ -29,6 +29,8 @@ func TestHeartbeat(t *testing.T) {
 	f.Grow()
 	f.Grow()
 
+	time.Sleep(1 * time.Second) // Wait for join notifiation triggered heartbeats to complete.
+
 	leader := f.Leader()
 	leaderState := f.State(leader)
 

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -28,7 +28,7 @@ import (
 	log "github.com/lxc/lxd/shared/log15"
 )
 
-// imageDownloadLock aquires a lock for downloading/transferring an image and returns the unlock function.
+// imageDownloadLock acquires a lock for downloading/transferring an image and returns the unlock function.
 func (d *Daemon) imageDownloadLock(fingerprint string) locking.UnlockFunc {
 	logger.Debugf("Acquiring lock for image download of %q", fingerprint)
 	defer logger.Debugf("Lock acquired for image download of %q", fingerprint)


### PR DESCRIPTION
This fixes an issue where when a member joins during a regular heartbeat round, if the offline_threshold (and hence the heartbeat interval) is long, the heartbeats are spread over the heartbeat interval round time. However the member status is only read from the database at the start of the round, and so the heartbeat round can be inadvertently broadcasting stale member information, which can lead to incorrect decisions being made on the other members as they receive this stale data.

The fix is to cancel and restart any ongoing heartbeat round when a member change heartbeat notification is received by the leader.