### PR TITLE
Network: Prevent using interface with global unicast IPs for physical network and OVN physical uplink

### DIFF
--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -36,7 +36,7 @@ func NetworkSetDevMTU(devName string, mtu uint32) error {
 	// Only try and change the MTU if the requested mac is different to current one.
 	if curMTU != mtu {
 		link := &ip.Link{Name: devName}
-		err := link.SetMtu(fmt.Sprintf("%d", mtu))
+		err := link.SetMTU(fmt.Sprintf("%d", mtu))
 		if err != nil {
 			return err
 		}

--- a/lxd/device/infiniband_physical.go
+++ b/lxd/device/infiniband_physical.go
@@ -3,10 +3,12 @@ package device
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
-	"github.com/lxc/lxd/lxd/network"
+	"github.com/lxc/lxd/lxd/ip"
 	"github.com/lxc/lxd/lxd/resources"
 	"github.com/lxc/lxd/shared"
 )
@@ -98,9 +100,10 @@ func (d *infinibandPhysical) Start() (*deviceConfig.RunConfig, error) {
 
 	// Set the MTU.
 	if d.config["mtu"] != "" {
-		err = network.InterfaceSetMTU(saveData["host_name"], d.config["mtu"])
+		link := &ip.Link{Name: saveData["host_name"]}
+		err := link.SetMTU(d.config["mtu"])
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "Failed setting MTU %q on %q", d.config["mtu"], saveData["host_name"])
 		}
 	}
 

--- a/lxd/device/infiniband_sriov.go
+++ b/lxd/device/infiniband_sriov.go
@@ -3,9 +3,12 @@ package device
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/lxd/ip"
 	"github.com/lxc/lxd/lxd/network"
 	"github.com/lxc/lxd/lxd/resources"
 	"github.com/lxc/lxd/shared"
@@ -120,9 +123,10 @@ func (d *infinibandSRIOV) Start() (*deviceConfig.RunConfig, error) {
 
 	// Set the MTU.
 	if d.config["mtu"] != "" {
-		err = network.InterfaceSetMTU(saveData["host_name"], d.config["mtu"])
+		link := &ip.Link{Name: saveData["host_name"]}
+		err := link.SetMTU(d.config["mtu"])
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "Failed setting MTU %q on %q", d.config["mtu"], saveData["host_name"])
 		}
 	}
 

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -184,9 +184,10 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 
 	// Set the MTU.
 	if d.config["mtu"] != "" {
-		err = network.InterfaceSetMTU(saveData["host_name"], d.config["mtu"])
+		link := &ip.Link{Name: saveData["host_name"]}
+		err := link.SetMTU(d.config["mtu"])
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "Failed setting MTU %q on %q", d.config["mtu"], saveData["host_name"])
 		}
 	}
 

--- a/lxd/device/nic_physical.go
+++ b/lxd/device/nic_physical.go
@@ -129,9 +129,10 @@ func (d *nicPhysical) Start() (*deviceConfig.RunConfig, error) {
 
 		// Set the MTU.
 		if d.config["mtu"] != "" {
-			err = network.InterfaceSetMTU(saveData["host_name"], d.config["mtu"])
+			link := &ip.Link{Name: saveData["host_name"]}
+			err := link.SetMTU(d.config["mtu"])
 			if err != nil {
-				return nil, err
+				return nil, errors.Wrapf(err, "Failed setting MTU %q on %q", d.config["mtu"], saveData["host_name"])
 			}
 		}
 	} else if d.inst.Type() == instancetype.VM {

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -164,9 +164,10 @@ func (d *nicSRIOV) Start() (*deviceConfig.RunConfig, error) {
 
 		// Set the MTU.
 		if d.config["mtu"] != "" {
-			err = network.InterfaceSetMTU(saveData["host_name"], d.config["mtu"])
+			link := &ip.Link{Name: saveData["host_name"]}
+			err := link.SetMTU(d.config["mtu"])
 			if err != nil {
-				return nil, err
+				return nil, errors.Wrapf(err, "Failed setting MTU %q on %q", d.config["mtu"], saveData["host_name"])
 			}
 		}
 

--- a/lxd/ip/link.go
+++ b/lxd/ip/link.go
@@ -7,7 +7,7 @@ import (
 // Link represents base arguments for link device
 type Link struct {
 	Name   string
-	Mtu    string
+	MTU    string
 	Parent string
 }
 
@@ -17,8 +17,8 @@ func (l *Link) args(linkType string) []string {
 	if l.Parent != "" {
 		result = append(result, "link", l.Parent)
 	}
-	if l.Mtu != "" {
-		result = append(result, "mtu", l.Mtu)
+	if l.MTU != "" {
+		result = append(result, "mtu", l.MTU)
 	}
 	result = append(result, "type", linkType)
 	return result

--- a/lxd/ip/link.go
+++ b/lxd/ip/link.go
@@ -54,8 +54,8 @@ func (l *Link) SetDown() error {
 	return nil
 }
 
-// SetMtu sets the mtu of the link device
-func (l *Link) SetMtu(mtu string) error {
+// SetMTU sets the MTU of the link device
+func (l *Link) SetMTU(mtu string) error {
 	_, err := shared.RunCommand("ip", "link", "set", "dev", l.Name, "mtu", mtu)
 	if err != nil {
 		return err

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -645,7 +645,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 	// Attempt to add a dummy device to the bridge to force the MTU.
 	if mtu != "" && n.config["bridge.driver"] != "openvswitch" {
 		dummy := &ip.Dummy{
-			Link: ip.Link{Name: fmt.Sprintf("%s-mtu", n.name), Mtu: mtu},
+			Link: ip.Link{Name: fmt.Sprintf("%s-mtu", n.name), MTU: mtu},
 		}
 		err = dummy.Add()
 		if err == nil {
@@ -662,7 +662,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		mtu = "1500"
 	}
 
-	err = bridgeLink.SetMtu(mtu)
+	err = bridgeLink.SetMTU(mtu)
 	if err != nil {
 		return err
 	}
@@ -1184,13 +1184,13 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 				mtu = fanMtu
 				if n.config["bridge.driver"] != "openvswitch" {
 					mtuLink := &ip.Link{Name: fmt.Sprintf("%s-mtu", n.name)}
-					err = mtuLink.SetMtu(mtu)
+					err = mtuLink.SetMTU(mtu)
 					if err != nil {
 						return err
 					}
 				}
 
-				err = bridgeLink.SetMtu(mtu)
+				err = bridgeLink.SetMTU(mtu)
 				if err != nil {
 					return err
 				}
@@ -1277,7 +1277,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 				return err
 			}
 
-			err = vxlan.SetMtu(mtu)
+			err = vxlan.SetMTU(mtu)
 			if err != nil {
 				return err
 			}
@@ -1413,7 +1413,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		}
 
 		tunLink := &ip.Link{Name: tunName}
-		err = tunLink.SetMtu(mtu)
+		err = tunLink.SetMTU(mtu)
 		if err != nil {
 			return err
 		}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -931,14 +931,16 @@ func (n *ovn) startUplinkPortBridgeNative(uplinkNet Network, bridgeDevice string
 	// Ensure that the veth interfaces inherit the uplink bridge's MTU (which the OVS bridge also inherits).
 	uplinkNetConfig := uplinkNet.Config()
 	if uplinkNetConfig["bridge.mtu"] != "" {
-		err := InterfaceSetMTU(vars.uplinkEnd, uplinkNetConfig["bridge.mtu"])
+		uplinkEndLink := &ip.Link{Name: vars.uplinkEnd}
+		err := uplinkEndLink.SetMTU(uplinkNetConfig["bridge.mtu"])
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "Failed setting MTU %q on %q", uplinkNetConfig["bridge.mtu"], uplinkEndLink.Name)
 		}
 
-		err = InterfaceSetMTU(vars.ovsEnd, uplinkNetConfig["bridge.mtu"])
+		ovsEndLink := &ip.Link{Name: vars.ovsEnd}
+		err = ovsEndLink.SetMTU(uplinkNetConfig["bridge.mtu"])
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "Failed setting MTU %q on %q", uplinkNetConfig["bridge.mtu"], ovsEndLink.Name)
 		}
 	}
 

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -162,6 +162,16 @@ func (n *physical) Start() error {
 		revert.Add(func() { InterfaceRemove(hostName) })
 	}
 
+	// Check no global unicast IPs defined on parent, as that may indicate it is in use by another application.
+	addresses, _, err := InterfaceStatus(hostName)
+	if err != nil {
+		return errors.Wrapf(err, "Failed getting interface status for %q", hostName)
+	}
+
+	if len(addresses) > 0 {
+		return fmt.Errorf("Cannot start network as parent interface %q has one or more IP addresses configured on it", hostName)
+	}
+
 	// Set the MTU.
 	if n.config["mtu"] != "" {
 		phyLink := &ip.Link{Name: hostName}

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -1152,19 +1152,6 @@ func InterfaceExists(nic string) bool {
 	return false
 }
 
-// InterfaceSetMTU sets the MTU of a network interface.
-func InterfaceSetMTU(nic string, mtu string) error {
-	if mtu != "" {
-		link := &ip.Link{Name: nic}
-		err := link.SetMtu(mtu)
-		if err != nil {
-			return errors.Wrapf(err, "Failed setting MTU %q on %q", mtu, nic)
-		}
-	}
-
-	return nil
-}
-
 // SubnetContains returns true if outerSubnet contains innerSubnet.
 func SubnetContains(outerSubnet *net.IPNet, innerSubnet *net.IPNet) bool {
 	if outerSubnet == nil || innerSubnet == nil {


### PR DESCRIPTION
Also cleans up "Mtu" to "MTU" in `ip` package, and removes unnecessary `InterfaceSetMTU` function.