### PR TITLE
Cluster: Fix heartbeatInterval()

### DIFF
--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -219,7 +219,7 @@ func HeartbeatTask(gateway *Gateway) (task.Func, task.Schedule) {
 func (g *Gateway) heartbeatInterval() time.Duration {
 	threshold := g.HeartbeatOfflineThreshold
 	if threshold <= 0 {
-		threshold = db.DefaultOfflineThreshold
+		threshold = time.Duration(db.DefaultOfflineThreshold) * time.Second
 	}
 
 	return threshold / 2


### PR DESCRIPTION
To return db.DefaultOfflineThreshold as time.Duration if g.HeartbeatOfflineThreshold not set.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>