### PR TITLE
Storage: Disable filesystem resize safety checks when importing containers

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -671,7 +671,7 @@ func (d *btrfs) GetVolumeUsage(vol Volume) (int64, error) {
 	return usage, nil
 }
 
-// SetVolumeQuota sets the quota on the volume.
+// SetVolumeQuota applies a size limit on volume.
 // Does nothing if supplied with an empty/zero size for block volumes, and for filesystem volumes removes quota.
 func (d *btrfs) SetVolumeQuota(vol Volume, size string, op *operations.Operation) error {
 	// Convert to bytes.

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -930,8 +930,9 @@ func (d *ceph) SetVolumeQuota(vol Volume, size string, op *operations.Operation)
 				return ErrInUse // We don't allow online shrinking of filesytem volumes.
 			}
 
-			// Shrink filesystem first.
-			err = shrinkFileSystem(fsType, devPath, vol, sizeBytes)
+			// Shrink filesystem first. Pass vol.allowUnsafeResize to allow disabling of filesystem
+			// resize safety checks.
+			err = shrinkFileSystem(fsType, devPath, vol, sizeBytes, vol.allowUnsafeResize)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -248,6 +248,8 @@ func (d *common) runFiller(vol Volume, devPath string, filler *VolumeFiller) err
 	// when creating the initial image volume and filling it before the snapshot is taken resizing can be
 	// allowed and is required in order to support unpacking images larger than the default volume size.
 	// The filler function is still expected to obey any volume size restrictions configured on the pool.
+	// Also needed allow unsafe resize to disable filesystem resize safety checks. This is safe because if for
+	// some reason an error occurs the volume will be discarded rather than leaving a corrupt filesystem.
 	if vol.Type() == VolumeTypeImage {
 		vol.allowUnsafeResize = true
 	}

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -268,9 +268,27 @@ func (d *common) runFiller(vol Volume, devPath string, filler *VolumeFiller) err
 // specified in the volume's config. Can be used as the post hook function returned from createVolumeFromBackup
 // to allow the restored instance volume to be sized correctly after the DB records have been recreated.
 func (d *common) createVolumeFromBackupInstancePostHookResize(driver Driver, vol Volume, op *operations.Operation) error {
+	volType := vol.Type()
+	if volType != VolumeTypeContainer && volType != VolumeTypeVM {
+		return fmt.Errorf("Post import resize hook doesn't support volume type %v", volType)
+	}
+
 	size := vol.ExpandedConfig("size")
 	if size != "" {
 		d.logger.Debug("Applying volume quota from root disk config", log.Ctx{"size": size})
+
+		if volType == VolumeTypeContainer {
+			// Enable allowUnsafeResize for container imports so that filesystem resize safety checks
+			// are avoided in order to allow more imports to succeed when otherwise the pre-resize
+			// estimated checks of resize2fs would prevent import. If there is truly insufficient size
+			// to complete the import the resize will still fail, but its OK as we will then delete
+			// the volume rather than leaving it in a corrupted state.
+			// We don't need to do this for non-container volumes (nor should we) because block volumes
+			// won't error if we shrink them too much, and custom volumes can be created at the correct
+			// size immediately and don't need a post-import resize step.
+			vol.allowUnsafeResize = true
+		}
+
 		err := driver.SetVolumeQuota(vol, size, op)
 		if err != nil {
 			// The restored volume can end up being larger than the root disk config's size

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -259,7 +259,7 @@ func (d *dir) GetVolumeUsage(vol Volume) (int64, error) {
 	return size, nil
 }
 
-// SetVolumeQuota sets the quota on the volume.
+// SetVolumeQuota applies a size limit on volume.
 // Does nothing if supplied with an empty/zero size for block volumes, and for filesystem volumes removes quota.
 func (d *dir) SetVolumeQuota(vol Volume, size string, op *operations.Operation) error {
 	// Convert to bytes.

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -381,7 +381,7 @@ func (d *lvm) GetVolumeUsage(vol Volume) (int64, error) {
 	return -1, ErrNotSupported
 }
 
-// SetVolumeQuota sets the quota on the volume.
+// SetVolumeQuota applies a size limit on volume.
 // Does nothing if supplied with an empty/zero size.
 func (d *lvm) SetVolumeQuota(vol Volume, size string, op *operations.Operation) error {
 	// Do nothing if size isn't specified.

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -445,7 +445,12 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 			}
 
 			// Shrink filesystem first.
-			err = shrinkFileSystem(fsType, volDevPath, vol, sizeBytes)
+			// Pass vol.allowUnsafeResize to allow disabling of filesystem resize safety checks.
+			// We do this as a separate step rather than passing -r to lvresize in resizeLogicalVolume
+			// so that we can have more control over when we trigger unsafe filesystem resize mode,
+			// otherwise by passing -f to lvresize (required for other reasons) this would then pass
+			// -f onto resize2fs as well.
+			err = shrinkFileSystem(fsType, volDevPath, vol, sizeBytes, vol.allowUnsafeResize)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage/drivers/driver_mock.go
+++ b/lxd/storage/drivers/driver_mock.go
@@ -130,7 +130,7 @@ func (d *mock) GetVolumeUsage(vol Volume) (int64, error) {
 	return 0, nil
 }
 
-// SetVolumeQuota sets the quota on the volume.
+// SetVolumeQuota applies a size limit on volume.
 func (d *mock) SetVolumeQuota(vol Volume, size string, op *operations.Operation) error {
 	return nil
 }

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -512,7 +512,9 @@ func filesystemTypeCanBeShrunk(fsType string) bool {
 // shrinkFileSystem shrinks a filesystem if it is supported.
 // EXT4 volumes will be unmounted temporarily if needed.
 // BTRFS volumes will be mounted temporarily if needed.
-func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64) error {
+// Accepts a force argument that indicates whether to skip some safety checks when resizing the volume.
+// This should only be used if the volume will be deleted on resize error.
+func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64, force bool) error {
 	if fsType == "" {
 		fsType = DefaultFilesystem
 	}
@@ -548,7 +550,17 @@ func shrinkFileSystem(fsType string, devPath string, vol Volume, byteSize int64)
 				}
 			}
 
-			_, err = shared.RunCommand("resize2fs", devPath, strSize)
+			var args []string
+			if force {
+				// Enable force mode if requested. Should only be done if volume will be deleted
+				// on error as this can result in corrupting the filesystem if fails during resize.
+				// This is useful because sometimes the pre-checks performed by resize2fs are not
+				// accurate and would prevent a successful filesystem shrink.
+				args = append(args, "-f")
+			}
+
+			args = append(args, devPath, strSize)
+			_, err = shared.RunCommand("resize2fs", args...)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This is required, at least for LVM, in certain circumstances, as the pre-resize checks run by resize2fs are not always accurate and can prevent successful resize.

For example in the reported forum thread, a container with a 2GB LVM disk, of which 1.2GB was showing as used inside the container, when trying to resize after import from 10GB to 2GB caused the error:

```
resize2fs: New size smaller than minimum (548890)
```

With a block size of 4096, that indicates resize2fs thinks the minimum size is 2248253440 bytes (2.248GB).

The resize2fs manual says that the minimum size is an estimate:

"-P Print an estimate of the number of file system blocks in the file system if it is shrunk using resize2fs's -M option and then exit."

I found that if we skipped doing manual resize using resize2fs and just used the `-r` flag on `lvresize` then it succeeded.

After further investigation it seems that lvresize calles the fsadm.sh script in the lvm2 distribution, which calls resize2fs with the `-f` flag when using the `-r` flag of lvresize with the `-f` flag (as we do in LXD).

In my tests, even with the -f flag, resize2fs still prevents shrinking the disk beyond the minimum size, although if it fails then the resize2fs suggests that an fsck should be run.

Reported from https://discuss.linuxcontainers.org/t/unable-to-restore-container/11242/

Includes https://github.com/lxc/lxd/pull/8872

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>