### PR TITLE
Instance: Make operation lock usage for Start, Stop and Shutdown consistent across lxc and qemu drivers 

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2817,39 +2817,6 @@ func (d *lxc) Restart(timeout time.Duration) error {
 	return nil
 }
 
-// onStopOperationSetup creates or picks up the relevant operation. This is used in the stopns and stop hooks to
-// ensure that a lock on their activities is held before the liblxc container is stopped. This prevents a start
-// request run at the same time from overlapping with the stop process.
-func (d *lxc) onStopOperationSetup(target string) (*operationlock.InstanceOperation, error) {
-	var err error
-
-	// Pick up the existing stop operation lock created in Stop() function.
-	// If there is another ongoing operation (such as start), wait until that has finished before proceeding
-	// to run the hook (this should be quick as it will fail showing instance is already running).
-	op := operationlock.Get(d.id)
-	if op != nil && !shared.StringInSlice(op.Action(), []string{"stop", "restart", "restore"}) {
-		d.logger.Debug("Waiting for existing operation to finish before running hook", log.Ctx{"opAction": op.Action()})
-		op.Wait()
-		op = nil
-	}
-
-	if op == nil {
-		d.logger.Debug("Container initiated stop", log.Ctx{"action": target})
-
-		action := "stop"
-		if target == "reboot" {
-			action = "restart"
-		}
-
-		op, err = operationlock.Create(d.id, action, false, false)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Failed creating %s operation", action)
-		}
-	}
-
-	return op, nil
-}
-
 // onStopNS is triggered by LXC's stop hook once a container is shutdown but before the container's
 // namespaces have been closed. The netns path of the stopped container is provided.
 func (d *lxc) onStopNS(args map[string]string) error {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -881,7 +881,8 @@ func (d *qemu) Start(stateful bool) error {
 	d.logger.Debug("Start started", log.Ctx{"stateful": stateful})
 	defer d.logger.Debug("Start finished", log.Ctx{"stateful": stateful})
 
-	// Must be run prior to creating the operation lock.
+	// Check that we're not already running before creating an operation lock, so if the instance is in the
+	// process of stopping we don't prevent the stop hooks from running due to our start operation lock.
 	if d.IsRunning() {
 		return fmt.Errorf("The instance is already running")
 	}
@@ -891,7 +892,7 @@ func (d *qemu) Start(stateful bool) error {
 		return fmt.Errorf("Stateful start requires migration.stateful to be set to true")
 	}
 
-	// Setup a new operation
+	// Setup a new operation.
 	exists, op, err := operationlock.CreateWaitGet(d.id, "start", []string{"restart", "restore"}, false, false)
 	if err != nil {
 		return errors.Wrap(err, "Create instance start operation")

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -574,19 +574,10 @@ func (d *qemu) onStop(target string) error {
 	d.logger.Debug("onStop hook started", log.Ctx{"target": target})
 	defer d.logger.Debug("onStop hook finished", log.Ctx{"target": target})
 
-	var err error
-
-	// Pick up the existing stop operation lock created in Stop() function.
-	op := operationlock.Get(d.id)
-	if op != nil && !shared.StringInSlice(op.Action(), []string{"stop", "restart", "restore"}) {
-		return fmt.Errorf("Instance is already running a %s operation", op.Action())
-	}
-
-	if op == nil && target == "reboot" {
-		op, err = operationlock.Create(d.id, "restart", false, false)
-		if err != nil {
-			return errors.Wrap(err, "Create restart operation")
-		}
+	// Create/pick up operation.
+	op, err := d.onStopOperationSetup(target)
+	if err != nil {
+		return err
 	}
 
 	// Reset timeout to 30s.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -580,13 +580,10 @@ func (d *qemu) onStop(target string) error {
 		return err
 	}
 
-	// Reset timeout to 30s.
-	op.Reset()
-
 	// Wait for QEMU process to end (to avoiding racing start when restarting).
-	// Wait up to 20s to allow for flushing any pending data to disk.
+	// Wait up to 5 minutes to allow for flushing any pending data to disk.
 	d.logger.Debug("Waiting for VM process to finish")
-	waitDuration := time.Duration(time.Second * time.Duration(20))
+	waitDuration := time.Duration(time.Minute * time.Duration(5))
 	waitUntil := time.Now().Add(waitDuration)
 	for {
 		pid, _ := d.pid()
@@ -600,6 +597,7 @@ func (d *qemu) onStop(target string) error {
 			break // Continue clean up as best we can.
 		}
 
+		op.Reset() // Reset timeout to 30s.
 		time.Sleep(time.Millisecond * time.Duration(100))
 	}
 


### PR DESCRIPTION
- Use the same logic and messaging for operation lock usage in Start, Stop and Shutdown across instance driver types.
- Increase VM qemu driver onStop wait timeout to 5 minutes to accommodate VMs that take a long time to flush to disk on stop.
- Add Start, Stop and Shutdown debug logging to lxc driver to be consistent with qemu logging.