### PR TITLE
Image expiration on Publish

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -308,7 +308,12 @@ func imgPostInstanceInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *ope
 	var meta api.ImageMetadata
 
 	writer = shared.NewQuotaWriter(writer, budget)
-	meta, err = c.Export(writer, req.Properties)
+	meta, err = c.Export(writer, req.Properties, req.ExpiresAt)
+
+	// Get ExpiresAt
+	if meta.ExpiryDate != 0 {
+		info.ExpiresAt = time.Unix(meta.ExpiryDate, 0)
+	}
 
 	// Clean up file handles.
 	// When compression is used, Close on imageProgressWriter/tarWriter is required for compressFile/gzip to

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4167,7 +4167,7 @@ func (d *qemu) deviceRemove(deviceName string, rawConfig deviceConfig.Device, in
 }
 
 // Export publishes the instance.
-func (d *qemu) Export(w io.Writer, properties map[string]string) (api.ImageMetadata, error) {
+func (d *qemu) Export(w io.Writer, properties map[string]string, expiration time.Time) (api.ImageMetadata, error) {
 	ctxMap := log.Ctx{
 		"created":   d.creationDate,
 		"ephemeral": d.ephemeral,
@@ -4250,6 +4250,9 @@ func (d *qemu) Export(w io.Writer, properties map[string]string) (api.ImageMetad
 		meta.Architecture = arch
 		meta.CreationDate = time.Now().UTC().Unix()
 		meta.Properties = properties
+		if !expiration.IsZero() {
+			meta.ExpiryDate = expiration.UTC().Unix()
+		}
 
 		data, err := yaml.Marshal(&meta)
 		if err != nil {
@@ -4296,9 +4299,15 @@ func (d *qemu) Export(w io.Writer, properties map[string]string) (api.ImageMetad
 			return meta, err
 		}
 
+		if !expiration.IsZero() {
+			meta.ExpiryDate = expiration.UTC().Unix()
+		}
+
 		if properties != nil {
 			meta.Properties = properties
+		}
 
+		if properties != nil || !expiration.IsZero() {
 			// Generate a new metadata.yaml.
 			tempDir, err := ioutil.TempDir("", "lxd_lxd_metadata_")
 			if err != nil {
@@ -4334,7 +4343,7 @@ func (d *qemu) Export(w io.Writer, properties map[string]string) (api.ImageMetad
 			return meta, err
 		}
 
-		if properties != nil {
+		if properties != nil || !expiration.IsZero() {
 			tmpOffset := len(filepath.Dir(fnam)) + 1
 			err = tarWriter.WriteFile(fnam[tmpOffset:], fnam, fi, false)
 		} else {

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -84,7 +84,7 @@ type Instance interface {
 	Update(newConfig db.InstanceArgs, userRequested bool) error
 
 	Delete(force bool) error
-	Export(w io.Writer, properties map[string]string) (api.ImageMetadata, error)
+	Export(w io.Writer, properties map[string]string, expiration time.Time) (api.ImageMetadata, error)
 
 	// Used for security.
 	DevPaths() []string

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -714,7 +714,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -930,7 +930,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1279,7 +1279,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1868,6 +1868,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1942,7 +1946,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1951,7 +1955,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
@@ -2423,7 +2427,7 @@ msgstr ""
 msgid "Make image public"
 msgstr "Veröffentliche Abbild"
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 #, fuzzy
 msgid "Make the image public"
 msgstr "Veröffentliche Abbild"
@@ -2841,7 +2845,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -3128,12 +3132,12 @@ msgstr ""
 msgid "Public: %s"
 msgstr "Öffentlich: %s\n"
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 #, fuzzy
 msgid "Publish instances as images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -3788,11 +3792,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 #, fuzzy
 msgid "Stopping instance failed!"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3933,7 +3937,7 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3973,7 +3977,7 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "The specified device doesn't match the network"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4674,7 +4678,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -533,7 +533,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -734,7 +734,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1058,7 +1058,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1611,6 +1611,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1682,7 +1686,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1691,7 +1695,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2131,7 +2135,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2522,7 +2526,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Network usage:"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3422,11 +3426,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3557,7 +3561,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3594,7 +3598,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4070,7 +4074,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -682,7 +682,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -886,7 +886,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1219,7 +1219,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1774,6 +1774,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1846,7 +1850,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 #, fuzzy
 msgid "Instance name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
@@ -1856,7 +1860,7 @@ msgstr "Nombre del contenedor es obligatorio"
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Contenedor publicado con huella digital: %s"
@@ -2301,7 +2305,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2695,7 +2699,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2976,11 +2980,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr "Público: %s"
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3601,11 +3605,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3736,7 +3740,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3773,7 +3777,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4294,7 +4298,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -709,7 +709,7 @@ msgstr "Image copiée avec succès !"
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -922,7 +922,7 @@ msgstr ""
 "commandes ci-dessous.\n"
 "Pour de l'aide avec l'une des commandes, simplement les utiliser avec --help."
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 #, fuzzy
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -1293,7 +1293,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1890,6 +1890,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr "Image copiée avec succès !"
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 #, fuzzy
 msgid "Image exported successfully!"
@@ -1967,7 +1971,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 #, fuzzy
 msgid "Instance name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
@@ -1977,7 +1981,7 @@ msgstr "Le nom du conteneur est obligatoire"
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Conteneur publié avec l'empreinte : %s"
@@ -2486,7 +2490,7 @@ msgstr ""
 msgid "Make image public"
 msgstr "Rendre l'image publique"
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr "Rendre l'image publique"
 
@@ -2908,7 +2912,7 @@ msgstr "Nom du réseau"
 msgid "Network usage:"
 msgstr "  Réseau utilisé :"
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr "Nouvel alias à définir sur la cible"
 
@@ -3207,12 +3211,12 @@ msgstr "Serveur d'images public"
 msgid "Public: %s"
 msgstr "Public : %s"
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 #, fuzzy
 msgid "Publish instances as images"
 msgstr "Création du conteneur"
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -3896,12 +3900,12 @@ msgstr "État : %s"
 msgid "Stop instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 #, fuzzy
 msgid "Stop the instance if currently running"
 msgstr "Arrêter le conteneur s'il est en cours d'exécution"
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 #, fuzzy
 msgid "Stopping instance failed!"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -4041,7 +4045,7 @@ msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 "Le conteneur est en cours d'exécution, l'arrêter d'abord ou ajouter --force."
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 #, fuzzy
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
@@ -4084,7 +4088,7 @@ msgstr "Le périphérique indiqué n'existe pas"
 msgid "The specified device doesn't match the network"
 msgstr "le périphérique indiqué ne correspond pas au réseau"
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr "Il n'existe pas d'\"image\".  Vouliez-vous un alias ?"
 
@@ -4844,7 +4848,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -673,7 +673,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -875,7 +875,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1208,7 +1208,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1765,6 +1765,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1837,7 +1841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1846,7 +1850,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2293,7 +2297,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2688,7 +2692,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2968,11 +2972,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Creazione del container in corso"
@@ -3596,11 +3600,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3732,7 +3736,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3770,7 +3774,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4294,7 +4298,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "Creazione del container in corso"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: 2021-02-02 15:21+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -687,7 +687,7 @@ msgstr "バックアップのエクスポートが成功しました!"
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -894,7 +894,7 @@ msgstr ""
 "LXD の機能のすべてが、以下の色々なコマンドから操作できます。\n"
 "コマンドのヘルプは、--help をコマンドに付けて実行するだけです。"
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "圧縮アルゴリズムを指定します: (圧縮しない場合は `none`)"
 
@@ -1230,7 +1230,7 @@ msgstr "イメージを削除します"
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1830,6 +1830,10 @@ msgstr "イメージは更新済みです。"
 msgid "Image copied successfully!"
 msgstr "イメージのコピーが成功しました!"
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr "イメージのエクスポートが成功しました!"
@@ -1908,7 +1912,7 @@ msgstr "Infiniband:"
 msgid "Input data"
 msgstr "入力するデータ"
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr "インスタンス名を指定する必要があります"
 
@@ -1917,7 +1921,7 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "インスタンスは以下のフィンガープリントで publish されます: %s"
@@ -2510,7 +2514,7 @@ msgstr "MTU: %d"
 msgid "Make image public"
 msgstr "イメージを public にする"
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr "イメージを public にする"
 
@@ -2924,7 +2928,7 @@ msgstr "ネットワークタイプ:"
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr "新しいエイリアスを定義する"
 
@@ -3204,11 +3208,11 @@ msgstr "Public なイメージサーバとして設定します"
 msgid "Public: %s"
 msgstr "パブリック: %s"
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr "インスタンスをイメージとして出力します"
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr "インスタンスの出力中: %s"
@@ -3878,11 +3882,11 @@ msgstr "状態: %s"
 msgid "Stop instances"
 msgstr "インスタンスを停止します"
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr "実行中の場合、インスタンスを停止します"
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr "インスタンスの停止に失敗しました！"
 
@@ -4013,7 +4017,7 @@ msgstr "デバイスが存在しません"
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr "インスタンスは実行中です。先に停止させるか、--force を指定してください"
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -4055,7 +4059,7 @@ msgstr "指定したデバイスが存在しません"
 msgid "The specified device doesn't match the network"
 msgstr "指定したデバイスはネットワークとマッチしません"
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 "publish 先にはイメージ名は指定できません。\"--alias\" オプションを使ってくだ"
@@ -4569,7 +4573,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2021-05-28 17:11-0400\n"
+        "POT-Creation-Date: 2021-06-01 22:11+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -511,7 +511,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175 lxc/storage.go:123 lxc/storage_volume.go:528
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179 lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -696,7 +696,7 @@ msgid   "Command line client for LXD\n"
         "For help with any of those, simply call them with --help."
 msgstr  ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid   "Compression algorithm to use (`none` for uncompressed)"
 msgstr  ""
 
@@ -970,7 +970,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163 lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431 lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52 lxc/config_metadata.go:174 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:73 lxc/config_trust.go:135 lxc/config_trust.go:247 lxc/config_trust.go:327 lxc/config_trust.go:370 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605 lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235 lxc/storage_volume.go:322 lxc/storage_volume.go:484 lxc/storage_volume.go:563 lxc/storage_volume.go:639 lxc/storage_volume.go:721 lxc/storage_volume.go:802 lxc/storage_volume.go:1002 lxc/storage_volume.go:1090 lxc/storage_volume.go:1177 lxc/storage_volume.go:1361 lxc/storage_volume.go:1392 lxc/storage_volume.go:1505 lxc/storage_volume.go:1581 lxc/storage_volume.go:1680 lxc/storage_volume.go:1714 lxc/storage_volume.go:1812 lxc/storage_volume.go:1879 lxc/storage_volume.go:2020 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:67 lxc/warning.go:247 lxc/warning.go:288 lxc/warning.go:342
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163 lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431 lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52 lxc/config_metadata.go:174 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:73 lxc/config_trust.go:135 lxc/config_trust.go:247 lxc/config_trust.go:327 lxc/config_trust.go:370 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605 lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235 lxc/storage_volume.go:322 lxc/storage_volume.go:484 lxc/storage_volume.go:563 lxc/storage_volume.go:639 lxc/storage_volume.go:721 lxc/storage_volume.go:802 lxc/storage_volume.go:1002 lxc/storage_volume.go:1090 lxc/storage_volume.go:1177 lxc/storage_volume.go:1361 lxc/storage_volume.go:1392 lxc/storage_volume.go:1505 lxc/storage_volume.go:1581 lxc/storage_volume.go:1680 lxc/storage_volume.go:1714 lxc/storage_volume.go:1812 lxc/storage_volume.go:1879 lxc/storage_volume.go:2020 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:67 lxc/warning.go:247 lxc/warning.go:288 lxc/warning.go:342
 msgid   "Description"
 msgstr  ""
 
@@ -1480,6 +1480,10 @@ msgstr  ""
 msgid   "Image copied successfully!"
 msgstr  ""
 
+#: lxc/publish.go:42
+msgid   "Image expiration date (format: rfc3339)"
+msgstr  ""
+
 #: lxc/image.go:605
 msgid   "Image exported successfully!"
 msgstr  ""
@@ -1550,7 +1554,7 @@ msgstr  ""
 msgid   "Input data"
 msgstr  ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid   "Instance name is mandatory"
 msgstr  ""
 
@@ -1559,7 +1563,7 @@ msgstr  ""
 msgid   "Instance name is: %s"
 msgstr  ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid   "Instance published with fingerprint: %s"
 msgstr  ""
@@ -1985,7 +1989,7 @@ msgstr  ""
 msgid   "Make image public"
 msgstr  ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid   "Make the image public"
 msgstr  ""
 
@@ -2341,7 +2345,7 @@ msgstr  ""
 msgid   "Network usage:"
 msgstr  ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid   "New alias to define at target"
 msgstr  ""
 
@@ -2615,11 +2619,11 @@ msgstr  ""
 msgid   "Public: %s"
 msgstr  ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid   "Publish instances as images"
 msgstr  ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid   "Publishing instance: %s"
 msgstr  ""
@@ -3215,11 +3219,11 @@ msgstr  ""
 msgid   "Stop instances"
 msgstr  ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid   "Stop the instance if currently running"
 msgstr  ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid   "Stopping instance failed!"
 msgstr  ""
 
@@ -3347,7 +3351,7 @@ msgstr  ""
 msgid   "The instance is currently running, stop it first or pass --force"
 msgstr  ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid   "The instance is currently running. Use --force to have it stopped and restarted"
 msgstr  ""
 
@@ -3381,7 +3385,7 @@ msgstr  ""
 msgid   "The specified device doesn't match the network"
 msgstr  ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid   "There is no \"image name\".  Did you want an alias?"
 msgstr  ""
 
@@ -3836,7 +3840,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid   "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -668,7 +668,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -868,7 +868,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1742,6 +1742,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1813,7 +1817,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1822,7 +1826,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2262,7 +2266,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2649,7 +2653,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2927,11 +2931,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3549,11 +3553,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3684,7 +3688,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3721,7 +3725,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4197,7 +4201,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -686,7 +686,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -886,7 +886,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1210,7 +1210,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1760,6 +1760,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1831,7 +1835,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1840,7 +1844,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2280,7 +2284,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2667,7 +2671,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2945,11 +2949,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3567,11 +3571,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3702,7 +3706,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3739,7 +3743,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4215,7 +4219,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -699,7 +699,7 @@ msgstr "Backup exportado com sucesso!"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -906,7 +906,7 @@ msgstr ""
 "abaixo.\n"
 "Para obter ajuda com qualquer um desses, simplesmente use-os com --help."
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 #, fuzzy
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -1250,7 +1250,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1818,6 +1818,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr "Imagem exportada com sucesso!"
@@ -1890,7 +1894,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1899,7 +1903,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
@@ -2341,7 +2345,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2739,7 +2743,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -3021,11 +3025,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Editar arquivos no container"
@@ -3666,11 +3670,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3805,7 +3809,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3842,7 +3846,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4336,7 +4340,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: 2020-10-08 08:16+0000\n"
 "Last-Translator: Artem <KovalevArtem.ru@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -903,7 +903,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1242,7 +1242,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1804,6 +1804,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1878,7 +1882,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 #, fuzzy
 msgid "Instance name is mandatory"
 msgstr "Имя контейнера является обязательным"
@@ -1888,7 +1892,7 @@ msgstr "Имя контейнера является обязательным"
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2336,7 +2340,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2740,7 +2744,7 @@ msgstr " Использование сети:"
 msgid "Network usage:"
 msgstr " Использование сети:"
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -3019,11 +3023,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3655,11 +3659,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 #, fuzzy
 msgid "Stopping instance failed!"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3792,7 +3796,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3829,7 +3833,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4489,7 +4493,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: 2020-11-05 02:45+0000\n"
 "Last-Translator: wdggg <wdggg7@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -584,7 +584,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -784,7 +784,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1108,7 +1108,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1658,6 +1658,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1729,7 +1733,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1738,7 +1742,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2178,7 +2182,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2565,7 +2569,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2843,11 +2847,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3465,11 +3469,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3600,7 +3604,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3637,7 +3641,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4113,7 +4117,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-05-28 17:11-0400\n"
+"POT-Creation-Date: 2021-06-01 22:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:175
+#: lxc/copy.go:121 lxc/init.go:185 lxc/project.go:126 lxc/publish.go:179
 #: lxc/storage.go:123 lxc/storage_volume.go:528
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -730,7 +730,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/export.go:43 lxc/publish.go:38
+#: lxc/export.go:43 lxc/publish.go:41
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 #: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:31 lxc/query.go:32 lxc/remote.go:33
+#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
 #: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
 #: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
@@ -1604,6 +1604,10 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "Image expiration date (format: rfc3339)"
+msgstr ""
+
 #: lxc/image.go:605
 msgid "Image exported successfully!"
 msgstr ""
@@ -1675,7 +1679,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/publish.go:76
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -1684,7 +1688,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/publish.go:277
+#: lxc/publish.go:289
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:35
+#: lxc/publish.go:38
 msgid "Make the image public"
 msgstr ""
 
@@ -2511,7 +2515,7 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:39
 msgid "New alias to define at target"
 msgstr ""
 
@@ -2789,11 +2793,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:30 lxc/publish.go:31
+#: lxc/publish.go:33 lxc/publish.go:34
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:223
+#: lxc/publish.go:235
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -3411,11 +3415,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:40
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:137
+#: lxc/publish.go:141
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -3546,7 +3550,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:106
+#: lxc/publish.go:110
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:79
+#: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -4059,7 +4063,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:29
+#: lxc/publish.go:32
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 


### PR DESCRIPTION
Addressing #8808:

* Add `--expire` flag to `lxc publish` to allow setting image expiration date when publishing an instance.
* Fallback to reading instance metadata expiration date (if given), if `--expire` is not used.
* Default behaviour is no expiration date.