### PR TITLE
lxd/resources: Set RPM to 1 instead of 0 when rotational

### DIFF
--- a/lxd/resources/storage.go
+++ b/lxd/resources/storage.go
@@ -359,6 +359,15 @@ func GetStorage() (*api.ResourcesStorage, error) {
 				return nil, errors.Wrapf(err, "Failed to retrieve disk information from %q", filepath.Join("/dev", entryName))
 			}
 
+			// If no RPM set and drive is rotational, set to RPM to 1
+			diskRotationalPath := filepath.Join("/sys/class/block/", entryName, "queue/rotational")
+			if disk.RPM == 0 && sysfsExists(diskRotationalPath) {
+				diskRotational, err := readUint(diskRotationalPath)
+				if err == nil {
+					disk.RPM = diskRotational
+				}
+			}
+
 			// Add to list
 			storage.Disks = append(storage.Disks, disk)
 		}


### PR DESCRIPTION
Non-ATA drives don't expose their RPMs through udev.
As we don't want to directly have to poke the drives, we instead just
indicate that they are rotating by setting the RPM to 1 if it's
currently 0 and if the kernel recorded them as spinning.

Closes #8718

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>