### PR TITLE
VM: Fix readonly disk shares

### DIFF
--- a/lxd-agent/main_agent.go
+++ b/lxd-agent/main_agent.go
@@ -98,6 +98,7 @@ func (c *cmdAgent) Run(cmd *cobra.Command, args []string) error {
 			}
 		}
 
+		logger.Info("Rebooting")
 		shared.RunCommand("reboot")
 
 		// Wait up to 5min for the reboot to actually happen, if it doesn't, then move on to allowing connections.

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -568,18 +568,17 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				DevName: d.name,
 			}
 
+			readonly := shared.IsTrue(d.config["readonly"])
+			if readonly {
+				mount.Opts = append(mount.Opts, "ro")
+			}
+
 			// If the source being added is a directory, then we will be using lxd-agent directory
 			// sharing to mount the directory inside the VM, as such we need to indicate to the VM the
 			// target path to mount to.
 			if shared.IsDir(srcPath) {
 				mount.TargetPath = d.config["path"]
 				mount.FSType = "9p"
-
-				readonly := shared.IsTrue(d.config["readonly"])
-
-				if readonly {
-					mount.Opts = append(mount.Opts, "ro")
-				}
 
 				// Start virtfs-proxy-helper for 9p share.
 				err = func() error {

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -568,16 +568,21 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				DevName: d.name,
 			}
 
-			// If the source being added is a directory, then we will be using 9p directory sharing to mount
-			// the directory inside the VM, as such we need to indicate to the VM the target path to mount to.
+			// If the source being added is a directory, then we will be using lxd-agent directory
+			// sharing to mount the directory inside the VM, as such we need to indicate to the VM the
+			// target path to mount to.
 			if shared.IsDir(srcPath) {
 				mount.TargetPath = d.config["path"]
 				mount.FSType = "9p"
 
-				if shared.IsTrue(d.config["readonly"]) {
-					// Don't use proxy in readonly mode.
+				readonly := shared.IsTrue(d.config["readonly"])
+
+				if readonly {
 					mount.Opts = append(mount.Opts, "ro")
-				} else {
+				}
+
+				// Start virtfs-proxy-helper for 9p share.
+				err = func() error {
 					sockPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("%s.sock", d.name))
 					mount.DevPath = sockPath // Use socket path as dev path so qemu connects to proxy.
 
@@ -593,7 +598,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					}
 
 					if cmd == "" {
-						return nil, fmt.Errorf("Required binary 'virtfs-proxy-helper' couldn't be found")
+						return fmt.Errorf(`Required binary "virtfs-proxy-helper" couldn't be found`)
 					}
 
 					// Start the virtfs-proxy-helper process in non-daemon mode and as root so that
@@ -601,12 +606,12 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					// directories that process cannot access.
 					proc, err := subprocess.NewProcess(cmd, []string{"-n", "-u", "0", "-g", "0", "-s", sockPath, "-p", srcPath}, "", "")
 					if err != nil {
-						return nil, err
+						return err
 					}
 
 					err = proc.Start()
 					if err != nil {
-						return nil, errors.Wrapf(err, "Failed to start virtfs-proxy-helper for device %q", d.name)
+						return errors.Wrapf(err, "Failed to start virtfs-proxy-helper")
 					}
 
 					revert.Add(func() { proc.Stop() })
@@ -614,7 +619,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					pidPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("%s.pid", d.name))
 					err = proc.Save(pidPath)
 					if err != nil {
-						return nil, errors.Wrapf(err, "Failed to save virtfs-proxy-helper state for device %q", d.name)
+						return errors.Wrapf(err, "Failed to save virtfs-proxy-helper state")
 					}
 
 					// Wait for socket file to exist (as otherwise qemu can race the creation of this file).
@@ -625,37 +630,63 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 
 						time.Sleep(50 * time.Millisecond)
 					}
-				}
 
-				// Start virtiofsd as LXD prefers virtio-fs over 9p. The latter will only be used
-				// as a fallback.
-
-				// Create the socket in this directory instead of the devices directory. QEMU will otherwise
-				// fail with "Permission Denied" which is probably caused by qemu being called with --chroot.
-				sockPath := filepath.Join(d.inst.Path(), fmt.Sprintf("%s.sock", d.name))
-				logPath := filepath.Join(d.inst.LogPath(), fmt.Sprintf("disk.%s.log", d.name))
-
-				// Remove old socket if needed.
-				os.Remove(sockPath)
-
-				// Locate virtiofsd.
-				cmd, err := exec.LookPath("virtiofsd")
+					return nil
+				}()
 				if err != nil {
-					if shared.PathExists("/usr/lib/qemu/virtiofsd") {
-						cmd = "/usr/lib/qemu/virtiofsd"
-					}
+					return nil, errors.Wrapf(err, "Failed to setup virtfs-proxy-helper for device %q", d.name)
 				}
 
-				if d.inst.Architecture() == osarch.ARCH_64BIT_INTEL_X86 && !shared.IsTrue(d.inst.ExpandedConfig()["migration.stateful"]) && cmd != "" {
+				// Start virtiofsd for virtio-fs share. The lxd-agent prefers to use this over the
+				// virtfs-proxy-helper 9p share. The latter will only be used as a fallback.
+				err = func() error {
+					// virtiofsd doesn't support readonly mode.
+					if readonly {
+						d.logger.Warn("Unable to use virtio-fs for device, using 9p as a fallback: readonly devices unsupported", log.Ctx{"device": d.name})
+						return nil
+					}
+
+					// Create the socket in this directory instead of the devices directory.
+					// QEMU will otherwise fail with "Permission Denied" which is probably
+					// caused by qemu being called with --chroot.
+					sockPath := filepath.Join(d.inst.Path(), fmt.Sprintf("%s.sock", d.name))
+					logPath := filepath.Join(d.inst.LogPath(), fmt.Sprintf("disk.%s.log", d.name))
+
+					// Remove old socket if needed.
+					os.Remove(sockPath)
+
+					// Locate virtiofsd.
+					cmd, err := exec.LookPath("virtiofsd")
+					if err != nil {
+						if shared.PathExists("/usr/lib/qemu/virtiofsd") {
+							cmd = "/usr/lib/qemu/virtiofsd"
+						}
+					}
+
+					if cmd == "" {
+						d.logger.Warn("Unable to use virtio-fs for device, using 9p as a fallback: virtiofsd missing", log.Ctx{"device": d.name})
+						return nil
+					}
+
+					if d.inst.Architecture() != osarch.ARCH_64BIT_INTEL_X86 {
+						d.logger.Warn("Unable to use virtio-fs for device, using 9p as a fallback: architecture unsupported", log.Ctx{"device": d.name})
+						return nil
+					}
+
+					if shared.IsTrue(d.inst.ExpandedConfig()["migration.stateful"]) {
+						d.logger.Warn("Unable to use virtio-fs for device, using 9p as a fallback: stateful migration unsupported", log.Ctx{"device": d.name})
+						return nil
+					}
+
 					// Start the virtiofsd process in non-daemon mode.
 					proc, err := subprocess.NewProcess(cmd, []string{fmt.Sprintf("--socket-path=%s", sockPath), "-o", fmt.Sprintf("source=%s", srcPath)}, logPath, logPath)
 					if err != nil {
-						return nil, err
+						return err
 					}
 
 					err = proc.Start()
 					if err != nil {
-						return nil, errors.Wrapf(err, "Failed to start virtiofsd for device %q", d.name)
+						return errors.Wrapf(err, "Failed to start virtiofsd")
 					}
 
 					revert.Add(func() { proc.Stop() })
@@ -663,7 +694,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					pidPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("virtio-fs.%s.pid", d.name))
 					err = proc.Save(pidPath)
 					if err != nil {
-						return nil, errors.Wrapf(err, "Failed to save virtiofsd state for device %q", d.name)
+						return errors.Wrapf(err, "Failed to save virtiofsd state")
 					}
 
 					// Wait for socket file to exist
@@ -676,10 +707,13 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					}
 
 					if !shared.PathExists(sockPath) {
-						return nil, fmt.Errorf("virtiofsd failed to bind socket within 10s")
+						return fmt.Errorf("virtiofsd failed to bind socket within 10s")
 					}
-				} else {
-					d.logger.Warn("Unable to use virtio-fs for device, using 9p as a fallback: virtiofsd missing", log.Ctx{"device": d.name})
+
+					return nil
+				}()
+				if err != nil {
+					return nil, errors.Wrapf(err, "Failed to setup virtiofsd for device %q", d.name)
 				}
 			}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2560,6 +2560,8 @@ func (d *qemu) addDriveConfig(sb *strings.Builder, bootIndexes map[string]int, d
 	cacheMode := "none" // Bypass host cache, use O_DIRECT semantics.
 	media := "disk"
 
+	readonly := shared.StringInSlice("ro", driveConf.Opts)
+
 	// If drive config indicates we need to use unsafe I/O then use it.
 	if shared.StringInSlice(qemuUnsafeIO, driveConf.Opts) {
 		d.logger.Warn("Using unsafe cache I/O", log.Ctx{"DevPath": driveConf.DevPath})
@@ -2602,6 +2604,7 @@ func (d *qemu) addDriveConfig(sb *strings.Builder, bootIndexes map[string]int, d
 		"aioMode":   aioMode,
 		"media":     media,
 		"shared":    driveConf.TargetPath != "/" && !strings.HasPrefix(driveConf.DevPath, "rbd:"),
+		"readonly":  readonly,
 	})
 }
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1677,27 +1677,29 @@ func (d *qemu) generateConfigShare() error {
 	}
 
 	// Add the VM agent.
-	path, err := exec.LookPath("lxd-agent")
+	lxdAgentSrcPath, err := exec.LookPath("lxd-agent")
 	if err != nil {
 		d.logger.Warn("lxd-agent not found, skipping its inclusion in the VM config drive", log.Ctx{"err": err})
 	} else {
 		// Install agent into config drive dir if found.
-		path, err = filepath.EvalSymlinks(path)
+		lxdAgentSrcPath, err = filepath.EvalSymlinks(lxdAgentSrcPath)
 		if err != nil {
 			return err
 		}
 
-		err = shared.FileCopy(path, filepath.Join(configDrivePath, "lxd-agent"))
+		lxdAgentInstallPath := filepath.Join(configDrivePath, "lxd-agent")
+		d.logger.Debug("Installing lxd-agent", log.Ctx{"srcPath": lxdAgentSrcPath, "installPath": lxdAgentInstallPath})
+		err = shared.FileCopy(lxdAgentSrcPath, lxdAgentInstallPath)
 		if err != nil {
 			return err
 		}
 
-		err = os.Chmod(filepath.Join(configDrivePath, "lxd-agent"), 0500)
+		err = os.Chmod(lxdAgentInstallPath, 0500)
 		if err != nil {
 			return err
 		}
 
-		err = os.Chown(filepath.Join(configDrivePath, "lxd-agent"), 0, 0)
+		err = os.Chown(lxdAgentInstallPath, 0, 0)
 		if err != nil {
 			return err
 		}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1421,13 +1421,19 @@ func (d *qemu) setupNvram() error {
 		srcOvmfFile = filepath.Join(d.ovmfPath(), "OVMF_VARS.ms.fd")
 	}
 
+	missingEFIFirmwareErr := fmt.Errorf("Required EFI firmware settings file missing %q", srcOvmfFile)
+
+	if !shared.PathExists(srcOvmfFile) {
+		return missingEFIFirmwareErr
+	}
+
 	srcOvmfFile, err = filepath.EvalSymlinks(srcOvmfFile)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "Failed resolving EFI firmware symlink %q", srcOvmfFile)
 	}
 
 	if !shared.PathExists(srcOvmfFile) {
-		return fmt.Errorf("Required EFI firmware settings file missing: %s", srcOvmfFile)
+		return missingEFIFirmwareErr
 	}
 
 	os.Remove(d.nvramPath())

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -434,6 +434,11 @@ media = "{{.media}}"
 {{if .shared -}}
 file.locking = "off"
 {{- end }}
+{{- if .readonly}}
+readonly = "on"
+{{- else}}
+readonly = "off"
+{{- end}}
 
 [device "dev-lxd_{{.devName}}"]
 {{- if eq .media "disk" }}

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -376,15 +376,12 @@ var qemuDriveDir = template.Must(template.New("qemuDriveDir").Parse(`
 # {{.devName}} drive ({{.protocol}})
 {{- if eq .protocol "9p" }}
 [fsdev "lxd_{{.devName}}"]
-{{- if .readonly}}
-readonly = "on"
-fsdriver = "local"
-security_model = "none"
-path = "{{.path}}"
-{{- else}}
-readonly = "off"
 fsdriver = "proxy"
 sock_fd = "{{.proxyFD}}"
+{{- if .readonly}}
+readonly = "on"
+{{- else}}
+readonly = "off"
 {{- end}}
 {{- else if eq .protocol "virtio-fs" }}
 [chardev "lxd_{{.devName}}"]


### PR DESCRIPTION
 - Use 9p virtfs-proxy-helper even when `readonly=true` (fixes #8809 by avoiding qemu apparmor profile).
 - Log why virtio-fs isn't being used - rather than a generic, and potentially inaccurate warning.
 - Don't use virtio-fs if disk device config has readonly=true (as doesn't appear to be supported). Fallback to 9p instead.
 - Improve lxd-agent startup process by waiting for `/dev/vsock` to appear and activating listener before setting up agent mounts. This avoid prematurely exiting (and getting systemd to restart lxd-agent) which was causing the virtiofs mount to be replaced (mounted over) by the fallback 9p mount.
 - Adds support for readonly block device disks (previously the `readonly` property was silently ignored).