### PR TITLE
Cluster: Rebalance roles when removing raft member

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1717,6 +1717,10 @@ func internalClusterPostRebalance(d *Daemon, r *http.Request) response.Response 
 // Check if there's a dqlite node whose role should be changed, and post a
 // change role request if so.
 func rebalanceMemberRoles(d *Daemon) error {
+	if d.clusterMembershipClosing {
+		return nil
+	}
+
 again:
 	address, nodes, err := cluster.Rebalance(d.State(), d.gateway)
 	if err != nil {

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -26,6 +26,7 @@ import (
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/osarch"
 	"github.com/lxc/lxd/shared/version"
@@ -2067,6 +2068,11 @@ func internalClusterRaftNodeDelete(d *Daemon, r *http.Request) response.Response
 	err := cluster.RemoveRaftNode(d.gateway, address)
 	if err != nil {
 		return response.SmartError(err)
+	}
+
+	err = rebalanceMemberRoles(d)
+	if err != nil && errors.Cause(err) != cluster.ErrNotLeader {
+		logger.Warn("Could not rebalance cluster member roles after raft member removal", log.Ctx{"err": err})
 	}
 
 	return response.SyncResponse(true, nil)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1746,7 +1746,7 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat) {
 	if d.lastNodeList == nil || d.lastNodeList.Version.APIExtensions != heartbeatData.Version.APIExtensions || d.lastNodeList.Version.Schema != heartbeatData.Version.Schema {
 		err := cluster.MaybeUpdate(d.State())
 		if err != nil {
-			logger.Errorf("Error updating: %v", err)
+			logger.Error("Error updating", log.Ctx{"err": err})
 			return
 		}
 	}
@@ -1788,7 +1788,7 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat) {
 
 			err := networkUpdateForkdnsServersTask(d.State(), heartbeatData)
 			if err != nil {
-				logger.Errorf("Error refreshing forkdns: %v", err)
+				logger.Error("Error refreshing forkdns", log.Ctx{"err": err})
 				return
 			}
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3666,13 +3666,13 @@ func imageSyncBetweenNodes(d *Daemon, project string, fingerprint string) error 
 
 	// If none of the nodes have the image, there's nothing to sync.
 	if len(syncNodeAddresses) == 0 {
-		logger.Debug("No members have image, nothing to do", log.Ctx{"fingerprint": fingerprint, "project": project})
+		logger.Info("No members have image, nothing to do", log.Ctx{"fingerprint": fingerprint, "project": project})
 		return nil
 	}
 
 	nodeCount := desiredSyncNodeCount - int64(len(syncNodeAddresses))
 	if nodeCount <= 0 {
-		logger.Debug("Sufficient members have image", log.Ctx{"fingerprint": fingerprint, "project": project, "desiredSyncCount": desiredSyncNodeCount, "syncedCount": len(syncNodeAddresses)})
+		logger.Info("Sufficient members have image", log.Ctx{"fingerprint": fingerprint, "project": project, "desiredSyncCount": desiredSyncNodeCount, "syncedCount": len(syncNodeAddresses)})
 		return nil
 	}
 
@@ -3701,7 +3701,7 @@ func imageSyncBetweenNodes(d *Daemon, project string, fingerprint string) error 
 		}
 
 		if len(addresses) <= 0 {
-			logger.Debug("All members have image", log.Ctx{"fingerprint": fingerprint, "project": project})
+			logger.Info("All members have image", log.Ctx{"fingerprint": fingerprint, "project": project})
 			return nil
 		}
 


### PR DESCRIPTION
This fixes an issue when a raft member was removed that didn't immediately trigger a role rebalance causing out of date role info in the local raft_nodes table.

Also moves to contextual logging for some cluster related sections.