### PR TITLE
Network: Return -1 for Mtu in State() for bridged and ovn NICs if host interface not available

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -1233,10 +1233,15 @@ func (d *nicBridged) State() (*api.InstanceStateNetwork, error) {
 		addresses = append(addresses, addr)
 	}
 
-	// Get MTU.
+	// Get MTU of host interface if exists.
 	iface, err := net.InterfaceByName(d.config["host_name"])
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed getting host interface state for %q", d.config["host_name"])
+		d.logger.Warn("Failed getting host interface state for MTU", log.Ctx{"host_name": d.config["host_name"], "err": err})
+	}
+
+	mtu := -1
+	if iface != nil {
+		mtu = iface.MTU
 	}
 
 	// Retrieve the host counters, as we report the values from the instance's point of view,
@@ -1256,7 +1261,7 @@ func (d *nicBridged) State() (*api.InstanceStateNetwork, error) {
 		},
 		Hwaddr:   d.config["hwaddr"],
 		HostName: d.config["host_name"],
-		Mtu:      iface.MTU,
+		Mtu:      mtu,
 		State:    "up",
 		Type:     "broadcast",
 	}

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -597,10 +597,15 @@ func (d *nicOVN) State() (*api.InstanceStateNetwork, error) {
 		}
 	}
 
-	// Get MTU of host interface that connects to OVN integration bridge.
+	// Get MTU of host interface that connects to OVN integration bridge if exists.
 	iface, err := net.InterfaceByName(d.config["host_name"])
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed getting host interface state")
+		d.logger.Warn("Failed getting host interface state for MTU", log.Ctx{"host_name": d.config["host_name"], "err": err})
+	}
+
+	mtu := -1
+	if iface != nil {
+		mtu = iface.MTU
 	}
 
 	// Retrieve the host counters, as we report the values from the instance's point of view,
@@ -620,7 +625,7 @@ func (d *nicOVN) State() (*api.InstanceStateNetwork, error) {
 		},
 		Hwaddr:   d.config["hwaddr"],
 		HostName: d.config["host_name"],
-		Mtu:      iface.MTU,
+		Mtu:      mtu,
 		State:    "up",
 		Type:     "broadcast",
 	}


### PR DESCRIPTION
Rather than failing the entire State() call.

This ensures that if a client is polling the /state endpoint to find when a VM has stopped that it won't sometimes return an error during the VM shutdown process, if the NIC has been cleaned up but the VM is not yet recorded as stopped.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>