### PR TITLE
VM: NIC hotplug

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -41,6 +41,11 @@ type nicBridged struct {
 	deviceCommon
 }
 
+// CanHotPlug returns whether the device can be managed whilst the instance is running. Returns true.
+func (d *nicBridged) CanHotPlug() bool {
+	return true
+}
+
 // validateConfig checks the supplied config for correctness.
 func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 	if !instanceSupported(instConf.Type(), instancetype.Container, instancetype.VM) {

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -20,6 +20,11 @@ type nicMACVLAN struct {
 	deviceCommon
 }
 
+// CanHotPlug returns whether the device can be managed whilst the instance is running. Returns true.
+func (d *nicMACVLAN) CanHotPlug() bool {
+	return true
+}
+
 // validateConfig checks the supplied config for correctness.
 func (d *nicMACVLAN) validateConfig(instConf instance.ConfigReader) error {
 	if !instanceSupported(instConf.Type(), instancetype.Container, instancetype.VM) {

--- a/lxd/device/nic_p2p.go
+++ b/lxd/device/nic_p2p.go
@@ -15,6 +15,11 @@ type nicP2P struct {
 	deviceCommon
 }
 
+// CanHotPlug returns whether the device can be managed whilst the instance is running. Returns true.
+func (d *nicP2P) CanHotPlug() bool {
+	return true
+}
+
 // validateConfig checks the supplied config for correctness.
 func (d *nicP2P) validateConfig(instConf instance.ConfigReader) error {
 	if !instanceSupported(instConf.Type(), instancetype.Container, instancetype.VM) {

--- a/lxd/device/nic_physical.go
+++ b/lxd/device/nic_physical.go
@@ -20,6 +20,11 @@ type nicPhysical struct {
 	deviceCommon
 }
 
+// CanHotPlug returns whether the device can be managed whilst the instance is running. Returns true.
+func (d *nicPhysical) CanHotPlug() bool {
+	return true
+}
+
 // validateConfig checks the supplied config for correctness.
 func (d *nicPhysical) validateConfig(instConf instance.ConfigReader) error {
 	if !instanceSupported(instConf.Type(), instancetype.Container, instancetype.VM) {

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -29,6 +29,11 @@ type nicSRIOV struct {
 	deviceCommon
 }
 
+// CanHotPlug returns whether the device can be managed whilst the instance is running. Returns true.
+func (d *nicSRIOV) CanHotPlug() bool {
+	return true
+}
+
 // validateConfig checks the supplied config for correctness.
 func (d *nicSRIOV) validateConfig(instConf instance.ConfigReader) error {
 	if !instanceSupported(instConf.Type(), instancetype.Container, instancetype.VM) {

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -514,12 +514,10 @@ func (d *common) restartCommon(inst instance.Instance, timeout time.Duration) er
 // runHooks executes the callback functions returned from a function.
 func (d *common) runHooks(hooks []func() error) error {
 	// Run any post start hooks.
-	if len(hooks) > 0 {
-		for _, hook := range hooks {
-			err := hook()
-			if err != nil {
-				return err
-			}
+	for _, hook := range hooks {
+		err := hook()
+		if err != nil {
+			return err
 		}
 	}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -73,6 +73,9 @@ const qemuSerialChardevName = "qemu_serial-chardev"
 // qemuDefaultMemSize is the default memory size for VMs if not limit specified.
 const qemuDefaultMemSize = "1GiB"
 
+// qemuPCIDeviceIDStart is the first PCI slot used for user configurable devices.
+const qemuPCIDeviceIDStart = 4
+
 var errQemuAgentOffline = fmt.Errorf("LXD VM agent isn't currently running")
 
 var vmConsole = map[int]bool{}
@@ -2129,7 +2132,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 	// on PCIe (which we need to maintain compatibility with network configuration in our existing VM images).
 	// It's also meant to group all low-bandwidth internal devices onto a single address. PCIe bus allows a
 	// total of 256 devices, but this assumes 32 chassis * 8 function. By using VFs for the internal fixed
-	// devices we avoid consuming a chassis for each one.
+	// devices we avoid consuming a chassis for each one. See also the qemuPCIDeviceIDStart constant.
 	devBus, devAddr, multi := bus.allocate(busFunctionGroupGeneric)
 	err = qemuBalloon.Execute(sb, map[string]interface{}{
 		"bus":           bus.name,

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2364,6 +2364,11 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 
 	}
 
+	// Allocate 4 PCI slots for hotplug devices.
+	for i := 0; i < 4; i++ {
+		bus.allocate(busFunctionGroupNone)
+	}
+
 	// Write the agent mount config.
 	agentMountJSON, err := json.Marshal(agentMounts)
 	if err != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1603,6 +1603,72 @@ func (d *qemu) deviceStart(deviceName string, rawConfig deviceConfig.Device, ins
 	return runConf, nil
 }
 
+// deviceAttachNIC live attaches a NIC device to the instance.
+func (d *qemu) deviceAttachNIC(deviceName string, configCopy map[string]string, netIF []deviceConfig.RunConfigItem) error {
+	devName := ""
+	for _, dev := range netIF {
+		if dev.Key == "link" {
+			devName = dev.Value
+			break
+		}
+	}
+
+	if devName == "" {
+		return fmt.Errorf("Device didn't provide a link property to use")
+	}
+
+	_, qemuBus, err := d.qemuArchConfig(d.architecture)
+	if err != nil {
+		return err
+	}
+
+	// Check if the agent is running.
+	monitor, err := qmp.Connect(d.monitorPath(), qemuSerialChardevName, d.getMonitorEventHandler())
+	if err != nil {
+		return err
+	}
+
+	qemuDev := make(map[string]string)
+
+	// PCIe and PCI require a port device name to hotplug the NIC into.
+	if shared.StringInSlice(qemuBus, []string{"pcie", "pci"}) {
+		pciDevID := qemuPCIDeviceIDStart
+
+		// Iterate through all the instance devices in the same sorted order as is used when allocating the
+		// boot time devices in order to find the PCI bus slot device we would have used at boot time.
+		// Then attempt to use that same device, assuming it is available.
+		for _, dev := range d.expandedDevices.Sorted() {
+			if dev.Name == deviceName {
+				break // Found our device.
+			}
+
+			pciDevID++
+		}
+
+		pciDeviceName := fmt.Sprintf("%s%d", busDevicePortPrefix, pciDevID)
+		d.logger.Debug("Using PCI bus device to hotplug NIC into", log.Ctx{"device": deviceName, "port": pciDeviceName})
+		qemuDev["bus"] = pciDeviceName
+		qemuDev["addr"] = "00.0"
+	}
+
+	cpuCount, err := d.addCPUMemoryConfig(nil)
+	if err != nil {
+		return err
+	}
+
+	monHook, err := d.addNetDevConfig(cpuCount, qemuBus, qemuDev, nil, netIF)
+	if err != nil {
+		return err
+	}
+
+	err = monHook(monitor)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // deviceStop loads a new device and calls its Stop() function.
 func (d *qemu) deviceStop(deviceName string, rawConfig deviceConfig.Device, instanceRunning bool) error {
 	logger := logging.AddContext(d.logger, log.Ctx{"device": deviceName, "type": rawConfig["type"]})

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2713,7 +2713,7 @@ func (d *qemu) addNetDevConfig(cpuCount int, busName string, qemuDev map[string]
 	}
 
 	var qemuNetDev map[string]interface{}
-	qemuDev["id"] = fmt.Sprintf("dev-lxd_%s", devName)
+	qemuDev["id"] = fmt.Sprintf("%s%s", qemuDeviceIDPrefix, devName)
 
 	if len(bootIndexes) > 0 {
 		bootIndex, found := bootIndexes[devName]
@@ -2736,7 +2736,7 @@ func (d *qemu) addNetDevConfig(cpuCount int, busName string, qemuDev map[string]
 		}
 
 		qemuNetDev = map[string]interface{}{
-			"id":    fmt.Sprintf("lxd_%s", devName),
+			"id":    fmt.Sprintf("%s%s", qemuNetDevIDPrefix, devName),
 			"type":  "tap",
 			"vhost": true,
 			"fd":    fmt.Sprintf("/dev/tap%d", ifindex), // Indicates the file to open and the FD name.
@@ -2748,12 +2748,12 @@ func (d *qemu) addNetDevConfig(cpuCount int, busName string, qemuDev map[string]
 			qemuDev["driver"] = "virtio-net-ccw"
 		}
 
-		qemuDev["netdev"] = fmt.Sprintf("lxd_%s", devName)
+		qemuDev["netdev"] = qemuNetDev["id"].(string)
 		qemuDev["mac"] = devHwaddr
 	} else if shared.PathExists(fmt.Sprintf("/sys/class/net/%s/tun_flags", nicName)) {
 		// Detect TAP (via TUN driver) device.
 		qemuNetDev = map[string]interface{}{
-			"id":         fmt.Sprintf("lxd_%s", devName),
+			"id":         fmt.Sprintf("%s%s", qemuNetDevIDPrefix, devName),
 			"type":       "tap",
 			"vhost":      true,
 			"script":     "no",
@@ -2786,7 +2786,7 @@ func (d *qemu) addNetDevConfig(cpuCount int, busName string, qemuDev map[string]
 			}
 		}
 
-		qemuDev["netdev"] = fmt.Sprintf("lxd_%s", devName)
+		qemuDev["netdev"] = qemuNetDev["id"].(string)
 		qemuDev["mac"] = devHwaddr
 	} else if pciSlotName != "" {
 		// Detect physical passthrough device.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1586,7 +1586,7 @@ func (d *qemu) deviceStart(deviceName string, rawConfig deviceConfig.Device, ins
 	logger := logging.AddContext(d.logger, log.Ctx{"device": deviceName, "type": rawConfig["type"]})
 	logger.Debug("Starting device")
 
-	dev, _, err := d.deviceLoad(deviceName, rawConfig)
+	dev, configCopy, err := d.deviceLoad(deviceName, rawConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -1598,6 +1598,27 @@ func (d *qemu) deviceStart(deviceName string, rawConfig deviceConfig.Device, ins
 	runConf, err := dev.Start()
 	if err != nil {
 		return nil, err
+	}
+
+	// If runConf supplied, perform any instance specific setup of device.
+	if runConf != nil {
+		// If instance is running and then live attach device.
+		if instanceRunning {
+			// Attach network interface if requested.
+			if len(runConf.NetworkInterface) > 0 {
+				err = d.deviceAttachNIC(deviceName, configCopy, runConf.NetworkInterface)
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			// If running, run post start hooks now (if not running LXD will run them
+			// once the instance is started).
+			err = d.runHooks(runConf.PostHooks)
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	return runConf, nil

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2390,6 +2390,7 @@ func (d *qemu) generateQemuConfigFile(mountInfo *storagePools.MountInfo, busName
 }
 
 // addCPUMemoryConfig adds the qemu config required for setting the number of virtualised CPUs and memory.
+// If sb is nil then no config is written and instead just the CPU count is returned.
 func (d *qemu) addCPUMemoryConfig(sb *strings.Builder) (int, error) {
 	// Default to a single core.
 	cpus := d.expandedConfig["limits.cpu"]
@@ -2490,16 +2491,24 @@ func (d *qemu) addCPUMemoryConfig(sb *strings.Builder) (int, error) {
 	memSizeBytes = nodeMemory * int64(len(hostNodes))
 	ctx["memory"] = nodeMemory
 
-	err = qemuMemory.Execute(sb, map[string]interface{}{
-		"architecture": d.architectureName,
-		"memSizeBytes": memSizeBytes,
-	})
-	if err != nil {
-		return -1, err
+	if sb != nil {
+		err = qemuMemory.Execute(sb, map[string]interface{}{
+			"architecture": d.architectureName,
+			"memSizeBytes": memSizeBytes,
+		})
+
+		if err != nil {
+			return -1, err
+		}
+
+		err = qemuCPU.Execute(sb, ctx)
+		if err != nil {
+			return -1, err
+		}
 	}
 
 	// Configure the CPU limit.
-	return ctx["cpuCount"].(int), qemuCPU.Execute(sb, ctx)
+	return ctx["cpuCount"].(int), nil
 }
 
 // addFileDescriptor adds a file path to the list of files to open and pass file descriptor to qemu.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1735,6 +1735,16 @@ func (d *qemu) deviceStop(deviceName string, rawConfig deviceConfig.Device, inst
 	}
 
 	if runConf != nil {
+		if runConf != nil {
+			// Detach NIC from running instance.
+			if rawConfig["type"] == "nic" && instanceRunning {
+				err = d.deviceDetachNIC(deviceName)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
 		// Run post stop hooks irrespective of run state of instance.
 		err = d.runHooks(runConf.PostHooks)
 		if err != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -76,6 +76,12 @@ const qemuDefaultMemSize = "1GiB"
 // qemuPCIDeviceIDStart is the first PCI slot used for user configurable devices.
 const qemuPCIDeviceIDStart = 4
 
+// qemuDeviceIDPrefix used as part of the name given QEMU devices generated from user added devices.
+const qemuDeviceIDPrefix = "dev-lxd_"
+
+// qemuNetDevIDPrefix used as part of the name given QEMU netdevs generated from user added devices.
+const qemuNetDevIDPrefix = "lxd_"
+
 var errQemuAgentOffline = fmt.Errorf("LXD VM agent isn't currently running")
 
 var vmConsole = map[int]bool{}

--- a/lxd/instance/drivers/driver_qemu_bus.go
+++ b/lxd/instance/drivers/driver_qemu_bus.go
@@ -8,6 +8,7 @@ import (
 const busFunctionGroupNone = ""           // Add a non multi-function port.
 const busFunctionGroupGeneric = "generic" // Add multi-function port to generic group (used for internal devices).
 const busFunctionGroup9p = "9p"           // Add multi-function port to 9p group (used for 9p shares).
+const busDevicePortPrefix = "qemu_pcie"   // Prefix used for name of PCIe ports.
 
 type qemuBusEntry struct {
 	bridgeDev int // Device number on the root bridge.
@@ -116,14 +117,16 @@ func (a *qemuBus) allocate(multiFunctionGroup string) (string, string, bool) {
 
 	if a.name == "pcie" {
 		if p.fn == 0 {
+			portName := fmt.Sprintf("%s%d", busDevicePortPrefix, a.portNum)
 			qemuPCIe.Execute(a.sb, map[string]interface{}{
-				"index": a.portNum,
-				"addr":  fmt.Sprintf("%x.%d", p.bridgeDev, p.bridgeFn),
+				"portName": portName,
+				"index":    a.portNum,
+				"addr":     fmt.Sprintf("%x.%d", p.bridgeDev, p.bridgeFn),
 
 				// First root port added on a bridge bus address needs multi-function enabled.
 				"multifunction": p.bridgeFn == 0,
 			})
-			p.dev = fmt.Sprintf("qemu_pcie%d", a.portNum)
+			p.dev = portName
 			a.portNum++
 		}
 

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -101,7 +101,7 @@ bus = "dev-qemu_serial.0"
 `))
 
 var qemuPCIe = template.Must(template.New("qemuPCIe").Parse(`
-[device "qemu_pcie{{.index}}"]
+[device "{{.portName}}"]
 driver = "pcie-root-port"
 bus = "pcie.0"
 addr = "{{.addr}}"

--- a/lxd/instance/drivers/qmp/commands.go
+++ b/lxd/instance/drivers/qmp/commands.go
@@ -347,3 +347,42 @@ func (m *Monitor) Reset() error {
 
 	return nil
 }
+
+// PCIClassInfo info about a device's class.
+type PCIClassInfo struct {
+	Class       int    `json:"class"`
+	Description string `json:"desc"`
+}
+
+// PCIDevice represents a PCI device.
+type PCIDevice struct {
+	DevID    string       `json:"qdev_id"`
+	Bus      int          `json:"bus"`
+	Slot     int          `json:"slot"`
+	Function int          `json:"function"`
+	Devices  []PCIDevice  `json:"devices"`
+	Class    PCIClassInfo `json:"class_info"`
+	Bridge   PCIBridge    `json:"pci_bridge"`
+}
+
+// PCIBridge represents a PCI bridge.
+type PCIBridge struct {
+	Devices []PCIDevice `json:"devices"`
+}
+
+// QueryPCI returns info about PCI devices.
+func (m *Monitor) QueryPCI() ([]PCIDevice, error) {
+	// Prepare the response.
+	var resp struct {
+		Return []struct {
+			Devices []PCIDevice `json:"devices"`
+		} `json:"return"`
+	}
+
+	err := m.run("query-pci", "", &resp)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed querying PCI devices")
+	}
+
+	return resp.Return[0].Devices, nil
+}

--- a/lxd/instance/drivers/qmp/commands.go
+++ b/lxd/instance/drivers/qmp/commands.go
@@ -296,6 +296,48 @@ func (m *Monitor) AddNIC(netDev map[string]interface{}, device map[string]string
 	return nil
 }
 
+// RemoveNIC removes a NIC device.
+func (m *Monitor) RemoveNIC(netDevID string, deviceID string) error {
+	if deviceID != "" {
+		deviceID := map[string]string{
+			"id": deviceID,
+		}
+
+		args, err := json.Marshal(deviceID)
+		if err != nil {
+			return err
+		}
+
+		err = m.run("device_del", string(args), nil)
+		if err != nil {
+			// If the device has already been removed then all good.
+			if err != nil && !strings.Contains(err.Error(), "not found") {
+				return errors.Wrapf(err, "Failed removing NIC device")
+			}
+		}
+	}
+
+	if netDevID != "" {
+		netDevID := map[string]string{
+			"id": netDevID,
+		}
+
+		args, err := json.Marshal(netDevID)
+		if err != nil {
+			return err
+		}
+
+		err = m.run("netdev_del", string(args), nil)
+
+		// Not all NICs need a netdev, so if its missing, its not a problem.
+		if err != nil && !strings.Contains(err.Error(), "not found") {
+			return errors.Wrapf(err, "Failed removing NIC netdev")
+		}
+	}
+
+	return nil
+}
+
 // Reset VM.
 func (m *Monitor) Reset() error {
 	err := m.run("system_reset", "", nil)

--- a/lxd/instance/drivers/qmp/commands.go
+++ b/lxd/instance/drivers/qmp/commands.go
@@ -273,7 +273,10 @@ func (m *Monitor) AddNIC(netDev map[string]interface{}, device map[string]string
 				return
 			}
 
-			m.run("netdev_del", string(args), nil)
+			err = m.run("netdev_del", string(args), nil)
+			if err != nil {
+				return
+			}
 		})
 	}
 


### PR DESCRIPTION
This PR adds hot plug and hot unplug support for VM NIC devices.

QEMU does not currently support hotplugging `pcie-root-port` devices (which are required in order to connect a NIC device to) so in order to support hotplugging we now pre-create 4 "free" PCI ports (in addition to the devices present at boot time), these free slots are what new devices are hotplugged into.

However we do not just find the next free slot and plug the NIC into it. This is because NIC device names inside the VM guest are derived from their PCI slot location (i.e `enp5s0`) and so if we just found the next free slot to hotplug a NIC into then its name would likely change when it was rebooted (as it could be reordered differently at boot time based on the LXD name of the device).

So in order to support some semblance of predicability we only support hotplugging into a free PCI slot if that slot would be the same one used when the VM is rebooted. If the slot is already taken by another device then hotplugging is not possible without changing the name of the LXD device name so that it lines up with a free slot.

E.g.

This will remove the profile's NIC (hot unplug), leaving the first useable PCI slot (which happens to be ID 4) free, and then hotplug a new macvlan NIC into the same slot (because this `eth0` device will be at the same position when the VM is rebooted).

```
lxc config device add v1 eth0 nic nictype=macvlan parent=enp1s0 
```

Then hotplugging a device called `eth1` will try and use the next port (ID 5), as it comes alphabetically after `eth0`.

```
lxc config device add v1 eth1 nic nictype=physical parent=enp4s0
```

However adding a NIC called `a1` will fail because it comes alphahetically before `eth0` and `eth1` and so would use the first slot (ID 4) on boot, and this is currently used by the `eth0` device.

```
lxc config device add v1 a1 nic nictype=p2p  # Will fail
```

- [x] Add PCI querying command.
- [x] Add NIC hot plug support.
- [x] Add NIC hot unplug support.

Tested with:

- bridged
- p2p
- macvlan
- physical
- sriov

