### PR TITLE
doc/environment: Documents LXD_CONF and LXD_GLOBAL_CONF env vars

### DIFF
--- a/doc/environment.md
+++ b/doc/environment.md
@@ -19,6 +19,8 @@ Name                            | Description
 :---                            | :----
 `EDITOR`                        | What text editor to use
 `VISUAL`                        | What text editor to use (if `EDITOR` isn't set)
+`LXD_CONF`                      | Path to the LXC configuration directory
+`LXD_GLOBAL_CONF`               | Path to the global LXC configuration directory
 
 ## Server environment variable
 Name                            | Description


### PR DESCRIPTION
There is no information in environment section of the documentation about LXD_CONF and LXD_GLOBAL_CONF environment variables. This PR fixes this.

Signed-off-by: Piotr Resztak <piotr.resztak@gmail.com>