### PR TITLE
Add warning for networks with IPv6 prefix larger than /64

### DIFF
--- a/lxd/db/warnings_types.go
+++ b/lxd/db/warnings_types.go
@@ -43,6 +43,8 @@ const (
 	WarningUnableToConnectToMAAS
 	// WarningAppArmorDisabledDueToRawDnsmasq represents the disabled AppArmor due to raw.dnsmasq warning
 	WarningAppArmorDisabledDueToRawDnsmasq
+	// WarningLargerIPv6PrefixThanSupported represents the larger IPv6 prefix than supported warning
+	WarningLargerIPv6PrefixThanSupported
 )
 
 // WarningTypeNames associates a warning code to its name.
@@ -65,6 +67,7 @@ var WarningTypeNames = map[WarningType]string{
 	WarningMissingVirtiofsd:                       "Missing virtiofsd",
 	WarningUnableToConnectToMAAS:                  "Unable to connect to MAAS",
 	WarningAppArmorDisabledDueToRawDnsmasq:        "Skipping AppArmor for dnsmasq due to raw.dnsmasq being set",
+	WarningLargerIPv6PrefixThanSupported:          "IPv6 networks with a prefix larger than 64 aren't properly supported by dnsmasq",
 }
 
 // WarningTypes associates a warning type to its type code.
@@ -114,6 +117,8 @@ func (t WarningType) Severity() WarningSeverity {
 	case WarningUnableToConnectToMAAS:
 		return WarningSeverityLow
 	case WarningAppArmorDisabledDueToRawDnsmasq:
+		return WarningSeverityLow
+	case WarningLargerIPv6PrefixThanSupported:
 		return WarningSeverityLow
 	}
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -1023,6 +1023,16 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 
 		if subnetSize > 64 {
 			n.logger.Warn("IPv6 networks with a prefix larger than 64 aren't properly supported by dnsmasq")
+
+			err = n.state.Cluster.UpsertWarningLocalNode(n.project, dbCluster.TypeNetwork, int(n.id), db.WarningLargerIPv6PrefixThanSupported, "")
+			if err != nil {
+				n.logger.Warn("Failed to create warning", log.Ctx{"err": err})
+			}
+		} else {
+			err = warnings.ResolveWarningsByLocalNodeAndProjectAndTypeAndEntity(n.state.Cluster, n.project, db.WarningLargerIPv6PrefixThanSupported, dbCluster.TypeNetwork, int(n.id))
+			if err != nil {
+				n.logger.Warn("Failed to resolve warning", log.Ctx{"err": err})
+			}
 		}
 
 		// Update the dnsmasq config.


### PR DESCRIPTION
- lxd/db: Add WarningLargerIPv6PrefixThanSupported
- lxd/network: Create warning if IPv6 prefix is too large
