### PR TITLE
HAProxy protocol header support

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1377,3 +1377,9 @@ without using the trust password.
 
 ## clustering\_description
 Adds an editable description to the cluster members.
+
+## server\_trusted\_proxy
+This introduces support for `core.https_trusted_proxy` which has LXD
+parse a HAProxy style connection header on such connections and if
+present, will rewrite the request's source address to that provided by
+the proxy server.

--- a/doc/server.md
+++ b/doc/server.md
@@ -30,6 +30,7 @@ core.https\_allowed\_credentials    | boolean   | global    | -                 
 core.https\_allowed\_headers        | string    | global    | -                                 | Access-Control-Allow-Headers http header value
 core.https\_allowed\_methods        | string    | global    | -                                 | Access-Control-Allow-Methods http header value
 core.https\_allowed\_origin         | string    | global    | -                                 | Access-Control-Allow-Origin http header value
+core.https\_trusted\_proxy          | string    | global    | -                                 | Comma-separated list of IP addresses of trusted servers to provide the client's address through the proxy connection header
 core.proxy\_https                   | string    | global    | -                                 | https proxy to use, if any (falls back to HTTPS\_PROXY environment variable)
 core.proxy\_http                    | string    | global    | -                                 | http proxy to use, if any (falls back to HTTP\_PROXY environment variable)
 core.proxy\_ignore\_hosts           | string    | global    | -                                 | hosts which don't need the proxy for use (similar format to NO\_PROXY, e.g. 1.2.3.4,1.2.3.5, falls back to NO\_PROXY environment variable)

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -658,6 +658,8 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 
 	for key := range clusterChanged {
 		switch key {
+		case "core.https_trusted_proxy":
+			d.endpoints.NetworkUpdateTrustedProxy(clusterChanged[key])
 		case "core.proxy_http":
 			fallthrough
 		case "core.proxy_https":
@@ -717,6 +719,7 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		if err != nil {
 			return err
 		}
+		d.endpoints.NetworkUpdateTrustedProxy(clusterConfig.HTTPSTrustedProxy())
 	}
 
 	value, ok = nodeChanged["cluster.https_address"]
@@ -725,6 +728,7 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		if err != nil {
 			return err
 		}
+		d.endpoints.NetworkUpdateTrustedProxy(clusterConfig.HTTPSTrustedProxy())
 	}
 
 	value, ok = nodeChanged["core.debug_address"]

--- a/lxd/cluster/config.go
+++ b/lxd/cluster/config.go
@@ -104,6 +104,11 @@ func (c *Config) ProxyIgnoreHosts() string {
 	return c.m.GetString("core.proxy_ignore_hosts")
 }
 
+// HTTPSTrustedProxy returns the configured HTTPS trusted proxy setting, if any.
+func (c *Config) HTTPSTrustedProxy() string {
+	return c.m.GetString("core.https_trusted_proxy")
+}
+
 // MAASController the configured MAAS url and key, if any.
 func (c *Config) MAASController() (string, string) {
 	url := c.m.GetString("maas.api.url")
@@ -241,6 +246,7 @@ var ConfigSchema = config.Schema{
 	"core.https_allowed_methods":     {},
 	"core.https_allowed_origin":      {},
 	"core.https_allowed_credentials": {Type: config.Bool},
+	"core.https_trusted_proxy":       {},
 	"core.proxy_http":                {},
 	"core.proxy_https":               {},
 	"core.proxy_ignore_hosts":        {},

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1166,6 +1166,8 @@ func (d *Daemon) init() error {
 		rbacAPIURL, rbacAPIKey, rbacExpiry, rbacAgentURL, rbacAgentUsername, rbacAgentPrivateKey, rbacAgentPublicKey = config.RBACServer()
 		d.gateway.HeartbeatOfflineThreshold = config.OfflineThreshold()
 
+		d.endpoints.NetworkUpdateTrustedProxy(config.HTTPSTrustedProxy())
+
 		return nil
 	})
 	if err != nil {

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -271,6 +271,7 @@ var APIExtensions = []string{
 	"projects_restricted_backups_and_snapshots",
 	"clustering_join_token",
 	"clustering_description",
+	"server_trusted_proxy",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Resolves #8757

@stgraber, this is implemented a little bit different then your implementation in https://github.com/nsec/askgod. I used `proxyproto.NewConn()` method because we need to know incoming remote address to check is it in `core.https_trusted_proxy` config. I'm also not quite sure if I'm not miss something. I mean, I update proxy address when server is starting and also when network or cluster listeners are changed. `proxyproto.newConn()` as a second argument takes timeout value (ProxyHeaderTimeout). This value should by configurable or should we use some static value?