### PR TITLE
Storage: Remove vol.allowUnsafeResize var in place of per-function bool arguments instead

### DIFF
--- a/lxd/revert/revert.go
+++ b/lxd/revert/revert.go
@@ -1,8 +1,12 @@
 package revert
 
+// Hook is a function that can be added to the revert via the Add() function.
+// These will be run in the reverse order that they were added if the reverter's Fail() function is called.
+type Hook func()
+
 // Reverter is a helper type to manage revert functions.
 type Reverter struct {
-	revertFuncs []func()
+	revertFuncs []Hook
 }
 
 // New returns a new Reverter.
@@ -11,7 +15,7 @@ func New() *Reverter {
 }
 
 // Add adds a revert function to the list to be run when Revert() is called.
-func (r *Reverter) Add(f func()) {
+func (r *Reverter) Add(f Hook) {
 	r.revertFuncs = append(r.revertFuncs, f)
 }
 
@@ -37,7 +41,7 @@ func (r *Reverter) Success() {
 // execute the previously deferred reverter.Fail() function.
 func (r *Reverter) Clone() *Reverter {
 	rNew := New()
-	rNew.revertFuncs = append(make([]func(), 0, len(r.revertFuncs)), r.revertFuncs...)
+	rNew.revertFuncs = append(make([]Hook, 0, len(r.revertFuncs)), r.revertFuncs...)
 
 	return rNew
 }

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -572,7 +572,7 @@ func (b *lxdBackend) CreateInstance(inst instance.Instance, op *operations.Opera
 // it is necessary to return two functions; a post hook that can be run once the instance has been
 // created in the database to run any storage layer finalisations, and a revert hook that can be
 // run if the instance database load process fails that will remove anything created thus far.
-func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(instance.Instance) error, func(), error) {
+func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(instance.Instance) error, revert.Hook, error) {
 	logger := logging.AddContext(b.logger, log.Ctx{"project": srcBackup.Project, "instance": srcBackup.Name, "snapshots": srcBackup.Snapshots, "optimizedStorage": *srcBackup.OptimizedStorage})
 	logger.Debug("CreateInstanceFromBackup started")
 	defer logger.Debug("CreateInstanceFromBackup finished")

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1041,8 +1041,8 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 // imageFiller returns a function that can be used as a filler function with CreateVolume().
 // The function returned will unpack the specified image archive into the specified mount path
 // provided, and for VM images, a raw root block path is required to unpack the qcow2 image into.
-func (b *lxdBackend) imageFiller(fingerprint string, op *operations.Operation) func(vol drivers.Volume, rootBlockPath string) (int64, error) {
-	return func(vol drivers.Volume, rootBlockPath string) (int64, error) {
+func (b *lxdBackend) imageFiller(fingerprint string, op *operations.Operation) func(vol drivers.Volume, rootBlockPath string, allowUnsafeResize bool) (int64, error) {
+	return func(vol drivers.Volume, rootBlockPath string, allowUnsafeResize bool) (int64, error) {
 		var tracker *ioprogress.ProgressTracker
 		if op != nil { // Not passed when being done as part of pre-migration setup.
 			metadata := make(map[string]interface{})
@@ -1053,7 +1053,7 @@ func (b *lxdBackend) imageFiller(fingerprint string, op *operations.Operation) f
 				}}
 		}
 		imageFile := shared.VarPath("images", fingerprint)
-		return ImageUnpack(imageFile, vol, rootBlockPath, b.driver.Info().BlockBacking, b.state.OS.RunningInUserNS, tracker)
+		return ImageUnpack(imageFile, vol, rootBlockPath, b.driver.Info().BlockBacking, b.state.OS.RunningInUserNS, allowUnsafeResize, tracker)
 	}
 }
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -681,7 +681,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 		// so that any volume initialisation has been completed first.
 		if rootDiskConf["size"] != "" {
 			logger.Debug("Applying volume quota from root disk config", log.Ctx{"size": rootDiskConf["size"]})
-			err = b.driver.SetVolumeQuota(vol, rootDiskConf["size"], op)
+			err = b.driver.SetVolumeQuota(vol, rootDiskConf["size"], false, op)
 			if err != nil {
 				// The restored volume can end up being larger than the root disk config's size
 				// property due to the block boundary rounding some storage drivers use. As such
@@ -1722,7 +1722,7 @@ func (b *lxdBackend) SetInstanceQuota(inst instance.Instance, size string, vmSta
 	// Apply the main volume quota.
 	// There's no need to pass config as it's not needed when setting quotas.
 	vol := b.newVolume(volType, contentVolume, volStorageName, nil)
-	err = b.driver.SetVolumeQuota(vol, size, op)
+	err = b.driver.SetVolumeQuota(vol, size, false, op)
 	if err != nil {
 		return err
 	}
@@ -1734,7 +1734,7 @@ func (b *lxdBackend) SetInstanceQuota(inst instance.Instance, size string, vmSta
 		}
 
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := b.driver.SetVolumeQuota(fsVol, vmStateSize, op)
+		err := b.driver.SetVolumeQuota(fsVol, vmStateSize, false, op)
 		if err != nil {
 			return err
 		}
@@ -2298,7 +2298,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 			// Try applying the current size policy to the existing volume. If it is the same the
 			// driver should make no changes, and if not then attempt to resize it to the new policy.
 			logger.Debug("Setting image volume size", "size", imgVol.ConfigSize())
-			err = b.driver.SetVolumeQuota(imgVol, imgVol.ConfigSize(), op)
+			err = b.driver.SetVolumeQuota(imgVol, imgVol.ConfigSize(), false, op)
 			if errors.Cause(err) == drivers.ErrCannotBeShrunk || errors.Cause(err) == drivers.ErrNotSupported {
 				// If the driver cannot resize the existing image volume to the new policy size
 				// then delete the image volume and try to recreate using the new policy settings.

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
+	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/storage/drivers"
 	"github.com/lxc/lxd/shared/api"
@@ -96,7 +97,7 @@ func (b *mockBackend) CreateInstance(inst instance.Instance, op *operations.Oper
 	return nil
 }
 
-func (b *mockBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(instance.Instance) error, func(), error) {
+func (b *mockBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(instance.Instance) error, revert.Hook, error) {
 	return nil, nil, nil
 }
 

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -92,7 +92,7 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 		}
 	} else if vol.contentType == ContentTypeFS {
 		// Set initial quota for filesystem volumes.
-		err := d.SetVolumeQuota(vol, vol.ConfigSize(), op)
+		err := d.SetVolumeQuota(vol, vol.ConfigSize(), false, op)
 		if err != nil {
 			return err
 		}
@@ -370,7 +370,7 @@ func (d *btrfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bo
 
 	// Resize volume to the size specified. Only uses volume "size" property and does not use pool/defaults
 	// to give the caller more control over the size being used.
-	err = d.SetVolumeQuota(vol, vol.config["size"], nil)
+	err = d.SetVolumeQuota(vol, vol.config["size"], false, op)
 	if err != nil {
 		return err
 	}
@@ -557,7 +557,7 @@ func (d *btrfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, v
 
 	if vol.contentType == ContentTypeFS {
 		// Apply the size limit.
-		err = d.SetVolumeQuota(vol, vol.ConfigSize(), op)
+		err = d.SetVolumeQuota(vol, vol.ConfigSize(), false, op)
 		if err != nil {
 			return err
 		}
@@ -621,7 +621,7 @@ func (d *btrfs) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 func (d *btrfs) UpdateVolume(vol Volume, changedConfig map[string]string) error {
 	newSize, sizeChanged := changedConfig["size"]
 	if sizeChanged {
-		err := d.SetVolumeQuota(vol, newSize, nil)
+		err := d.SetVolumeQuota(vol, newSize, false, nil)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -73,11 +73,12 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 		// created from, and that doesn't get updated when the original volumes size is changed.
 		// However during initial volume fill we allow growing of image volumes because the snapshot hasn't
 		// been taken yet. This is why no unsupported volume types are passed to ensureVolumeBlockFile.
-		// This is important, as combined with not setting allowUnsafeResize on the volume it still
-		// prevents us from accidentally shrinking the filled volume if it is larger than vol.ConfigSize().
+		// This is important, as combined with not enabling allowUnsafeResize it still prevents us from
+		// accidentally shrinking the filled volume if it is larger than vol.ConfigSize().
 		// In that situation ensureVolumeBlockFile returns ErrCannotBeShrunk, but we ignore it as this just
-		// means the filler has needed to increase the volume size beyond the default block volume size.
-		_, err = ensureVolumeBlockFile(vol, rootBlockPath, sizeBytes)
+		// means the filler run above has needed to increase the volume size beyond the default block
+		// volume size.
+		_, err = ensureVolumeBlockFile(vol, rootBlockPath, sizeBytes, false)
 		if err != nil && errors.Cause(err) != ErrCannotBeShrunk {
 			return err
 		}

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -116,7 +116,7 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *btrfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
+func (d *btrfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, func(), error) {
 	// Handle the non-optimized tarballs through the generic unpacker.
 	if !*srcBackup.OptimizedStorage {
 		return genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -116,7 +116,7 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *btrfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, func(), error) {
+func (d *btrfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
 	// Handle the non-optimized tarballs through the generic unpacker.
 	if !*srcBackup.OptimizedStorage {
 		return genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -850,7 +850,7 @@ func (d *ceph) GetVolumeUsage(vol Volume) (int64, error) {
 
 // SetVolumeQuota applies a size limit on volume.
 // Does nothing if supplied with an empty/zero size.
-func (d *ceph) SetVolumeQuota(vol Volume, size string, op *operations.Operation) error {
+func (d *ceph) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
 	// Convert to bytes.
 	sizeBytes, err := units.ParseByteSizeString(size)
 	if err != nil {
@@ -884,7 +884,7 @@ func (d *ceph) SetVolumeQuota(vol Volume, size string, op *operations.Operation)
 	// Block image volumes cannot be resized because they have a readonly snapshot that doesn't get
 	// updated when the volume's size is changed, and this is what instances are created from.
 	// During initial volume fill allowUnsafeResize is enabled because snapshot hasn't been taken yet.
-	if !vol.allowUnsafeResize && vol.volType == VolumeTypeImage {
+	if !allowUnsafeResize && vol.volType == VolumeTypeImage {
 		return ErrNotSupported
 	}
 
@@ -903,9 +903,9 @@ func (d *ceph) SetVolumeQuota(vol Volume, size string, op *operations.Operation)
 				return ErrInUse // We don't allow online shrinking of filesytem volumes.
 			}
 
-			// Shrink filesystem first. Pass vol.allowUnsafeResize to allow disabling of filesystem
+			// Shrink filesystem first. Pass allowUnsafeResize to allow disabling of filesystem
 			// resize safety checks.
-			err = shrinkFileSystem(fsType, devPath, vol, sizeBytes, vol.allowUnsafeResize)
+			err = shrinkFileSystem(fsType, devPath, vol, sizeBytes, allowUnsafeResize)
 			if err != nil {
 				return err
 			}
@@ -931,7 +931,7 @@ func (d *ceph) SetVolumeQuota(vol Volume, size string, op *operations.Operation)
 	} else {
 		// Only perform pre-resize checks if we are not in "unsafe" mode.
 		// In unsafe mode we expect the caller to know what they are doing and understand the risks.
-		if !vol.allowUnsafeResize {
+		if !allowUnsafeResize {
 			if sizeBytes < oldSizeBytes {
 				return errors.Wrap(ErrCannotBeShrunk, "Block volumes cannot be shrunk")
 			}
@@ -942,14 +942,14 @@ func (d *ceph) SetVolumeQuota(vol Volume, size string, op *operations.Operation)
 		}
 
 		// Resize block device.
-		err = d.resizeVolume(vol, sizeBytes, vol.allowUnsafeResize)
+		err = d.resizeVolume(vol, sizeBytes, allowUnsafeResize)
 		if err != nil {
 			return err
 		}
 
 		// Move the VM GPT alt header to end of disk if needed (not needed in unsafe resize mode as it is
 		// expected the caller will do all necessary post resize actions themselves).
-		if vol.IsVMBlock() && !vol.allowUnsafeResize {
+		if vol.IsVMBlock() && !allowUnsafeResize {
 			err = d.moveGPTAltHeader(devPath)
 			if err != nil {
 				return err

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -288,34 +288,7 @@ func (d *ceph) getVolumeSize(volumeName string) (int64, error) {
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
 func (d *ceph) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
-	postHook, revertHook, err := genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// genericVFSBackupUnpack returns a nil postHook when volume's type is VolumeTypeCustom which
-	// doesn't need any post hook processing after DB record creation.
-	if postHook != nil {
-		// Define a post hook function that can be run once the backup config has been restored.
-		// This will setup the quota using the restored config.
-		postHookWrapper := func(vol Volume) error {
-			err := postHook(vol)
-			if err != nil {
-				return err
-			}
-
-			err = d.createVolumeFromBackupInstancePostHookResize(d, vol, op)
-			if err != nil {
-				return err
-			}
-
-			return nil
-		}
-
-		return postHookWrapper, revertHook, nil
-	}
-
-	return nil, revertHook, nil
+	return genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -287,7 +287,7 @@ func (d *ceph) getVolumeSize(volumeName string) (int64, error) {
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *ceph) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
+func (d *ceph) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, func(), error) {
 	return genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
 }
 

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -326,7 +326,7 @@ func (d *ceph) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots boo
 
 		// Resize volume to the size specified. Only uses volume "size" property and does not use
 		// pool/defaults to give the caller more control over the size being used.
-		err = d.SetVolumeQuota(vol, vol.config["size"], nil)
+		err = d.SetVolumeQuota(vol, vol.config["size"], false, op)
 		if err != nil {
 			return err
 		}
@@ -763,7 +763,7 @@ func (d *ceph) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 func (d *ceph) UpdateVolume(vol Volume, changedConfig map[string]string) error {
 	newSize, sizeChanged := changedConfig["size"]
 	if sizeChanged {
-		err := d.SetVolumeQuota(vol, newSize, nil)
+		err := d.SetVolumeQuota(vol, newSize, false, nil)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -287,7 +287,7 @@ func (d *ceph) getVolumeSize(volumeName string) (int64, error) {
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *ceph) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, func(), error) {
+func (d *ceph) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
 	return genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
 }
 

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lxc/lxd/lxd/backup"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
+	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/rsync"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/instancewriter"
@@ -61,7 +62,7 @@ func (d *cephfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.O
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *cephfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, func(), error) {
+func (d *cephfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
 	return nil, nil, ErrNotImplemented
 }
 

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -46,7 +46,7 @@ func (d *cephfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.O
 	}()
 
 	// Apply the volume quota if specified.
-	err = d.SetVolumeQuota(vol, vol.ConfigSize(), op)
+	err = d.SetVolumeQuota(vol, vol.ConfigSize(), false, op)
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func (d *cephfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots b
 		}
 
 		// Apply the volume quota if specified.
-		err = d.SetVolumeQuota(vol, vol.ConfigSize(), op)
+		err = d.SetVolumeQuota(vol, vol.ConfigSize(), false, op)
 		if err != nil {
 			return err
 		}
@@ -216,7 +216,7 @@ func (d *cephfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, 
 
 		if vol.contentType == ContentTypeFS {
 			// Apply the size limit.
-			err = d.SetVolumeQuota(vol, vol.ConfigSize(), op)
+			err = d.SetVolumeQuota(vol, vol.ConfigSize(), false, op)
 			if err != nil {
 				return err
 			}
@@ -293,7 +293,7 @@ func (d *cephfs) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 func (d *cephfs) UpdateVolume(vol Volume, changedConfig map[string]string) error {
 	newSize, sizeChanged := changedConfig["size"]
 	if sizeChanged {
-		err := d.SetVolumeQuota(vol, newSize, nil)
+		err := d.SetVolumeQuota(vol, newSize, false, nil)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -323,7 +323,7 @@ func (d *cephfs) GetVolumeUsage(vol Volume) (int64, error) {
 }
 
 // SetVolumeQuota applies a size limit on volume.
-func (d *cephfs) SetVolumeQuota(vol Volume, size string, op *operations.Operation) error {
+func (d *cephfs) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
 	// If size not specified in volume config, then use pool's default volume.size setting.
 	if size == "" || size == "0" {
 		size = d.config["volume.size"]

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -61,7 +61,7 @@ func (d *cephfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.O
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *cephfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
+func (d *cephfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, func(), error) {
 	return nil, nil, ErrNotImplemented
 }
 

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -279,6 +279,8 @@ func (d *common) createVolumeFromBackupInstancePostHookResize(driver Driver, vol
 	if size != "" {
 		d.logger.Debug("Applying volume quota from root disk config", log.Ctx{"size": size})
 
+		allowUnsafeResize := false
+
 		if volType == VolumeTypeContainer {
 			// Enable allowUnsafeResize for container imports so that filesystem resize safety checks
 			// are avoided in order to allow more imports to succeed when otherwise the pre-resize
@@ -288,10 +290,10 @@ func (d *common) createVolumeFromBackupInstancePostHookResize(driver Driver, vol
 			// We don't need to do this for non-container volumes (nor should we) because block volumes
 			// won't error if we shrink them too much, and custom volumes can be created at the correct
 			// size immediately and don't need a post-import resize step.
-			vol.allowUnsafeResize = true
+			allowUnsafeResize = true
 		}
 
-		err := driver.SetVolumeQuota(vol, size, op)
+		err := driver.SetVolumeQuota(vol, size, allowUnsafeResize, op)
 		if err != nil {
 			// The restored volume can end up being larger than the root disk config's size
 			// property due to the block boundary rounding some storage drivers use. As such

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -243,6 +243,8 @@ func (d *common) runFiller(vol Volume, devPath string, filler *VolumeFiller) err
 		return nil
 	}
 
+	allowUnsafeResize := false
+
 	// Allow filler to resize initial image volume as needed. Some storage drivers don't normally allow
 	// image volumes to be resized due to them having read-only snapshots that cannot be resized. However
 	// when creating the initial image volume and filling it before the snapshot is taken resizing can be
@@ -251,11 +253,11 @@ func (d *common) runFiller(vol Volume, devPath string, filler *VolumeFiller) err
 	// Also needed allow unsafe resize to disable filesystem resize safety checks. This is safe because if for
 	// some reason an error occurs the volume will be discarded rather than leaving a corrupt filesystem.
 	if vol.Type() == VolumeTypeImage {
-		vol.allowUnsafeResize = true
+		allowUnsafeResize = true
 	}
 
 	vol.driver.Logger().Debug("Running filler function", log.Ctx{"dev": devPath, "path": vol.MountPath()})
-	volSize, err := filler.Fill(vol, devPath)
+	volSize, err := filler.Fill(vol, devPath, allowUnsafeResize)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/lxc/lxd/lxd/migration"
-	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 	log "github.com/lxc/lxd/shared/log15"
@@ -263,50 +262,5 @@ func (d *common) runFiller(vol Volume, devPath string, filler *VolumeFiller) err
 	}
 
 	filler.Size = volSize
-	return nil
-}
-
-// createVolumeFromBackupInstancePostHookResize provides a common post-hook that resizes the an volume to the size
-// specified in the volume's config. Can be used as the post hook function returned from createVolumeFromBackup
-// to allow the restored instance volume to be sized correctly after the DB records have been recreated.
-func (d *common) createVolumeFromBackupInstancePostHookResize(driver Driver, vol Volume, op *operations.Operation) error {
-	volType := vol.Type()
-	if volType != VolumeTypeContainer && volType != VolumeTypeVM {
-		return fmt.Errorf("Post import resize hook doesn't support volume type %v", volType)
-	}
-
-	size := vol.ExpandedConfig("size")
-	if size != "" {
-		d.logger.Debug("Applying volume quota from root disk config", log.Ctx{"size": size})
-
-		allowUnsafeResize := false
-
-		if volType == VolumeTypeContainer {
-			// Enable allowUnsafeResize for container imports so that filesystem resize safety checks
-			// are avoided in order to allow more imports to succeed when otherwise the pre-resize
-			// estimated checks of resize2fs would prevent import. If there is truly insufficient size
-			// to complete the import the resize will still fail, but its OK as we will then delete
-			// the volume rather than leaving it in a corrupted state.
-			// We don't need to do this for non-container volumes (nor should we) because block volumes
-			// won't error if we shrink them too much, and custom volumes can be created at the correct
-			// size immediately and don't need a post-import resize step.
-			allowUnsafeResize = true
-		}
-
-		err := driver.SetVolumeQuota(vol, size, allowUnsafeResize, op)
-		if err != nil {
-			// The restored volume can end up being larger than the root disk config's size
-			// property due to the block boundary rounding some storage drivers use. As such
-			// if the restored volume is larger than the config's size and it cannot be shrunk
-			// to the equivalent size on the target storage driver, don't fail as the backup
-			// has still been restored successfully.
-			if errors.Cause(err) == ErrCannotBeShrunk {
-				d.logger.Warn("Could not apply volume quota from root disk config as restored volume cannot be shrunk", log.Ctx{"size": size})
-			} else {
-				return errors.Wrapf(err, "Failed applying volume quota to root disk")
-			}
-		}
-	}
-
 	return nil
 }

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -90,7 +90,7 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *dir) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
+func (d *dir) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, func(), error) {
 	// Run the generic backup unpacker
 	postHook, revertHook, err := genericVFSBackupUnpack(d.withoutGetVolID(), vol, srcBackup.Snapshots, srcData, op)
 	if err != nil {

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -117,11 +117,6 @@ func (d *dir) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 			}
 			revert.Add(revertQuota)
 
-			err = d.createVolumeFromBackupInstancePostHookResize(d, vol, op)
-			if err != nil {
-				return err
-			}
-
 			revert.Success()
 			return nil
 		}

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -215,7 +215,7 @@ func (d *dir) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 func (d *dir) UpdateVolume(vol Volume, changedConfig map[string]string) error {
 	newSize, sizeChanged := changedConfig["size"]
 	if sizeChanged {
-		err := d.SetVolumeQuota(vol, newSize, nil)
+		err := d.SetVolumeQuota(vol, newSize, false, nil)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -69,9 +69,9 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 			return err
 		}
 
-		// Ignore ErrCannotBeShrunk when setting size this just means the filler has needed to increase
-		// the volume size beyond the default block volume size.
-		_, err = ensureVolumeBlockFile(vol, rootBlockPath, sizeBytes)
+		// Ignore ErrCannotBeShrunk when setting size this just means the filler run above has needed to
+		// increase the volume size beyond the default block volume size.
+		_, err = ensureVolumeBlockFile(vol, rootBlockPath, sizeBytes, false)
 		if err != nil && errors.Cause(err) != ErrCannotBeShrunk {
 			return err
 		}

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -90,7 +90,7 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *dir) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, func(), error) {
+func (d *dir) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
 	// Run the generic backup unpacker
 	postHook, revertHook, err := genericVFSBackupUnpack(d.withoutGetVolID(), vol, srcBackup.Snapshots, srcData, op)
 	if err != nil {

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -632,7 +632,7 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []Volume, refr
 
 	// Resize volume to the size specified. Only uses volume "size" property and does not use pool/defaults
 	// to give the caller more control over the size being used.
-	err = d.SetVolumeQuota(vol, vol.config["size"], nil)
+	err = d.SetVolumeQuota(vol, vol.config["size"], false, nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -102,7 +102,7 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *lvm) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, func(), error) {
+func (d *lvm) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
 	return genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
 }
 

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -103,34 +103,7 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
 func (d *lvm) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
-	postHook, revertHook, err := genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// genericVFSBackupUnpack returns a nil postHook when volume's type is VolumeTypeCustom which
-	// doesn't need any post hook processing after DB record creation.
-	if postHook != nil {
-		// Define a post hook function that can be run once the backup config has been restored.
-		// This will setup the quota using the restored config.
-		postHookWrapper := func(vol Volume) error {
-			err := postHook(vol)
-			if err != nil {
-				return err
-			}
-
-			err = d.createVolumeFromBackupInstancePostHookResize(d, vol, op)
-			if err != nil {
-				return err
-			}
-
-			return nil
-		}
-
-		return postHookWrapper, revertHook, nil
-	}
-
-	return nil, revertHook, nil
+	return genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -303,7 +303,7 @@ func (d *lvm) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 func (d *lvm) UpdateVolume(vol Volume, changedConfig map[string]string) error {
 	newSize, sizeChanged := changedConfig["size"]
 	if sizeChanged {
-		err := d.SetVolumeQuota(vol, newSize, nil)
+		err := d.SetVolumeQuota(vol, newSize, false, nil)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -356,7 +356,7 @@ func (d *lvm) GetVolumeUsage(vol Volume) (int64, error) {
 
 // SetVolumeQuota applies a size limit on volume.
 // Does nothing if supplied with an empty/zero size.
-func (d *lvm) SetVolumeQuota(vol Volume, size string, op *operations.Operation) error {
+func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
 	// Do nothing if size isn't specified.
 	if size == "" || size == "0" {
 		return nil
@@ -418,12 +418,12 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 			}
 
 			// Shrink filesystem first.
-			// Pass vol.allowUnsafeResize to allow disabling of filesystem resize safety checks.
+			// Pass allowUnsafeResize to allow disabling of filesystem resize safety checks.
 			// We do this as a separate step rather than passing -r to lvresize in resizeLogicalVolume
 			// so that we can have more control over when we trigger unsafe filesystem resize mode,
 			// otherwise by passing -f to lvresize (required for other reasons) this would then pass
 			// -f onto resize2fs as well.
-			err = shrinkFileSystem(fsType, volDevPath, vol, sizeBytes, vol.allowUnsafeResize)
+			err = shrinkFileSystem(fsType, volDevPath, vol, sizeBytes, allowUnsafeResize)
 			if err != nil {
 				return err
 			}
@@ -451,7 +451,7 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 	} else {
 		// Only perform pre-resize checks if we are not in "unsafe" mode.
 		// In unsafe mode we expect the caller to know what they are doing and understand the risks.
-		if !vol.allowUnsafeResize {
+		if !allowUnsafeResize {
 			if sizeBytes < oldSizeBytes {
 				return errors.Wrap(ErrCannotBeShrunk, "Block volumes cannot be shrunk")
 			}
@@ -468,7 +468,7 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 
 		// Move the VM GPT alt header to end of disk if needed (not needed in unsafe resize mode as it is
 		// expected the caller will do all necessary post resize actions themselves).
-		if vol.IsVMBlock() && !vol.allowUnsafeResize {
+		if vol.IsVMBlock() && !allowUnsafeResize {
 			err = d.moveGPTAltHeader(volDevPath)
 			if err != nil {
 				return err

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -102,7 +102,7 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *lvm) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
+func (d *lvm) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, func(), error) {
 	return genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
 }
 

--- a/lxd/storage/drivers/driver_mock.go
+++ b/lxd/storage/drivers/driver_mock.go
@@ -74,7 +74,7 @@ func (d *mock) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *mock) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
+func (d *mock) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, func(), error) {
 	return nil, nil, nil
 }
 

--- a/lxd/storage/drivers/driver_mock.go
+++ b/lxd/storage/drivers/driver_mock.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lxc/lxd/lxd/backup"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
+	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/instancewriter"
 )
@@ -74,7 +75,7 @@ func (d *mock) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *mock) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, func(), error) {
+func (d *mock) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
 	return nil, nil, nil
 }
 

--- a/lxd/storage/drivers/driver_mock.go
+++ b/lxd/storage/drivers/driver_mock.go
@@ -117,7 +117,7 @@ func (d *mock) UpdateVolume(vol Volume, changedConfig map[string]string) error {
 	}
 
 	if _, changed := changedConfig["size"]; changed {
-		err := d.SetVolumeQuota(vol, changedConfig["size"], nil)
+		err := d.SetVolumeQuota(vol, changedConfig["size"], false, nil)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_mock.go
+++ b/lxd/storage/drivers/driver_mock.go
@@ -132,7 +132,7 @@ func (d *mock) GetVolumeUsage(vol Volume) (int64, error) {
 }
 
 // SetVolumeQuota applies a size limit on volume.
-func (d *mock) SetVolumeQuota(vol Volume, size string, op *operations.Operation) error {
+func (d *mock) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error {
 	return nil
 }
 

--- a/lxd/storage/drivers/driver_types.go
+++ b/lxd/storage/drivers/driver_types.go
@@ -19,8 +19,8 @@ type Info struct {
 
 // VolumeFiller provides a struct for filling a volume.
 type VolumeFiller struct {
-	Fill func(vol Volume, rootBlockPath string) (int64, error) // Function to fill the volume.
-	Size int64                                                 // Size of the unpacked volume in bytes.
+	Fill func(vol Volume, rootBlockPath string, allowUnsafeResize bool) (int64, error) // Function to fill the volume.
+	Size int64                                                                         // Size of the unpacked volume in bytes.
 
 	Fingerprint string // If the Filler will unpack an image, it should be this fingerprint.
 }

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -136,7 +136,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 		}
 
 		// Apply the size limit.
-		err = d.SetVolumeQuota(vol, vol.ConfigSize(), op)
+		err = d.SetVolumeQuota(vol, vol.ConfigSize(), false, op)
 		if err != nil {
 			return err
 		}
@@ -635,7 +635,7 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 
 	// Resize volume to the size specified. Only uses volume "size" property and does not use pool/defaults
 	// to give the caller more control over the size being used.
-	err := d.SetVolumeQuota(vol, vol.config["size"], nil)
+	err := d.SetVolumeQuota(vol, vol.config["size"], false, op)
 	if err != nil {
 		return err
 	}
@@ -741,7 +741,7 @@ func (d *zfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vol
 		}
 
 		// Apply the size limit.
-		err = d.SetVolumeQuota(vol, vol.ConfigSize(), op)
+		err = d.SetVolumeQuota(vol, vol.ConfigSize(), false, op)
 		if err != nil {
 			return err
 		}
@@ -826,7 +826,7 @@ func (d *zfs) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 func (d *zfs) UpdateVolume(vol Volume, changedConfig map[string]string) error {
 	for k, v := range changedConfig {
 		if k == "size" {
-			return d.SetVolumeQuota(vol, v, nil)
+			return d.SetVolumeQuota(vol, v, false, nil)
 		}
 
 		if k == "zfs.use_refquota" {
@@ -851,14 +851,14 @@ func (d *zfs) UpdateVolume(vol Volume, changedConfig map[string]string) error {
 
 			// Set new quota by temporarily modifying the volume config.
 			vol.config["zfs.use_refquota"] = v
-			err := d.SetVolumeQuota(vol, size, nil)
+			err := d.SetVolumeQuota(vol, size, false, nil)
 			vol.config["zfs.use_refquota"] = cur
 			if err != nil {
 				return err
 			}
 
 			// Unset old quota.
-			err = d.SetVolumeQuota(vol, "", nil)
+			err = d.SetVolumeQuota(vol, "", false, nil)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -248,7 +248,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, func(), error) {
+func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
 	// Handle the non-optimized tarballs through the generic unpacker.
 	if !*srcBackup.OptimizedStorage {
 		return genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -248,7 +248,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
+func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, func(), error) {
 	// Handle the non-optimized tarballs through the generic unpacker.
 	if !*srcBackup.OptimizedStorage {
 		return genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
@@ -407,7 +407,7 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 		}
 	}
 
-	var postHook func(vol Volume) error
+	var postHook VolumePostHook
 
 	// Only mount instance filesystem volumes for backup.yaml access.
 	if vol.volType != VolumeTypeCustom && vol.contentType != ContentTypeBlock {

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -251,34 +251,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
 	// Handle the non-optimized tarballs through the generic unpacker.
 	if !*srcBackup.OptimizedStorage {
-		postHook, revertHook, err := genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		// genericVFSBackupUnpack returns a nil postHook when volume's type is VolumeTypeCustom which
-		// doesn't need any post hook processing after DB record creation.
-		if postHook != nil {
-			// Define a post hook function that can be run once the backup config has been restored.
-			// This will setup the quota using the restored config.
-			postHookWrapper := func(vol Volume) error {
-				err := postHook(vol)
-				if err != nil {
-					return err
-				}
-
-				err = d.createVolumeFromBackupInstancePostHookResize(d, vol, op)
-				if err != nil {
-					return err
-				}
-
-				return nil
-			}
-
-			return postHookWrapper, revertHook, nil
-		}
-
-		return nil, revertHook, nil
+		return genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
 	}
 
 	if d.HasVolume(vol) {

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -822,7 +822,11 @@ func genericVFSBackupUnpack(d Driver, vol Volume, snapshots []string, srcData io
 		// backup restoration process). Create a post hook function that will be called at the end of the
 		// backup restore process to unmount the volume if needed.
 		postHook = func(vol Volume) error {
-			d.UnmountVolume(vol, false, op)
+			_, err = d.UnmountVolume(vol, false, op)
+			if err != nil {
+				return err
+			}
+
 			return nil
 		}
 	} else {

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -693,6 +693,8 @@ func genericVFSBackupUnpack(d Driver, vol Volume, snapshots []string, srcData io
 				}
 
 				if hdr.Name == srcFile {
+					var allowUnsafeResize bool
+
 					// Open block file (use O_CREATE to support drivers that use image files).
 					to, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)
 					if err != nil {
@@ -705,8 +707,8 @@ func genericVFSBackupUnpack(d Driver, vol Volume, snapshots []string, srcData io
 
 					// Allow potentially destructive resize of volume as we are going to be
 					// overwriting it entirely anyway. This allows shrinking of block volumes.
-					vol.allowUnsafeResize = true
-					err = d.SetVolumeQuota(vol, fmt.Sprintf("%d", hdr.Size), op)
+					allowUnsafeResize = true
+					err = d.SetVolumeQuota(vol, fmt.Sprintf("%d", hdr.Size), allowUnsafeResize, op)
 					if err != nil {
 						return err
 					}

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -620,7 +620,7 @@ func genericVFSBackupVolume(d Driver, vol Volume, tarWriter *instancewriter.Inst
 // created and a revert function that can be used to undo the actions this function performs should something
 // subsequently fail. For VolumeTypeCustom volumes, a nil post hook is returned as it is expected that the DB
 // record be created before the volume is unpacked due to differences in the archive format that allows this.
-func genericVFSBackupUnpack(d Driver, vol Volume, snapshots []string, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error) {
+func genericVFSBackupUnpack(d Driver, vol Volume, snapshots []string, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, func(), error) {
 	// Define function to unpack a volume from a backup tarball file.
 	unpackVolume := func(r io.ReadSeeker, tarArgs []string, unpacker []string, srcPrefix string, mountPath string) error {
 		volTypeName := "container"
@@ -814,7 +814,7 @@ func genericVFSBackupUnpack(d Driver, vol Volume, snapshots []string, srcData io
 	revertExternal := revert.Clone() // Clone before calling revert.Success() so we can return the Fail func.
 	revert.Success()
 
-	var postHook func(vol Volume) error
+	var postHook VolumePostHook
 	if vol.volType != VolumeTypeCustom {
 		// Leave volume mounted (as is needed during backup.yaml generation during latter parts of the
 		// backup restoration process). Create a post hook function that will be called at the end of the

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -620,7 +620,7 @@ func genericVFSBackupVolume(d Driver, vol Volume, tarWriter *instancewriter.Inst
 // created and a revert function that can be used to undo the actions this function performs should something
 // subsequently fail. For VolumeTypeCustom volumes, a nil post hook is returned as it is expected that the DB
 // record be created before the volume is unpacked due to differences in the archive format that allows this.
-func genericVFSBackupUnpack(d Driver, vol Volume, snapshots []string, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, func(), error) {
+func genericVFSBackupUnpack(d Driver, vol Volume, snapshots []string, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
 	// Define function to unpack a volume from a backup tarball file.
 	unpackVolume := func(r io.ReadSeeker, tarArgs []string, unpacker []string, srcPrefix string, mountPath string) error {
 		volTypeName := "container"

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lxc/lxd/lxd/backup"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
+	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/instancewriter"
@@ -86,5 +87,5 @@ type Driver interface {
 
 	// Backup.
 	BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error
-	CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, func(), error)
+	CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error)
 }

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -56,7 +56,7 @@ type Driver interface {
 	RenameVolume(vol Volume, newName string, op *operations.Operation) error
 	UpdateVolume(vol Volume, changedConfig map[string]string) error
 	GetVolumeUsage(vol Volume) (int64, error)
-	SetVolumeQuota(vol Volume, size string, op *operations.Operation) error
+	SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error
 	GetVolumeDiskPath(vol Volume) (string, error)
 
 	// MountVolume mounts a storage volume (if not mounted) and increments reference counter.

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -86,5 +86,5 @@ type Driver interface {
 
 	// Backup.
 	BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error
-	CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(vol Volume) error, func(), error)
+	CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, func(), error)
 }

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -339,9 +339,9 @@ func roundVolumeBlockFileSizeBytes(sizeBytes int64) int64 {
 // ensureVolumeBlockFile creates new block file or enlarges the raw block file for a volume to the specified size.
 // Returns true if resize took place, false if not. Requested size is rounded to nearest block size using
 // roundVolumeBlockFileSizeBytes() before decision whether to resize is taken. Accepts unsupportedResizeTypes
-// list that indicates which volume types it should not attempt to resize (when vol.allowUnsafeResize=false) and
+// list that indicates which volume types it should not attempt to resize (when allowUnsafeResize=false) and
 // instead return ErrNotSupported.
-func ensureVolumeBlockFile(vol Volume, path string, sizeBytes int64, unsupportedResizeTypes ...VolumeType) (bool, error) {
+func ensureVolumeBlockFile(vol Volume, path string, sizeBytes int64, allowUnsafeResize bool, unsupportedResizeTypes ...VolumeType) (bool, error) {
 	if sizeBytes <= 0 {
 		return false, fmt.Errorf("Size cannot be zero")
 	}
@@ -362,7 +362,7 @@ func ensureVolumeBlockFile(vol Volume, path string, sizeBytes int64, unsupported
 
 		// Only perform pre-resize checks if we are not in "unsafe" mode.
 		// In unsafe mode we expect the caller to know what they are doing and understand the risks.
-		if !vol.allowUnsafeResize {
+		if !allowUnsafeResize {
 			// Reject if would try and resize a volume type that is not supported.
 			// This needs to come before the ErrCannotBeShrunk check below so that any resize attempt
 			// is blocked with ErrNotSupported error.

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -70,15 +70,14 @@ var BaseDirectories = map[VolumeType][]string{
 
 // Volume represents a storage volume, and provides functions to mount and unmount it.
 type Volume struct {
-	name              string
-	pool              string
-	poolConfig        map[string]string
-	volType           VolumeType
-	contentType       ContentType
-	config            map[string]string
-	driver            Driver
-	customMountPath   string
-	allowUnsafeResize bool // Whether to allow potentially destructive unchecked resizing of volume.
+	name            string
+	pool            string
+	poolConfig      map[string]string
+	volType         VolumeType
+	contentType     ContentType
+	config          map[string]string
+	driver          Driver
+	customMountPath string
 }
 
 // NewVolume instantiates a new Volume struct.

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -57,6 +57,9 @@ const ContentTypeFS = ContentType("filesystem")
 // know which filesystem(s) (if any) are in use.
 const ContentTypeBlock = ContentType("block")
 
+// VolumePostHook function returned from a storage action that should be run later to complete the action.
+type VolumePostHook func(vol Volume) error
+
 // BaseDirectories maps volume types to the expected directories.
 var BaseDirectories = map[VolumeType][]string{
 	VolumeTypeContainer: {"containers", "containers-snapshots"},

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -354,8 +354,8 @@ func (v Volume) NewVMBlockFilesystemVolume() Volume {
 }
 
 // SetQuota calls SetVolumeQuota on the Volume's driver.
-func (v Volume) SetQuota(size string, op *operations.Operation) error {
-	return v.driver.SetVolumeQuota(v, size, op)
+func (v Volume) SetQuota(size string, allowUnsafeResize bool, op *operations.Operation) error {
+	return v.driver.SetVolumeQuota(v, size, allowUnsafeResize, op)
 }
 
 // SetConfigSize sets the size config property on the Volume (does not resize volume).

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
+	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/storage/drivers"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/instancewriter"
@@ -43,7 +44,7 @@ type Pool interface {
 	// Instances.
 	FillInstanceConfig(inst instance.Instance, config map[string]string) error
 	CreateInstance(inst instance.Instance, op *operations.Operation) error
-	CreateInstanceFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(instance.Instance) error, func(), error)
+	CreateInstanceFromBackup(srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (func(instance.Instance) error, revert.Hook, error)
 	CreateInstanceFromCopy(inst instance.Instance, src instance.Instance, snapshots bool, op *operations.Operation) error
 	CreateInstanceFromImage(inst instance.Instance, fingerprint string, op *operations.Operation) error
 	CreateInstanceFromMigration(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -421,7 +421,7 @@ func validateVolumeCommonRules(vol drivers.Volume) map[string]func(string) error
 // VM Format A: Separate metadata tarball and root qcow2 file.
 // 	- Unpack metadata tarball into mountPath.
 //	- Check rootBlockPath is a file and convert qcow2 file into raw format in rootBlockPath.
-func ImageUnpack(imageFile string, vol drivers.Volume, destBlockFile string, blockBackend, runningInUserns bool, tracker *ioprogress.ProgressTracker) (int64, error) {
+func ImageUnpack(imageFile string, vol drivers.Volume, destBlockFile string, blockBackend, runningInUserns bool, allowUnsafeResize bool, tracker *ioprogress.ProgressTracker) (int64, error) {
 	logger := logging.AddContext(logger.Log, log.Ctx{"imageFile": imageFile, "vol": vol.Name()})
 
 	// For all formats, first unpack the metadata (or combined) tarball into destPath.
@@ -519,7 +519,7 @@ func ImageUnpack(imageFile string, vol drivers.Volume, destBlockFile string, blo
 			// increase the target volume's size.
 			if volSizeBytes < imgInfo.VirtualSize {
 				logger.Debug("Increasing volume size", log.Ctx{"imgPath": imgPath, "dstPath": dstPath, "oldSize": volSizeBytes, "newSize": newVolSize})
-				err = vol.SetQuota(newVolSize, nil)
+				err = vol.SetQuota(newVolSize, allowUnsafeResize, nil)
 				if err != nil {
 					return -1, errors.Wrapf(err, "Error increasing volume size")
 				}


### PR DESCRIPTION
It was becoming increasingly difficult to track how the `allowUnsafeResize` property on `Volume` was being used.
So I thought it would be easier to reason about how it is being used by having each affected function have an `allowUnsafeResize` argument instead so we can more easily see where it is being used and set to true.

Also introduces `revert.Hook` type and `VolumePostHook` type for reader clarity.

Also reverts most of the changes from https://github.com/lxc/lxd/pull/8872 and https://github.com/lxc/lxd/pull/8864 and instead moves the `allowUnsafeResize` enabling for container imports into `CreateInstanceFromBackup`. I kept it in the backendLXD in the end so that the post-resize step is still applied to optimized volumes as well (in case the effective size of the root disk when taking into account the profiles has changed since the instance was exported).