### PR TITLE
VM: Workaround QEMU bug to restore boot.priority support

### DIFF
--- a/lxc/config.go
+++ b/lxc/config.go
@@ -253,7 +253,7 @@ func (c *cmdConfigEdit) Run(cmd *cobra.Command, args []string) error {
 			// Respawn the editor
 			if err != nil {
 				fmt.Fprintf(os.Stderr, i18n.G("Config parsing error: %s")+"\n", err)
-				fmt.Println(i18n.G("Press enter to start the editor again"))
+				fmt.Println(i18n.G("Press enter to open the editor again or ctrl+c to abort change"))
 
 				_, err := os.Stdin.Read(make([]byte, 1))
 				if err != nil {
@@ -326,7 +326,7 @@ func (c *cmdConfigEdit) Run(cmd *cobra.Command, args []string) error {
 		// Respawn the editor
 		if err != nil {
 			fmt.Fprintf(os.Stderr, i18n.G("Config parsing error: %s")+"\n", err)
-			fmt.Println(i18n.G("Press enter to start the editor again"))
+			fmt.Println(i18n.G("Press enter to open the editor again or ctrl+c to abort change"))
 
 			_, err := os.Stdin.Read(make([]byte, 1))
 			if err != nil {

--- a/lxc/config_metadata.go
+++ b/lxc/config_metadata.go
@@ -140,7 +140,7 @@ func (c *cmdConfigMetadataEdit) Run(cmd *cobra.Command, args []string) error {
 		// Respawn the editor
 		if err != nil {
 			fmt.Fprintf(os.Stderr, i18n.G("Config parsing error: %s")+"\n", err)
-			fmt.Println(i18n.G("Press enter to start the editor again"))
+			fmt.Println(i18n.G("Press enter to open the editor again or ctrl+c to abort change"))
 
 			_, err := os.Stdin.Read(make([]byte, 1))
 			if err != nil {

--- a/lxc/config_template.go
+++ b/lxc/config_template.go
@@ -200,7 +200,7 @@ func (c *cmdConfigTemplateEdit) Run(cmd *cobra.Command, args []string) error {
 		// Respawn the editor
 		if err != nil {
 			fmt.Fprintf(os.Stderr, i18n.G("Error updating template file: %s")+"\n", err)
-			fmt.Println(i18n.G("Press enter to start the editor again"))
+			fmt.Println(i18n.G("Press enter to open the editor again or ctrl+c to abort change"))
 
 			_, err := os.Stdin.Read(make([]byte, 1))
 			if err != nil {

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -429,7 +429,7 @@ func (c *cmdImageEdit) Run(cmd *cobra.Command, args []string) error {
 		// Respawn the editor
 		if err != nil {
 			fmt.Fprintf(os.Stderr, i18n.G("Config parsing error: %s")+"\n", err)
-			fmt.Println(i18n.G("Press enter to start the editor again"))
+			fmt.Println(i18n.G("Press enter to open the editor again or ctrl+c to abort change"))
 
 			_, err := os.Stdin.Read(make([]byte, 1))
 			if err != nil {

--- a/lxd/instance/drivers/qmp/commands.go
+++ b/lxd/instance/drivers/qmp/commands.go
@@ -274,3 +274,13 @@ func (m *Monitor) AddNIC(netDev map[string]interface{}, device map[string]string
 
 	return nil
 }
+
+// Reset VM.
+func (m *Monitor) Reset() error {
+	err := m.run("system_reset", "", nil)
+	if err != nil {
+		return errors.Wrapf(err, "Failed resetting")
+	}
+
+	return nil
+}

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -2992,15 +2992,12 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -2669,15 +2669,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2842,15 +2842,12 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -3071,17 +3071,14 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
-msgstr "Appuyer sur Entrée pour lancer à nouveau l'éditeur"
 
 #: lxc/monitor.go:46
 msgid "Pretty rendering"
@@ -5673,6 +5670,9 @@ msgstr ""
 #: lxc/image.go:1079
 msgid "yes"
 msgstr "oui"
+
+#~ msgid "Press enter to start the editor again"
+#~ msgstr "Appuyer sur Entrée pour lancer à nouveau l'éditeur"
 
 #~ msgid "default"
 #~ msgstr "par défaut"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2836,15 +2836,12 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: 2021-02-02 15:21+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -3072,17 +3072,14 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "再度エディタを開くためには Enter キーを押します"
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
-msgstr "再度エディタを起動するには Enter キーを押します"
 
 #: lxc/monitor.go:46
 msgid "Pretty rendering"
@@ -5238,6 +5235,9 @@ msgstr "y"
 #: lxc/image.go:1079
 msgid "yes"
 msgstr "yes"
+
+#~ msgid "Press enter to start the editor again"
+#~ msgstr "再度エディタを起動するには Enter キーを押します"
 
 #~ msgid "default"
 #~ msgstr "default"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2021-05-10 13:40+0100\n"
+        "POT-Creation-Date: 2021-05-18 10:50+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2488,12 +2488,8 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660 lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310 lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143 lxc/config_template.go:203 lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660 lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310 lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
-msgstr  ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143 lxc/config_template.go:203 lxc/image.go:432
-msgid   "Press enter to start the editor again"
 msgstr  ""
 
 #: lxc/monitor.go:46

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -2796,15 +2796,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2814,15 +2814,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -2886,15 +2886,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: 2020-10-08 08:16+0000\n"
 "Last-Translator: Artem <KovalevArtem.ru@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2888,15 +2888,12 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: 2020-11-05 02:45+0000\n"
 "Last-Translator: wdggg <wdggg7@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -2712,15 +2712,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-10 13:40+0100\n"
+"POT-Creation-Date: 2021-05-18 10:50+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2658,15 +2658,12 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config_trust.go:214 lxc/network.go:660
+#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/config_metadata.go:143 lxc/config_template.go:203
+#: lxc/config_trust.go:214 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
 #: lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid "Press enter to open the editor again or ctrl+c to abort change"
-msgstr ""
-
-#: lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143
-#: lxc/config_template.go:203 lxc/image.go:432
-msgid "Press enter to start the editor again"
 msgstr ""
 
 #: lxc/monitor.go:46


### PR DESCRIPTION
As part of our work to support QEMU 6.0, because support for the config file has been removed, we are now switching to use QMP to add devices to the VM. However due to a bug in QEMU devices added via QMP didn't have their `bootindex` setting respected (which broke PXE boot for NICs) unless we initiated a QMP `system_reset` command after adding the devices but before the emulation was started with the `cont` command.

However initiating a `system_reset` command caused us more issues because we use the `-no-reboot` flag (so that LXD can be in control of guest initiated reboots) which then caused the QEMU process to exit. 

Instead we have now removed the use of the `-no-reboot` flag and now handle the guest initiated `RESET` events from QMP to trigger a normal LXD controlled restart process. This then allowed us to issue the `system_reset` command at VM start to allow QMP added devices to have their `bootindex` settings respected.