### PR TITLE
Instance: Add KVM module check for VMs

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/config"
 	"github.com/lxc/lxd/lxd/db"
+	instanceDrivers "github.com/lxc/lxd/lxd/instance/drivers"
 	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/rbac"
@@ -308,19 +309,18 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		"shiftfs":                   fmt.Sprintf("%v", d.os.Shiftfs),
 	}
 
-	instanceDrivers := readInstanceDriversCache()
-	for driver, version := range instanceDrivers {
+	for _, driverInfo := range instanceDrivers.SupportedInstanceTypes() {
 		if env.Driver != "" {
-			env.Driver = env.Driver + " | " + driver
+			env.Driver = env.Driver + " | " + driverInfo.Name
 		} else {
-			env.Driver = driver
+			env.Driver = driverInfo.Name
 		}
 
 		// Get the version of the instance drivers in use.
 		if env.DriverVersion != "" {
-			env.DriverVersion = env.DriverVersion + " | " + version
+			env.DriverVersion = env.DriverVersion + " | " + driverInfo.Version
 		} else {
-			env.DriverVersion = version
+			env.DriverVersion = driverInfo.Version
 		}
 	}
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -401,7 +401,20 @@ func (d *Daemon) State() *state.State {
 	// If the daemon is shutting down, the context will be cancelled.
 	// This information will be available throughout the code, and can be used to prevent new
 	// operations from starting during shutdown.
-	return state.NewState(d.ctx, d.db, d.cluster, d.maas, d.os, d.endpoints, d.events, d.devlxdEvents, d.firewall, d.proxy, d.serverCert, func() { updateCertificateCache(d) })
+	return &state.State{
+		Context:                d.ctx,
+		Node:                   d.db,
+		Cluster:                d.cluster,
+		MAAS:                   d.maas,
+		OS:                     d.os,
+		Endpoints:              d.endpoints,
+		Events:                 d.events,
+		DevlxdEvents:           d.devlxdEvents,
+		Firewall:               d.firewall,
+		Proxy:                  d.proxy,
+		ServerCert:             d.serverCert,
+		UpdateCertificateCache: func() { updateCertificateCache(d) },
+	}
 }
 
 // UnixSocket returns the full path to the unix.socket file that this daemon is

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -15,7 +13,6 @@ import (
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/instance"
-	"github.com/lxc/lxd/lxd/instance/drivers"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/project"
@@ -581,39 +578,4 @@ func pruneExpiredContainerSnapshots(ctx context.Context, d *Daemon, snapshots []
 	}
 
 	return nil
-}
-
-var instanceDriversCacheVal atomic.Value
-var instanceDriversCacheLock sync.Mutex
-
-func readInstanceDriversCache() map[string]string {
-	drivers := instanceDriversCacheVal.Load()
-	if drivers == nil {
-		createInstanceDriversCache()
-		drivers = instanceDriversCacheVal.Load()
-	}
-
-	return drivers.(map[string]string)
-}
-
-func createInstanceDriversCache() {
-	// Create the list of instance drivers in use on this LXD instance
-	// namely LXC and QEMU. Given that LXC and QEMU cannot update while
-	// the LXD instance is running, only one cache is ever needed.
-
-	data := map[string]string{}
-
-	info := drivers.SupportedInstanceDrivers()
-	for _, entry := range info {
-		if entry.Version != "" {
-			data[entry.Name] = entry.Version
-		}
-	}
-
-	// Store the value in the cache
-	instanceDriversCacheLock.Lock()
-	instanceDriversCacheVal.Store(data)
-	instanceDriversCacheLock.Unlock()
-
-	return
 }

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6728,5 +6728,6 @@ func (d *lxc) Info() instance.Info {
 	return instance.Info{
 		Name:    "lxc",
 		Version: liblxc.Version(),
+		Error:   nil,
 	}
 }

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6728,6 +6728,7 @@ func (d *lxc) Info() instance.Info {
 	return instance.Info{
 		Name:    "lxc",
 		Version: liblxc.Version(),
+		Type:    instancetype.Container,
 		Error:   nil,
 	}
 }

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5552,6 +5552,12 @@ func (d *qemu) Info() instance.Info {
 		return data
 	}
 
+	err := util.LoadModule("vhost_vsock")
+	if err != nil {
+		data.Error = fmt.Errorf("vhost_vsock kernel module not loaded: %v", err)
+		return data
+	}
+
 	hostArch, err := osarch.ArchitectureGetLocalID()
 	if err != nil {
 		data.Error = fmt.Errorf("Failed getting architecture")

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5547,6 +5547,11 @@ func (d *qemu) Info() instance.Info {
 		Error: fmt.Errorf("Unknown error"),
 	}
 
+	if !shared.PathExists("/dev/kvm") {
+		data.Error = fmt.Errorf("KVM support is missing")
+		return data
+	}
+
 	hostArch, err := osarch.ArchitectureGetLocalID()
 	if err != nil {
 		data.Error = fmt.Errorf("Failed getting architecture")

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5543,31 +5543,37 @@ func (d *qemu) writeInstanceData() error {
 // Info returns "qemu" and the currently loaded qemu version.
 func (d *qemu) Info() instance.Info {
 	data := instance.Info{
-		Name: "qemu",
+		Name:  "qemu",
+		Error: fmt.Errorf("Unknown error"),
 	}
 
 	hostArch, err := osarch.ArchitectureGetLocalID()
 	if err != nil {
+		data.Error = fmt.Errorf("Failed getting architecture")
 		return data
 	}
 
 	qemuPath, _, err := d.qemuArchConfig(hostArch)
 	if err != nil {
+		data.Error = fmt.Errorf("QEMU command not available for architecture")
 		return data
 	}
 
 	out, err := exec.Command(qemuPath, "--version").Output()
 	if err != nil {
+		data.Error = fmt.Errorf("Failed getting QEMU version")
 		return data
 	}
 
 	qemuOutput := strings.Fields(string(out))
-	if len(qemuOutput) < 4 {
-		data.Version = "unknown"
-		return data
+	if len(qemuOutput) >= 4 {
+		qemuVersion := strings.Fields(string(out))[3]
+		data.Version = qemuVersion
+	} else {
+		data.Version = "unknown" // Not necessarily an error that should prevent us using driver.
 	}
 
-	qemuVersion := strings.Fields(string(out))[3]
-	data.Version = qemuVersion
+	data.Error = nil
+
 	return data
 }

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5544,6 +5544,7 @@ func (d *qemu) writeInstanceData() error {
 func (d *qemu) Info() instance.Info {
 	data := instance.Info{
 		Name:  "qemu",
+		Type:  instancetype.VM,
 		Error: fmt.Errorf("Unknown error"),
 	}
 

--- a/lxd/instance/drivers/load.go
+++ b/lxd/instance/drivers/load.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lxc/lxd/shared/logger"
 )
 
+// Instance driver definitions.
 var instanceDrivers = map[string]func() instance.Instance{
 	"lxc":  func() instance.Instance { return &lxc{} },
 	"qemu": func() instance.Instance { return &qemu{} },

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -182,4 +182,5 @@ type CriuMigrationArgs struct {
 type Info struct {
 	Name    string // Name of an instance driver, e.g. "lxc"
 	Version string // Version number of a loaded instance driver
+	Error   error  // Whether there is an operational impediment.
 }

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -180,7 +180,8 @@ type CriuMigrationArgs struct {
 
 // Info represents information about an instance driver.
 type Info struct {
-	Name    string // Name of an instance driver, e.g. "lxc"
-	Version string // Version number of a loaded instance driver
-	Error   error  // Whether there is an operational impediment.
+	Name    string            // Name of an instance driver, e.g. "lxc"
+	Version string            // Version number of a loaded instance driver
+	Error   error             // Whether there is an operational impediment.
+	Type    instancetype.Type // Instance type that the driver provides support for.
 }

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -920,6 +920,11 @@ func ValidName(instanceName string, isSnapshot bool) error {
 // Accepts a reverter that revert steps this function does will be added to. It is up to the caller to call the
 // revert's Fail() or Success() function as needed.
 func CreateInternal(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (Instance, error) {
+	// Check instance type requested is supported by this machine.
+	if _, supported := s.InstanceTypes[args.Type]; !supported {
+		return nil, fmt.Errorf("Instance type %q is not supported on this server", args.Type)
+	}
+
 	// Set default values.
 	if args.Project == "" {
 		args.Project = project.Default

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -195,7 +195,10 @@ func (c *cmdInit) availableStorageDrivers(poolType poolType) []string {
 	}
 
 	// Get info for supported drivers.
-	s := state.NewState(nil, nil, nil, nil, sys.DefaultOS(), nil, nil, nil, nil, nil, nil, func() {})
+	s := &state.State{
+		OS:                     sys.DefaultOS(),
+		UpdateCertificateCache: func() {},
+	}
 	supportedDrivers := storageDrivers.SupportedDrivers(s)
 
 	drivers := make([]string, 0, len(supportedDrivers))

--- a/lxd/state/state.go
+++ b/lxd/state/state.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lxc/lxd/lxd/endpoints"
 	"github.com/lxc/lxd/lxd/events"
 	"github.com/lxc/lxd/lxd/firewall"
+	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/maas"
 	"github.com/lxc/lxd/lxd/sys"
 	"github.com/lxc/lxd/shared"
@@ -48,4 +49,7 @@ type State struct {
 	// Server certificate
 	ServerCert             func() *shared.CertInfo
 	UpdateCertificateCache func()
+
+	// Available instance types based on operational drivers.
+	InstanceTypes map[instancetype.Type]struct{}
 }

--- a/lxd/state/state.go
+++ b/lxd/state/state.go
@@ -21,6 +21,9 @@ import (
 // and the operating system. It's typically used by model entities such as
 // containers, volumes, etc. in order to perform changes.
 type State struct {
+	// Context
+	Context context.Context
+
 	// Databases
 	Node    *db.Node
 	Cluster *db.Cluster
@@ -45,6 +48,4 @@ type State struct {
 	// Server certificate
 	ServerCert             func() *shared.CertInfo
 	UpdateCertificateCache func()
-
-	Context context.Context
 }

--- a/lxd/state/state.go
+++ b/lxd/state/state.go
@@ -48,22 +48,3 @@ type State struct {
 
 	Context context.Context
 }
-
-// NewState returns a new State object with the given database and operating
-// system components.
-func NewState(ctx context.Context, node *db.Node, cluster *db.Cluster, maas *maas.Controller, os *sys.OS, endpoints *endpoints.Endpoints, events *events.Server, devlxdEvents *events.Server, firewall firewall.Firewall, proxy func(req *http.Request) (*url.URL, error), serverCert func() *shared.CertInfo, updateCertificateCache func()) *State {
-	return &State{
-		Node:                   node,
-		Cluster:                cluster,
-		MAAS:                   maas,
-		OS:                     os,
-		Endpoints:              endpoints,
-		DevlxdEvents:           devlxdEvents,
-		Events:                 events,
-		Firewall:               firewall,
-		Proxy:                  proxy,
-		Context:                ctx,
-		ServerCert:             serverCert,
-		UpdateCertificateCache: updateCertificateCache,
-	}
-}

--- a/lxd/state/testing.go
+++ b/lxd/state/testing.go
@@ -28,7 +28,14 @@ func NewTestState(t *testing.T) (*State, func()) {
 		osCleanup()
 	}
 
-	state := NewState(context.TODO(), node, cluster, nil, os, nil, nil, nil, firewall.New(), nil, nil, func() {})
+	state := &State{
+		Context:                context.TODO(),
+		Node:                   node,
+		Cluster:                cluster,
+		OS:                     os,
+		Firewall:               firewall.New(),
+		UpdateCertificateCache: func() {},
+	}
 
 	return state, cleanup
 }


### PR DESCRIPTION
- Only indicate instance drivers that are operational in `lxc info` (`/1.0` API endpoint) output.
- Add detection for present of `/dev/kvm` and `vhost_vsock` module for `qemu` instance driver support.
- Prevents creation of instances where there is no operational supported driver for that instance type.

This ensures that you cannot copy a VM to a server that doesn't support it:

```
lxc copy va v2:
Error: Failed instance creation: Failed creating instance record: Instance type "virtual-machine" is not supported
```

Fixes #8899