### PR TITLE
Validate: Make IsOneOf only allow the specified values

### DIFF
--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -822,11 +822,15 @@ func projectIsEmpty(project *api.Project) bool {
 }
 
 func isEitherAllowOrBlock(value string) error {
-	return validate.IsOneOf(value, []string{"block", "allow"})
+	return validate.Optional(func(value string) error {
+		return validate.IsOneOf(value, []string{"block", "allow"})
+	})(value)
 }
 
 func isEitherAllowOrBlockOrManaged(value string) error {
-	return validate.IsOneOf(value, []string{"block", "allow", "managed"})
+	return validate.Optional(func(value string) error {
+		return validate.IsOneOf(value, []string{"block", "allow", "managed"})
+	})(value)
 }
 
 func projectValidateConfig(s *state.State, config map[string]string) error {
@@ -855,9 +859,9 @@ func projectValidateConfig(s *state.State, config map[string]string) error {
 		"restricted.cluster.target":      isEitherAllowOrBlock,
 		"restricted.containers.nesting":  isEitherAllowOrBlock,
 		"restricted.containers.lowlevel": isEitherAllowOrBlock,
-		"restricted.containers.privilege": func(value string) error {
+		"restricted.containers.privilege": validate.Optional(func(value string) error {
 			return validate.IsOneOf(value, []string{"allow", "unprivileged", "isolated"})
-		},
+		}),
 		"restricted.virtual-machines.lowlevel": isEitherAllowOrBlock,
 		"restricted.devices.unix-char":         isEitherAllowOrBlock,
 		"restricted.devices.unix-block":        isEitherAllowOrBlock,

--- a/lxd/cluster/config.go
+++ b/lxd/cluster/config.go
@@ -260,7 +260,7 @@ var ConfigSchema = config.Schema{
 	"images.auto_update_cached":      {Type: config.Bool, Default: "true"},
 	"images.auto_update_interval":    {Type: config.Int64, Default: "6"},
 	"images.compression_algorithm":   {Default: "gzip", Validator: validate.IsCompressionAlgorithm},
-	"images.default_architecture":    {Validator: validate.IsArchitecture},
+	"images.default_architecture":    {Validator: validate.Optional(validate.IsArchitecture)},
 	"images.remote_cache_expiry":     {Type: config.Int64, Default: "10"},
 	"maas.api.key":                   {},
 	"maas.api.url":                   {},

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -206,13 +206,13 @@ func (n *bridge) Validate(config map[string]string) error {
 		}),
 
 		"fan.overlay_subnet": validate.Optional(validate.IsNetworkV4),
-		"fan.underlay_subnet": func(value string) error {
+		"fan.underlay_subnet": validate.Optional(func(value string) error {
 			if value == "auto" {
 				return nil
 			}
 
-			return validate.Optional(validate.IsNetworkV4)(value)
-		},
+			return validate.IsNetworkV4(value)
+		}),
 		"fan.type": validate.Optional(func(value string) error {
 			return validate.IsOneOf(value, []string{"vxlan", "ipip"})
 		}),

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -186,9 +186,9 @@ func (n *bridge) ValidateName(name string) error {
 func (n *bridge) Validate(config map[string]string) error {
 	// Build driver specific rules dynamically.
 	rules := map[string]func(value string) error{
-		"bridge.driver": func(value string) error {
+		"bridge.driver": validate.Optional(func(value string) error {
 			return validate.IsOneOf(value, []string{"native", "openvswitch"})
-		},
+		}),
 		"bridge.external_interfaces": validate.Optional(func(value string) error {
 			for _, entry := range strings.Split(value, ",") {
 				entry = strings.TrimSpace(entry)
@@ -201,9 +201,9 @@ func (n *bridge) Validate(config map[string]string) error {
 		}),
 		"bridge.hwaddr": validate.Optional(validate.IsNetworkMAC),
 		"bridge.mtu":    validate.Optional(validate.IsNetworkMTU),
-		"bridge.mode": func(value string) error {
+		"bridge.mode": validate.Optional(func(value string) error {
 			return validate.IsOneOf(value, []string{"standard", "fan"})
-		},
+		}),
 
 		"fan.overlay_subnet": validate.Optional(validate.IsNetworkV4),
 		"fan.underlay_subnet": func(value string) error {
@@ -213,22 +213,22 @@ func (n *bridge) Validate(config map[string]string) error {
 
 			return validate.Optional(validate.IsNetworkV4)(value)
 		},
-		"fan.type": func(value string) error {
+		"fan.type": validate.Optional(func(value string) error {
 			return validate.IsOneOf(value, []string{"vxlan", "ipip"})
-		},
+		}),
 
-		"ipv4.address": func(value string) error {
+		"ipv4.address": validate.Optional(func(value string) error {
 			if validate.IsOneOf(value, []string{"none", "auto"}) == nil {
 				return nil
 			}
 
-			return validate.Optional(validate.IsNetworkAddressCIDRV4)(value)
-		},
+			return validate.IsNetworkAddressCIDRV4(value)
+		}),
 		"ipv4.firewall": validate.Optional(validate.IsBool),
 		"ipv4.nat":      validate.Optional(validate.IsBool),
-		"ipv4.nat.order": func(value string) error {
+		"ipv4.nat.order": validate.Optional(func(value string) error {
 			return validate.IsOneOf(value, []string{"before", "after"})
-		},
+		}),
 		"ipv4.nat.address":  validate.Optional(validate.IsNetworkAddressV4),
 		"ipv4.dhcp":         validate.Optional(validate.IsBool),
 		"ipv4.dhcp.gateway": validate.Optional(validate.IsNetworkAddressV4),
@@ -238,18 +238,18 @@ func (n *bridge) Validate(config map[string]string) error {
 		"ipv4.routing":      validate.Optional(validate.IsBool),
 		"ipv4.ovn.ranges":   validate.Optional(validate.IsNetworkRangeV4List),
 
-		"ipv6.address": func(value string) error {
+		"ipv6.address": validate.Optional(func(value string) error {
 			if validate.IsOneOf(value, []string{"none", "auto"}) == nil {
 				return nil
 			}
 
-			return validate.Optional(validate.IsNetworkAddressCIDRV6)(value)
-		},
+			return validate.IsNetworkAddressCIDRV6(value)
+		}),
 		"ipv6.firewall": validate.Optional(validate.IsBool),
 		"ipv6.nat":      validate.Optional(validate.IsBool),
-		"ipv6.nat.order": func(value string) error {
+		"ipv6.nat.order": validate.Optional(func(value string) error {
 			return validate.IsOneOf(value, []string{"before", "after"})
-		},
+		}),
 		"ipv6.nat.address":   validate.Optional(validate.IsNetworkAddressV6),
 		"ipv6.dhcp":          validate.Optional(validate.IsBool),
 		"ipv6.dhcp.expiry":   validate.IsAny,
@@ -260,9 +260,9 @@ func (n *bridge) Validate(config map[string]string) error {
 		"ipv6.ovn.ranges":    validate.Optional(validate.IsNetworkRangeV6List),
 		"dns.domain":         validate.IsAny,
 		"dns.search":         validate.IsAny,
-		"dns.mode": func(value string) error {
+		"dns.mode": validate.Optional(func(value string) error {
 			return validate.IsOneOf(value, []string{"dynamic", "managed", "none"})
-		},
+		}),
 		"raw.dnsmasq":      validate.IsAny,
 		"maas.subnet.ipv4": validate.IsAny,
 		"maas.subnet.ipv6": validate.IsAny,
@@ -296,9 +296,9 @@ func (n *bridge) Validate(config map[string]string) error {
 			// Add the correct validation rule for the dynamic field based on last part of key.
 			switch tunnelKey {
 			case "protocol":
-				rules[k] = func(value string) error {
+				rules[k] = validate.Optional(func(value string) error {
 					return validate.IsOneOf(value, []string{"gre", "vxlan"})
-				}
+				})
 			case "local":
 				rules[k] = validate.Optional(validate.IsNetworkAddress)
 			case "remote":

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -190,21 +190,21 @@ func (n *ovn) Validate(config map[string]string) error {
 		"network":       validate.IsAny,
 		"bridge.hwaddr": validate.Optional(validate.IsNetworkMAC),
 		"bridge.mtu":    validate.Optional(validate.IsNetworkMTU),
-		"ipv4.address": func(value string) error {
+		"ipv4.address": validate.Optional(func(value string) error {
 			if validate.IsOneOf(value, []string{"none", "auto"}) == nil {
 				return nil
 			}
 
-			return validate.Optional(validate.IsNetworkAddressCIDRV4)(value)
-		},
+			return validate.IsNetworkAddressCIDRV4(value)
+		}),
 		"ipv4.dhcp": validate.Optional(validate.IsBool),
-		"ipv6.address": func(value string) error {
+		"ipv6.address": validate.Optional(func(value string) error {
 			if validate.IsOneOf(value, []string{"none", "auto"}) == nil {
 				return nil
 			}
 
-			return validate.Optional(validate.IsNetworkAddressCIDRV6)(value)
-		},
+			return validate.IsNetworkAddressCIDRV6(value)
+		}),
 		"ipv6.dhcp":          validate.Optional(validate.IsBool),
 		"ipv6.dhcp.stateful": validate.Optional(validate.IsBool),
 		"ipv4.nat":           validate.Optional(validate.IsBool),

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -250,12 +250,9 @@ func (d *ceph) Validate(config map[string]string) error {
 		"ceph.rbd.features":       validate.IsAny,
 		"ceph.user.name":          validate.IsAny,
 		"volatile.pool.pristine":  validate.IsAny,
-		"volume.block.filesystem": func(value string) error {
-			if value == "" {
-				return nil
-			}
+		"volume.block.filesystem": validate.Optional(func(value string) error {
 			return validate.IsOneOf(value, cephAllowedFilesystems)
-		},
+		}),
 		"volume.block.mount_options": validate.IsAny,
 	}
 

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -432,12 +432,9 @@ func (d *lvm) Validate(config map[string]string) error {
 		"lvm.thinpool_name":          validate.IsAny,
 		"lvm.use_thinpool":           validate.Optional(validate.IsBool),
 		"volume.block.mount_options": validate.IsAny,
-		"volume.block.filesystem": func(value string) error {
-			if value == "" {
-				return nil
-			}
+		"volume.block.filesystem": validate.Optional(func(value string) error {
 			return validate.IsOneOf(value, lvmAllowedFilesystems)
-		},
+		}),
 		"volume.lvm.stripes":      validate.Optional(validate.IsUint32),
 		"volume.lvm.stripes.size": validate.Optional(validate.IsSize),
 		"lvm.vg.force_reuse":      validate.Optional(validate.IsBool),

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -273,12 +273,9 @@ func (d *lvm) FillVolumeConfig(vol Volume) error {
 // ValidateVolume validates the supplied volume config.
 func (d *lvm) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 	rules := map[string]func(value string) error{
-		"block.filesystem": func(value string) error {
-			if value == "" {
-				return nil
-			}
+		"block.filesystem": validate.Optional(func(value string) error {
 			return validate.IsOneOf(value, lvmAllowedFilesystems)
-		},
+		}),
 		"lvm.stripes":      validate.Optional(validate.IsUint32),
 		"lvm.stripes.size": validate.Optional(validate.IsSize),
 	}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -254,7 +254,9 @@ var SupportedPoolTypes = []string{"btrfs", "ceph", "cephfs", "dir", "lvm", "zfs"
 // Deprecated: these are being moved to the per-storage-driver implementations.
 var StorageVolumeConfigKeys = map[string]func(value string) ([]string, error){
 	"block.filesystem": func(value string) ([]string, error) {
-		err := validate.IsOneOf(value, []string{"btrfs", "ext4", "xfs"})
+		err := validate.Optional(func(value string) error {
+			return validate.IsOneOf(value, []string{"btrfs", "ext4", "xfs"})
+		})(value)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/storage_pools_config.go
+++ b/lxd/storage_pools_config.go
@@ -66,9 +66,9 @@ var storagePoolConfigKeys = map[string]func(value string) error{
 	"volatile.initial_source": validate.IsAny,
 
 	// valid drivers: ceph, lvm
-	"volume.block.filesystem": func(value string) error {
+	"volume.block.filesystem": validate.Optional(func(value string) error {
 		return validate.IsOneOf(value, []string{"btrfs", "ext4", "xfs"})
-	},
+	}),
 	"volume.block.mount_options": validate.IsAny,
 
 	// valid drivers: ceph, lvm
@@ -94,9 +94,9 @@ var storagePoolConfigKeys = map[string]func(value string) error{
 }
 
 func storagePoolValidateConfig(name string, driver string, config map[string]string, oldConfig map[string]string) error {
-	err := func(value string) error {
+	err := validate.Optional(func(value string) error {
 		return validate.IsOneOf(value, storageDrivers.AllDriverNames())
-	}(driver)
+	})(driver)
 	if err != nil {
 		return err
 	}

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -169,9 +169,9 @@ var KnownInstanceConfigKeys = map[string]func(value string) error{
 
 		return nil
 	},
-	"limits.memory.enforce": func(value string) error {
+	"limits.memory.enforce": validate.Optional(func(value string) error {
 		return validate.IsOneOf(value, []string{"soft", "hard"})
-	},
+	}),
 	"limits.memory.swap":          validate.Optional(validate.IsBool),
 	"limits.memory.swap.priority": validate.Optional(validate.IsPriority),
 	"limits.memory.hugepages":     validate.Optional(validate.IsBool),

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -108,10 +108,6 @@ func IsBool(value string) error {
 
 // IsOneOf checks whether the string is present in the supplied slice of strings.
 func IsOneOf(value string, valid []string) error {
-	if value == "" {
-		return nil
-	}
-
 	if !stringInSlice(value, valid) {
 		return fmt.Errorf("Invalid value %q (not one of %s)", value, valid)
 	}


### PR DESCRIPTION
And don't allow empty value to pass validation, as this is confusing and not expected.

Wraps the existing use of `IsOneOf` where the allowed values did not include `""` with `validate.Optional()` to keep existing behaviour.