### PR TITLE
Revert "lxd/main_init_interactive: replace empty validator for choosi…

### DIFF
--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -309,9 +309,11 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer) error
 				return errors.Wrap(err, "Failed to retrieve cluster information")
 			}
 
+			// Nil validator to allow for empty values.
+			validator := func(string) error { return nil }
 			for i, config := range cluster.MemberConfig {
 				question := fmt.Sprintf("Choose %s: ", config.Description)
-				cluster.MemberConfig[i].Value = cli.AskString(question, "", nil)
+				cluster.MemberConfig[i].Value = cli.AskString(question, "", validator)
 			}
 
 			config.Cluster.MemberConfig = cluster.MemberConfig


### PR DESCRIPTION
…ng cluster config with nil"

This reverts commit 90b07150af5bc9766d8fa9e791e95866d30bcb28.

Also adding a comment to clarify what this logic is for :)

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>