### PR TITLE
lxd/include: include sys/wait.h in macro.h

### DIFF
--- a/lxd/include/macro.h
+++ b/lxd/include/macro.h
@@ -34,6 +34,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
+#include <sys/wait.h>
 
 #ifndef PATH_MAX
 #define PATH_MAX 4096


### PR DESCRIPTION
P_PIDFD is defined in sys/wait.h, but isn't included anywhere explicitly as
far as I can tell, so we'll always get this define even if the kernel
headers have it.

This fixes an inscrutable compiler error on Alpine for me:

# github.com/lxc/lxd/shared/idmap
In file included from ./../../lxd/include/memory_utils.h:11,
                 from /root/go/pkg/mod/github.com/lxc/lxd@v0.0.0-20210607165116-5a9c2f17d640/shared/idmap/shift_linux.go:41:
./../../lxd/include/macro.h:279:17: error: expected identifier before numeric constant
  279 | #define P_PIDFD 3
      |                 ^

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>