### PR TITLE
AppArmor: Generate policy file when validating if needed

### DIFF
--- a/lxd/apparmor/instance.go
+++ b/lxd/apparmor/instance.go
@@ -88,8 +88,13 @@ func InstanceUnload(state *state.State, inst instance) error {
 	return nil
 }
 
-// InstanceParse validates the instance profile.
-func InstanceParse(state *state.State, inst instance) error {
+// InstanceValidate generates the instance profile file and validates it.
+func InstanceValidate(state *state.State, inst instance) error {
+	err := instanceProfileGenerate(state, inst)
+	if err != nil {
+		return err
+	}
+
 	return parseProfile(state, instanceProfileFilename(inst))
 }
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -4053,9 +4053,9 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		return err
 	}
 
-	// If apparmor changed, re-validate the apparmor profile
+	// If apparmor changed, re-validate the apparmor profile (even if not running).
 	if shared.StringInSlice("raw.apparmor", changedConfig) || shared.StringInSlice("security.nesting", changedConfig) {
-		err = apparmor.InstanceParse(d.state, d)
+		err = apparmor.InstanceValidate(d.state, d)
 		if err != nil {
 			return errors.Wrap(err, "Parse AppArmor profile")
 		}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3862,6 +3862,14 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 	}
 
+	// If apparmor changed, re-validate the apparmor profile (even if not running).
+	if shared.StringInSlice("raw.apparmor", changedConfig) {
+		err = apparmor.InstanceValidate(d.state, d)
+		if err != nil {
+			return errors.Wrap(err, "Parse AppArmor profile")
+		}
+	}
+
 	isRunning := d.IsRunning()
 
 	// Use the device interface to apply update changes.


### PR DESCRIPTION
Fixes #8909

Ensure that if the instance has never been started we can still validate apparmor profile if it is changed.