### PR TITLE
docs: Removes statement about VMs being considered experimental

### DIFF
--- a/doc/virtual-machines.md
+++ b/doc/virtual-machines.md
@@ -4,9 +4,8 @@ Virtual machines are a new instance type supported by LXD alongside containers.
 
 They are implemented through the use of `qemu`.
 
-This feature is currently considered to be experimental with a lot of
-functionality still yet to be implemented in order to reach feature
-parity with containers.
+Please note, currently not all features that are available with containers have been implemented for VMs,
+however we continue to strive for feature parity with containers.
 
 ## Configuration
 See [instance configuration](instances.md) for valid configuration options.


### PR DESCRIPTION

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>