### PR TITLE
lxd/lxd: IP filtering on un-managed bridges

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -681,8 +681,9 @@ func (d *nicBridged) setFilters() (err error) {
 
 	// If parent bridge is unmanaged check that IP filtering isn't enabled.
 	if err == db.ErrNoSuchObject || n == nil {
-		if shared.IsTrue(d.config["security.ipv4_filtering"]) || shared.IsTrue(d.config["security.ipv6_filtering"]) {
-			return fmt.Errorf("IP filtering requires using a managed parent bridge")
+		if shared.IsTrue(d.config["security.ipv4_filtering"]) && d.config["ipv4.address"] == "" && d.config["nictype"] != "bridged" ||
+			shared.IsTrue(d.config["security.ipv6_filtering"]) && d.config["ipv6.address"] == "" && d.config["nictype"] != "bridged" {
+			return fmt.Errorf("IP filtering requires using a managed parent bridge, or using a unmanaged bridge with accordingly configured address config entries for each filter")
 		}
 	}
 


### PR DESCRIPTION
Maybe resolves #7477. I have the feeling i'm missing out a crutial part, seems to easy. But the code says host and instance filters are set and i wasnt able to spoof the a secured ip address without spoofing the mac address also.


Signed-off-by: Sascha Bast <sash@mischkonsum.org>