### PR TITLE
Cluster: Join token improvements

### DIFF
--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -340,7 +340,7 @@ func clusterMemberJoinTokenValid(d *Daemon, projectName string, joinToken *api.C
 		// Token is single-use, so cancel it now.
 		err = operationCancel(d, projectName, foundOp)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Failed to cancel operation")
+			return nil, errors.Wrapf(err, "Failed to cancel operation %q", foundOp.ID)
 		}
 
 		return foundOp, nil

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2305,7 +2305,7 @@ func imageValidSecret(d *Daemon, projectName string, fingerprint string, secret 
 			// Token is single-use, so cancel it now.
 			err = operationCancel(d, projectName, op)
 			if err != nil {
-				return nil, errors.Wrapf(err, "Failed to cancel operation")
+				return nil, errors.Wrapf(err, "Failed to cancel operation %q", op.ID)
 			}
 
 			return op, nil

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -173,6 +173,8 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer) error
 					return fmt.Errorf("Server name does not match the one specified in join token")
 				}
 
+				// Attempt to find a working cluster member to use for joining by retrieving the
+				// cluster certificate from each address in the join token until we succeed.
 				for _, clusterAddress := range joinToken.Addresses {
 					// Cluster URL
 					_, _, err := net.SplitHostPort(clusterAddress)
@@ -194,6 +196,8 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer) error
 					}
 
 					config.Cluster.ClusterCertificate = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
+
+					break // We've found a working cluster member.
 				}
 
 				if config.Cluster.ClusterCertificate == "" {

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/cancel"
+	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/version"
 )
@@ -324,7 +325,7 @@ func (op *Operation) Cancel() (chan error, error) {
 				op.lock.Unlock()
 				chanCancel <- err
 
-				logger.Debugf("Failed to cancel %s Operation: %s: %s", op.class.String(), op.id, err)
+				logger.Debug("Failed to cancel operation", log.Ctx{"operation": op.id, "class": op.class.String(), "err": err})
 				_, md, _ := op.Render()
 
 				op.lock.Lock()
@@ -340,7 +341,7 @@ func (op *Operation) Cancel() (chan error, error) {
 			op.done()
 			chanCancel <- nil
 
-			logger.Debugf("Cancelled %s Operation: %s", op.class.String(), op.id)
+			logger.Debug("Cancelled operation", log.Ctx{"operation": op.ID(), "class": op.class.String()})
 			_, md, _ := op.Render()
 
 			op.lock.Lock()
@@ -350,7 +351,7 @@ func (op *Operation) Cancel() (chan error, error) {
 		}(op, oldStatus, chanCancel)
 	}
 
-	logger.Debugf("Cancelling %s Operation: %s", op.class.String(), op.id)
+	logger.Debug("Cancelling operation", log.Ctx{"operation": op.ID(), "class": op.class.String()})
 	_, md, _ := op.Render()
 	op.sendEvent(md)
 
@@ -369,7 +370,7 @@ func (op *Operation) Cancel() (chan error, error) {
 		chanCancel <- nil
 	}
 
-	logger.Debugf("Cancelled %s Operation: %s", op.class.String(), op.id)
+	logger.Debug("Cancelled operation", log.Ctx{"operation": op.ID(), "class": op.class.String()})
 	_, md, _ = op.Render()
 
 	op.lock.Lock()


### PR DESCRIPTION
- Don't attempt to connect all cluster members in join token to get cluster certificate, stop at first successful one.
- Delete any existing join tokens for requested new member name when adding join token - to ensure we only ever have 1 active join token per potential new member.
- Add some structured logging.