### PR TITLE
VM: Increase max wait time for qemu process to exit

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -573,8 +573,9 @@ func (d *qemu) onStop(target string) error {
 	op.Reset()
 
 	// Wait for QEMU process to end (to avoiding racing start when restarting).
+	// Wait up to 20s to allow for flushing any pending data to disk.
 	d.logger.Debug("Waiting for VM process to finish")
-	waitDuration := time.Duration(time.Second * time.Duration(5))
+	waitDuration := time.Duration(time.Second * time.Duration(20))
 	waitUntil := time.Now().Add(waitDuration)
 	for {
 		pid, _ := d.pid()
@@ -590,6 +591,9 @@ func (d *qemu) onStop(target string) error {
 
 		time.Sleep(time.Millisecond * time.Duration(100))
 	}
+
+	// Reset timeout to 30s.
+	op.Reset()
 
 	// Cleanup.
 	d.cleanupDevices() // Must be called before unmount.


### PR DESCRIPTION
To allow time for flushing pending I/O to disk.
Also reset the operation afterwards to give more time for operation to complete.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>