### PR TITLE
lxd/instances: Unmount shiftfs on startup failures

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5868,6 +5868,16 @@ func (d *lxc) unmount() (bool, error) {
 		return unmounted, nil
 	}
 
+	// Workaround for liblxc failures on startup when shiftfs is used.
+	diskIdmap, err := d.DiskIdmap()
+	if err != nil {
+		return false, err
+	}
+
+	if d.state.OS.Shiftfs && !d.IsPrivileged() && diskIdmap == nil {
+		unix.Unmount(d.RootfsPath(), unix.MNT_DETACH)
+	}
+
 	unmounted, err := pool.UnmountInstance(d, nil)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>