### PR TITLE
Network: Add support for using bridged NIC IP filtering on unmanaged parent bridges

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -684,10 +684,14 @@ func (d *nicBridged) setFilters() (err error) {
 		return err
 	}
 
-	// If parent bridge is unmanaged check that IP filtering isn't enabled.
+	// If parent bridge is unmanaged check that a manually specified IP is available if IP filtering enabled.
 	if err == db.ErrNoSuchObject || n == nil {
-		if shared.IsTrue(d.config["security.ipv4_filtering"]) || shared.IsTrue(d.config["security.ipv6_filtering"]) {
-			return fmt.Errorf("IP filtering requires using a managed parent bridge")
+		if shared.IsTrue(d.config["security.ipv4_filtering"]) && d.config["ipv4.address"] == "" {
+			return fmt.Errorf("IPv4 filtering requires a manually specified ipv4.address when using an unmanaged parent bridge")
+		}
+
+		if shared.IsTrue(d.config["security.ipv6_filtering"]) && d.config["ipv6.address"] == "" {
+			return fmt.Errorf("IPv6 filtering requires a manually specified ipv6.address when using an unmanaged parent bridge")
 		}
 	}
 

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -745,7 +745,7 @@ func (d *nicBridged) setFilters() (err error) {
 		IPv6 = net.ParseIP(firewallDrivers.FilterIPv6All)
 	}
 
-	err = d.state.Firewall.InstanceSetupBridgeFilter(d.inst.Project(), d.inst.Name(), d.name, d.config["parent"], d.config["host_name"], d.config["hwaddr"], IPv4, IPv6)
+	err = d.state.Firewall.InstanceSetupBridgeFilter(d.inst.Project(), d.inst.Name(), d.name, d.config["parent"], d.config["host_name"], d.config["hwaddr"], IPv4, IPv6, n != nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/firewall/drivers/drivers_nftables.go
+++ b/lxd/firewall/drivers/drivers_nftables.go
@@ -381,7 +381,7 @@ func (d Nftables) instanceDeviceLabel(projectName, instanceName, deviceName stri
 }
 
 // InstanceSetupBridgeFilter sets up the filter rules to apply bridged device IP filtering.
-func (d Nftables) InstanceSetupBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4 net.IP, IPv6 net.IP) error {
+func (d Nftables) InstanceSetupBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4 net.IP, IPv6 net.IP, _ bool) error {
 	deviceLabel := d.instanceDeviceLabel(projectName, instanceName, deviceName)
 
 	mac, err := net.ParseMAC(hwAddr)

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -1022,7 +1022,10 @@ func (d Xtables) generateFilterEbtablesRules(hostName string, hwAddr string, IPv
 }
 
 // generateFilterIptablesRules returns a customised set of iptables filter rules based on the device.
-func (d Xtables) generateFilterIptablesRules(parentName string, hostName string, hwAddr string, IPv6 net.IP) (rules [][]string, err error) {
+// If parentManaged is true then the rules are added to the iptablesChainACLFilterPrefix chain whereas if its false
+// then the rules are added to both the INPUT and FORWARD chains (so that no additional NIC chain is required, as
+// there's no managed network setup step available to create it and add jump rules).
+func (d Xtables) generateFilterIptablesRules(parentName string, hostName string, hwAddr string, IPv6 net.IP, parentManaged bool) (rules [][]string, err error) {
 	mac, err := net.ParseMAC(hwAddr)
 	if err != nil {
 		return
@@ -1039,15 +1042,30 @@ func (d Xtables) generateFilterIptablesRules(parentName string, hostName string,
 	// correct source address and MAC at the IP & ethernet layers, but a fraudulent IP or MAC
 	// inside the ICMPv6 NDP packet.
 	if IPv6 != nil {
-		chain := fmt.Sprintf("%s_%s", iptablesChainNICFilterPrefix, parentName)
-
 		ipv6Hex := hex.EncodeToString(IPv6)
-		rules = append(rules,
-			// Prevent Neighbor Advertisement IP spoofing (prevents the instance redirecting traffic for IPs that are not its own).
-			[]string{"6", chain, "-i", parentName, "-p", "ipv6-icmp", "-m", "physdev", "--physdev-in", hostName, "-m", "icmp6", "--icmpv6-type", "136", "-m", "string", "!", "--hex-string", fmt.Sprintf("|%s|", ipv6Hex), "--algo", "bm", "--from", "48", "--to", "64", "-j", "DROP"},
-			// Prevent Neighbor Advertisement MAC spoofing (prevents the instance poisoning the NDP cache of its neighbours with a MAC address that isn't its own).
-			[]string{"6", chain, "-i", parentName, "-p", "ipv6-icmp", "-m", "physdev", "--physdev-in", hostName, "-m", "icmp6", "--icmpv6-type", "136", "-m", "string", "!", "--hex-string", fmt.Sprintf("|%s|", macHex), "--algo", "bm", "--from", "66", "--to", "72", "-j", "DROP"},
-		)
+
+		var chains []string
+
+		if parentManaged {
+			// Managed networks should have setup the iptablesChainNICFilterPrefix chain and added the
+			// jump rules to INPUT and FORWARD already, so reduce the overhead of adding the rules to
+			// both chains and just add it to the iptablesChainNICFilterPrefix chain instead.
+			chains = append(chains, fmt.Sprintf("%s_%s", iptablesChainNICFilterPrefix, parentName))
+		} else {
+			// We add the NIC rules to both the INPUT and FORWARD chain as there is no managed network
+			// setup step that could have created the iptablesChainNICFilterPrefix chain and added the
+			// necessary jump rules to INPUT and FORWARD chains to make them work.
+			chains = append(chains, "INPUT", "FORWARD")
+		}
+
+		for _, chain := range chains {
+			rules = append(rules,
+				// Prevent Neighbor Advertisement IP spoofing (prevents the instance redirecting traffic for IPs that are not its own).
+				[]string{"6", chain, "-i", parentName, "-p", "ipv6-icmp", "-m", "physdev", "--physdev-in", hostName, "-m", "icmp6", "--icmpv6-type", "136", "-m", "string", "!", "--hex-string", fmt.Sprintf("|%s|", ipv6Hex), "--algo", "bm", "--from", "48", "--to", "64", "-j", "DROP"},
+				// Prevent Neighbor Advertisement MAC spoofing (prevents the instance poisoning the NDP cache of its neighbours with a MAC address that isn't its own).
+				[]string{"6", chain, "-i", parentName, "-p", "ipv6-icmp", "-m", "physdev", "--physdev-in", hostName, "-m", "icmp6", "--icmpv6-type", "136", "-m", "string", "!", "--hex-string", fmt.Sprintf("|%s|", macHex), "--algo", "bm", "--from", "66", "--to", "72", "-j", "DROP"},
+			)
+		}
 	}
 
 	return

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -769,7 +769,10 @@ func (d Xtables) instanceDeviceIPTablesComment(projectName string, instanceName 
 }
 
 // InstanceSetupBridgeFilter sets up the filter rules to apply bridged device IP filtering.
-func (d Xtables) InstanceSetupBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4 net.IP, IPv6 net.IP) error {
+// If the parent bridge is managed by LXD then parentManaged argument should be true so that the rules added can
+// use the iptablesChainACLFilterPrefix chain. If not they are added to the main filter chains directly (which only
+// works for unmanaged bridges because those don't support ACLs).
+func (d Xtables) InstanceSetupBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4 net.IP, IPv6 net.IP, parentManaged bool) error {
 	comment := d.instanceDeviceIPTablesComment(projectName, instanceName, deviceName)
 
 	rules := d.generateFilterEbtablesRules(hostName, hwAddr, IPv4, IPv6)
@@ -780,7 +783,7 @@ func (d Xtables) InstanceSetupBridgeFilter(projectName string, instanceName stri
 		}
 	}
 
-	rules, err := d.generateFilterIptablesRules(parentName, hostName, hwAddr, IPv6)
+	rules, err := d.generateFilterIptablesRules(parentName, hostName, hwAddr, IPv6, parentManaged)
 	if err != nil {
 		return err
 	}

--- a/lxd/firewall/firewall_interface.go
+++ b/lxd/firewall/firewall_interface.go
@@ -16,7 +16,7 @@ type Firewall interface {
 	NetworkClear(networkName string, delete bool, ipVersions []uint) error
 	NetworkApplyACLRules(networkName string, rules []drivers.ACLRule) error
 
-	InstanceSetupBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4 net.IP, IPv6 net.IP) error
+	InstanceSetupBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4 net.IP, IPv6 net.IP, parentManaged bool) error
 	InstanceClearBridgeFilter(projectName string, instanceName string, deviceName string, parentName string, hostName string, hwAddr string, IPv4 net.IP, IPv6 net.IP) error
 
 	InstanceSetupProxyNAT(projectName string, instanceName string, deviceName string, listen *deviceConfig.ProxyAddress, connect *deviceConfig.ProxyAddress) error

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -9,6 +9,9 @@ test_container_devices_nic_bridged_filtering() {
     false
   fi
 
+  # Record how many nics we started with.
+  startNicCount=$(find /sys/class/net | wc -l)
+
   ctPrefix="nt$$"
   brName="lxdt$$"
 
@@ -28,9 +31,6 @@ test_container_devices_nic_bridged_filtering() {
   lxc network set "${brName}" ipv4.address 192.0.2.1/24
   lxc network set "${brName}" ipv6.address 2001:db8::1/64
   [ "$(cat /sys/class/net/${brName}/address)" = "00:11:22:33:44:55" ]
-
-  # Record how many nics we started with.
-  startNicCount=$(find /sys/class/net | wc -l)
 
   # Create profile for new containers.
   lxc profile copy default "${ctPrefix}"
@@ -657,14 +657,14 @@ test_container_devices_nic_bridged_filtering() {
     done
   fi
 
+  # Cleanup.
+  lxc profile delete "${ctPrefix}"
+  lxc network delete "${brName}"
+
   # Check we haven't left any NICS lying around.
   endNicCount=$(find /sys/class/net | wc -l)
   if [ "$startNicCount" != "$endNicCount" ]; then
     echo "leftover NICS detected"
     false
   fi
-
-  # Cleanup.
-  lxc profile delete "${ctPrefix}"
-  lxc network delete "${brName}"
 }

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -545,6 +545,9 @@ test_container_devices_nic_bridged_filtering() {
 
   # Test MAC filtering on unmanaged bridge.
   ip link add "${brName}2" type bridge
+  ip a add 192.0.2.1/24 dev "${brName}2"
+  ip a add 2001:db8::1/64 dev "${brName}2"
+  ip link set "${brName}2" up
 
   lxc init testimage "${ctPrefix}A" -p "${ctPrefix}"
   lxc config device add "${ctPrefix}A" eth0 nic \
@@ -602,6 +605,28 @@ test_container_devices_nic_bridged_filtering() {
       fi
     done
   fi
+
+  # Enable IP filtering and check container won't start without manual IP assigned in LXD config.
+  lxc config device set "${ctPrefix}A" eth0 security.ipv4_filtering=true security.ipv6_filtering=true
+  ! lxc start "${ctPrefix}A" || false
+  lxc config device set "${ctPrefix}A" eth0 ipv4.address=192.0.2.2
+  ! lxc start "${ctPrefix}A" || false
+  lxc config device set "${ctPrefix}A" eth0 ipv6.address=2001:db8::2
+  lxc start "${ctPrefix}A"
+  lxc exec "${ctPrefix}A" -- ip a add 192.0.2.2/24 dev eth0
+  lxc exec "${ctPrefix}A" -- ip a add 2001:db8::2/64 dev eth0
+
+  # Check basic connectivity without any filtering.
+  lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.1
+  lxc exec "${ctPrefix}A" -- ping -c2 -W1 2001:db8::1
+
+  # Check fraudulent IPs are blocked.
+  lxc exec "${ctPrefix}A" -- ip a flush dev eth0
+  lxc exec "${ctPrefix}A" -- ip a add 192.0.2.3/24 dev eth0
+  lxc exec "${ctPrefix}A" -- ip a add 2001:db8::3/64 dev eth0
+
+  ! lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.1 || false
+  ! lxc exec "${ctPrefix}A" -- ping -c2 -W1 2001:db8::1 || false
 
   lxc delete -f "${ctPrefix}A"
   ip link delete "${brName}2"


### PR DESCRIPTION
This requires the user specifies which IP the NIC should be using by setting `ipv{n}.address` on the NIC.

Fixes #7477
Closes #8849