### PR TITLE
Cluster: Get local cluster address from local DB and avoid sending heartbeats to ourself during cluster upgrade

### DIFF
--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -332,6 +332,11 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 		return
 	}
 
+	if localAddress == "" {
+		logger.Warn("No local address set, aborting heartbeat round")
+		return
+	}
+
 	startTime := time.Now()
 
 	heartbeatInterval := g.heartbeatInterval()

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/db/query"
+	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/task"
 	"github.com/lxc/lxd/shared"
 	log "github.com/lxc/lxd/shared/log15"
@@ -282,16 +283,16 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 		return
 	}
 
+	// Address of this node.
+	localAddress, err := node.ClusterAddress(g.db)
+	if err != nil {
+		logger.Error("Failed to fetch local cluster address", log.Ctx{"err": err})
+	}
+
 	var allNodes []db.NodeInfo
-	var localAddress string // Address of this node
 	err = g.Cluster.Transaction(func(tx *db.ClusterTx) error {
 		var err error
 		allNodes, err = tx.GetNodes()
-		if err != nil {
-			return err
-		}
-
-		localAddress, err = tx.GetLocalNodeAddress()
 		if err != nil {
 			return err
 		}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -584,7 +584,7 @@ func (d *qemu) onStop(target string) error {
 		}
 
 		if time.Now().After(waitUntil) {
-			d.logger.Error("VM process failed to stop after %v", waitDuration)
+			d.logger.Error("VM process failed to stop", log.Ctx{"waitDuration": waitDuration})
 			break // Continue clean up as best we can.
 		}
 


### PR DESCRIPTION
This is because the call to `db.OpenCluster()` (https://github.com/lxc/lxd/blob/966cf0739e1015acf14f21b0b5a303f881c1e80b/lxd/daemon.go#L1016) on start up will return `db.ErrSomeNodesAreBehind` when not all cluster members are up to date, and this is returned before the call to `cluster.NodeID(nodeID)` inside `db.OpenCluster()` which is used by the `tx.GetLocalNodeAddress()` function to get the local node address in order to skip sending a heartbeat request to ourselves.

Otherwise we will potentially end up sending heartbeat to ourself in a loop as the dqlite connection to itself is periodically reconnected as it waits for the schema version to match on all cluster members, this triggers an impromptu heartbeat, which if initiated before the DB connections active causes the resulting heartbeat to be sent back to itself, which then cancels the heartbeat round and restarts it...etc.

Fixes #8834

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>