### PR TITLE
VM: Deduplicate the virtiofsd start and stop logic and simplify disk apparmor rules

### DIFF
--- a/lxd/apparmor/instance.go
+++ b/lxd/apparmor/instance.go
@@ -24,6 +24,7 @@ type instance interface {
 	LogPath() string
 	Path() string
 	DevPaths() []string
+	DevicesPath() string
 }
 
 // InstanceProfileName returns the instance's AppArmor profile name.
@@ -187,6 +188,7 @@ func instanceProfile(state *state.State, inst instance) (string, error) {
 
 		err = qemuProfileTpl.Execute(sb, map[string]interface{}{
 			"externalDevPaths": externalDevPaths,
+			"devicesPath":      inst.DevicesPath(),
 			"exePath":          util.GetExecPath(),
 			"libraryPath":      strings.Split(os.Getenv("LD_LIBRARY_PATH"), ":"),
 			"logPath":          inst.LogPath(),

--- a/lxd/apparmor/instance.go
+++ b/lxd/apparmor/instance.go
@@ -167,9 +167,9 @@ func instanceProfile(state *state.State, inst instance) (string, error) {
 			return "", err
 		}
 
-		devPaths := inst.DevPaths()
-		for i := range devPaths {
-			devPaths[i], err = filepath.EvalSymlinks(devPaths[i])
+		externalDevPaths := inst.DevPaths()
+		for i := range externalDevPaths {
+			externalDevPaths[i], err = filepath.EvalSymlinks(externalDevPaths[i])
 			if err != nil {
 				return "", err
 			}
@@ -186,16 +186,16 @@ func instanceProfile(state *state.State, inst instance) (string, error) {
 		}
 
 		err = qemuProfileTpl.Execute(sb, map[string]interface{}{
-			"devPaths":    devPaths,
-			"exePath":     util.GetExecPath(),
-			"libraryPath": strings.Split(os.Getenv("LD_LIBRARY_PATH"), ":"),
-			"logPath":     inst.LogPath(),
-			"name":        InstanceProfileName(inst),
-			"path":        path,
-			"raw":         rawContent,
-			"rootPath":    rootPath,
-			"snap":        shared.InSnap(),
-			"ovmfPath":    ovmfPath,
+			"externalDevPaths": externalDevPaths,
+			"exePath":          util.GetExecPath(),
+			"libraryPath":      strings.Split(os.Getenv("LD_LIBRARY_PATH"), ":"),
+			"logPath":          inst.LogPath(),
+			"name":             InstanceProfileName(inst),
+			"path":             path,
+			"raw":              rawContent,
+			"rootPath":         rootPath,
+			"snap":             shared.InSnap(),
+			"ovmfPath":         ovmfPath,
 		})
 		if err != nil {
 			return "", err

--- a/lxd/apparmor/instance_qemu.go
+++ b/lxd/apparmor/instance_qemu.go
@@ -51,7 +51,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   {{ .devicesPath }}/** rwk,
 
   # Instance specific external device paths
-{{range $index, $element := .externalDevPaths}}
+{{- range $index, $element := .externalDevPaths}}
   {{$element}} rwk,
 {{- end }}
 

--- a/lxd/apparmor/instance_qemu.go
+++ b/lxd/apparmor/instance_qemu.go
@@ -48,6 +48,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   # Instance specific paths
   {{ .logPath }}/** rwk,
   {{ .path }}/** rwk,
+  {{ .devicesPath }}/** rwk,
 {{range $index, $element := .devPaths}}
   {{$element}} rwk,
 {{- end }}

--- a/lxd/apparmor/instance_qemu.go
+++ b/lxd/apparmor/instance_qemu.go
@@ -49,7 +49,9 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   {{ .logPath }}/** rwk,
   {{ .path }}/** rwk,
   {{ .devicesPath }}/** rwk,
-{{range $index, $element := .devPaths}}
+
+  # Instance specific external device paths
+{{range $index, $element := .externalDevPaths}}
   {{$element}} rwk,
 {{- end }}
 

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -29,7 +29,6 @@ import (
 	"github.com/lxc/lxd/shared/idmap"
 	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
-	"github.com/lxc/lxd/shared/osarch"
 	"github.com/lxc/lxd/shared/subprocess"
 	"github.com/lxc/lxd/shared/units"
 	"github.com/lxc/lxd/shared/validate"
@@ -675,62 +674,17 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					sockPath, pidPath := d.vmVirtiofsdPaths()
 					logPath := filepath.Join(d.inst.LogPath(), fmt.Sprintf("disk.%s.log", d.name))
 
-					// Remove old socket if needed.
-					os.Remove(sockPath)
-
-					// Locate virtiofsd.
-					cmd, err := exec.LookPath("virtiofsd")
+					err = DiskVMVirtiofsdStart(d.inst, sockPath, pidPath, logPath, srcPath)
 					if err != nil {
-						if shared.PathExists("/usr/lib/qemu/virtiofsd") {
-							cmd = "/usr/lib/qemu/virtiofsd"
+						var errUnsupported UnsupportedError
+						if errors.As(err, &errUnsupported) {
+							d.logger.Warn("Unable to use virtio-fs for device, using 9p as a fallback", log.Ctx{"err": errUnsupported})
+							return nil
 						}
-					}
 
-					if cmd == "" {
-						d.logger.Warn("Unable to use virtio-fs for device, using 9p as a fallback: virtiofsd missing", log.Ctx{"device": d.name})
-						return nil
-					}
-
-					if d.inst.Architecture() != osarch.ARCH_64BIT_INTEL_X86 {
-						d.logger.Warn("Unable to use virtio-fs for device, using 9p as a fallback: architecture unsupported", log.Ctx{"device": d.name})
-						return nil
-					}
-
-					if shared.IsTrue(d.inst.ExpandedConfig()["migration.stateful"]) {
-						d.logger.Warn("Unable to use virtio-fs for device, using 9p as a fallback: stateful migration unsupported", log.Ctx{"device": d.name})
-						return nil
-					}
-
-					// Start the virtiofsd process in non-daemon mode.
-					proc, err := subprocess.NewProcess(cmd, []string{fmt.Sprintf("--socket-path=%s", sockPath), "-o", fmt.Sprintf("source=%s", srcPath)}, logPath, logPath)
-					if err != nil {
 						return err
 					}
-
-					err = proc.Start()
-					if err != nil {
-						return errors.Wrapf(err, "Failed to start virtiofsd")
-					}
-
-					revert.Add(func() { proc.Stop() })
-
-					err = proc.Save(pidPath)
-					if err != nil {
-						return errors.Wrapf(err, "Failed to save virtiofsd state")
-					}
-
-					// Wait for socket file to exist
-					for i := 0; i < 200; i++ {
-						if shared.PathExists(sockPath) {
-							break
-						}
-
-						time.Sleep(50 * time.Millisecond)
-					}
-
-					if !shared.PathExists(sockPath) {
-						return fmt.Errorf("virtiofsd failed to bind socket within 10s")
-					}
+					revert.Add(func() { DiskVMVirtiofsdStop(sockPath, pidPath) })
 
 					// Add the socket path to the mount options to indicate to the qemu driver
 					// that this share is available.
@@ -1427,30 +1381,7 @@ func (d *disk) stopVM() (*deviceConfig.RunConfig, error) {
 	}
 
 	// Stop the virtiofsd process and clean up.
-	err = func() error {
-		sockPath, pidPath := d.vmVirtiofsdPaths()
-		if shared.PathExists(pidPath) {
-			proc, err := subprocess.ImportProcess(pidPath)
-			if err != nil {
-				return err
-			}
-
-			err = proc.Stop()
-			// The virtiofsd process will terminate automatically once the VM has stopped.
-			// We therefore should only return an error if it's still running and fails to stop.
-			if err != nil && err != subprocess.ErrNotRunning {
-				return err
-			}
-
-			// Remove PID file and socket file.
-			os.Remove(pidPath)
-		}
-
-		// Remove socket file.
-		os.Remove(sockPath)
-
-		return nil
-	}()
+	err = DiskVMVirtiofsdStop(d.vmVirtiofsdPaths())
 	if err != nil {
 		return &deviceConfig.RunConfig{}, errors.Wrapf(err, "Failed cleaning up virtiofsd")
 	}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -668,7 +668,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					// virtiofsd doesn't support readonly mode, so its important we don't
 					// expose the share as writable when the LXD device is set as readonly.
 					if readonly {
-						d.logger.Warn("Unable to use virtio-fs for device, using 9p as a fallback: readonly devices unsupported", log.Ctx{"device": d.name})
+						d.logger.Warn("Unable to use virtio-fs for device, using 9p as a fallback", log.Ctx{"err": "readonly devices unsupported"})
 						return nil
 					}
 

--- a/lxd/device/errors.go
+++ b/lxd/device/errors.go
@@ -4,8 +4,17 @@ import (
 	"fmt"
 )
 
+// UnsupportedError used for indicating the error is caused due to a lack of support.
+type UnsupportedError struct {
+	msg string
+}
+
+func (e UnsupportedError) Error() string {
+	return e.msg
+}
+
 // ErrUnsupportedDevType is the error that occurs when an unsupported device type is created.
-var ErrUnsupportedDevType = fmt.Errorf("Unsupported device type")
+var ErrUnsupportedDevType = UnsupportedError{msg: "Unsupported device type"}
 
 // ErrCannotUpdate is the error that occurs when a device cannot be updated.
 var ErrCannotUpdate = fmt.Errorf("Device does not support updates")

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3885,7 +3885,6 @@ func (d *qemu) removeUnixDevices() error {
 		return err
 	}
 
-	// Go through all the unix devices.
 	for _, f := range dents {
 		// Skip non-Unix devices.
 		if !strings.HasPrefix(f.Name(), "forkmknod.unix.") && !strings.HasPrefix(f.Name(), "unix.") && !strings.HasPrefix(f.Name(), "infiniband.unix.") {
@@ -3904,7 +3903,7 @@ func (d *qemu) removeUnixDevices() error {
 }
 
 func (d *qemu) removeDiskDevices() error {
-	// Check that we indeed have devices to remove.vm
+	// Check that we indeed have devices to remove.
 	if !shared.PathExists(d.DevicesPath()) {
 		return nil
 	}
@@ -3915,17 +3914,16 @@ func (d *qemu) removeDiskDevices() error {
 		return err
 	}
 
-	// Go through all the unix devices
 	for _, f := range dents {
 		// Skip non-disk devices
 		if !strings.HasPrefix(f.Name(), "disk.") {
 			continue
 		}
 
-		// Always try to unmount the host side
+		// Always try to unmount the host side.
 		_ = unix.Unmount(filepath.Join(d.DevicesPath(), f.Name()), unix.MNT_DETACH)
 
-		// Remove the entry
+		// Remove the entry.
 		diskPath := filepath.Join(d.DevicesPath(), f.Name())
 		err := os.Remove(diskPath)
 		if err != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2154,6 +2154,8 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 		return "", nil, err
 	}
 
+	// Always export the config directory as a 9p config drive, in case the host or VM guest doesn't support
+	// virtio-fs.
 	devBus, devAddr, multi = bus.allocate(busFunctionGroup9p)
 	err = qemuDriveConfig.Execute(sb, map[string]interface{}{
 		"bus":           bus.name,
@@ -2168,6 +2170,9 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 		return "", nil, err
 	}
 
+	// If virtiofsd is running for the config directory then export the config drive via virtio-fs.
+	// This is used by the lxd-agent in preference to 9p (due to its improved performance) and in scenarios
+	// where 9p isn't available in the VM guest OS.
 	sockPath, _ := d.configVirtiofsdPaths()
 	if shared.PathExists(sockPath) {
 		devBus, devAddr, multi = bus.allocate(busFunctionGroup9p)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -529,6 +529,14 @@ func (d *qemu) Freeze() error {
 	return nil
 }
 
+// configVirtiofsdPaths returns the path for the socket and PID file to use with config drive virtiofsd process.
+func (d *qemu) configVirtiofsdPaths() (string, string) {
+	sockPath := filepath.Join(d.LogPath(), "virtio-fs.config.sock")
+	pidPath := filepath.Join(d.LogPath(), "virtiofsd.pid")
+
+	return sockPath, pidPath
+}
+
 // onStop is run when the instance stops.
 func (d *qemu) onStop(target string) error {
 	var err error
@@ -555,12 +563,9 @@ func (d *qemu) onStop(target string) error {
 	os.Remove(d.monitorPath())
 	d.unmount()
 
-	pidPath := filepath.Join(d.LogPath(), "virtiofsd.pid")
-
-	proc, err := subprocess.ImportProcess(pidPath)
-	if err == nil {
-		proc.Stop()
-		os.Remove(pidPath)
+	err = device.DiskVMVirtiofsdStop(d.configVirtiofsdPaths())
+	if err != nil {
+		d.logger.Warn("Failed cleaning up virtiofsd", log.Ctx{"err": err})
 	}
 
 	// Record power state.
@@ -923,62 +928,22 @@ func (d *qemu) Start(stateful bool) error {
 		return err
 	}
 
-	// Setup virtiofsd for config path.
-	sockPath := filepath.Join(d.LogPath(), "virtio-fs.config.sock")
-
-	// Remove old socket if needed.
-	os.Remove(sockPath)
-
-	cmd, err := exec.LookPath("virtiofsd")
+	// Setup virtiofsd for config drive path.
+	// This is used by the lxd-agent in preference to 9p (due to its improved performance) and in scenarios
+	// where 9p isn't available in the VM guest OS.
+	sockPath, pidPath := d.configVirtiofsdPaths()
+	configSrcPath := filepath.Join(d.Path(), "config")
+	err = device.DiskVMVirtiofsdStart(d, sockPath, pidPath, "", configSrcPath)
 	if err != nil {
-		if shared.PathExists("/usr/lib/qemu/virtiofsd") {
-			cmd = "/usr/lib/qemu/virtiofsd"
+		var errUnsupported device.UnsupportedError
+		if errors.As(err, &errUnsupported) {
+			d.logger.Warn("Unable to use virtio-fs for config drive, using 9p as a fallback", log.Ctx{"err": errUnsupported})
+		} else {
+			op.Done(err)
+			return errors.Wrapf(err, "Failed to setup virtiofsd for config drive")
 		}
 	}
-
-	// Currently, virtiofs is broken on at least the ARM architecture.
-	// We therefore restrict virtiofs to 64BIT_INTEL_X86.
-	if d.Architecture() == osarch.ARCH_64BIT_INTEL_X86 && !shared.IsTrue(d.expandedConfig["migration.stateful"]) && cmd != "" {
-		// Start the virtiofsd process in non-daemon mode.
-		proc, err := subprocess.NewProcess(cmd, []string{fmt.Sprintf("--socket-path=%s", sockPath), "-o", fmt.Sprintf("source=%s", filepath.Join(d.Path(), "config"))}, "", "")
-		if err != nil {
-			op.Done(err)
-			return err
-		}
-
-		err = proc.Start()
-		if err != nil {
-			op.Done(err)
-			return err
-		}
-
-		revert.Add(func() { proc.Stop() })
-
-		pidPath := filepath.Join(d.LogPath(), "virtiofsd.pid")
-
-		err = proc.Save(pidPath)
-		if err != nil {
-			op.Done(err)
-			return err
-		}
-
-		// Wait for socket file to exist
-		for i := 0; i < 200; i++ {
-			if shared.PathExists(sockPath) {
-				break
-			}
-
-			time.Sleep(50 * time.Millisecond)
-		}
-
-		if !shared.PathExists(sockPath) {
-			err = fmt.Errorf("virtiofsd failed to bind socket within 10s")
-			op.Done(err)
-			return err
-		}
-	} else {
-		d.logger.Warn("Unable to use virtio-fs for config drive, using 9p as a fallback: virtiofsd missing")
-	}
+	revert.Add(func() { device.DiskVMVirtiofsdStop(sockPath, pidPath) })
 
 	// Generate UUID if not present.
 	instUUID := d.localConfig["volatile.uuid"]
@@ -2203,7 +2168,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 		return "", nil, err
 	}
 
-	sockPath := filepath.Join(d.LogPath(), "virtio-fs.config.sock")
+	sockPath, _ := d.configVirtiofsdPaths()
 	if shared.PathExists(sockPath) {
 		devBus, devAddr, multi = bus.allocate(busFunctionGroup9p)
 		err = qemuDriveConfig.Execute(sb, map[string]interface{}{

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -864,7 +864,7 @@ func (d *qemu) Start(stateful bool) error {
 	revert := revert.New()
 	defer revert.Fail()
 
-	// Start accumulating device paths.
+	// Start accumulating external device paths.
 	d.devPaths = []string{}
 
 	// Rotate the log file.
@@ -2507,9 +2507,6 @@ func (d *qemu) addDriveDirConfig(sb *strings.Builder, bus *qemuBus, fdFiles *[]s
 			return fmt.Errorf("virtiofsd socket path %q doesn't exist", virtiofsdSockPath)
 		}
 
-		// Add to devPaths to allow apparmor access.
-		d.devPaths = append(d.devPaths, virtiofsdSockPath)
-
 		devBus, devAddr, multi := bus.allocate(busFunctionGroup9p)
 
 		// Add virtio-fs device as this will be preferred over 9p.
@@ -2541,7 +2538,7 @@ func (d *qemu) addDriveDirConfig(sb *strings.Builder, bus *qemuBus, fdFiles *[]s
 
 		"devName":  driveConf.DevName,
 		"mountTag": mountTag,
-		"proxyFD":  proxyFD, // Pass by file descriptor, so no need to add to d.devPaths.
+		"proxyFD":  proxyFD, // Pass by file descriptor, so no need add to d.devPaths for apparmor access.
 		"readonly": readonly,
 		"protocol": "9p",
 	})
@@ -2587,6 +2584,7 @@ func (d *qemu) addDriveConfig(sb *strings.Builder, bootIndexes map[string]int, d
 	}
 
 	if !strings.HasPrefix(driveConf.DevPath, "rbd:") {
+		// Add path to external devPaths. This way, the path will be included in the apparmor profile.
 		d.devPaths = append(d.devPaths, driveConf.DevPath)
 	}
 
@@ -2908,7 +2906,7 @@ func (d *qemu) addUSBDeviceConfig(sb *strings.Builder, bus *qemuBus, usbConfig [
 		return err
 	}
 
-	// Add path to devPaths. This way, the path will be included in the apparmor profile.
+	// Add path to external devPaths. This way, the path will be included in the apparmor profile.
 	d.devPaths = append(d.devPaths, hostDevice)
 
 	return nil

--- a/lxd/storage/drivers/driver_zfs_utils.go
+++ b/lxd/storage/drivers/driver_zfs_utils.go
@@ -89,7 +89,7 @@ func (d *zfs) deleteDatasetRecursive(dataset string) error {
 	}
 
 	// Delete the dataset (and any snapshots left).
-	_, err = shared.RunCommand("zfs", "destroy", "-r", dataset)
+	_, err = shared.TryRunCommand("zfs", "destroy", "-r", dataset)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Removes duplicate virtiofsd start and stop logic to centralise the knowledge for when virtiofsd should be used, rather than duplicating it in both the qemu driver and the disk device packages.

- Also centralises the variable generation for the config drive's virtiofsd socket and pid paths.
- Also explicitly allows the qemu process r/w access to the instance's devices directory. This is to allow access to the virtiofsd socket, and in the future bind-mounted disk directories themselves. I've allowed access to the whole directory rather than explicitly adding boot-time rules individually to allow us to support hot plugged disks in the future.