### PR TITLE
Network: Relax physical network parent IP checks

### DIFF
--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -162,16 +162,6 @@ func (n *physical) Start() error {
 		revert.Add(func() { InterfaceRemove(hostName) })
 	}
 
-	// Check no global unicast IPs defined on parent, as that may indicate it is in use by another application.
-	addresses, _, err := InterfaceStatus(hostName)
-	if err != nil {
-		return errors.Wrapf(err, "Failed getting interface status for %q", hostName)
-	}
-
-	if len(addresses) > 0 {
-		return fmt.Errorf("Cannot start network as parent interface %q has one or more IP addresses configured on it", hostName)
-	}
-
 	// Set the MTU.
 	if n.config["mtu"] != "" {
 		phyLink := &ip.Link{Name: hostName}


### PR DESCRIPTION
- If an OVN network uses a physical network who's parent is a bridge, then it is valid for the parent interface to have IPs configured.
- Only prevent OVN networks from using the physical network is the parent isn't a bridge.
- Fixes OVN tests.