### PR TITLE
VM: Ensure bootindex ordering is stable and consistent

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -473,6 +473,22 @@ func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 	return &runConf, nil
 }
 
+// vmVirtfsProxyHelperPaths returns the path for the socket and PID file to use with virtfs-proxy-helper process.
+func (d *disk) vmVirtfsProxyHelperPaths() (string, string) {
+	sockPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("%s.sock", d.name))
+	pidPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("%s.pid", d.name))
+
+	return sockPath, pidPath
+}
+
+// vmVirtiofsdPaths returns the path for the socket and PID file to use with virtiofsd process.
+func (d *disk) vmVirtiofsdPaths() (string, string) {
+	sockPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("virtio-fs.%s.sock", d.name))
+	pidPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("virtio-fs.%s.pid", d.name))
+
+	return sockPath, pidPath
+}
+
 // startVM starts the disk device for a virtual machine instance.
 func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 	runConf := deviceConfig.RunConfig{}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -652,6 +652,10 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 						time.Sleep(50 * time.Millisecond)
 					}
 
+					if !shared.PathExists(sockPath) {
+						return fmt.Errorf("virtfs-proxy-helper failed to bind socket within 10s")
+					}
+
 					return nil
 				}()
 				if err != nil {

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -38,6 +38,10 @@ import (
 // Special disk "source" value used for generating a VM cloud-init config ISO.
 const diskSourceCloudInit = "cloud-init:config"
 
+// DiskVirtiofsdSockMountOpt indicates the mount option prefix used to provide the virtiofsd socket path to
+// the QEMU driver.
+const DiskVirtiofsdSockMountOpt = "virtiofsdSock"
+
 type diskBlockLimit struct {
 	readBps   int64
 	readIops  int64

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -622,9 +622,9 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 						return fmt.Errorf(`Required binary "virtfs-proxy-helper" couldn't be found`)
 					}
 
-					// Start the virtfs-proxy-helper process in non-daemon mode and as root so that
-					// when the VM process is started as an unprivileged user, we can still share
-					// directories that process cannot access.
+					// Start the virtfs-proxy-helper process in non-daemon mode and as root so
+					// that when the VM process is started as an unprivileged user, we can
+					// still share directories that process cannot access.
 					proc, err := subprocess.NewProcess(cmd, []string{"-n", "-u", "0", "-g", "0", "-s", sockPath, "-p", srcPath}, "", "")
 					if err != nil {
 						return err
@@ -642,7 +642,8 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 						return errors.Wrapf(err, "Failed to save virtfs-proxy-helper state")
 					}
 
-					// Wait for socket file to exist (as otherwise qemu can race the creation of this file).
+					// Wait for socket file to exist (as otherwise qemu can race the creation
+					// of this file).
 					for i := 0; i < 10; i++ {
 						if shared.PathExists(sockPath) {
 							break
@@ -658,9 +659,10 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				}
 
 				// Start virtiofsd for virtio-fs share. The lxd-agent prefers to use this over the
-				// virtfs-proxy-helper 9p share. The latter will only be used as a fallback.
+				// virtfs-proxy-helper 9p share. The 9p share will only be used as a fallback.
 				err = func() error {
-					// virtiofsd doesn't support readonly mode.
+					// virtiofsd doesn't support readonly mode, so its important we don't
+					// expose the share as writable when the LXD device is set as readonly.
 					if readonly {
 						d.logger.Warn("Unable to use virtio-fs for device, using 9p as a fallback: readonly devices unsupported", log.Ctx{"device": d.name})
 						return nil

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2554,10 +2554,10 @@ func (d *qemu) addDriveDirConfig(sb *strings.Builder, bus *qemuBus, fdFiles *[]s
 		}
 	}
 
+	// Add 9p share config.
 	devBus, devAddr, multi := bus.allocate(busFunctionGroup9p)
-
-	// Only use proxy for writable shares.
 	proxyFD := d.addFileDescriptor(fdFiles, driveConf.DevPath)
+
 	return qemuDriveDir.Execute(sb, map[string]interface{}{
 		"bus":           bus.name,
 		"devBus":        devBus,
@@ -2566,7 +2566,7 @@ func (d *qemu) addDriveDirConfig(sb *strings.Builder, bus *qemuBus, fdFiles *[]s
 
 		"devName":  driveConf.DevName,
 		"mountTag": mountTag,
-		"proxyFD":  proxyFD,
+		"proxyFD":  proxyFD, // Pass by file descriptor, so no need to add to d.devPaths.
 		"readonly": readonly,
 		"protocol": "9p",
 	})

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2513,9 +2513,28 @@ func (d *qemu) addDriveDirConfig(sb *strings.Builder, bus *qemuBus, fdFiles *[]s
 	// Record the 9p mount for the agent.
 	*agentMounts = append(*agentMounts, agentMount)
 
-	sockPath := filepath.Join(d.Path(), fmt.Sprintf("%s.sock", driveConf.DevName))
+	// Check if the disk device has provided a virtiofsd socket path.
+	var virtiofsdSockPath string
+	for _, opt := range driveConf.Opts {
+		if strings.HasPrefix(opt, fmt.Sprintf("%s=", device.DiskVirtiofsdSockMountOpt)) {
+			parts := strings.SplitN(opt, "=", 2)
+			virtiofsdSockPath = parts[1]
+		}
+	}
 
-	if shared.PathExists(sockPath) {
+	// If there is a virtiofsd socket path setup the virtio-fs share.
+	if virtiofsdSockPath != "" {
+		if readonly {
+			return fmt.Errorf("virtiofsd doesn't support readonly shares")
+		}
+
+		if !shared.PathExists(virtiofsdSockPath) {
+			return fmt.Errorf("virtiofsd socket path %q doesn't exist", virtiofsdSockPath)
+		}
+
+		// Add to devPaths to allow apparmor access.
+		d.devPaths = append(d.devPaths, virtiofsdSockPath)
+
 		devBus, devAddr, multi := bus.allocate(busFunctionGroup9p)
 
 		// Add virtio-fs device as this will be preferred over 9p.
@@ -2527,7 +2546,7 @@ func (d *qemu) addDriveDirConfig(sb *strings.Builder, bus *qemuBus, fdFiles *[]s
 
 			"devName":  driveConf.DevName,
 			"mountTag": mountTag,
-			"path":     sockPath,
+			"path":     virtiofsdSockPath,
 			"protocol": "virtio-fs",
 		})
 		if err != nil {


### PR DESCRIPTION
- Ensure bootindex is generated in a stable manner in `deviceBootPriorities()`, as the boot index is used for SCSI-ID which in turn influences disk device name in /dev.
- Move the disk device virtiofsd socket path into the instance's devices directory (to align with where the pid files are stored),  as we don't start qemu with chroot option anymore, so that is not a blocker.
- Stop relying on duplicate path logic in disk device and qemu driver packages to detect virtiofsd socket path, and instead pass the socket path via a mount option (using an option name that is defined as a shared constant to clearly show dependencies).
- Update qemu driver's d.devPaths with the virtiofsd socket path when setting up qemu config file so that its not blocked by apparmor.
