### PR TITLE
Storage: Push instance import post hook resize into storage drivers

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -677,25 +677,6 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 			}
 		}
 
-		// Apply quota config from root device if its set. Should be done after driver's post hook if set
-		// so that any volume initialisation has been completed first.
-		if rootDiskConf["size"] != "" {
-			logger.Debug("Applying volume quota from root disk config", log.Ctx{"size": rootDiskConf["size"]})
-			err = b.driver.SetVolumeQuota(vol, rootDiskConf["size"], op)
-			if err != nil {
-				// The restored volume can end up being larger than the root disk config's size
-				// property due to the block boundary rounding some storage drivers use. As such
-				// if the restored volume is larger than the config's size and it cannot be shrunk
-				// to the equivalent size on the target storage driver, don't fail as the backup
-				// has still been restored successfully.
-				if errors.Cause(err) == drivers.ErrCannotBeShrunk {
-					logger.Warn("Could not apply volume quota from root disk config as restored volume cannot be shrunk", log.Ctx{"size": rootDiskConf["size"]})
-				} else {
-					return errors.Wrapf(err, "Failed applying volume quota to root disk")
-				}
-			}
-		}
-
 		return nil
 	}
 

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -119,7 +119,34 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 func (d *btrfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
 	// Handle the non-optimized tarballs through the generic unpacker.
 	if !*srcBackup.OptimizedStorage {
-		return genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
+		postHook, revertHook, err := genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// genericVFSBackupUnpack returns a nil postHook when volume's type is VolumeTypeCustom which
+		// doesn't need any post hook processing after DB record creation.
+		if postHook != nil {
+			// Define a post hook function that can be run once the backup config has been restored.
+			// This will setup the quota using the restored config.
+			postHookWrapper := func(vol Volume) error {
+				err := postHook(vol)
+				if err != nil {
+					return err
+				}
+
+				err = d.createVolumeFromBackupInstancePostHookResize(d, vol, op)
+				if err != nil {
+					return err
+				}
+
+				return nil
+			}
+
+			return postHookWrapper, revertHook, nil
+		}
+
+		return nil, revertHook, nil
 	}
 
 	if d.HasVolume(vol) {

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -97,17 +97,15 @@ func (d *dir) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 		return nil, nil, err
 	}
 
-	// genericVFSBackupUnpack returns a nil postHook when volume's type is VolumeTypeCustom and doesn't need
-	// any post hook processing after DB record creation.
+	// genericVFSBackupUnpack returns a nil postHook when volume's type is VolumeTypeCustom which
+	// doesn't need any post hook processing after DB record creation.
 	if postHook != nil {
 		// Define a post hook function that can be run once the backup config has been restored.
 		// This will setup the quota using the restored config.
 		postHookWrapper := func(vol Volume) error {
-			if postHook != nil {
-				err := postHook(vol)
-				if err != nil {
-					return err
-				}
+			err := postHook(vol)
+			if err != nil {
+				return err
 			}
 
 			revert := revert.New()
@@ -118,6 +116,11 @@ func (d *dir) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 				return err
 			}
 			revert.Add(revertQuota)
+
+			err = d.createVolumeFromBackupInstancePostHookResize(d, vol, op)
+			if err != nil {
+				return err
+			}
 
 			revert.Success()
 			return nil

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -103,7 +103,34 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
 func (d *lvm) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
-	return genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
+	postHook, revertHook, err := genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// genericVFSBackupUnpack returns a nil postHook when volume's type is VolumeTypeCustom which
+	// doesn't need any post hook processing after DB record creation.
+	if postHook != nil {
+		// Define a post hook function that can be run once the backup config has been restored.
+		// This will setup the quota using the restored config.
+		postHookWrapper := func(vol Volume) error {
+			err := postHook(vol)
+			if err != nil {
+				return err
+			}
+
+			err = d.createVolumeFromBackupInstancePostHookResize(d, vol, op)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}
+
+		return postHookWrapper, revertHook, nil
+	}
+
+	return nil, revertHook, nil
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -251,7 +251,34 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
 	// Handle the non-optimized tarballs through the generic unpacker.
 	if !*srcBackup.OptimizedStorage {
-		return genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
+		postHook, revertHook, err := genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// genericVFSBackupUnpack returns a nil postHook when volume's type is VolumeTypeCustom which
+		// doesn't need any post hook processing after DB record creation.
+		if postHook != nil {
+			// Define a post hook function that can be run once the backup config has been restored.
+			// This will setup the quota using the restored config.
+			postHookWrapper := func(vol Volume) error {
+				err := postHook(vol)
+				if err != nil {
+					return err
+				}
+
+				err = d.createVolumeFromBackupInstancePostHookResize(d, vol, op)
+				if err != nil {
+					return err
+				}
+
+				return nil
+			}
+
+			return postHookWrapper, revertHook, nil
+		}
+
+		return nil, revertHook, nil
 	}
 
 	if d.HasVolume(vol) {


### PR DESCRIPTION
This allows a future modification to alter the way we resize filesystem block volumes (ceph and lvm) during an import.

Related to https://discuss.linuxcontainers.org/t/unable-to-restore-container/11242/