### PR TITLE
lxd/instance/qemu: Support for security.devlxd default (true) value

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5334,7 +5334,7 @@ func (d *qemu) devlxdEventSend(eventType string, eventMessage interface{}) error
 
 func (d *qemu) writeInstanceData() error {
 	// Only write instance-data file if security.devlxd is true.
-	if !shared.IsTrue(d.expandedConfig["security.devlxd"]) {
+	if !(d.expandedConfig["security.devlxd"] == "" || shared.IsTrue(d.expandedConfig["security.devlxd"])) {
 		return nil
 	}
 


### PR DESCRIPTION
`writeInstanceData` in `driver_qemu.go` doesn't respect empty security.devlxd value which is by default true. This is fix for that.

Signed-off-by: Piotr Resztak <piotr.resztak@gmail.com>