### PR TITLE
VM: Create bind mount of config drive and instance disk devices for exporting via 9p and virtiofsd

### DIFF
--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -119,6 +119,25 @@ func DiskMount(srcPath string, dstPath string, readonly bool, recursive bool, pr
 	return nil
 }
 
+// DiskMountClear unmounts and removes the mount path used for disk shares.
+func DiskMountClear(mntPath string) error {
+	if shared.PathExists(mntPath) {
+		if shared.IsMountPoint(mntPath) {
+			err := unix.Unmount(mntPath, unix.MNT_DETACH)
+			if err != nil {
+				return errors.Wrapf(err, "Failed unmounting %q", mntPath)
+			}
+		}
+
+		err := os.Remove(mntPath)
+		if err != nil {
+			return errors.Wrapf(err, "Failed removing %q", mntPath)
+		}
+	}
+
+	return nil
+}
+
 func diskCephRbdMap(clusterName string, userName string, poolName string, volumeName string) (string, error) {
 	devPath, err := shared.RunCommand(
 		"rbd",

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -974,7 +974,7 @@ func (w *cgroupWriter) Set(version cgroup.Backend, controller string, key string
 
 // mountPoolVolume mounts the pool volume specified in d.config["source"] from pool specified in d.config["pool"]
 // and return the mount path. If the instance type is container volume will be shifted if needed.
-func (d *disk) mountPoolVolume(reverter *revert.Reverter) (string, error) {
+func (d *disk) mountPoolVolume(revert *revert.Reverter) (string, error) {
 	// Deal with mounting storage volumes created via the storage api. Extract the name of the storage volume
 	// that we are supposed to attach. We assume that the only syntactically valid ways of specifying a
 	// storage volume are:
@@ -1032,7 +1032,7 @@ func (d *disk) mountPoolVolume(reverter *revert.Reverter) (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "Failed mounting storage volume %q of type %q on storage pool %q", volumeName, volumeTypeName, pool.Name())
 	}
-	reverter.Add(func() { pool.UnmountCustomVolume(storageProjectName, volumeName, nil) })
+	revert.Add(func() { pool.UnmountCustomVolume(storageProjectName, volumeName, nil) })
 
 	_, vol, err := d.state.Cluster.GetLocalStoragePoolVolume(storageProjectName, volumeName, db.StoragePoolVolumeTypeCustom, pool.ID())
 	if err != nil {

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1039,10 +1039,14 @@ func (d *disk) mountPoolVolume(revert *revert.Reverter) (string, error) {
 		return "", errors.Wrapf(err, "Failed to fetch local storage volume record")
 	}
 
-	if d.inst.Type() == instancetype.Container && vol.ContentType == db.StoragePoolVolumeContentTypeNameFS {
-		err = d.storagePoolVolumeAttachShift(storageProjectName, pool.Name(), volumeName, db.StoragePoolVolumeTypeCustom, srcPath)
-		if err != nil {
-			return "", errors.Wrapf(err, "Failed shifting storage volume %q of type %q on storage pool %q", volumeName, volumeTypeName, pool.Name())
+	if d.inst.Type() == instancetype.Container {
+		if vol.ContentType == db.StoragePoolVolumeContentTypeNameFS {
+			err = d.storagePoolVolumeAttachShift(storageProjectName, pool.Name(), volumeName, db.StoragePoolVolumeTypeCustom, srcPath)
+			if err != nil {
+				return "", errors.Wrapf(err, "Failed shifting storage volume %q of type %q on storage pool %q", volumeName, volumeTypeName, pool.Name())
+			}
+		} else {
+			return "", fmt.Errorf("Only filesystem volumes are supported for containers")
 		}
 	}
 

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -690,13 +690,6 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				// Start virtiofsd for virtio-fs share. The lxd-agent prefers to use this over the
 				// virtfs-proxy-helper 9p share. The 9p share will only be used as a fallback.
 				err = func() error {
-					// virtiofsd doesn't support readonly mode, so its important we don't
-					// expose the share as writable when the LXD device is set as readonly.
-					if readonly {
-						d.logger.Warn("Unable to use virtio-fs for device, using 9p as a fallback", log.Ctx{"err": "readonly devices unsupported"})
-						return nil
-					}
-
 					sockPath, pidPath := d.vmVirtiofsdPaths()
 					logPath := filepath.Join(d.inst.LogPath(), fmt.Sprintf("disk.%s.log", d.name))
 

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -343,6 +343,7 @@ func (d *disk) Start() (*deviceConfig.RunConfig, error) {
 func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 	runConf := deviceConfig.RunConfig{}
 	isReadOnly := shared.IsTrue(d.config["readonly"])
+	isRequired := d.isRequired(d.config)
 
 	// Apply cgroups only after all the mounts have been processed.
 	runConf.PostHooks = append(runConf.PostHooks, func() error {
@@ -360,6 +361,9 @@ func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 
 		return nil
 	})
+
+	revert := revert.New()
+	defer revert.Fail()
 
 	// Deal with a rootfs.
 	if shared.IsRootDiskDevice(d.config) {
@@ -448,7 +452,23 @@ func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 			options = append(options, "create=dir")
 		}
 
-		sourceDevPath, err := d.createDevice()
+		// Mount the pool volume and set poolVolSrcPath for createDevice below.
+		var poolVolSrcPath string
+		if d.config["pool"] != "" {
+			var err error
+			poolVolSrcPath, err = d.mountPoolVolume(revert)
+			if err != nil {
+				if !isRequired {
+					d.logger.Warn(err.Error())
+					return nil, nil
+				}
+
+				return nil, err
+			}
+		}
+
+		// Mount the source in the instance devices directory.
+		sourceDevPath, err := d.createDevice(revert, poolVolSrcPath)
 		if err != nil {
 			return nil, err
 		}
@@ -469,6 +489,7 @@ func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 		}
 	}
 
+	revert.Success()
 	return &runConf, nil
 }
 

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1061,10 +1061,8 @@ func (d *disk) mountPoolVolume(revert *revert.Reverter) (string, error) {
 }
 
 // createDevice creates a disk device mount on host.
-func (d *disk) createDevice() (string, error) {
-	revert := revert.New()
-	defer revert.Fail()
-
+// The poolVolSrcPath takes the path to the mounted custom pool volume when d.config["pool"] is non-empty.
+func (d *disk) createDevice(revert *revert.Reverter, poolVolSrcPath string) (string, error) {
 	// Paths.
 	devPath := d.getDevicePath(d.name, d.config)
 	srcPath := shared.HostPath(d.config["source"])
@@ -1116,11 +1114,11 @@ func (d *disk) createDevice() (string, error) {
 			if err != nil {
 				msg := fmt.Sprintf("Could not mount map Ceph RBD: %v", err)
 				if !isRequired {
-					// Will fail the PathExists test below.
 					d.logger.Warn(msg)
-				} else {
-					return "", fmt.Errorf(msg)
+					return "", nil
 				}
+
+				return "", fmt.Errorf(msg)
 			}
 
 			// Record the device path.
@@ -1133,17 +1131,7 @@ func (d *disk) createDevice() (string, error) {
 			isFile = false
 		}
 	} else {
-		// Mount the pool volume.
-		var err error
-		srcPath, err = d.mountPoolVolume(revert)
-		if err != nil {
-			if !isRequired {
-				// Leave to the pathExists check below.
-				d.logger.Warn(err.Error())
-			} else {
-				return "", err
-			}
-		}
+		srcPath = poolVolSrcPath // Use pool source path override.
 	}
 
 	// Check if the source exists unless it is a cephfs.
@@ -1151,6 +1139,7 @@ func (d *disk) createDevice() (string, error) {
 		if !isRequired {
 			return "", nil
 		}
+
 		return "", fmt.Errorf("Source path %q doesn't exist for device %q", srcPath, d.name)
 	}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2192,7 +2192,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 		"multifunction": multi,
 		"protocol":      "9p",
 
-		"path": filepath.Join(d.Path(), "config"),
+		"path": d.configDriveMountPath(),
 	})
 	if err != nil {
 		return "", nil, err

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -578,7 +578,7 @@ func (d *qemu) onStop(target string) error {
 	// Clear up the config drive virtiofsd process.
 	err = device.DiskVMVirtiofsdStop(d.configVirtiofsdPaths())
 	if err != nil {
-		d.logger.Warn("Failed cleaning up virtiofsd", log.Ctx{"err": err})
+		d.logger.Warn("Failed cleaning up config drive virtiofsd", log.Ctx{"err": err})
 	}
 
 	// Record power state.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -570,16 +570,10 @@ func (d *qemu) onStop(target string) error {
 	op.Reset()
 
 	// Cleanup.
-	d.cleanupDevices()
+	d.cleanupDevices() // Must be called before unmount.
 	os.Remove(d.pidFilePath())
 	os.Remove(d.monitorPath())
 	d.unmount()
-
-	// Clear up the config drive virtiofsd process.
-	err = device.DiskVMVirtiofsdStop(d.configVirtiofsdPaths())
-	if err != nil {
-		d.logger.Warn("Failed cleaning up config drive virtiofsd", log.Ctx{"err": err})
-	}
 
 	// Record power state.
 	err = d.state.Cluster.UpdateInstancePowerState(d.id, "STOPPED")
@@ -3961,7 +3955,20 @@ func (d *qemu) cleanup() {
 }
 
 // cleanupDevices performs any needed device cleanup steps when instance is stopped.
+// Must be called before root volume is unmounted.
 func (d *qemu) cleanupDevices() {
+	// Clear up the config drive virtiofsd process.
+	err := device.DiskVMVirtiofsdStop(d.configVirtiofsdPaths())
+	if err != nil {
+		d.logger.Warn("Failed cleaning up config drive virtiofsd", log.Ctx{"err": err})
+	}
+
+	// Clear up the config drive mount.
+	err = d.configDriveMountPathClear()
+	if err != nil {
+		d.logger.Warn("Failed cleaning up config drive mount", log.Ctx{"err": err})
+	}
+
 	for _, dev := range d.expandedDevices.Reversed() {
 		// Use the device interface if device supports it.
 		err := d.deviceStop(dev.Name, dev.Config, false)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -529,6 +529,18 @@ func (d *qemu) Freeze() error {
 	return nil
 }
 
+// configDriveMountPath returns the path for the config drive bind mount.
+func (d *qemu) configDriveMountPath() string {
+	// Use instance path and config.mount directory rather than devices path to avoid conflicts with an
+	// instance disk device mount of the same name.
+	return filepath.Join(d.Path(), "config.mount")
+}
+
+// configDriveMountPathClear attempts to unmount the config drive bind mount and remove the directory.
+func (d *qemu) configDriveMountPathClear() error {
+	return device.DiskMountClear(d.configDriveMountPath())
+}
+
 // configVirtiofsdPaths returns the path for the socket and PID file to use with config drive virtiofsd process.
 func (d *qemu) configVirtiofsdPaths() (string, string) {
 	sockPath := filepath.Join(d.LogPath(), "virtio-fs.config.sock")

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -575,6 +575,7 @@ func (d *qemu) onStop(target string) error {
 	os.Remove(d.monitorPath())
 	d.unmount()
 
+	// Clear up the config drive virtiofsd process.
 	err = device.DiskVMVirtiofsdStop(d.configVirtiofsdPaths())
 	if err != nil {
 		d.logger.Warn("Failed cleaning up virtiofsd", log.Ctx{"err": err})

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2527,10 +2527,6 @@ func (d *qemu) addDriveDirConfig(sb *strings.Builder, bus *qemuBus, fdFiles *[]s
 
 	// If there is a virtiofsd socket path setup the virtio-fs share.
 	if virtiofsdSockPath != "" {
-		if readonly {
-			return fmt.Errorf("virtiofsd doesn't support readonly shares")
-		}
-
 		if !shared.PathExists(virtiofsdSockPath) {
 			return fmt.Errorf("virtiofsd socket path %q doesn't exist", virtiofsdSockPath)
 		}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2566,7 +2566,7 @@ func (d *qemu) addDriveDirConfig(sb *strings.Builder, bus *qemuBus, fdFiles *[]s
 
 		"devName":  driveConf.DevName,
 		"mountTag": mountTag,
-		"proxyFD":  proxyFD, // Pass by file descriptor, so no need add to d.devPaths for apparmor access.
+		"proxyFD":  proxyFD, // Pass by file descriptor, so don't add to d.devPaths for apparmor access.
 		"readonly": readonly,
 		"protocol": "9p",
 	})

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2201,8 +2201,8 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	// If virtiofsd is running for the config directory then export the config drive via virtio-fs.
 	// This is used by the lxd-agent in preference to 9p (due to its improved performance) and in scenarios
 	// where 9p isn't available in the VM guest OS.
-	sockPath, _ := d.configVirtiofsdPaths()
-	if shared.PathExists(sockPath) {
+	configSockPath, _ := d.configVirtiofsdPaths()
+	if shared.PathExists(configSockPath) {
 		devBus, devAddr, multi = bus.allocate(busFunctionGroup9p)
 		err = qemuDriveConfig.Execute(sb, map[string]interface{}{
 			"bus":           bus.name,
@@ -2211,7 +2211,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 			"multifunction": multi,
 			"protocol":      "virtio-fs",
 
-			"path": sockPath,
+			"path": configSockPath,
 		})
 		if err != nil {
 			return "", nil, err


### PR DESCRIPTION
This works around the lack of read-only support in virtio-fs and provides an additional layer of protection for 9p shares.