### PR TITLE
VM: Wait for QEMU process to end before considering VM stopped

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2974,11 +2974,11 @@ func (d *qemu) pidFilePath() string {
 	return filepath.Join(d.LogPath(), "qemu.pid")
 }
 
-// pid gets the PID of the running qemu process.
+// pid gets the PID of the running qemu process. Returns 0 if PID file or process not found, and -1 if err non-nil.
 func (d *qemu) pid() (int, error) {
 	pidStr, err := ioutil.ReadFile(d.pidFilePath())
 	if os.IsNotExist(err) {
-		return 0, nil
+		return 0, nil // PID file has gone.
 	}
 
 	if err != nil {
@@ -2993,13 +2993,13 @@ func (d *qemu) pid() (int, error) {
 	cmdLineProcFilePath := fmt.Sprintf("/proc/%d/cmdline", pid)
 	cmdLine, err := ioutil.ReadFile(cmdLineProcFilePath)
 	if err != nil {
-		return -1, err
+		return 0, nil // Process has gone.
 	}
 
 	qemuSearchString := []byte("qemu-system")
 	instUUID := []byte(d.localConfig["volatile.uuid"])
 	if !bytes.Contains(cmdLine, qemuSearchString) || !bytes.Contains(cmdLine, instUUID) {
-		return -1, fmt.Errorf("Pid doesn't match the running process")
+		return -1, fmt.Errorf("PID doesn't match the running process")
 	}
 
 	return pid, nil

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3033,8 +3033,8 @@ func (d *qemu) Stop(stateful bool) error {
 	// Connect to the monitor.
 	monitor, err := qmp.Connect(d.monitorPath(), qemuSerialChardevName, d.getMonitorEventHandler())
 	if err != nil {
-		// If we fail to connect, it's most likely because the VM is already off.
-		// but it could also be because the qemu process is hung, check for that
+		// If we fail to connect, it's most likely because the VM is already off, but it could also be
+		// because the qemu process is hung, check if process still exists and kill it if needed.
 		pid, _ := d.pid()
 		if pid > 0 {
 			d.killQemuProcess(pid)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1241,8 +1241,8 @@ func (d *qemu) Start(stateful bool) error {
 	}
 
 	pid, err := d.pid()
-	if err != nil {
-		d.logger.Error("Failed to get VM process ID", log.Ctx{"pid": pid})
+	if err != nil || pid <= 0 {
+		d.logger.Error("Failed to get VM process ID", log.Ctx{"err": err, "pid": pid})
 		op.Done(err)
 		return err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -551,6 +551,9 @@ func (d *qemu) configVirtiofsdPaths() (string, string) {
 
 // onStop is run when the instance stops.
 func (d *qemu) onStop(target string) error {
+	d.logger.Debug("onStop hook started", log.Ctx{"target": target})
+	defer d.logger.Debug("onStop hook finished", log.Ctx{"target": target})
+
 	var err error
 
 	// Pick up the existing stop operation lock created in Stop() function.
@@ -622,6 +625,9 @@ func (d *qemu) onStop(target string) error {
 
 // Shutdown shuts the instance down.
 func (d *qemu) Shutdown(timeout time.Duration) error {
+	d.logger.Debug("Shutdown started", log.Ctx{"timeout": timeout})
+	defer d.logger.Debug("Shutdown finished", log.Ctx{"timeout": timeout})
+
 	// Must be run prior to creating the operation lock.
 	if !d.IsRunning() {
 		return fmt.Errorf("The instance is already stopped")
@@ -840,6 +846,9 @@ func (d *qemu) saveState(monitor *qmp.Monitor) error {
 
 // Start starts the instance.
 func (d *qemu) Start(stateful bool) error {
+	d.logger.Debug("Start started", log.Ctx{"stateful": stateful})
+	defer d.logger.Debug("Start finished", log.Ctx{"stateful": stateful})
+
 	// Must be run prior to creating the operation lock.
 	if d.IsRunning() {
 		return fmt.Errorf("The instance is already running")
@@ -2998,6 +3007,9 @@ func (d *qemu) pid() (int, error) {
 
 // Stop the VM.
 func (d *qemu) Stop(stateful bool) error {
+	d.logger.Debug("Stop started", log.Ctx{"stateful": stateful})
+	defer d.logger.Debug("Stop finished", log.Ctx{"stateful": stateful})
+
 	// Must be run prior to creating the operation lock.
 	if !d.IsRunning() {
 		return fmt.Errorf("The instance is already stopped")


### PR DESCRIPTION
- Wait for QEMU process to end before considering VM stopped - to avoid racing the start process when restarting. This should prevent issues caused when the `onStop()` hook is still in the process of cleaning up devices when the VM is being started again.
- Also adds some instance start/stop debug logging.