### PR TITLE
client: Only retry target addresses if initial connection fails

### DIFF
--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -200,7 +200,11 @@ func (r *ProtocolLXD) tryCreateContainer(req api.ContainersPost, urls []string) 
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors[serverURL] = err
-				continue
+
+				// If we were able to connect and then operation failed, don't attempt another
+				// endpoint address as it was not a connection error, and we may end up
+				// exacerbating the problem by trying again via another address.
+				break
 			}
 
 			success = true
@@ -554,7 +558,11 @@ func (r *ProtocolLXD) tryMigrateContainer(source InstanceServer, name string, re
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors[serverURL] = err
-				continue
+
+				// If we were able to connect and then operation failed, don't attempt another
+				// endpoint address as it was not a connection error, and we may end up
+				// exacerbating the problem by trying again via another address.
+				break
 			}
 
 			success = true
@@ -1220,7 +1228,11 @@ func (r *ProtocolLXD) tryMigrateContainerSnapshot(source InstanceServer, contain
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors[serverURL] = err
-				continue
+
+				// If we were able to connect and then operation failed, don't attempt another
+				// endpoint address as it was not a connection error, and we may end up
+				// exacerbating the problem by trying again via another address.
+				break
 			}
 
 			success = true

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -600,7 +600,11 @@ func (r *ProtocolLXD) tryCopyImage(req api.ImagesPost, urls []string) (RemoteOpe
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors[serverURL] = err
-				continue
+
+				// If we were able to connect and then operation failed, don't attempt another
+				// endpoint address as it was not a connection error, and we may end up
+				// exacerbating the problem by trying again via another address.
+				break
 			}
 
 			success = true

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -290,7 +290,11 @@ func (r *ProtocolLXD) tryCreateInstance(req api.InstancesPost, urls []string, op
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors[serverURL] = err
-				continue
+
+				// If we were able to connect and then operation failed, don't attempt another
+				// endpoint address as it was not a connection error, and we may end up
+				// exacerbating the problem by trying again via another address.
+				break
 			}
 
 			success = true
@@ -660,7 +664,11 @@ func (r *ProtocolLXD) tryMigrateInstance(source InstanceServer, name string, req
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors[serverURL] = err
-				continue
+
+				// If we were able to connect and then operation failed, don't attempt another
+				// endpoint address as it was not a connection error, and we may end up
+				// exacerbating the problem by trying again via another address.
+				break
 			}
 
 			success = true
@@ -1434,7 +1442,11 @@ func (r *ProtocolLXD) tryMigrateInstanceSnapshot(source InstanceServer, instance
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors[serverURL] = err
-				continue
+
+				// If we were able to connect and then operation failed, don't attempt another
+				// endpoint address as it was not a connection error, and we may end up
+				// exacerbating the problem by trying again via another address.
+				break
 			}
 
 			success = true

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -306,7 +306,11 @@ func (r *ProtocolLXD) tryMigrateStoragePoolVolume(source InstanceServer, pool st
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors[serverURL] = err
-				continue
+
+				// If we were able to connect and then operation failed, don't attempt another
+				// endpoint address as it was not a connection error, and we may end up
+				// exacerbating the problem by trying again via another address.
+				break
 			}
 
 			success = true
@@ -361,7 +365,11 @@ func (r *ProtocolLXD) tryCreateStoragePoolVolume(pool string, req api.StorageVol
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors[serverURL] = err
-				continue
+
+				// If we were able to connect and then operation failed, don't attempt another
+				// endpoint address as it was not a connection error, and we may end up
+				// exacerbating the problem by trying again via another address.
+				break
 			}
 
 			success = true


### PR DESCRIPTION
Don't try next address if the initial operation creation succeeds, but then the actual operation fails.

This suggests that the error is internal to the server and retrying the same operation just on a different address for the same target can potentially exacerbate the problem.

In one example #8900 the instance copy to a remote target node failed on the target due to insufficent pool size.
This error was successfully being returned to the client, but it subsequently retried, but the original operation was not cleaned up, causing a hang.

There was no reason to retry as this could not have succeeded on a different address.

Fixes #8900

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>