### PR TITLE
Network: Check if dnsmasq has prematurely exited during startup and log an error if so

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1229,7 +1230,7 @@ func (d *qemu) Start(stateful bool) error {
 		return err
 	}
 
-	_, err = p.Wait()
+	_, err = p.Wait(context.Background())
 	if err != nil {
 		stderr, _ := ioutil.ReadFile(d.EarlyLogFilePath())
 		err = errors.Wrapf(err, "Failed to run: %s: %s", strings.Join(p.Args, " "), string(stderr))

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
@@ -11,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -1519,6 +1521,16 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		if err != nil {
 			return fmt.Errorf("Failed to run: %s %s: %v", command, strings.Join(dnsmasqCmd, " "), err)
 		}
+
+		// Check dnsmasq started OK.
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Millisecond*time.Duration(500)))
+		_, err = p.Wait(ctx)
+		if errors.Cause(err) != context.DeadlineExceeded {
+			// Just log an error if dnsmasq has exited, and still proceed with normal setup so we
+			// don't leave the firewall in an inconsistent state.
+			n.logger.Error("The dnsmasq process exited prematurely", log.Ctx{"err": err})
+		}
+		cancel()
 
 		err = p.Save(shared.VarPath("networks", n.name, "dnsmasq.pid"))
 		if err != nil {

--- a/shared/subprocess/bgpm_test.go
+++ b/shared/subprocess/bgpm_test.go
@@ -4,6 +4,7 @@
 package subprocess
 
 import (
+	"context"
 	"io"
 	"os"
 	"strings"
@@ -38,7 +39,7 @@ func TestSignalHandling(t *testing.T) {
 		t.Error("Unable to Signal process: ", err)
 	}
 
-	ecode, err := p.Wait()
+	ecode, err := p.Wait(context.Background())
 	if err == nil {
 		t.Error("Did not exit with an error")
 	} else if ecode != 1 {
@@ -119,7 +120,7 @@ func TestStopRestart(t *testing.T) {
 		t.Error("Failed to restart process: ", err)
 	}
 
-	exitcode, err := p.Wait()
+	exitcode, err := p.Wait(context.Background())
 	if err != nil {
 		t.Error("Could not wait for process: ", err)
 	} else if exitcode != 0 {
@@ -148,7 +149,7 @@ func TestProcessStartWaitExit(t *testing.T) {
 		t.Error("Failed to start process: ", err)
 	}
 
-	ecode, err := p.Wait()
+	ecode, err := p.Wait(context.Background())
 	if err == nil {
 		t.Error("Did not exit with an error")
 	} else if ecode != 1 {

--- a/shared/subprocess/proc.go
+++ b/shared/subprocess/proc.go
@@ -181,7 +181,7 @@ func (p *Process) start(fds []*os.File) error {
 		exitcode := int64(procstate.ExitCode())
 		p.exitCode = exitcode
 		if p.exitCode != 0 {
-			p.exitErr = fmt.Errorf("Process exited with a non-zero value")
+			p.exitErr = fmt.Errorf("Process exited with non-zero value %d", p.exitCode)
 		}
 		close(p.chExit)
 	}()

--- a/shared/subprocess/proc.go
+++ b/shared/subprocess/proc.go
@@ -4,6 +4,7 @@
 package subprocess
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -254,11 +255,15 @@ func (p *Process) Signal(signal int64) error {
 }
 
 // Wait will wait for the given process object exit code
-func (p *Process) Wait() (int64, error) {
+func (p *Process) Wait(ctx context.Context) (int64, error) {
 	if !p.hasMonitor {
 		return -1, fmt.Errorf("Unable to wait on process we didn't spawn")
 	}
 
-	<-p.chExit
-	return p.exitCode, p.exitErr
+	select {
+	case <-p.chExit:
+		return p.exitCode, p.exitErr
+	case <-ctx.Done():
+		return -1, ctx.Err()
+	}
 }


### PR DESCRIPTION
Currently LXD's logs won't show if dnsmasq started and then quickly exits due to conflicting socket listeners.

This adds a 500ms wait and then checks for dnsmasq process exiting, and if it does, then logs an error.

Inspired by https://discuss.linuxcontainers.org/t/dhcp-stoped-working/11114