### PR TITLE
VM: Don't set multifunction=off as this upsets ccw driver

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2706,8 +2706,6 @@ func (d *qemu) addNetDevConfig(sb *strings.Builder, cpuCount int, bus *qemuBus, 
 
 	if multi {
 		qemuDev["multifunction"] = "on"
-	} else {
-		qemuDev["multifunction"] = "off"
 	}
 
 	if qemuDev["driver"] != "" {


### PR DESCRIPTION
This should restore the old functionality, that only wrote `multifunction` to config if enabled, otherwise it defaults to off.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>