### PR TITLE
Storage: Avoid deleting existing storage volume on conflict during create

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -27,6 +27,7 @@ import (
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/response"
+	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/state"
 	storagePools "github.com/lxc/lxd/lxd/storage"
 	storageDrivers "github.com/lxc/lxd/lxd/storage/drivers"
@@ -801,6 +802,10 @@ func internalImport(d *Daemon, projectName string, req *internalImportPost, reco
 	if err != nil {
 		return response.SmartError(err)
 	}
+
+	revert := revert.New()
+	defer revert.Fail()
+
 	_, err = instance.CreateInternal(d.State(), db.InstanceArgs{
 		Project:      projectName,
 		Architecture: arch,
@@ -815,7 +820,7 @@ func internalImport(d *Daemon, projectName string, req *internalImportPost, reco
 		Name:         backupConf.Container.Name,
 		Profiles:     backupConf.Container.Profiles,
 		Stateful:     backupConf.Container.Stateful,
-	})
+	}, revert)
 	if err != nil {
 		return response.SmartError(errors.Wrap(err, "Failed creating instance record"))
 	}
@@ -910,7 +915,7 @@ func internalImport(d *Daemon, projectName string, req *internalImportPost, reco
 			Name:         snap.Name,
 			Profiles:     snap.Profiles,
 			Stateful:     snap.Stateful,
-		})
+		}, revert)
 		if err != nil {
 			return response.SmartError(errors.Wrapf(err, "Failed creating instance snapshot record %q", snap.Name))
 		}
@@ -927,6 +932,7 @@ func internalImport(d *Daemon, projectName string, req *internalImportPost, reco
 		}
 	}
 
+	revert.Success()
 	return response.EmptySyncResponse
 }
 

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -31,15 +31,14 @@ import (
 
 // instanceCreateAsEmpty creates an empty instance.
 func instanceCreateAsEmpty(d *Daemon, args db.InstanceArgs) (instance.Instance, error) {
+	revert := revert.New()
+	defer revert.Fail()
+
 	// Create the instance record.
-	inst, err := instance.CreateInternal(d.State(), args)
+	inst, err := instance.CreateInternal(d.State(), args, revert)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed creating instance record")
 	}
-
-	revert := revert.New()
-	defer revert.Fail()
-	revert.Add(func() { inst.Delete(true) })
 
 	pool, err := storagePools.GetPoolByInstance(d.State(), inst)
 	if err != nil {
@@ -50,6 +49,8 @@ func instanceCreateAsEmpty(d *Daemon, args db.InstanceArgs) (instance.Instance, 
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed creating instance")
 	}
+
+	revert.Add(func() { inst.Delete(true) })
 
 	err = inst.UpdateBackupFile()
 	if err != nil {

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -208,12 +208,10 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 	// If we are not in refresh mode, then create a new instance as we are in copy mode.
 	if !opts.refresh {
 		// Create the instance.
-		inst, err = instance.CreateInternal(s, opts.targetInstance)
+		inst, err = instance.CreateInternal(s, opts.targetInstance, revert)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed creating instance record")
 		}
-
-		revert.Add(func() { inst.Delete(true) })
 	}
 
 	// At this point we have already figured out the instance's root disk device so we can simply retrieve it
@@ -305,7 +303,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 			}
 
 			// Create the snapshots.
-			snapInst, err := instance.CreateInternal(s, snapInstArgs)
+			snapInst, err := instance.CreateInternal(s, snapInstArgs, revert)
 			if err != nil {
 				return nil, errors.Wrapf(err, "Failed creating instance snapshot record %q", newSnapName)
 			}
@@ -335,6 +333,8 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 		if err != nil {
 			return nil, errors.Wrap(err, "Create instance from copy")
 		}
+
+		revert.Add(func() { inst.Delete(true) })
 
 		if opts.applyTemplateTrigger {
 			// Trigger the templates on next start.

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -547,11 +547,10 @@ func (d *common) snapshotCommon(inst instance.Instance, name string, expiry time
 	}
 
 	// Create the snapshot.
-	snap, err := instance.CreateInternal(d.state, args)
+	snap, err := instance.CreateInternal(d.state, args, revert)
 	if err != nil {
 		return errors.Wrapf(err, "Failed creating instance snapshot record %q", name)
 	}
-	revert.Add(func() { snap.Delete(true) })
 
 	pool, err := storagePools.GetPoolByInstance(d.state, snap)
 	if err != nil {
@@ -562,6 +561,8 @@ func (d *common) snapshotCommon(inst instance.Instance, name string, expiry time
 	if err != nil {
 		return errors.Wrap(err, "Create instance snapshot")
 	}
+
+	revert.Add(func() { snap.Delete(true) })
 
 	// Mount volume for backup.yaml writing.
 	_, err = pool.MountInstance(inst, d.op)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -163,7 +163,9 @@ func qemuInstantiate(s *state.State, args db.InstanceArgs, expandedDevices devic
 }
 
 // qemuCreate creates a new storage volume record and returns an initialised Instance.
-func qemuCreate(s *state.State, args db.InstanceArgs) (instance.Instance, error) {
+// Accepts a reverter that revert steps this function does will be added to. It is up to the caller to call the
+// revert's Fail() or Success() function as needed.
+func qemuCreate(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (instance.Instance, error) {
 	// Create the instance struct.
 	d := &qemu{
 		common: common{
@@ -188,13 +190,6 @@ func qemuCreate(s *state.State, args db.InstanceArgs) (instance.Instance, error)
 			stateful:     args.Stateful,
 		},
 	}
-
-	revert := revert.New()
-	defer revert.Fail()
-
-	// Use d.Delete() in revert on error as this function doesn't just create DB records, it can also cause
-	// other modifications to the host when devices are added.
-	revert.Add(func() { d.Delete(true) })
 
 	// Get the architecture name.
 	archName, err := osarch.ArchitectureName(d.architecture)
@@ -308,26 +303,35 @@ func qemuCreate(s *state.State, args db.InstanceArgs) (instance.Instance, error)
 		}
 	}
 
+	revert.Add(func() {
+		s.Cluster.RemoveStoragePoolVolume(args.Project, args.Name, db.StoragePoolVolumeTypeVM, d.storagePool.ID())
+	})
+
 	if !d.IsSnapshot() {
-		// Update MAAS.
+		// Add devices to instance.
+		for k, m := range d.expandedDevices {
+			devName := k
+			devConfig := m
+			err = d.deviceAdd(devName, devConfig, false)
+			if err != nil && err != device.ErrUnsupportedDevType {
+				return nil, errors.Wrapf(err, "Failed to add device %q", devName)
+			}
+
+			revert.Add(func() { d.deviceRemove(devName, devConfig, false) })
+		}
+
+		// Update MAAS (must run after the MAC addresses have been generated).
 		err = d.maasUpdate(d, nil)
 		if err != nil {
 			return nil, err
 		}
 
-		// Add devices to instance.
-		for k, m := range d.expandedDevices {
-			err = d.deviceAdd(k, m, false)
-			if err != nil && err != device.ErrUnsupportedDevType {
-				return nil, errors.Wrapf(err, "Failed to add device %q", k)
-			}
-		}
+		revert.Add(func() { d.maasDelete(d) })
 	}
 
 	d.logger.Info("Created instance", log.Ctx{"ephemeral": d.ephemeral})
 	d.lifecycle("created", nil)
 
-	revert.Success()
 	return d, nil
 }
 

--- a/lxd/instance/drivers/load.go
+++ b/lxd/instance/drivers/load.go
@@ -10,6 +10,7 @@ import (
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -92,11 +93,11 @@ func validDevices(state *state.State, cluster *db.Cluster, projectName string, i
 	return nil
 }
 
-func create(s *state.State, args db.InstanceArgs) (instance.Instance, error) {
+func create(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (instance.Instance, error) {
 	if args.Type == instancetype.Container {
-		return lxcCreate(s, args)
+		return lxcCreate(s, args, revert)
 	} else if args.Type == instancetype.VM {
-		return qemuCreate(s, args)
+		return qemuCreate(s, args, revert)
 	}
 
 	return nil, fmt.Errorf("Instance type invalid")

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -40,7 +40,9 @@ var ValidDevices func(state *state.State, cluster *db.Cluster, projectName strin
 var Load func(s *state.State, args db.InstanceArgs, profiles []api.Profile) (Instance, error)
 
 // Create is linked from instance/drivers.create to allow difference instance types to be created.
-var Create func(s *state.State, args db.InstanceArgs) (Instance, error)
+// Accepts a reverter that revert steps this function does will be added to. It is up to the caller to call the
+// revert's Fail() or Success() function as needed.
+var Create func(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (Instance, error)
 
 // CompareSnapshots returns a list of snapshots to sync to the target and a list of
 // snapshots to remove from the target. A snapshot will be marked as "to sync" if it either doesn't

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -12,6 +12,7 @@ import (
 	instanceDrivers "github.com/lxc/lxd/lxd/instance/drivers"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/revert"
 	driver "github.com/lxc/lxd/lxd/storage"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -29,7 +30,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesDefault() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args)
+	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
 	suite.Req.Nil(err)
 	defer c.Delete(true)
 
@@ -72,7 +73,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args)
+	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
 	suite.Req.Nil(err)
 	defer c.Delete(true)
 
@@ -103,7 +104,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesOverwriteDefaultNic() {
 	_, err := suite.d.State().Cluster.CreateNetwork(project.Default, "unknownbr0", "", db.NetworkTypeBridge, nil)
 	suite.Req.Nil(err)
 
-	c, err := instance.CreateInternal(suite.d.State(), args)
+	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
 	suite.Req.Nil(err)
 
 	suite.True(c.IsPrivileged(), "This container should be privileged.")
@@ -138,7 +139,7 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 	suite.Req.Nil(err)
 
 	// Create the container
-	c, err := instance.CreateInternal(state, args)
+	c, err := instance.CreateInternal(state, args, revert.New())
 	suite.Req.Nil(err)
 	defer c.Delete(true)
 
@@ -166,7 +167,7 @@ func (suite *containerTestSuite) TestContainer_Path_Regular() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args)
+	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
 	suite.Req.Nil(err)
 	defer c.Delete(true)
 
@@ -182,7 +183,7 @@ func (suite *containerTestSuite) TestContainer_LogPath() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args)
+	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
 	suite.Req.Nil(err)
 	defer c.Delete(true)
 
@@ -197,7 +198,7 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Privileged() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args)
+	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
 	suite.Req.Nil(err)
 
 	suite.Req.True(c.IsPrivileged(), "This container should be privileged.")
@@ -220,7 +221,7 @@ func (suite *containerTestSuite) TestContainer_AddRoutedNicValidation() {
 		Name: "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args)
+	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
 	suite.Req.NoError(err)
 
 	err = c.Update(db.InstanceArgs{
@@ -269,7 +270,7 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Unprivileged() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args)
+	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
 	suite.Req.Nil(err)
 
 	suite.Req.False(c.IsPrivileged(), "This container should be unprivileged.")
@@ -283,7 +284,7 @@ func (suite *containerTestSuite) TestContainer_Rename() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args)
+	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
 	suite.Req.Nil(err)
 	defer c.Delete(true)
 
@@ -298,7 +299,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
 		},
-	})
+	}, revert.New())
 	suite.Req.Nil(err)
 	defer c1.Delete(true)
 
@@ -308,7 +309,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
 		},
-	})
+	}, revert.New())
 	suite.Req.Nil(err)
 	defer c2.Delete(true)
 
@@ -339,7 +340,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 		Config: map[string]string{
 			"security.idmap.isolated": "false",
 		},
-	})
+	}, revert.New())
 	suite.Req.Nil(err)
 	defer c1.Delete(true)
 
@@ -349,7 +350,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
 		},
-	})
+	}, revert.New())
 	suite.Req.Nil(err)
 	defer c2.Delete(true)
 
@@ -381,7 +382,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_raw() {
 			"security.idmap.isolated": "false",
 			"raw.idmap":               "both 1000 1000",
 		},
-	})
+	}, revert.New())
 	suite.Req.Nil(err)
 	defer c1.Delete(true)
 
@@ -419,7 +420,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_maxed() {
 			Config: map[string]string{
 				"security.idmap.isolated": "true",
 			},
-		})
+		}, revert.New())
 
 		/* we should fail if there are no ids left */
 		if i != 6 {

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -286,12 +286,14 @@ func createFromMigration(d *Daemon, r *http.Request, projectName string, req *ap
 		}
 	}
 
-	revert := true
-	defer func() {
-		if revert && !req.Source.Refresh && inst != nil {
+	revert := revert.New()
+	defer revert.Fail()
+
+	revert.Add(func() {
+		if !req.Source.Refresh && inst != nil {
 			inst.Delete(true)
 		}
-	}()
+	})
 
 	instanceOnly := req.Source.InstanceOnly || req.Source.ContainerOnly
 
@@ -305,7 +307,7 @@ func createFromMigration(d *Daemon, r *http.Request, projectName string, req *ap
 		// Note: At this stage we do not yet know if snapshots are going to be received and so we cannot
 		// create their DB records. This will be done if needed in the migrationSink.Do() function called
 		// as part of the operation below.
-		inst, err = instance.CreateInternal(d.State(), args)
+		inst, err = instance.CreateInternal(d.State(), args, revert)
 		if err != nil {
 			return response.InternalError(errors.Wrap(err, "Failed creating instance record"))
 		}
@@ -353,12 +355,8 @@ func createFromMigration(d *Daemon, r *http.Request, projectName string, req *ap
 	}
 
 	run := func(op *operations.Operation) error {
-		opRevert := true
-		defer func() {
-			if opRevert && !req.Source.Refresh && inst != nil {
-				inst.Delete(true)
-			}
-		}()
+		opRevert := revert.Clone()
+		defer opRevert.Fail()
 
 		// And finally run the migration.
 		err = sink.Do(d.State(), op)
@@ -371,7 +369,7 @@ func createFromMigration(d *Daemon, r *http.Request, projectName string, req *ap
 			return err
 		}
 
-		opRevert = false
+		opRevert.Success()
 		return nil
 	}
 
@@ -395,7 +393,7 @@ func createFromMigration(d *Daemon, r *http.Request, projectName string, req *ap
 		}
 	}
 
-	revert = false
+	revert.Success()
 	return operations.OperationResponse(op)
 }
 

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -289,12 +289,6 @@ func createFromMigration(d *Daemon, r *http.Request, projectName string, req *ap
 	revert := revert.New()
 	defer revert.Fail()
 
-	revert.Add(func() {
-		if !req.Source.Refresh && inst != nil {
-			inst.Delete(true)
-		}
-	})
-
 	instanceOnly := req.Source.InstanceOnly || req.Source.ContainerOnly
 
 	if !req.Source.Refresh {
@@ -354,12 +348,14 @@ func createFromMigration(d *Daemon, r *http.Request, projectName string, req *ap
 		return response.InternalError(err)
 	}
 
+	// Copy reverter so far so we can use it inside run after this function has finished.
+	runRevert := revert.Clone()
+
 	run := func(op *operations.Operation) error {
-		opRevert := revert.Clone()
-		defer opRevert.Fail()
+		defer runRevert.Fail()
 
 		// And finally run the migration.
-		err = sink.Do(d.State(), op)
+		err = sink.Do(d.State(), runRevert, op)
 		if err != nil {
 			return fmt.Errorf("Error transferring instance data: %s", err)
 		}
@@ -369,7 +365,7 @@ func createFromMigration(d *Daemon, r *http.Request, projectName string, req *ap
 			return err
 		}
 
-		opRevert.Success()
+		runRevert.Success()
 		return nil
 	}
 

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
+	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/rsync"
 	"github.com/lxc/lxd/lxd/state"
 	storagePools "github.com/lxc/lxd/lxd/storage"
@@ -774,7 +775,7 @@ func newMigrationSink(args *MigrationSinkArgs) (*migrationSink, error) {
 	return &sink, nil
 }
 
-func (c *migrationSink) Do(state *state.State, migrateOp *operations.Operation) error {
+func (c *migrationSink) Do(state *state.State, revert *revert.Reverter, migrateOp *operations.Operation) error {
 	var err error
 
 	if c.push {
@@ -920,7 +921,7 @@ func (c *migrationSink) Do(state *state.State, migrateOp *operations.Operation) 
 				_, err := instance.LoadByProjectAndName(state, args.Instance.Project(), snapArgs.Name)
 				if err != nil {
 					// Create the snapshot as it doesn't seem to exist.
-					_, err := instance.CreateInternal(state, snapArgs)
+					_, err := instance.CreateInternal(state, snapArgs, revert)
 					if err != nil {
 						return errors.Wrapf(err, "Failed creating instance snapshot record %q", snapArgs.Name)
 					}

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -165,37 +165,37 @@ func (s *migrationSourceWs) checkForPreDumpSupport() (bool, int) {
 
 	// CRIU says it can actually do pre-dump. Let's set it to true
 	// unless the user wants something else.
-	use_pre_dumps := true
+	usePreDumps := true
 
 	// What does the configuration say about pre-copy
 	tmp := s.instance.ExpandedConfig()["migration.incremental.memory"]
 
 	if tmp != "" {
-		use_pre_dumps = shared.IsTrue(tmp)
+		usePreDumps = shared.IsTrue(tmp)
 	}
 
-	var max_iterations int
+	var maxIterations int
 
 	// migration.incremental.memory.iterations is the value after which the
 	// container will be definitely migrated, even if the remaining number
 	// of memory pages is below the defined threshold.
 	tmp = s.instance.ExpandedConfig()["migration.incremental.memory.iterations"]
 	if tmp != "" {
-		max_iterations, _ = strconv.Atoi(tmp)
+		maxIterations, _ = strconv.Atoi(tmp)
 	} else {
 		// default to 10
-		max_iterations = 10
+		maxIterations = 10
 	}
-	if max_iterations > 999 {
+	if maxIterations > 999 {
 		// the pre-dump directory is hardcoded to a string
 		// with maximal 3 digits. 999 pre-dumps makes no
 		// sense at all, but let's make sure the number
 		// is not higher than this.
-		max_iterations = 999
+		maxIterations = 999
 	}
-	logger.Debugf("Using maximal %d iterations for pre-dumping", max_iterations)
+	logger.Debugf("Using maximal %d iterations for pre-dumping", maxIterations)
 
-	return use_pre_dumps, max_iterations
+	return usePreDumps, maxIterations
 }
 
 // The function readCriuStatsDump() reads the CRIU 'stats-dump' file
@@ -284,19 +284,19 @@ func (s *migrationSourceWs) preDumpLoop(state *state.State, args *preDumpLoopArg
 	// Read the CRIU's 'stats-dump' file
 	dumpPath := shared.AddSlash(args.checkpointDir)
 	dumpPath += shared.AddSlash(args.dumpDir)
-	written, skipped_parent, err := readCriuStatsDump(dumpPath)
+	written, skippedParent, err := readCriuStatsDump(dumpPath)
 	if err != nil {
 		return final, err
 	}
 
 	logger.Debugf("CRIU pages written %d", written)
-	logger.Debugf("CRIU pages skipped %d", skipped_parent)
+	logger.Debugf("CRIU pages skipped %d", skippedParent)
 
-	total_pages := written + skipped_parent
+	totalPages := written + skippedParent
 
-	percentage_skipped := int(100 - ((100 * written) / total_pages))
+	percentageSkipped := int(100 - ((100 * written) / totalPages))
 
-	logger.Debugf("CRIU pages skipped percentage %d%%", percentage_skipped)
+	logger.Debugf("CRIU pages skipped percentage %d%%", percentageSkipped)
 
 	// threshold is the percentage of memory pages that needs
 	// to be pre-copied for the pre-copy migration to stop.
@@ -309,8 +309,8 @@ func (s *migrationSourceWs) preDumpLoop(state *state.State, args *preDumpLoopArg
 		threshold = 70
 	}
 
-	if percentage_skipped > threshold {
-		logger.Debugf("Memory pages skipped (%d%%) due to pre-copy is larger than threshold (%d%%)", percentage_skipped, threshold)
+	if percentageSkipped > threshold {
+		logger.Debugf("Memory pages skipped (%d%%) due to pre-copy is larger than threshold (%d%%)", percentageSkipped, threshold)
 		logger.Debugf("This was the last pre-dump; next dump is the final dump")
 		final = true
 	}

--- a/lxd/snapshot_common_test.go
+++ b/lxd/snapshot_common_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/lxd/revert"
 )
 
 func (suite *containerTestSuite) TestSnapshotScheduling() {
@@ -17,7 +18,7 @@ func (suite *containerTestSuite) TestSnapshotScheduling() {
 		Name:      "hal9000",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args)
+	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
 	suite.Req.Nil(err)
 	suite.Equal(true, snapshotIsScheduledNow("* * * * *",
 		int64(c.ID())),


### PR DESCRIPTION
This PR improves the revert situation when creating instances such that if the storage pool volume create fails we do not trigger a full instance delete. This is so that if the pool volume creation failed due to an existing conflicting volume, the revert step won't then delete that existing volume (as it would if we triggered an instance delete action).

Instead this PR moves to passing around a top-level reverter which can be used to add more nuanced specific reversion steps rather than using the blunt tool of `instance.Delete()`.

Fixes #8861
