### PR TITLE
Instance: Exclude VM config.mount directory from backup exports

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -543,7 +543,7 @@ func (d *qemu) Freeze() error {
 func (d *qemu) configDriveMountPath() string {
 	// Use instance path and config.mount directory rather than devices path to avoid conflicts with an
 	// instance disk device mount of the same name.
-	return filepath.Join(d.Path(), "config.mount")
+	return filepath.Join(d.Path(), storageDrivers.VMConfigDriveMountDir)
 }
 
 // configDriveMountPathClear attempts to unmount the config drive bind mount and remove the directory.

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -471,7 +471,10 @@ func genericVFSBackupVolume(d Driver, vol Volume, tarWriter *instancewriter.Inst
 				}
 
 				var blockDiskSize int64
-				var exclude []string
+
+				// Exclude config.mount share directory as this is a temporary mount and shouldn't
+				// be included in the backup.
+				var exclude = []string{filepath.Join(mountPath, VMConfigDriveMountDir)}
 
 				// Get size of disk block device for tarball header.
 				blockDiskSize, err = BlockDiskSizeBytes(blockPath)
@@ -497,7 +500,7 @@ func genericVFSBackupVolume(d Driver, vol Volume, tarWriter *instancewriter.Inst
 					}
 
 					// Skip any exluded files.
-					if shared.StringInSlice(srcPath, exclude) {
+					if shared.StringHasPrefix(srcPath, exclude...) {
 						return nil
 					}
 

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -28,6 +28,9 @@ import (
 // genericVolumeDiskFile used to indicate the file name used for block volume disk files.
 const genericVolumeDiskFile = "root.img"
 
+// VMConfigDriveMountDir name of the config drive share mount directory.
+const VMConfigDriveMountDir = "config.mount"
+
 // genericVFSGetResources is a generic GetResources implementation for VFS-only drivers.
 func genericVFSGetResources(d Driver) (*api.ResourcesStoragePool, error) {
 	// Get the VFS information


### PR DESCRIPTION
Otherwise when a non-optimized VM is imported it won't start due to a non-empty config.mount dir.