### PR TITLE
lxd: check for new idmapped mounts extension in LXC

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -754,7 +754,7 @@ func (d *Daemon) init() error {
 		"seccomp_allow_deny_syntax",
 		"devpts_fd",
 		"seccomp_proxy_send_notify_fd",
-		"idmapped_mounts",
+		"idmapped_mounts_v2",
 	}
 	for _, extension := range lxcExtensions {
 		d.os.LXCFeatures[extension] = liblxc.HasApiExtension(extension)

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1311,7 +1311,7 @@ func (d *lxc) IdmappedStorage(path string) idmap.IdmapStorageType {
 		mode = idmap.IdmapStorageShiftfs
 	}
 
-	if !d.state.OS.LXCFeatures["idmapped_mounts"] {
+	if !d.state.OS.LXCFeatures["idmapped_mounts_v2"] {
 		return mode
 	}
 


### PR DESCRIPTION
Some versions of LXC come with support for idmapped rootfs but do not
support idmapped mount entries. Let's not support those LXC version and
only support the ones that have full support.

Link: https://github.com/lxc/lxd/issues/8870
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>