### PR TITLE
Proxy: Don't write out pid file until process has started OK

### DIFF
--- a/lxd/device/proxy.go
+++ b/lxd/device/proxy.go
@@ -237,19 +237,9 @@ func (d *proxy) Start() (*deviceConfig.RunConfig, error) {
 			if err != nil {
 				return fmt.Errorf("Failed to run: %s %s: %v", command, strings.Join(forkproxyargs, " "), err)
 			}
+
 			for _, file := range proxyValues.inheritFds {
 				file.Close()
-			}
-
-			err = p.Save(pidPath)
-			if err != nil {
-				// Kill Process if started, but could not save the file
-				err2 := p.Stop()
-				if err != nil {
-					return fmt.Errorf("Could not kill subprocess while handling saving error: %s: %s", err, err2)
-				}
-
-				return fmt.Errorf("Failed to save subprocess details: %s", err)
 			}
 
 			// Poll log file a few times until we see "Started" to indicate successful start.
@@ -261,6 +251,17 @@ func (d *proxy) Start() (*deviceConfig.RunConfig, error) {
 				}
 
 				if started {
+					err = p.Save(pidPath)
+					if err != nil {
+						// Kill Process if started, but could not save the file
+						err2 := p.Stop()
+						if err != nil {
+							return fmt.Errorf("Could not kill subprocess while handling saving error: %s: %s", err, err2)
+						}
+
+						return fmt.Errorf("Failed to save subprocess details: %s", err)
+					}
+
 					return nil
 				}
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2816,6 +2816,39 @@ func (d *lxc) Restart(timeout time.Duration) error {
 	return nil
 }
 
+// onStopOperationSetup creates or picks up the relevant operation. This is used in the stopns and stop hooks to
+// ensure that a lock on their activities is held before the liblxc container is stopped. This prevents a start
+// request run at the same time from overlapping with the stop process.
+func (d *lxc) onStopOperationSetup(target string) (*operationlock.InstanceOperation, error) {
+	var err error
+
+	// Pick up the existing stop operation lock created in Stop() function.
+	// If there is another ongoing operation (such as start), wait until that has finished before proceeding
+	// to run the hook (this should be quick as it will fail showing instance is already running).
+	op := operationlock.Get(d.id)
+	if op != nil && !shared.StringInSlice(op.Action(), []string{"stop", "restart", "restore"}) {
+		d.logger.Debug("Waiting for existing operation to finish before running hook", log.Ctx{"opAction": op.Action()})
+		op.Wait()
+		op = nil
+	}
+
+	if op == nil {
+		d.logger.Debug("Container initiated stop", log.Ctx{"action": target})
+
+		action := "stop"
+		if target == "reboot" {
+			action = "restart"
+		}
+
+		op, err = operationlock.Create(d.id, action, false, false)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed creating %s operation", action)
+		}
+	}
+
+	return op, nil
+}
+
 // onStopNS is triggered by LXC's stop hook once a container is shutdown but before the container's
 // namespaces have been closed. The netns path of the stopped container is provided.
 func (d *lxc) onStopNS(args map[string]string) error {

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2861,6 +2861,12 @@ func (d *lxc) onStopNS(args map[string]string) error {
 		return fmt.Errorf("Invalid stop target %q", target)
 	}
 
+	// Create/pick up operation, but don't complete it as we leave operation running for the onStop hook below.
+	_, err := d.onStopOperationSetup(target)
+	if err != nil {
+		return err
+	}
+
 	// Clean up devices.
 	d.cleanupDevices(false, netns)
 


### PR DESCRIPTION
Helps to avoid leaving orphaned proxy processes if the process fails to start up because another one is running. 
Previously this would have written over the pid file for the current process, preventing it from being stopped in the future.

Also starts to create operation locks on the `onStop` and `onStopNS` hooks to try and prevent `Start()` from trying to start the container during a container-initiated stop process. There is already a check in `startCommon()` to check if the container is running using `IsRunning()` but there is a window between the container being considered stopped by liblxc and the stop hooks running that we need to also prevent `Start()` from progressing with container start. 

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>