### PR TITLE
lxd: update instructions for compilation from a release tarball

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -100,6 +100,7 @@ tarball is downloaded and extracted, set the `GOPATH` as follows:
 ```bash
 cd lxd-3.18
 export GOPATH=$(pwd)/_dist
+export GOBIN=$GOPATH/bin
 ```
 
 ### Starting the Build


### PR DESCRIPTION
Today compilation was not possible with the instruction from the README.
I added the command that was missing 