### PR TITLE
Revoke cluster join tokens directly from lxc cluster

### DIFF
--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -63,6 +63,10 @@ func (c *cmdCluster) Command() *cobra.Command {
 	cmdClusterListTokens := cmdClusterListTokens{global: c.global, cluster: c}
 	cmd.AddCommand(cmdClusterListTokens.Command())
 
+	// Revoke tokens
+	cmdClusterRevokeToken := cmdClusterRevokeToken{global: c.global, cluster: c}
+	cmd.AddCommand(cmdClusterRevokeToken.Command())
+
 	return cmd
 }
 
@@ -727,4 +731,82 @@ func (c *cmdClusterListTokens) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	return utils.RenderTable(c.flagFormat, header, data, displayTokens)
+}
+
+// Revoke Tokens.
+type cmdClusterRevokeToken struct {
+	global  *cmdGlobal
+	cluster *cmdCluster
+}
+
+func (c *cmdClusterRevokeToken) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("revoke-token", i18n.G("[<remote>:]<token>"))
+	cmd.Short = i18n.G("Revoke cluster member join token")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), cmd.Short)
+
+	cmd.RunE = c.Run
+	return cmd
+}
+
+func (c *cmdClusterRevokeToken) Run(cmd *cobra.Command, args []string) error {
+	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	if exit {
+		return err
+	}
+
+	// Parse remote
+	resources, err := c.global.ParseServers(args[0])
+	if err != nil {
+		return err
+	}
+
+	resource := resources[0]
+
+	// Check if clustered.
+	cluster, _, err := resource.server.GetCluster()
+	if err != nil {
+		return err
+	}
+
+	if !cluster.Enabled {
+		return fmt.Errorf(i18n.G("LXD server isn't part of a cluster"))
+	}
+
+	// Get the cluster member join tokens. Use default project as join tokens are created in default project.
+	ops, err := resource.server.UseProject("default").GetOperations()
+	if err != nil {
+		return err
+	}
+
+	for _, op := range ops {
+		if op.Class != api.OperationClassToken {
+			continue
+		}
+
+		if op.StatusCode != api.Running {
+			continue // Tokens are single use, so if cancelled but not deleted yet its not available.
+		}
+
+		joinToken, err := clusterJoinTokenOperationToAPI(&op)
+		if err != nil {
+			continue // Operation is not a valid cluster member join token operation.
+		}
+
+		if joinToken.ServerName == resource.name {
+			// Delete the operation
+			err = resource.server.DeleteOperation(op.ID)
+			if err != nil {
+				return err
+			}
+
+			if !c.global.flagQuiet {
+				fmt.Printf(i18n.G("Cluster join token for %s:%s deleted")+"\n", resource.remote, resource.name)
+			}
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf(i18n.G("No cluster join token for member %s on remote: %s"), resource.name, resource.remote)
 }

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -346,7 +346,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -513,7 +513,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
@@ -898,6 +898,11 @@ msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -914,7 +919,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -954,7 +959,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -1155,11 +1160,11 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1245,52 +1250,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1394,7 +1400,7 @@ msgstr " Prozessorauslastung:"
 msgid "Disks:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1421,7 +1427,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -1486,11 +1492,11 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1596,7 +1602,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1658,7 +1664,7 @@ msgstr "Fingerabdruck: %s\n"
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1675,7 +1681,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1699,7 +1705,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -2082,7 +2088,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2114,12 +2120,12 @@ msgstr ""
 msgid "List aliases"
 msgstr "Aliasse:\n"
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2419,7 +2425,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2564,17 +2570,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -2612,7 +2618,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2744,7 +2750,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2862,6 +2868,11 @@ msgstr ""
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "kann nicht zum selben Container Namen kopieren"
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
+msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
 #, fuzzy
@@ -3005,7 +3016,7 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -3260,7 +3271,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3296,7 +3307,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3352,7 +3363,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3407,6 +3418,11 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+#, fuzzy
+msgid "Revoke cluster member join token"
+msgstr "der Name des Ursprung Containers muss angegeben werden"
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3431,7 +3447,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3630,7 +3646,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3890,7 +3906,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -4098,7 +4114,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -4206,7 +4222,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4308,7 +4324,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -4345,7 +4361,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -4454,7 +4470,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr ""
@@ -4715,7 +4731,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -4724,7 +4740,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -5074,6 +5090,14 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
+#: lxc/cluster.go:744
+#, fuzzy
+msgid "[<remote>:]<token>"
+msgstr ""
+"Ändert den Laufzustand eines Containers in %s.\n"
+"\n"
+"lxd %s <Name>\n"
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
@@ -5181,7 +5205,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5455,7 +5479,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -199,7 +199,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -345,7 +345,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -701,6 +701,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -717,7 +722,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -754,7 +759,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -938,11 +943,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1023,52 +1028,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1164,7 +1170,7 @@ msgstr "  Χρήση CPU:"
 msgid "Disks:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1191,7 +1197,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1249,11 +1255,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1350,7 +1356,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1407,7 +1413,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1423,7 +1429,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1447,7 +1453,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1815,7 +1821,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1846,11 +1852,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2126,7 +2132,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2255,17 +2261,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2304,7 +2310,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2424,7 +2430,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2540,6 +2546,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2681,7 +2692,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2927,7 +2938,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2959,7 +2970,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3010,7 +3021,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3061,6 +3072,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3085,7 +3100,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3275,7 +3290,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3518,7 +3533,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3716,7 +3731,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3818,7 +3833,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3900,7 +3915,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3919,7 +3934,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3971,7 +3986,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4095,11 +4110,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4274,6 +4289,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4354,7 +4373,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4624,7 +4643,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -342,7 +342,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -493,7 +493,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
@@ -854,6 +854,11 @@ msgstr "Certificado del cliente almacenado en el servidor: "
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -870,7 +875,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -909,7 +914,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -1099,11 +1104,11 @@ msgstr "Creando el contenedor"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1185,52 +1190,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1325,7 +1331,7 @@ msgstr "Uso del disco:"
 msgid "Disks:"
 msgstr "Uso del disco:"
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1352,7 +1358,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1410,11 +1416,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1513,7 +1519,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Exporting the image: %s"
 msgstr "Exportando la imagen: %s"
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1571,7 +1577,7 @@ msgstr "Huella dactilar: %s"
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1587,7 +1593,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1611,7 +1617,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1981,7 +1987,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2013,12 +2019,12 @@ msgstr ""
 msgid "List aliases"
 msgstr "Aliases:"
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2297,7 +2303,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2427,17 +2433,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Perfil %s creado"
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2475,7 +2481,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Nombre del Miembro del Cluster"
@@ -2600,7 +2606,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2714,6 +2720,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2855,7 +2866,7 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -3104,7 +3115,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3136,7 +3147,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3188,7 +3199,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3241,6 +3252,11 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+#, fuzzy
+msgid "Revoke cluster member join token"
+msgstr "Nombre del Miembro del Cluster"
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3265,7 +3281,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3455,7 +3471,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3698,7 +3714,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3896,7 +3912,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3998,7 +4014,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4082,7 +4098,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -4105,7 +4121,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4170,7 +4186,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4323,12 +4339,12 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4545,6 +4561,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
+#: lxc/cluster.go:744
+#, fuzzy
+msgid "[<remote>:]<token>"
+msgstr "No se puede proveer el nombre del container a la lista"
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
@@ -4631,7 +4652,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4901,7 +4922,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -345,7 +345,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -509,7 +509,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -884,6 +884,11 @@ msgstr "Certificat client enregistré sur le serveur : "
 msgid "Client version: %s\n"
 msgstr "Afficher la version du client"
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -900,7 +905,7 @@ msgstr "Afficher la version du client"
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -947,7 +952,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -1165,11 +1170,11 @@ msgstr "Création du conteneur"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1259,52 +1264,53 @@ msgstr "Récupération de l'image : %s"
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1402,7 +1408,7 @@ msgstr "  Disque utilisé :"
 msgid "Disks:"
 msgstr "  Disque utilisé :"
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 #, fuzzy
 msgid "Don't require user confirmation for using --force"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -1430,7 +1436,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -1496,11 +1502,11 @@ msgstr "Clé de configuration invalide"
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1612,7 +1618,7 @@ msgstr "Import de l'image : %s"
 msgid "Exporting the image: %s"
 msgstr "Import de l'image : %s"
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1673,7 +1679,7 @@ msgstr "Empreinte : %s"
 msgid "Force pseudo-terminal allocation"
 msgstr "Forcer l'allocation d'un pseudo-terminal"
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1691,7 +1697,7 @@ msgstr "Forcer la suppression des conteneurs arrêtés"
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1715,7 +1721,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -2104,7 +2110,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2136,12 +2142,12 @@ msgstr ""
 msgid "List aliases"
 msgstr "Alias :"
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2482,7 +2488,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2625,17 +2631,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Profils : %s"
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -2676,7 +2682,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr "Empreinte du certificat : %s"
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2811,7 +2817,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2930,6 +2936,11 @@ msgstr "Nouvel alias à définir sur la cible"
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
+msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
 msgid "No device found for this network"
@@ -3084,7 +3095,7 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -3342,7 +3353,7 @@ msgstr "Serveur distant : %s"
 msgid "Remove %s (yes/no): "
 msgstr "Supprimer %s (oui/non) : "
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3378,7 +3389,7 @@ msgstr "Création du conteneur"
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3433,7 +3444,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3505,6 +3516,11 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
 
+#: lxc/cluster.go:745
+#, fuzzy
+msgid "Revoke cluster member join token"
+msgstr "Vous devez fournir le nom d'un conteneur pour : "
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3529,7 +3545,7 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr "ÉTAT"
 
@@ -3732,7 +3748,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4000,7 +4016,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -4211,7 +4227,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr "URL"
 
@@ -4322,7 +4338,7 @@ msgstr "Publié : %s"
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 #, fuzzy
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
@@ -4421,7 +4437,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -4461,7 +4477,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -4582,7 +4598,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr ""
@@ -4891,7 +4907,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -4903,7 +4919,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -5274,6 +5290,14 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
+#: lxc/cluster.go:744
+#, fuzzy
+msgid "[<remote>:]<token>"
+msgstr ""
+"Change l'état d'un ou plusieurs conteneurs à %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
@@ -5391,7 +5415,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5684,7 +5708,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr "oui"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -335,7 +335,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -484,7 +484,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
@@ -843,6 +843,11 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -859,7 +864,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -896,7 +901,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -1087,11 +1092,11 @@ msgstr "Creazione del container in corso"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1174,52 +1179,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1314,7 +1320,7 @@ msgstr "Utilizzo disco:"
 msgid "Disks:"
 msgstr "Utilizzo disco:"
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1341,7 +1347,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1400,11 +1406,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1503,7 +1509,7 @@ msgstr "Creazione del container in corso"
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1561,7 +1567,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1577,7 +1583,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1601,7 +1607,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1972,7 +1978,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2004,12 +2010,12 @@ msgstr ""
 msgid "List aliases"
 msgstr "Alias:"
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2289,7 +2295,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2422,17 +2428,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2469,7 +2475,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Il nome del container è: %s"
@@ -2593,7 +2599,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2707,6 +2713,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2849,7 +2860,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -3097,7 +3108,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3130,7 +3141,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3182,7 +3193,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3235,6 +3246,11 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+#, fuzzy
+msgid "Revoke cluster member join token"
+msgstr "Il nome del container è: %s"
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3259,7 +3275,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3449,7 +3465,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3694,7 +3710,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3893,7 +3909,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3996,7 +4012,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4082,7 +4098,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -4105,7 +4121,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "Creazione del container in corso"
@@ -4170,7 +4186,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr "Creazione del container in corso"
@@ -4323,12 +4339,12 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr "Creazione del container in corso"
@@ -4545,6 +4561,11 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "Creazione del container in corso"
 
+#: lxc/cluster.go:744
+#, fuzzy
+msgid "[<remote>:]<token>"
+msgstr "Creazione del container in corso"
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
@@ -4631,7 +4652,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4902,7 +4923,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr "si"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: 2021-02-02 15:21+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -335,7 +335,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -487,7 +487,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -858,6 +858,11 @@ msgstr "クライアント証明書がサーバに格納されました:"
 msgid "Client version: %s\n"
 msgstr "クライアントバージョン: %s\n"
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -874,7 +879,7 @@ msgstr "クライアントバージョン: %s\n"
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
@@ -915,7 +920,7 @@ msgstr "新しいプロジェクトに適用するキー/値の設定"
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -1108,11 +1113,11 @@ msgstr "インスタンスを作成中"
 msgid "Current number of VFs: %d"
 msgstr "現在の VF 数: %d"
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr "DATABASE"
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1196,52 +1201,53 @@ msgstr "イメージを削除します"
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1336,7 +1342,7 @@ msgstr "ディスク:"
 msgid "Disks:"
 msgstr "ディスク:"
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr "--force を使う際にユーザーの確認を必要としない"
 
@@ -1365,7 +1371,7 @@ msgstr ""
 "ファイル転送のサーバ側の初期処理はキャンセルできません（強制的に中断するには"
 "あと2回行ってください）"
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
@@ -1426,12 +1432,12 @@ msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 "'%s' 中のカラムエントリが空です (カラムの指定に空文字列が指定されています)"
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 "クラスタリングで動作していないLXDサーバ上でクラスタリングを有効にします"
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1552,7 +1558,7 @@ msgstr "バックアップのエクスポート中: %s"
 msgid "Exporting the image: %s"
 msgstr "イメージのエクスポート中: %s"
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr "FAILURE DOMAIN"
 
@@ -1609,7 +1615,7 @@ msgstr "証明書のフィンガープリント: %s"
 msgid "Force pseudo-terminal allocation"
 msgstr "強制的に擬似端末を割り当てます"
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr "degraded 状態であっても強制的にメンバを削除します"
 
@@ -1625,7 +1631,7 @@ msgstr "稼働中のインスタンスを強制的に削除します"
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1664,7 +1670,7 @@ msgstr ""
 "\n"
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -2049,7 +2055,7 @@ msgstr ""
 "LXD は spicy か remote-viewer がインストールされている場合は自動的にどちらか"
 "を使います。"
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
 
@@ -2080,12 +2086,12 @@ msgstr "DHCP のリースを一覧表示します"
 msgid "List aliases"
 msgstr "エイリアスを一覧表示します"
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "クラスタのメンバをすべて一覧表示します"
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr "クラスタのメンバをすべて一覧表示します"
 
@@ -2506,7 +2512,7 @@ msgstr "MEMORY USAGE"
 msgid "MEMORY USAGE%"
 msgstr "MEMORY USAGE%"
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr "MESSAGE"
 
@@ -2655,17 +2661,17 @@ msgstr "VF の最大数: %d"
 msgid "Mdev profiles:"
 msgstr "Mdevプロファイル:"
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "メンバ名 %s を %s に変更しました"
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr "メンバ %s が削除されました"
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
@@ -2703,7 +2709,7 @@ msgstr "表示するログメッセージの最小レベル"
 msgid "Missing certificate fingerprint"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
 
@@ -2829,7 +2835,7 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2944,6 +2950,11 @@ msgstr "イメージに新しいエイリアスを追加します"
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr "指定するデバイスに適用する新しいキー/値"
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
+msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
 msgid "No device found for this network"
@@ -3085,7 +3096,7 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -3333,7 +3344,7 @@ msgstr "リムーバブルディスク: %v"
 msgid "Remove %s (yes/no): "
 msgstr "%s を消去しますか (yes/no): "
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr "クラスタからメンバを削除します"
 
@@ -3366,7 +3377,7 @@ msgstr "インスタンスからプロファイルを削除します"
 msgid "Remove trusted clients"
 msgstr "信頼済みクライアントを削除します"
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr "クラスタメンバの名前を変更します"
 
@@ -3419,7 +3430,7 @@ msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しまし�
 msgid "Render: %s (%s)"
 msgstr "レンダー: %s (%s)"
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 #, fuzzy
 msgid "Request a join token for adding a cluster member"
 msgstr "クラスタメンバの詳細を表示します"
@@ -3477,6 +3488,11 @@ msgstr "インスタンスのコンソールログを取得します"
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
 
+#: lxc/cluster.go:745
+#, fuzzy
+msgid "Revoke cluster member join token"
+msgstr "クラスタのメンバをすべて一覧表示します"
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr "すべてのインスタンスに対してコマンドを実行します"
@@ -3501,7 +3517,7 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr "STATE"
 
@@ -3729,7 +3745,7 @@ msgstr "詳細な情報を出力します"
 msgid "Show content of instance file templates"
 msgstr "インスタンスのファイルテンプレートの内容を表示します"
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr "クラスタメンバの詳細を表示します"
 
@@ -3975,7 +3991,7 @@ msgstr "デフォルトのリモートを切り替えます"
 msgid "TARGET"
 msgstr "TARGET"
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -4198,7 +4214,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr "URL"
 
@@ -4305,7 +4321,7 @@ msgstr "使用済: %v"
 msgid "User ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
@@ -4392,7 +4408,7 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -4411,7 +4427,7 @@ msgstr "[<remote>:] <cert>"
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr "[<remote>:] <hostname|fingerprint>"
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr "[<remote>:] <name>"
 
@@ -4469,7 +4485,7 @@ msgstr "[<remote>:]<alias> <fingerprint>"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "[<remote>:]<alias> <new-name>"
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr "[<remote>:]<cluster member>"
 
@@ -4597,11 +4613,11 @@ msgid ""
 msgstr ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr "[<remote>:]<member>"
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr "[<remote>:]<member> <new-name>"
 
@@ -4779,6 +4795,11 @@ msgstr "[<remote>:]<project> <new-name>"
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 
+#: lxc/cluster.go:744
+#, fuzzy
+msgid "[<remote>:]<token>"
+msgstr "[<remote>:]<network>"
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
@@ -4866,7 +4887,7 @@ msgstr ""
 "lxc alias rename list my-list\n"
 "    エイリアス名 \"list\" を \"my-list\" に変更します。"
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5249,7 +5270,7 @@ msgstr "ストレージを使用中の"
 msgid "y"
 msgstr "y"
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr "yes"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2021-06-03 17:20-0400\n"
+        "POT-Creation-Date: 2021-06-04 18:09+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -185,7 +185,7 @@ msgid   "### This is a YAML representation of the project.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid   "### This is a yaml representation of the cluster member.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
@@ -327,7 +327,7 @@ msgstr  ""
 msgid   "ALIASES"
 msgstr  ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid   "ARCHITECTURE"
 msgstr  ""
 
@@ -677,11 +677,16 @@ msgstr  ""
 msgid   "Client version: %s\n"
 msgstr  ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid   "Cluster join token for %s:%s deleted"
+msgstr  ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614 lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54 lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749 lxc/network.go:1046 lxc/network.go:1113 lxc/network.go:1175 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:397 lxc/storage.go:599 lxc/storage.go:671 lxc/storage.go:754 lxc/storage_volume.go:326 lxc/storage_volume.go:487 lxc/storage_volume.go:566 lxc/storage_volume.go:808 lxc/storage_volume.go:1005 lxc/storage_volume.go:1093 lxc/storage_volume.go:1365 lxc/storage_volume.go:1395 lxc/storage_volume.go:1511 lxc/storage_volume.go:1590 lxc/storage_volume.go:1683 lxc/storage_volume.go:1720 lxc/storage_volume.go:1814 lxc/storage_volume.go:1886 lxc/storage_volume.go:2025
 msgid   "Cluster member name"
 msgstr  ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid   "Clustering enabled"
 msgstr  ""
 
@@ -716,7 +721,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328 lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431 lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498 lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941 lxc/storage_volume.go:971
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328 lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431 lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498 lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941 lxc/storage_volume.go:971
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -894,11 +899,11 @@ msgstr  ""
 msgid   "Current number of VFs: %d"
 msgstr  ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid   "DATABASE"
 msgstr  ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574 lxc/storage_volume.go:1271
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489 lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160 lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574 lxc/storage_volume.go:1271
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -974,7 +979,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163 lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431 lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52 lxc/config_metadata.go:174 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235 lxc/storage_volume.go:322 lxc/storage_volume.go:484 lxc/storage_volume.go:563 lxc/storage_volume.go:639 lxc/storage_volume.go:721 lxc/storage_volume.go:802 lxc/storage_volume.go:1002 lxc/storage_volume.go:1090 lxc/storage_volume.go:1177 lxc/storage_volume.go:1361 lxc/storage_volume.go:1392 lxc/storage_volume.go:1505 lxc/storage_volume.go:1581 lxc/storage_volume.go:1680 lxc/storage_volume.go:1714 lxc/storage_volume.go:1812 lxc/storage_volume.go:1879 lxc/storage_volume.go:2020 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:67 lxc/warning.go:247 lxc/warning.go:288 lxc/warning.go:342
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167 lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435 lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30 lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52 lxc/config_metadata.go:174 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235 lxc/storage_volume.go:322 lxc/storage_volume.go:484 lxc/storage_volume.go:563 lxc/storage_volume.go:639 lxc/storage_volume.go:721 lxc/storage_volume.go:802 lxc/storage_volume.go:1002 lxc/storage_volume.go:1090 lxc/storage_volume.go:1177 lxc/storage_volume.go:1361 lxc/storage_volume.go:1392 lxc/storage_volume.go:1505 lxc/storage_volume.go:1581 lxc/storage_volume.go:1680 lxc/storage_volume.go:1714 lxc/storage_volume.go:1812 lxc/storage_volume.go:1879 lxc/storage_volume.go:2020 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:67 lxc/warning.go:247 lxc/warning.go:288 lxc/warning.go:342
 msgid   "Description"
 msgstr  ""
 
@@ -1056,7 +1061,7 @@ msgstr  ""
 msgid   "Disks:"
 msgstr  ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid   "Don't require user confirmation for using --force"
 msgstr  ""
 
@@ -1081,7 +1086,7 @@ msgstr  ""
 msgid   "Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"
 msgstr  ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
@@ -1138,11 +1143,11 @@ msgstr  ""
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid   "Enable clustering on a single non-clustered LXD server"
 msgstr  ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid   "Enable clustering on a single non-clustered LXD server\n"
         "\n"
         "  This command turns a non-clustered LXD server into the first member of a new\n"
@@ -1232,7 +1237,7 @@ msgstr  ""
 msgid   "Exporting the image: %s"
 msgstr  ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid   "FAILURE DOMAIN"
 msgstr  ""
 
@@ -1288,7 +1293,7 @@ msgstr  ""
 msgid   "Force pseudo-terminal allocation"
 msgstr  ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid   "Force removing a member, even if degraded"
 msgstr  ""
 
@@ -1304,7 +1309,7 @@ msgstr  ""
 msgid   "Force using the local unix socket"
 msgstr  ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid   "Forcefully removing a server from the cluster should only be done as a last\n"
         "resort.\n"
@@ -1323,7 +1328,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645 lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011 lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515 lxc/storage_volume.go:1195 lxc/warning.go:89
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649 lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011 lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923 lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:391 lxc/project.go:746 lxc/remote.go:527 lxc/storage.go:515 lxc/storage_volume.go:1195 lxc/warning.go:89
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
@@ -1681,7 +1686,7 @@ msgstr  ""
 msgid   "LXD automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid   "LXD server isn't part of a cluster"
 msgstr  ""
 
@@ -1712,11 +1717,11 @@ msgstr  ""
 msgid   "List aliases"
 msgstr  ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid   "List all active cluster member join tokens"
 msgstr  ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid   "List all the cluster members"
 msgstr  ""
 
@@ -1980,7 +1985,7 @@ msgstr  ""
 msgid   "MEMORY USAGE%"
 msgstr  ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid   "MESSAGE"
 msgstr  ""
 
@@ -2106,17 +2111,17 @@ msgstr  ""
 msgid   "Mdev profiles:"
 msgstr  ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid   "Member %s join token:"
 msgstr  ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid   "Member %s removed"
 msgstr  ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid   "Member %s renamed to %s"
 msgstr  ""
@@ -2153,7 +2158,7 @@ msgstr  ""
 msgid   "Missing certificate fingerprint"
 msgstr  ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid   "Missing cluster member name"
 msgstr  ""
 
@@ -2250,7 +2255,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567 lxc/storage_volume.go:1270
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320 lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620 lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567 lxc/storage_volume.go:1270
 msgid   "NAME"
 msgstr  ""
 
@@ -2359,6 +2364,11 @@ msgstr  ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid   "New key/value to apply to a specific device"
+msgstr  ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid   "No cluster join token for member %s on remote: %s"
 msgstr  ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2500,7 +2510,7 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143 lxc/config_template.go:203 lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660 lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310 lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329 lxc/config_metadata.go:143 lxc/config_template.go:203 lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660 lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310 lxc/storage.go:304 lxc/storage_volume.go:942 lxc/storage_volume.go:972
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -2741,7 +2751,7 @@ msgstr  ""
 msgid   "Remove %s (yes/no): "
 msgstr  ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid   "Remove a member from the cluster"
 msgstr  ""
 
@@ -2773,7 +2783,7 @@ msgstr  ""
 msgid   "Remove trusted clients"
 msgstr  ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid   "Rename a cluster member"
 msgstr  ""
 
@@ -2823,7 +2833,7 @@ msgstr  ""
 msgid   "Render: %s (%s)"
 msgstr  ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid   "Request a join token for adding a cluster member"
 msgstr  ""
 
@@ -2872,6 +2882,10 @@ msgstr  ""
 msgid   "Retrieving image: %s"
 msgstr  ""
 
+#: lxc/cluster.go:745
+msgid   "Revoke cluster member join token"
+msgstr  ""
+
 #: lxc/action.go:112
 msgid   "Run against all instances"
 msgstr  ""
@@ -2896,7 +2910,7 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid   "STATE"
 msgstr  ""
 
@@ -3068,7 +3082,7 @@ msgstr  ""
 msgid   "Show content of instance file templates"
 msgstr  ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid   "Show details of a cluster member"
 msgstr  ""
 
@@ -3311,7 +3325,7 @@ msgstr  ""
 msgid   "TARGET"
 msgstr  ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid   "TOKEN"
 msgstr  ""
 
@@ -3496,7 +3510,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid   "URL"
 msgstr  ""
 
@@ -3595,7 +3609,7 @@ msgstr  ""
 msgid   "User ID to run the command as (default 0)"
 msgstr  ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid   "User aborted delete operation"
 msgstr  ""
 
@@ -3672,7 +3686,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr  ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259 lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20 lxc/warning.go:64
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259 lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510 lxc/version.go:20 lxc/warning.go:64
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -3688,7 +3702,7 @@ msgstr  ""
 msgid   "[<remote>:] <hostname|fingerprint>"
 msgstr  ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid   "[<remote>:] <name>"
 msgstr  ""
 
@@ -3740,7 +3754,7 @@ msgstr  ""
 msgid   "[<remote>:]<alias> <new-name>"
 msgstr  ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid   "[<remote>:]<cluster member>"
 msgstr  ""
 
@@ -3860,11 +3874,11 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr  ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid   "[<remote>:]<member>"
 msgstr  ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid   "[<remote>:]<member> <new-name>"
 msgstr  ""
 
@@ -4032,6 +4046,10 @@ msgstr  ""
 msgid   "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr  ""
 
+#: lxc/cluster.go:744
+msgid   "[<remote>:]<token>"
+msgstr  ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid   "[<remote>:]<warning-uuid>"
 msgstr  ""
@@ -4109,7 +4127,7 @@ msgid   "lxc alias rename list my-list\n"
         "    Rename existing alias \"list\" to \"my-list\"."
 msgstr  ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid   "lxc cluster edit <cluster member> < member.yaml\n"
         "    Update a cluster member using the content of member.yaml"
 msgstr  ""
@@ -4342,7 +4360,7 @@ msgstr  ""
 msgid   "y"
 msgstr  ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896 lxc/image.go:1079
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896 lxc/image.go:1079
 msgid   "yes"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -334,7 +334,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -480,7 +480,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
@@ -835,6 +835,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -851,7 +856,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -888,7 +893,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -1072,11 +1077,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1157,52 +1162,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1295,7 +1301,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1322,7 +1328,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1380,11 +1386,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1481,7 +1487,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1538,7 +1544,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1554,7 +1560,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1578,7 +1584,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1946,7 +1952,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1977,11 +1983,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2257,7 +2263,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2386,17 +2392,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2433,7 +2439,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2553,7 +2559,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2667,6 +2673,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2808,7 +2819,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -3054,7 +3065,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3086,7 +3097,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3137,7 +3148,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3188,6 +3199,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3212,7 +3227,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3402,7 +3417,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3645,7 +3660,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3843,7 +3858,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3945,7 +3960,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4027,7 +4042,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -4046,7 +4061,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4098,7 +4113,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4222,11 +4237,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4401,6 +4416,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4481,7 +4500,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4751,7 +4770,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -352,7 +352,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -498,7 +498,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -853,6 +853,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -869,7 +874,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -906,7 +911,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -1090,11 +1095,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1175,52 +1180,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1313,7 +1319,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1340,7 +1346,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1398,11 +1404,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1499,7 +1505,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1556,7 +1562,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1572,7 +1578,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1596,7 +1602,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1964,7 +1970,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1995,11 +2001,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2275,7 +2281,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2404,17 +2410,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2451,7 +2457,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2571,7 +2577,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2685,6 +2691,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2826,7 +2837,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -3072,7 +3083,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3104,7 +3115,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3155,7 +3166,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3206,6 +3217,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3230,7 +3245,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3420,7 +3435,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3663,7 +3678,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3861,7 +3876,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3963,7 +3978,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4045,7 +4060,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -4064,7 +4079,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4116,7 +4131,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4240,11 +4255,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4419,6 +4434,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4499,7 +4518,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4769,7 +4788,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -346,7 +346,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -501,7 +501,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
@@ -869,6 +869,11 @@ msgstr "Certificado do cliente armazenado no servidor: "
 msgid "Client version: %s\n"
 msgstr "Versão do cliente: %s\n"
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -885,7 +890,7 @@ msgstr "Versão do cliente: %s\n"
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
@@ -930,7 +935,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -1125,11 +1130,11 @@ msgstr "Criando %s"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1216,52 +1221,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1358,7 +1364,7 @@ msgstr "Uso de disco:"
 msgid "Disks:"
 msgstr "Uso de disco:"
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1385,7 +1391,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -1451,11 +1457,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1552,7 +1558,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1609,7 +1615,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr "Forçar alocação de pseudo-terminal"
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1625,7 +1631,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1649,7 +1655,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -2024,7 +2030,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2055,12 +2061,12 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2337,7 +2343,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2474,17 +2480,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Copiar perfis"
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2522,7 +2528,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Nome de membro do cluster"
@@ -2644,7 +2650,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2758,6 +2764,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2899,7 +2910,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -3150,7 +3161,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3184,7 +3195,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3236,7 +3247,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3293,6 +3304,11 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+#, fuzzy
+msgid "Revoke cluster member join token"
+msgstr "Nome de membro do cluster"
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3317,7 +3333,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3513,7 +3529,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3764,7 +3780,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3965,7 +3981,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -4073,7 +4089,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4155,7 +4171,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -4175,7 +4191,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4233,7 +4249,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4362,11 +4378,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4546,6 +4562,11 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+#, fuzzy
+msgid "[<remote>:]<token>"
+msgstr "Criar perfis"
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
@@ -4627,7 +4648,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4897,7 +4918,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr "sim"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: 2020-10-08 08:16+0000\n"
 "Last-Translator: Artem <KovalevArtem.ru@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -348,7 +348,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -508,7 +508,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
@@ -871,6 +871,11 @@ msgstr "Сертификат клиента хранится на сервере
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -887,7 +892,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -924,7 +929,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -1119,11 +1124,11 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1208,52 +1213,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1350,7 +1356,7 @@ msgstr " Использование диска:"
 msgid "Disks:"
 msgstr " Использование диска:"
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1377,7 +1383,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1437,11 +1443,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1543,7 +1549,7 @@ msgstr "Копирование образа: %s"
 msgid "Exporting the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1600,7 +1606,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1616,7 +1622,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1640,7 +1646,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -2013,7 +2019,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2045,12 +2051,12 @@ msgstr ""
 msgid "List aliases"
 msgstr "Псевдонимы:"
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2332,7 +2338,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2468,17 +2474,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2517,7 +2523,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Копирование образа: %s"
@@ -2643,7 +2649,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2759,6 +2765,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2901,7 +2912,7 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -3148,7 +3159,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3181,7 +3192,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3235,7 +3246,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3289,6 +3300,11 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+#, fuzzy
+msgid "Revoke cluster member join token"
+msgstr "Копирование образа: %s"
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3313,7 +3329,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3504,7 +3520,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3754,7 +3770,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3952,7 +3968,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -4054,7 +4070,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -4144,7 +4160,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -4179,7 +4195,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -4283,7 +4299,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr ""
@@ -4527,7 +4543,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -4535,7 +4551,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -4878,6 +4894,14 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
+#: lxc/cluster.go:744
+#, fuzzy
+msgid "[<remote>:]<token>"
+msgstr ""
+"Изменение состояния одного или нескольких контейнеров %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
@@ -4982,7 +5006,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -5252,7 +5276,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr "да"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: 2020-11-05 02:45+0000\n"
 "Last-Translator: wdggg <wdggg7@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -250,7 +250,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -396,7 +396,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -751,6 +751,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -767,7 +772,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -804,7 +809,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -988,11 +993,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1073,52 +1078,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1211,7 +1217,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1238,7 +1244,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1296,11 +1302,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1397,7 +1403,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1454,7 +1460,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1470,7 +1476,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1494,7 +1500,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1862,7 +1868,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1893,11 +1899,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2173,7 +2179,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2302,17 +2308,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2349,7 +2355,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2469,7 +2475,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2583,6 +2589,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2724,7 +2735,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2970,7 +2981,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -3002,7 +3013,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -3053,7 +3064,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3104,6 +3115,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3128,7 +3143,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3318,7 +3333,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3561,7 +3576,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3759,7 +3774,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3861,7 +3876,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3943,7 +3958,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3962,7 +3977,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -4014,7 +4029,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4138,11 +4153,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4317,6 +4332,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4397,7 +4416,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4667,7 +4686,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-06-03 15:59-0400\n"
+"POT-Creation-Date: 2021-06-04 18:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:443
+#: lxc/cluster.go:447
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -342,7 +342,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:143 lxc/image.go:1025 lxc/list.go:486
+#: lxc/cluster.go:147 lxc/image.go:1025 lxc/list.go:486
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -697,6 +697,11 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
+#: lxc/cluster.go:804
+#, c-format
+msgid "Cluster join token for %s:%s deleted"
+msgstr ""
+
 #: lxc/config.go:95 lxc/config.go:364 lxc/config.go:467 lxc/config.go:614
 #: lxc/config.go:733 lxc/copy.go:52 lxc/info.go:46 lxc/init.go:54
 #: lxc/move.go:58 lxc/network.go:273 lxc/network.go:691 lxc/network.go:749
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:417
+#: lxc/cluster.go:421
 msgid "Clustering enabled"
 msgstr ""
 
@@ -750,7 +755,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:512 lxc/config.go:255 lxc/config.go:328
+#: lxc/cluster.go:516 lxc/config.go:255 lxc/config.go:328
 #: lxc/config_metadata.go:142 lxc/config_trust.go:228 lxc/image.go:431
 #: lxc/network.go:659 lxc/network_acl.go:528 lxc/profile.go:498
 #: lxc/project.go:309 lxc/storage.go:303 lxc/storage_volume.go:941
@@ -934,11 +939,11 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:142
+#: lxc/cluster.go:146
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/cluster.go:145 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
+#: lxc/cluster.go:149 lxc/image.go:1024 lxc/image_alias.go:234 lxc/list.go:489
 #: lxc/network.go:899 lxc/network_acl.go:141 lxc/operation.go:160
 #: lxc/profile.go:621 lxc/project.go:470 lxc/storage.go:574
 #: lxc/storage_volume.go:1271
@@ -1019,52 +1024,53 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
-#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:82 lxc/cluster.go:163
-#: lxc/cluster.go:213 lxc/cluster.go:263 lxc/cluster.go:346 lxc/cluster.go:431
-#: lxc/cluster.go:582 lxc/cluster.go:644 lxc/config.go:30 lxc/config.go:89
-#: lxc/config.go:360 lxc/config.go:452 lxc/config.go:610 lxc/config.go:730
-#: lxc/config_device.go:24 lxc/config_device.go:75 lxc/config_device.go:193
-#: lxc/config_device.go:265 lxc/config_device.go:336 lxc/config_device.go:429
-#: lxc/config_device.go:520 lxc/config_device.go:527 lxc/config_device.go:631
-#: lxc/config_device.go:703 lxc/config_metadata.go:27 lxc/config_metadata.go:52
-#: lxc/config_metadata.go:174 lxc/config_template.go:28
-#: lxc/config_template.go:65 lxc/config_template.go:108
-#: lxc/config_template.go:150 lxc/config_template.go:236
-#: lxc/config_template.go:295 lxc/config_trust.go:33 lxc/config_trust.go:74
-#: lxc/config_trust.go:150 lxc/config_trust.go:262 lxc/config_trust.go:342
-#: lxc/config_trust.go:385 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31
-#: lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105
-#: lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38
-#: lxc/image.go:141 lxc/image.go:287 lxc/image.go:338 lxc/image.go:463
-#: lxc/image.go:622 lxc/image.go:850 lxc/image.go:985 lxc/image.go:1283
-#: lxc/image.go:1362 lxc/image.go:1421 lxc/image.go:1473 lxc/image.go:1529
-#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
-#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50
-#: lxc/manpage.go:22 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:113 lxc/network.go:198 lxc/network.go:271 lxc/network.go:345
-#: lxc/network.go:395 lxc/network.go:480 lxc/network.go:565 lxc/network.go:688
-#: lxc/network.go:746 lxc/network.go:826 lxc/network.go:921 lxc/network.go:990
-#: lxc/network.go:1040 lxc/network.go:1110 lxc/network.go:1172
-#: lxc/network_acl.go:30 lxc/network_acl.go:88 lxc/network_acl.go:158
-#: lxc/network_acl.go:211 lxc/network_acl.go:260 lxc/network_acl.go:343
-#: lxc/network_acl.go:403 lxc/network_acl.go:430 lxc/network_acl.go:561
-#: lxc/network_acl.go:610 lxc/network_acl.go:659 lxc/network_acl.go:674
-#: lxc/network_acl.go:795 lxc/operation.go:24 lxc/operation.go:53
-#: lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29
-#: lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300
-#: lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577
-#: lxc/profile.go:637 lxc/profile.go:713 lxc/profile.go:763 lxc/profile.go:822
-#: lxc/profile.go:876 lxc/project.go:30 lxc/project.go:91 lxc/project.go:156
-#: lxc/project.go:219 lxc/project.go:339 lxc/project.go:389 lxc/project.go:488
-#: lxc/project.go:543 lxc/project.go:603 lxc/project.go:632 lxc/project.go:685
-#: lxc/project.go:744 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:85 lxc/remote.go:487 lxc/remote.go:523 lxc/remote.go:609
-#: lxc/remote.go:679 lxc/remote.go:733 lxc/remote.go:771 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:393
-#: lxc/storage.go:513 lxc/storage.go:593 lxc/storage.go:667 lxc/storage.go:751
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:162 lxc/storage_volume.go:235
+#: lxc/alias.go:195 lxc/cluster.go:31 lxc/cluster.go:86 lxc/cluster.go:167
+#: lxc/cluster.go:217 lxc/cluster.go:267 lxc/cluster.go:350 lxc/cluster.go:435
+#: lxc/cluster.go:586 lxc/cluster.go:648 lxc/cluster.go:746 lxc/config.go:30
+#: lxc/config.go:89 lxc/config.go:360 lxc/config.go:452 lxc/config.go:610
+#: lxc/config.go:730 lxc/config_device.go:24 lxc/config_device.go:75
+#: lxc/config_device.go:193 lxc/config_device.go:265 lxc/config_device.go:336
+#: lxc/config_device.go:429 lxc/config_device.go:520 lxc/config_device.go:527
+#: lxc/config_device.go:631 lxc/config_device.go:703 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:52 lxc/config_metadata.go:174
+#: lxc/config_template.go:28 lxc/config_template.go:65
+#: lxc/config_template.go:108 lxc/config_template.go:150
+#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:33
+#: lxc/config_trust.go:74 lxc/config_trust.go:150 lxc/config_trust.go:262
+#: lxc/config_trust.go:342 lxc/config_trust.go:385 lxc/console.go:36
+#: lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32
+#: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
+#: lxc/file.go:407 lxc/image.go:38 lxc/image.go:141 lxc/image.go:287
+#: lxc/image.go:338 lxc/image.go:463 lxc/image.go:622 lxc/image.go:850
+#: lxc/image.go:985 lxc/image.go:1283 lxc/image.go:1362 lxc/image.go:1421
+#: lxc/image.go:1473 lxc/image.go:1529 lxc/image_alias.go:25
+#: lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150
+#: lxc/image_alias.go:252 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40
+#: lxc/launch.go:25 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:22
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:33 lxc/network.go:113
+#: lxc/network.go:198 lxc/network.go:271 lxc/network.go:345 lxc/network.go:395
+#: lxc/network.go:480 lxc/network.go:565 lxc/network.go:688 lxc/network.go:746
+#: lxc/network.go:826 lxc/network.go:921 lxc/network.go:990 lxc/network.go:1040
+#: lxc/network.go:1110 lxc/network.go:1172 lxc/network_acl.go:30
+#: lxc/network_acl.go:88 lxc/network_acl.go:158 lxc/network_acl.go:211
+#: lxc/network_acl.go:260 lxc/network_acl.go:343 lxc/network_acl.go:403
+#: lxc/network_acl.go:430 lxc/network_acl.go:561 lxc/network_acl.go:610
+#: lxc/network_acl.go:659 lxc/network_acl.go:674 lxc/network_acl.go:795
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:637 lxc/profile.go:713
+#: lxc/profile.go:763 lxc/profile.go:822 lxc/profile.go:876 lxc/project.go:30
+#: lxc/project.go:91 lxc/project.go:156 lxc/project.go:219 lxc/project.go:339
+#: lxc/project.go:389 lxc/project.go:488 lxc/project.go:543 lxc/project.go:603
+#: lxc/project.go:632 lxc/project.go:685 lxc/project.go:744 lxc/publish.go:34
+#: lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:85 lxc/remote.go:487
+#: lxc/remote.go:523 lxc/remote.go:609 lxc/remote.go:679 lxc/remote.go:733
+#: lxc/remote.go:771 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213
+#: lxc/storage.go:333 lxc/storage.go:393 lxc/storage.go:513 lxc/storage.go:593
+#: lxc/storage.go:667 lxc/storage.go:751 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:162 lxc/storage_volume.go:235
 #: lxc/storage_volume.go:322 lxc/storage_volume.go:484
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:802
@@ -1157,7 +1163,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:268
+#: lxc/cluster.go:272
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1184,7 +1190,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster.go:430 lxc/cluster.go:431
+#: lxc/cluster.go:434 lxc/cluster.go:435
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1242,11 +1248,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:345
+#: lxc/cluster.go:349
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:346
+#: lxc/cluster.go:350
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1343,7 +1349,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:144
+#: lxc/cluster.go:148
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -1400,7 +1406,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:267
+#: lxc/cluster.go:271
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1416,7 +1422,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:275
+#: lxc/cluster.go:279
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1440,7 +1446,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:102 lxc/cluster.go:84 lxc/cluster.go:645
+#: lxc/alias.go:102 lxc/cluster.go:88 lxc/cluster.go:649
 #: lxc/config_template.go:238 lxc/config_trust.go:264 lxc/image.go:1011
 #: lxc/image_alias.go:155 lxc/list.go:131 lxc/network.go:830 lxc/network.go:923
 #: lxc/network_acl.go:91 lxc/operation.go:104 lxc/profile.go:581
@@ -1808,7 +1814,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:679
+#: lxc/cluster.go:122 lxc/cluster.go:683 lxc/cluster.go:773
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1839,11 +1845,11 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:643 lxc/cluster.go:644
+#: lxc/cluster.go:647 lxc/cluster.go:648
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster.go:81 lxc/cluster.go:82
+#: lxc/cluster.go:85 lxc/cluster.go:86
 msgid "List all the cluster members"
 msgstr ""
 
@@ -2119,7 +2125,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:147
+#: lxc/cluster.go:151
 msgid "MESSAGE"
 msgstr ""
 
@@ -2248,17 +2254,17 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster.go:625
+#: lxc/cluster.go:629
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:334
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:247
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2295,7 +2301,7 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster.go:464 lxc/cluster.go:605
+#: lxc/cluster.go:468 lxc/cluster.go:609
 msgid "Missing cluster member name"
 msgstr ""
 
@@ -2415,7 +2421,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:140 lxc/cluster.go:725 lxc/config_trust.go:320
+#: lxc/cluster.go:144 lxc/cluster.go:729 lxc/config_trust.go:320
 #: lxc/list.go:496 lxc/network.go:894 lxc/network_acl.go:140 lxc/profile.go:620
 #: lxc/project.go:465 lxc/remote.go:586 lxc/storage.go:567
 #: lxc/storage_volume.go:1270
@@ -2529,6 +2535,11 @@ msgstr ""
 
 #: lxc/copy.go:45 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
+msgstr ""
+
+#: lxc/cluster.go:811
+#, c-format
+msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
 
 #: lxc/network.go:448 lxc/network.go:533
@@ -2670,7 +2681,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/cluster.go:513 lxc/config.go:256 lxc/config.go:329
+#: lxc/cluster.go:517 lxc/config.go:256 lxc/config.go:329
 #: lxc/config_metadata.go:143 lxc/config_template.go:203
 #: lxc/config_trust.go:229 lxc/image.go:432 lxc/network.go:660
 #: lxc/network_acl.go:529 lxc/profile.go:499 lxc/project.go:310
@@ -2916,7 +2927,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:262 lxc/cluster.go:263
+#: lxc/cluster.go:266 lxc/cluster.go:267
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2948,7 +2959,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:212 lxc/cluster.go:213
+#: lxc/cluster.go:216 lxc/cluster.go:217
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2999,7 +3010,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:581 lxc/cluster.go:582
+#: lxc/cluster.go:585 lxc/cluster.go:586
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -3050,6 +3061,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/cluster.go:745
+msgid "Revoke cluster member join token"
+msgstr ""
+
 #: lxc/action.go:112
 msgid "Run against all instances"
 msgstr ""
@@ -3074,7 +3089,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
+#: lxc/cluster.go:150 lxc/list.go:501 lxc/network.go:903 lxc/storage.go:577
 msgid "STATE"
 msgstr ""
 
@@ -3264,7 +3279,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:162 lxc/cluster.go:163
+#: lxc/cluster.go:166 lxc/cluster.go:167
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -3507,7 +3522,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:726
+#: lxc/cluster.go:730
 msgid "TOKEN"
 msgstr ""
 
@@ -3705,7 +3720,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:141 lxc/remote.go:587
+#: lxc/cluster.go:145 lxc/remote.go:587
 msgid "URL"
 msgstr ""
 
@@ -3807,7 +3822,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:294 lxc/delete.go:48
+#: lxc/cluster.go:298 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3889,7 +3904,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/cluster.go:79 lxc/cluster.go:642 lxc/config_trust.go:259
+#: lxc/cluster.go:83 lxc/cluster.go:646 lxc/config_trust.go:259
 #: lxc/monitor.go:28 lxc/network.go:823 lxc/network_acl.go:85
 #: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:386 lxc/storage.go:510
 #: lxc/version.go:20 lxc/warning.go:64
@@ -3908,7 +3923,7 @@ msgstr ""
 msgid "[<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/cluster.go:344
+#: lxc/cluster.go:348
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -3960,7 +3975,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:429
+#: lxc/cluster.go:433
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -4084,11 +4099,11 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:161 lxc/cluster.go:260 lxc/cluster.go:580
+#: lxc/cluster.go:165 lxc/cluster.go:264 lxc/cluster.go:584
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster.go:210
+#: lxc/cluster.go:214
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4263,6 +4278,10 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
+#: lxc/cluster.go:744
+msgid "[<remote>:]<token>"
+msgstr ""
+
 #: lxc/warning.go:244 lxc/warning.go:286 lxc/warning.go:339
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -4343,7 +4362,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:433
+#: lxc/cluster.go:437
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -4613,7 +4632,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:293 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
+#: lxc/cluster.go:297 lxc/delete.go:47 lxc/image.go:891 lxc/image.go:896
 #: lxc/image.go:1079
 msgid "yes"
 msgstr ""

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -159,6 +159,19 @@ test_clustering_membership() {
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list-tokens
   ! LXD_DIR="${LXD_TWO_DIR}" lxc cluster list-tokens | grep node6 || false
 
+  # Generate a join token for a seventh node
+  token=$(LXD_DIR="${LXD_ONE_DIR}" lxc cluster add node7 | tail -n 1)
+
+  # Check token is associated to correct name
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster list-tokens | grep node7 | grep "${token}"
+
+  # Revoke the token
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster revoke-token node7 | tail -n 1
+
+  # Check token has been deleted
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster list-tokens
+  ! LXD_DIR="${LXD_TWO_DIR}" lxc cluster list-tokens | grep node7 || false
+
   LXD_DIR="${LXD_SIX_DIR}" lxd shutdown
   LXD_DIR="${LXD_FIVE_DIR}" lxd shutdown
   LXD_DIR="${LXD_FOUR_DIR}" lxd shutdown


### PR DESCRIPTION
* add `revoke-token` to `lxc cluster` to revoke a join token created by `lxc cluster add`

* Browses cluster operations for the operation with the same server name as supplied to `revoke-token` and cancels the operation. 

* Also added some rudimentary tests to the test suite for clustering.