### PR TITLE
Storage: Include unmount action in the ZFS revert hook returned from CreateVolumeFromBackup

### DIFF
--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -734,7 +734,7 @@ func createFromBackup(d *Daemon, r *http.Request, projectName string, data io.Re
 		if postHook != nil {
 			err = postHook(inst)
 			if err != nil {
-				return errors.Wrap(err, "Post hook")
+				return errors.Wrap(err, "Post hook failed")
 			}
 		}
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -691,7 +691,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 				if errors.Cause(err) == drivers.ErrCannotBeShrunk {
 					logger.Warn("Could not apply volume quota from root disk config as restored volume cannot be shrunk", log.Ctx{"size": rootDiskConf["size"]})
 				} else {
-					return err
+					return errors.Wrapf(err, "Failed applying volume quota to root disk")
 				}
 			}
 		}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -424,8 +424,10 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 		}
 	}
 
+	revertExternal := revert.Clone() // Clone before calling revert.Success() so we can return the Fail func.
+
 	revert.Success()
-	return postHook, revertHook, nil
+	return postHook, revertExternal.Fail, nil
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.


### PR DESCRIPTION
This way if a failure occurs after CreateVolumeFromBackup is finished, and its returned revert hook is run, the volume's internal mount counter is correctly cleared. This was not leaving an orphaned mount because the revert hook was already deleting the volume, however it was leaving an internal mount counter.

This prevents future import attempts from failing the post import volume resize due to In Use errors caused by the left over mount counter.

Fixes issue reported from https://discuss.linuxcontainers.org/t/why-does-lxd-kill-this-import-process-what-does-error-post-hook-in-use-even-mean-and-how-do-i-solve-it/11222/22 

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>