### PR TITLE
lxc cluster add shouldn't have any alias

### DIFF
--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -578,7 +578,6 @@ type cmdClusterAdd struct {
 func (c *cmdClusterAdd) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("add", i18n.G("[<remote>:]<member>"))
-	cmd.Aliases = []string{"rm"}
 	cmd.Short = i18n.G("Request a join token for adding a cluster member")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`Request a join token for adding a cluster member`))
 


### PR DESCRIPTION
Signed-off-by: Simon Deziel <simon.deziel@canonical.com>