### PR TITLE
Allow passing a fingerprint to compare during remote connection

### DIFF
--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -314,14 +314,18 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 			digest := shared.CertFingerprint(certificate)
 
 			fmt.Printf(i18n.G("Certificate fingerprint: %s")+"\n", digest)
-			fmt.Printf(i18n.G("ok (y/n)?") + " ")
+			fmt.Printf(i18n.G("ok (y/n/[fingerprint])?") + " ")
 			line, err := shared.ReadStdin()
 			if err != nil {
 				return err
 			}
 
-			if len(line) < 1 || strings.ToLower(string(line[0])) != i18n.G("y") {
-				return fmt.Errorf(i18n.G("Server certificate NACKed by user"))
+			if string(line) != digest {
+				if len(line) < 1 || strings.ToLower(string(line[0])) == i18n.G("n") {
+					return fmt.Errorf(i18n.G("Server certificate NACKed by user"))
+				} else if strings.ToLower(string(line[0])) != i18n.G("y") {
+					return fmt.Errorf(i18n.G("Please type 'y', 'n' or the fingerprint:"))
+				}
 			}
 		}
 

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -155,19 +155,38 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer) error
 				return fmt.Errorf("Joining an existing cluster requires root privileges")
 			}
 
-			if cli.AskBool("Do you have a join token? (yes/no) [default=no]: ", "no") {
-				var joinToken *api.ClusterMemberJoinToken
-				validJoinToken := func(input string) error {
-					j, err := clusterMemberJoinTokenDecode(input)
-					if err != nil {
-						return errors.Wrapf(err, "Invalid join token")
-					}
+			var joinToken *api.ClusterMemberJoinToken
 
-					joinToken = j // Store valid decoded join token
-					return nil
+			validJoinToken := func(input string) error {
+				j, err := clusterMemberJoinTokenDecode(input)
+				if err != nil {
+					return errors.Wrapf(err, "Invalid join token")
 				}
 
-				rawJoinToken := cli.AskString("Please provide join token: ", "", validJoinToken)
+				joinToken = j // Store valid decoded join token
+				return nil
+			}
+
+			validInput := func(input string) error {
+				if shared.StringInSlice(strings.ToLower(input), []string{"yes", "y"}) {
+					return nil
+				} else if shared.StringInSlice(strings.ToLower(input), []string{"no", "n"}) {
+					return nil
+				} else if validJoinToken(input) != nil {
+					return fmt.Errorf("Not yes/no, or invalid join token")
+				}
+
+				return nil
+			}
+
+			input := cli.AskString("Do you have a join token? (yes/no/[token]) [default=no]: ", "no", validInput)
+
+			if !shared.StringInSlice(strings.ToLower(input), []string{"no", "n"}) {
+				rawJoinToken := input
+
+				if shared.StringInSlice(strings.ToLower(input), []string{"yes", "y"}) {
+					rawJoinToken = cli.AskString("Please provide join token: ", "", validJoinToken)
+				}
 
 				if joinToken.ServerName != config.Cluster.ServerName {
 					return fmt.Errorf("Server name does not match the one specified in join token")

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -290,10 +290,9 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer) error
 				return errors.Wrap(err, "Failed to retrieve cluster information")
 			}
 
-			validator := func(string) error { return nil }
 			for i, config := range cluster.MemberConfig {
 				question := fmt.Sprintf("Choose %s: ", config.Description)
-				cluster.MemberConfig[i].Value = cli.AskString(question, "", validator)
+				cluster.MemberConfig[i].Value = cli.AskString(question, "", nil)
 			}
 
 			config.Cluster.MemberConfig = cluster.MemberConfig

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -475,15 +475,15 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -517,7 +517,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -583,7 +583,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Address: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "Administrator Passwort für %s: "
@@ -666,7 +666,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -835,7 +835,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -883,7 +883,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 #, fuzzy
 msgid "Client certificate stored at server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
@@ -1047,7 +1047,7 @@ msgstr "Fehler: %v\n"
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
@@ -1280,8 +1280,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1698,7 +1698,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1722,7 +1722,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2334,7 +2334,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2741,7 +2741,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2759,8 +2759,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2948,11 +2948,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2985,6 +2985,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -3197,13 +3201,13 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -3213,12 +3217,12 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -3274,7 +3278,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -3319,7 +3323,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3426,7 +3430,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3454,7 +3458,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -3592,7 +3596,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3692,7 +3696,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3873,7 +3877,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -4089,7 +4093,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -4259,8 +4263,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -5120,7 +5124,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -5393,6 +5397,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -5402,9 +5410,8 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-#, fuzzy
-msgid "ok (y/n)?"
-msgstr "OK (y/n)? "
+msgid "ok (y/n/[fingerprint])?"
+msgstr ""
 
 #: lxc/config.go:53
 msgid "please use `lxc profile`"
@@ -5439,7 +5446,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 
@@ -5447,6 +5454,10 @@ msgstr ""
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""
+
+#, fuzzy
+#~ msgid "ok (y/n)?"
+#~ msgstr "OK (y/n)? "
 
 #, fuzzy
 #~ msgid "The --instance-only flag can't be used with --storage"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -311,15 +311,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -349,7 +349,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -410,7 +410,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -487,7 +487,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -688,7 +688,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -843,7 +843,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1059,8 +1059,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1447,7 +1447,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1471,7 +1471,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2047,7 +2047,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2422,7 +2422,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2440,8 +2440,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2626,11 +2626,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2662,6 +2662,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2866,13 +2870,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2882,12 +2886,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2939,7 +2943,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2980,7 +2984,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3081,7 +3085,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3109,7 +3113,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3331,7 +3335,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3502,7 +3506,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3708,7 +3712,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3863,8 +3867,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4294,7 +4298,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4563,6 +4567,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4572,7 +4580,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4608,7 +4616,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -458,15 +458,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -497,7 +497,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -559,7 +559,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "Contraseña admin para %s: "
@@ -636,7 +636,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
@@ -794,7 +794,7 @@ msgstr "No se puede jalar un directorio sin - recursivo"
 msgid "Can't read from stdin: %s"
 msgstr "No se peude leer desde stdin: %s"
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr "Cacheado: %s"
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 #, fuzzy
 msgid "Client certificate stored at server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -999,7 +999,7 @@ msgstr "Expira: %s"
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1220,8 +1220,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1610,7 +1610,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1634,7 +1634,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2216,7 +2216,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2597,7 +2597,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2615,8 +2615,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2799,11 +2799,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2835,6 +2835,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -3042,13 +3046,13 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -3058,12 +3062,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -3115,7 +3119,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -3157,7 +3161,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3260,7 +3264,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3288,7 +3292,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3418,7 +3422,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3510,7 +3514,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3681,7 +3685,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3887,7 +3891,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -4042,8 +4046,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4570,7 +4574,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4839,6 +4843,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4848,7 +4856,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4884,7 +4892,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -468,17 +468,17 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 #, fuzzy
 msgid "<remote>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 #, fuzzy
 msgid "<remote> <URL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -513,7 +513,7 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
@@ -580,7 +580,7 @@ msgstr "Création du conteneur"
 msgid "Address: %s"
 msgstr "Expire : %s"
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "Mot de passe administrateur pour %s : "
@@ -661,7 +661,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
@@ -822,7 +822,7 @@ msgstr "impossible de récupérer un répertoire sans --recursive"
 msgid "Can't read from stdin: %s"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -869,7 +869,7 @@ msgstr "Créé : %s"
 msgid "Certificate fingerprint: %s"
 msgstr "Empreinte du certificat : %s"
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 #, fuzzy
 msgid "Client certificate stored at server:"
 msgstr "Certificat client enregistré sur le serveur : "
@@ -1041,7 +1041,7 @@ msgstr "erreur : %v"
 msgid "Cores:"
 msgstr "erreur : %v"
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
@@ -1294,8 +1294,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1714,7 +1714,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1738,7 +1738,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2401,7 +2401,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2808,7 +2808,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr "NOM"
@@ -2826,8 +2826,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr "NON"
 
@@ -3026,11 +3026,11 @@ msgstr "PROFILS"
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -3065,6 +3065,10 @@ msgstr ""
 #, c-format
 msgid "Pid: %d"
 msgstr "Pid : %d"
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
+msgstr ""
 
 #: lxc/info.go:209
 #, fuzzy, c-format
@@ -3279,13 +3283,13 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
@@ -3295,12 +3299,12 @@ msgstr "le serveur distant %s n'existe pas"
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
@@ -3356,7 +3360,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -3400,7 +3404,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr "Créé : %s"
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3524,7 +3528,7 @@ msgstr ""
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -3554,7 +3558,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -3694,7 +3698,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3799,7 +3803,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -3982,7 +3986,7 @@ msgstr "Swap (pointe)"
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 #, fuzzy
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -4202,7 +4206,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr "URL"
 
@@ -4372,8 +4376,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr "OUI"
 
@@ -5329,7 +5333,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -5621,6 +5625,11 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+#, fuzzy
+msgid "n"
+msgstr "non"
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -5630,8 +5639,8 @@ msgid "no"
 msgstr "non"
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
-msgstr "ok (y/n) ?"
+msgid "ok (y/n/[fingerprint])?"
+msgstr ""
 
 #: lxc/config.go:53
 msgid "please use `lxc profile`"
@@ -5666,7 +5675,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 
@@ -5674,6 +5683,9 @@ msgstr ""
 #: lxc/image.go:1079
 msgid "yes"
 msgstr "oui"
+
+#~ msgid "ok (y/n)?"
+#~ msgstr "ok (y/n) ?"
 
 #~ msgid "Press enter to start the editor again"
 #~ msgstr "Appuyer sur Entrée pour lancer à nouveau l'éditeur"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -449,15 +449,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -550,7 +550,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "Password amministratore per %s: "
@@ -627,7 +627,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -784,7 +784,7 @@ msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 msgid "Can't read from stdin: %s"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -828,7 +828,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 #, fuzzy
 msgid "Client certificate stored at server:"
 msgstr "Certificato del client salvato dal server: "
@@ -984,7 +984,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1209,8 +1209,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1600,7 +1600,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1624,7 +1624,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2208,7 +2208,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2590,7 +2590,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2608,8 +2608,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2792,11 +2792,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2829,6 +2829,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -3035,13 +3039,13 @@ msgstr "Creazione del container in corso"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
@@ -3051,12 +3055,12 @@ msgstr "il remote %s non esiste"
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
@@ -3109,7 +3113,7 @@ msgstr "Creazione del container in corso"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -3151,7 +3155,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3254,7 +3258,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3282,7 +3286,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3412,7 +3416,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3504,7 +3508,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3677,7 +3681,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3884,7 +3888,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -4040,8 +4044,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4570,7 +4574,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4839,6 +4843,11 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+#, fuzzy
+msgid "n"
+msgstr "no"
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4848,8 +4857,8 @@ msgid "no"
 msgstr "no"
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
-msgstr "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
+msgstr ""
 
 #: lxc/config.go:53
 msgid "please use `lxc profile`"
@@ -4884,7 +4893,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 
@@ -4892,6 +4901,9 @@ msgstr ""
 #: lxc/image.go:1079
 msgid "yes"
 msgstr "si"
+
+#~ msgid "ok (y/n)?"
+#~ msgstr "ok (y/n)?"
 
 #, fuzzy
 #~ msgid "create [<remote>:]<instance> <template>"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: 2021-02-02 15:21+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -451,15 +451,15 @@ msgstr "<pool>/<volume> <pool>/<volume>"
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr "<remote>"
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
@@ -491,7 +491,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
@@ -560,7 +560,7 @@ msgstr "インスタンスにプロファイルを追加します"
 msgid "Address: %s"
 msgstr "アドレス: %s"
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr "%s の管理者パスワード:"
@@ -641,7 +641,7 @@ msgstr ""
 "このコマンドはインスタンスのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
@@ -800,7 +800,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr "標準入力から読み込めません: %s"
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
@@ -844,7 +844,7 @@ msgstr "カード: %s (%s)"
 msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr "クライアント証明書がサーバに格納されました:"
 
@@ -1007,7 +1007,7 @@ msgstr "コア %d"
 msgid "Cores:"
 msgstr "コア:"
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
@@ -1231,8 +1231,8 @@ msgstr "イメージを削除します"
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1663,7 +1663,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr "フォーマット (csv|json|table|yaml)"
@@ -1687,7 +1687,7 @@ msgstr "クロック数: %vMhz"
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2400,7 +2400,7 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
@@ -2826,7 +2826,7 @@ msgstr "インスタンス名を指定する必要があります: "
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr "NAME"
@@ -2844,8 +2844,8 @@ msgid "NICs:"
 msgstr "NICs:"
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr "NO"
 
@@ -3029,11 +3029,11 @@ msgstr "PROFILES"
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -3066,6 +3066,10 @@ msgstr "インクリメンタルコピーを実行します"
 #, c-format
 msgid "Pid: %d"
 msgstr "Pid: %d"
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
+msgstr ""
 
 #: lxc/info.go:209
 #, c-format
@@ -3271,13 +3275,13 @@ msgstr "インスタンスの更新中: %s"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
@@ -3287,12 +3291,12 @@ msgstr "リモート %s は存在しません"
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "リモート %s は static ですので変更できません"
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
@@ -3344,7 +3348,7 @@ msgstr "インスタンスのデバイスを削除します"
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
@@ -3387,7 +3391,7 @@ msgstr "プロファイル名を変更します"
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
@@ -3496,7 +3500,7 @@ msgstr "SR-IOV 情報:"
 msgid "STATE"
 msgstr "STATE"
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr "STATIC"
 
@@ -3524,7 +3528,7 @@ msgstr "サーバの認証タイプ (tls もしくは candid)"
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
@@ -3692,7 +3696,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
@@ -3786,7 +3790,7 @@ msgstr "ストレージボリュームの設定を表示する"
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
@@ -3958,7 +3962,7 @@ msgstr "Swap (ピーク)"
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
@@ -4189,7 +4193,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr "URL"
 
@@ -4353,8 +4357,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr "インスタンスの稼動状態のスナップショットを取得するかどうか"
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr "YES"
 
@@ -4799,7 +4803,7 @@ msgstr "[<remote>] <IP|FQDN|URL>"
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr "現在値"
 
@@ -5186,6 +5190,11 @@ msgstr ""
 "    \"default\" プール内のコンテナ \"data\" のファイルシステムプロパティを表"
 "示します。"
 
+#: lxc/remote.go:323
+#, fuzzy
+msgid "n"
+msgstr "no"
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr "名前"
@@ -5195,8 +5204,8 @@ msgid "no"
 msgstr "no"
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
-msgstr "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
+msgstr ""
 
 #: lxc/config.go:53
 msgid "please use `lxc profile`"
@@ -5231,7 +5240,7 @@ msgstr "サーバに接続できません"
 msgid "used by"
 msgstr "ストレージを使用中の"
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr "y"
 
@@ -5239,6 +5248,9 @@ msgstr "y"
 #: lxc/image.go:1079
 msgid "yes"
 msgstr "yes"
+
+#~ msgid "ok (y/n)?"
+#~ msgstr "ok (y/n)?"
 
 #~ msgid "Press enter to start the editor again"
 #~ msgstr "再度エディタを起動するには Enter キーを押します"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2021-06-01 22:11+0000\n"
+        "POT-Creation-Date: 2021-06-02 04:58+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -295,15 +295,15 @@ msgstr  ""
 msgid   "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr  ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid   "<remote>"
 msgstr  ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid   "<remote> <URL>"
 msgstr  ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid   "<remote> <new-name>"
 msgstr  ""
 
@@ -331,7 +331,7 @@ msgstr  ""
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid   "AUTH TYPE"
 msgstr  ""
 
@@ -389,7 +389,7 @@ msgstr  ""
 msgid   "Address: %s"
 msgstr  ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid   "Admin password for %s:"
 msgstr  ""
@@ -465,7 +465,7 @@ msgid   "Attach to instance consoles\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
@@ -620,7 +620,7 @@ msgstr  ""
 msgid   "Can't read from stdin: %s"
 msgstr  ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid   "Can't remove the default remote"
 msgstr  ""
 
@@ -664,7 +664,7 @@ msgstr  ""
 msgid   "Certificate fingerprint: %s"
 msgstr  ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid   "Client certificate stored at server:"
 msgstr  ""
 
@@ -800,7 +800,7 @@ msgstr  ""
 msgid   "Cores:"
 msgstr  ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -970,7 +970,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163 lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431 lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52 lxc/config_metadata.go:174 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:73 lxc/config_trust.go:135 lxc/config_trust.go:247 lxc/config_trust.go:327 lxc/config_trust.go:370 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605 lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235 lxc/storage_volume.go:322 lxc/storage_volume.go:484 lxc/storage_volume.go:563 lxc/storage_volume.go:639 lxc/storage_volume.go:721 lxc/storage_volume.go:802 lxc/storage_volume.go:1002 lxc/storage_volume.go:1090 lxc/storage_volume.go:1177 lxc/storage_volume.go:1361 lxc/storage_volume.go:1392 lxc/storage_volume.go:1505 lxc/storage_volume.go:1581 lxc/storage_volume.go:1680 lxc/storage_volume.go:1714 lxc/storage_volume.go:1812 lxc/storage_volume.go:1879 lxc/storage_volume.go:2020 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:67 lxc/warning.go:247 lxc/warning.go:288 lxc/warning.go:342
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163 lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431 lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52 lxc/config_metadata.go:174 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:73 lxc/config_trust.go:135 lxc/config_trust.go:247 lxc/config_trust.go:327 lxc/config_trust.go:370 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235 lxc/storage_volume.go:322 lxc/storage_volume.go:484 lxc/storage_volume.go:563 lxc/storage_volume.go:639 lxc/storage_volume.go:721 lxc/storage_volume.go:802 lxc/storage_volume.go:1002 lxc/storage_volume.go:1090 lxc/storage_volume.go:1177 lxc/storage_volume.go:1361 lxc/storage_volume.go:1392 lxc/storage_volume.go:1505 lxc/storage_volume.go:1581 lxc/storage_volume.go:1680 lxc/storage_volume.go:1714 lxc/storage_volume.go:1812 lxc/storage_volume.go:1879 lxc/storage_volume.go:2020 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:67 lxc/warning.go:247 lxc/warning.go:288 lxc/warning.go:342
 msgid   "Description"
 msgstr  ""
 
@@ -1319,7 +1319,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645 lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515 lxc/storage_volume.go:1195 lxc/warning.go:89
+#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645 lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011 lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515 lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
@@ -1342,7 +1342,7 @@ msgstr  ""
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid   "GLOBAL"
 msgstr  ""
 
@@ -1902,7 +1902,7 @@ msgid   "List storage volumes\n"
         "    U - Current disk usage"
 msgstr  ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid   "List the available remotes"
 msgstr  ""
 
@@ -2246,7 +2246,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567 lxc/storage_volume.go:1270
+#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid   "NAME"
 msgstr  ""
 
@@ -2262,7 +2262,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540 lxc/remote.go:545 lxc/remote.go:550
+#: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434 lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544 lxc/remote.go:549 lxc/remote.go:554
 msgid   "NO"
 msgstr  ""
 
@@ -2445,11 +2445,11 @@ msgstr  ""
 msgid   "PROJECT"
 msgstr  ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -2481,6 +2481,10 @@ msgstr  ""
 #: lxc/info.go:487
 #, c-format
 msgid   "Pid: %d"
+msgstr  ""
+
+#: lxc/remote.go:328
+msgid   "Please type 'y', 'n' or the fingerprint:"
 msgstr  ""
 
 #: lxc/info.go:209
@@ -2681,12 +2685,12 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749 lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753 lxc/remote.go:791
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
@@ -2696,12 +2700,12 @@ msgstr  ""
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid   "Remote %s is global and cannot be removed"
 msgstr  ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
@@ -2753,7 +2757,7 @@ msgstr  ""
 msgid   "Remove profiles from instances"
 msgstr  ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -2793,7 +2797,7 @@ msgstr  ""
 msgid   "Rename projects"
 msgstr  ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid   "Rename remotes"
 msgstr  ""
 
@@ -2892,7 +2896,7 @@ msgstr  ""
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid   "STATIC"
 msgstr  ""
 
@@ -2920,7 +2924,7 @@ msgstr  ""
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
@@ -3032,7 +3036,7 @@ msgid   "Set storage volume configuration keys\n"
         "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid   "Set the URL for the remote"
 msgstr  ""
 
@@ -3124,7 +3128,7 @@ msgstr  ""
 msgid   "Show storage volume state information"
 msgstr  ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid   "Show the default remote"
 msgstr  ""
 
@@ -3295,7 +3299,7 @@ msgstr  ""
 msgid   "Switch the current project"
 msgstr  ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid   "Switch the default remote"
 msgstr  ""
 
@@ -3488,7 +3492,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid   "URL"
 msgstr  ""
 
@@ -3636,7 +3640,7 @@ msgstr  ""
 msgid   "Whether or not to snapshot the instance's running state"
 msgstr  ""
 
-#: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542 lxc/remote.go:547 lxc/remote.go:552
+#: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436 lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546 lxc/remote.go:551 lxc/remote.go:556
 msgid   "YES"
 msgstr  ""
 
@@ -4052,7 +4056,7 @@ msgstr  ""
 msgid   "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr  ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid   "current"
 msgstr  ""
 
@@ -4281,6 +4285,10 @@ msgid   "lxc storage volume show default data\n"
         "    Will show the properties of the filesystem for a container called \"data\" in the \"default\" pool."
 msgstr  ""
 
+#: lxc/remote.go:323
+msgid   "n"
+msgstr  ""
+
 #: lxc/storage.go:449
 msgid   "name"
 msgstr  ""
@@ -4290,7 +4298,7 @@ msgid   "no"
 msgstr  ""
 
 #: lxc/remote.go:317
-msgid   "ok (y/n)?"
+msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
 #: lxc/config.go:53
@@ -4326,7 +4334,7 @@ msgstr  ""
 msgid   "used by"
 msgstr  ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid   "y"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -446,15 +446,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -484,7 +484,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -622,7 +622,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -778,7 +778,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -822,7 +822,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -977,7 +977,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1193,8 +1193,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1578,7 +1578,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1602,7 +1602,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2178,7 +2178,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2551,7 +2551,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2569,8 +2569,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2753,11 +2753,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2789,6 +2789,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2993,13 +2997,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -3009,12 +3013,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -3066,7 +3070,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -3107,7 +3111,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3208,7 +3212,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3236,7 +3240,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3366,7 +3370,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3458,7 +3462,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3629,7 +3633,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3835,7 +3839,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3990,8 +3994,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4421,7 +4425,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4690,6 +4694,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4699,7 +4707,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4735,7 +4743,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -464,15 +464,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -502,7 +502,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -563,7 +563,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -640,7 +640,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -796,7 +796,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -840,7 +840,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -995,7 +995,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1211,8 +1211,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1596,7 +1596,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1620,7 +1620,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2196,7 +2196,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2569,7 +2569,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2587,8 +2587,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2771,11 +2771,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2807,6 +2807,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -3011,13 +3015,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -3027,12 +3031,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -3084,7 +3088,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -3125,7 +3129,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3226,7 +3230,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3254,7 +3258,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3384,7 +3388,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3476,7 +3480,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3647,7 +3651,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3853,7 +3857,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -4008,8 +4012,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4439,7 +4443,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4708,6 +4712,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4717,7 +4725,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4753,7 +4761,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -467,15 +467,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -505,7 +505,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
@@ -570,7 +570,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "Senha de administrador para %s: "
@@ -652,7 +652,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
@@ -810,7 +810,7 @@ msgstr "Não pode pegar um diretório sem --recursive"
 msgid "Can't read from stdin: %s"
 msgstr "Não é possível ler stdin: %s"
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
@@ -854,7 +854,7 @@ msgstr "Em cache: %s"
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 #, fuzzy
 msgid "Client certificate stored at server:"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
@@ -1251,8 +1251,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1648,7 +1648,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2257,7 +2257,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2641,7 +2641,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2659,8 +2659,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2843,11 +2843,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2879,6 +2879,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -3088,13 +3092,13 @@ msgstr "Editar arquivos no container"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -3104,12 +3108,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -3162,7 +3166,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -3205,7 +3209,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3312,7 +3316,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3340,7 +3344,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3475,7 +3479,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3574,7 +3578,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3747,7 +3751,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3956,7 +3960,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -4117,8 +4121,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4566,7 +4570,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4835,6 +4839,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4844,7 +4852,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4880,7 +4888,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: 2020-10-08 08:16+0000\n"
 "Last-Translator: Artem <KovalevArtem.ru@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -469,15 +469,15 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -512,7 +512,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -575,7 +575,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "Пароль администратора для %s: "
@@ -653,7 +653,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -812,7 +812,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 #, fuzzy
 msgid "Client certificate stored at server:"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -1014,7 +1014,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
@@ -1243,8 +1243,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1639,7 +1639,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2251,7 +2251,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2640,7 +2640,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2658,8 +2658,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2845,11 +2845,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2881,6 +2881,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -3086,13 +3090,13 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -3102,12 +3106,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -3160,7 +3164,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -3202,7 +3206,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3308,7 +3312,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3336,7 +3340,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3466,7 +3470,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3561,7 +3565,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3737,7 +3741,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3943,7 +3947,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -4098,8 +4102,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4921,7 +4925,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -5190,6 +5194,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -5199,7 +5207,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -5235,7 +5243,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: 2020-11-05 02:45+0000\n"
 "Last-Translator: wdggg <wdggg7@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -362,15 +362,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -400,7 +400,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -461,7 +461,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -538,7 +538,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -694,7 +694,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -893,7 +893,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1109,8 +1109,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1494,7 +1494,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2094,7 +2094,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2467,7 +2467,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2485,8 +2485,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2669,11 +2669,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2705,6 +2705,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2909,13 +2913,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2925,12 +2929,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2982,7 +2986,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -3023,7 +3027,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3124,7 +3128,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3152,7 +3156,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3282,7 +3286,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3374,7 +3378,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3545,7 +3549,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3751,7 +3755,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3906,8 +3910,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4337,7 +4341,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4606,6 +4610,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4615,7 +4623,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4651,7 +4659,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-01 22:11+0000\n"
+"POT-Creation-Date: 2021-06-02 04:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,15 +308,15 @@ msgstr ""
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
-#: lxc/remote.go:672 lxc/remote.go:727
+#: lxc/remote.go:676 lxc/remote.go:731
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:765
+#: lxc/remote.go:769
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:602
+#: lxc/remote.go:606
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:585
+#: lxc/remote.go:589
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:418
+#: lxc/remote.go:422
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
@@ -484,7 +484,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:404
+#: lxc/remote.go:408
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:707
+#: lxc/remote.go:711
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:457
+#: lxc/remote.go:461
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:335
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1055,8 +1055,8 @@ msgstr ""
 #: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
 #: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
 #: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:483 lxc/remote.go:519 lxc/remote.go:605
-#: lxc/remote.go:675 lxc/remote.go:729 lxc/remote.go:767 lxc/rename.go:21
+#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
+#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
 #: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
 #: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
@@ -1440,7 +1440,7 @@ msgstr ""
 #: lxc/config_template.go:238 lxc/config_trust.go:249 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
-#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:523 lxc/storage.go:515
+#: lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515
 #: lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:588
+#: lxc/remote.go:592
 msgid "GLOBAL"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:518 lxc/remote.go:519
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "List the available remotes"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 
 #: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:305
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
-#: lxc/project.go:465 lxc/remote.go:582 lxc/storage.go:567
+#: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
 msgid "NAME"
 msgstr ""
@@ -2431,8 +2431,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:871 lxc/operation.go:143 lxc/project.go:434
-#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:540
-#: lxc/remote.go:545 lxc/remote.go:550
+#: lxc/project.go:439 lxc/project.go:444 lxc/project.go:449 lxc/remote.go:544
+#: lxc/remote.go:549 lxc/remote.go:554
 msgid "NO"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:584
+#: lxc/remote.go:588
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/remote.go:586
+#: lxc/image.go:1023 lxc/remote.go:590
 msgid "PUBLIC"
 msgstr ""
 
@@ -2651,6 +2651,10 @@ msgstr ""
 #: lxc/info.go:487
 #, c-format
 msgid "Pid: %d"
+msgstr ""
+
+#: lxc/remote.go:328
+msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
 #: lxc/info.go:209
@@ -2855,13 +2859,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:633
+#: lxc/remote.go:637
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:711 lxc/remote.go:625 lxc/remote.go:695 lxc/remote.go:749
-#: lxc/remote.go:787
+#: lxc/project.go:711 lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:753
+#: lxc/remote.go:791
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -2871,12 +2875,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:703
+#: lxc/remote.go:707
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:629 lxc/remote.go:699 lxc/remote.go:791
+#: lxc/remote.go:633 lxc/remote.go:703 lxc/remote.go:795
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:674 lxc/remote.go:675
+#: lxc/remote.go:678 lxc/remote.go:679
 msgid "Remove remotes"
 msgstr ""
 
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:604 lxc/remote.go:605
+#: lxc/remote.go:608 lxc/remote.go:609
 msgid "Rename remotes"
 msgstr ""
 
@@ -3070,7 +3074,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:587
+#: lxc/remote.go:591
 msgid "STATIC"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:457
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -3228,7 +3232,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:766 lxc/remote.go:767
+#: lxc/remote.go:770 lxc/remote.go:771
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3320,7 +3324,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:482 lxc/remote.go:483
+#: lxc/remote.go:486 lxc/remote.go:487
 msgid "Show the default remote"
 msgstr ""
 
@@ -3491,7 +3495,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:728 lxc/remote.go:729
+#: lxc/remote.go:732 lxc/remote.go:733
 msgid "Switch the default remote"
 msgstr ""
 
@@ -3697,7 +3701,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:583
+#: lxc/cluster.go:141 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3852,8 +3856,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:873 lxc/operation.go:145 lxc/project.go:436
-#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:542
-#: lxc/remote.go:547 lxc/remote.go:552
+#: lxc/project.go:441 lxc/project.go:446 lxc/project.go:451 lxc/remote.go:546
+#: lxc/remote.go:551 lxc/remote.go:556
 msgid "YES"
 msgstr ""
 
@@ -4283,7 +4287,7 @@ msgstr ""
 msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
-#: lxc/project.go:456 lxc/remote.go:575
+#: lxc/project.go:456 lxc/remote.go:579
 msgid "current"
 msgstr ""
 
@@ -4552,6 +4556,10 @@ msgid ""
 "\" in the \"default\" pool."
 msgstr ""
 
+#: lxc/remote.go:323
+msgid "n"
+msgstr ""
+
 #: lxc/storage.go:449
 msgid "name"
 msgstr ""
@@ -4561,7 +4569,7 @@ msgid "no"
 msgstr ""
 
 #: lxc/remote.go:317
-msgid "ok (y/n)?"
+msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
 #: lxc/config.go:53
@@ -4597,7 +4605,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:327
 msgid "y"
 msgstr ""
 


### PR DESCRIPTION
Closes #8825

* `lxc remote add` and `lxd init` (cluster join) will now prompt for one of `(y/n/[fingerprint])` and compare the given string to the fingerprint.
* `lxd init` will now prompt for one of `(y/n/[token])` on joining/creating a cluster.

For a little easter egg, the error message on `lxc remote add` is the same as the one from SSH! :)
