### PR TITLE
Cluster: Fix join tokens

### DIFF
--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -679,8 +679,8 @@ func (c *cmdClusterListTokens) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf(i18n.G("LXD server isn't part of a cluster"))
 	}
 
-	// Get the cluster member join tokens.
-	ops, err := resource.server.GetOperations()
+	// Get the cluster member join tokens. Use default project as join tokens are created in default project.
+	ops, err := resource.server.UseProject("default").GetOperations()
 	if err != nil {
 		return err
 	}

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -417,6 +417,7 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 			if v.Project() != "" && v.Project() != projectName {
 				continue
 			}
+
 			status := strings.ToLower(v.Status().String())
 			_, ok := body[status]
 			if !ok {
@@ -440,6 +441,7 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 			if v.Project() != "" && v.Project() != projectName {
 				continue
 			}
+
 			status := strings.ToLower(v.Status().String())
 			_, ok := body[status]
 			if !ok {

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -549,7 +549,8 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Merge with existing data
-		for _, op := range ops {
+		for _, o := range ops {
+			op := o // Local var for pointer.
 			status := strings.ToLower(op.Status)
 
 			_, ok := md[status]
@@ -681,7 +682,9 @@ func operationsGetByType(d *Daemon, projectName string, opType db.OperationType)
 			continue
 		}
 
-		for _, op := range remoteOps {
+		for _, o := range remoteOps {
+			op := o // Local var for pointer.
+
 			// Exclude remote operations that don't have the desired type.
 			if memberOps[memberAddress][op.ID].Type != opType {
 				continue


### PR DESCRIPTION
When the joining member was requesting join to a member that didn't have the local join-token operation, the method used for iterating the remote result sets was incorrect and causing the last operation to be referenced as all items in the remote list, causing joining to fail.