### PR TITLE
Return error on invalid subcommand instead of usage message

### DIFF
--- a/lxc/alias.go
+++ b/lxc/alias.go
@@ -38,6 +38,9 @@ func (c *cmdAlias) Command() *cobra.Command {
 	aliasRemoveCmd := cmdAliasRemove{global: c.global, alias: c}
 	cmd.AddCommand(aliasRemoveCmd.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -71,6 +71,9 @@ func (c *cmdCluster) Command() *cobra.Command {
 	cmdClusterUpdateCertificate := cmdClusterUpdateCertificate{global: c.global, cluster: c}
 	cmd.AddCommand(cmdClusterUpdateCertificate.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -73,6 +73,9 @@ func (c *cmdConfig) Command() *cobra.Command {
 	configUnsetCmd := cmdConfigUnset{global: c.global, config: c, configSet: &configSetCmd}
 	cmd.AddCommand(configUnsetCmd.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/config_device.go
+++ b/lxc/config_device.go
@@ -58,6 +58,9 @@ func (c *cmdConfigDevice) Command() *cobra.Command {
 	configDeviceUnsetCmd := cmdConfigDeviceUnset{global: c.global, config: c.config, profile: c.profile, configDevice: c, configDeviceSet: &configDeviceSetCmd}
 	cmd.AddCommand(configDeviceUnsetCmd.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/config_metadata.go
+++ b/lxc/config_metadata.go
@@ -35,6 +35,9 @@ func (c *cmdConfigMetadata) Command() *cobra.Command {
 	configMetadataShowCmd := cmdConfigMetadataShow{global: c.global, config: c.config, configMetadata: c}
 	cmd.AddCommand(configMetadataShowCmd.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/config_template.go
+++ b/lxc/config_template.go
@@ -48,6 +48,9 @@ func (c *cmdConfigTemplate) Command() *cobra.Command {
 	configTemplateShowCmd := cmdConfigTemplateShow{global: c.global, config: c.config, configTemplate: c}
 	cmd.AddCommand(configTemplateShowCmd.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/config_trust.go
+++ b/lxc/config_trust.go
@@ -53,6 +53,9 @@ func (c *cmdConfigTrust) Command() *cobra.Command {
 	configTrustShowCmd := cmdConfigTrustShow{global: c.global, config: c.config, configTrust: c}
 	cmd.AddCommand(configTrustShowCmd.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -88,6 +88,9 @@ func (c *cmdFile) Command() *cobra.Command {
 	fileEditCmd := cmdFileEdit{global: c.global, file: c, filePull: &filePullCmd, filePush: &filePushCmd}
 	cmd.AddCommand(fileEditCmd.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -104,6 +104,9 @@ hash or alias name (if one is set).`))
 	imageUnsetPropCmd := cmdImageUnsetProp{global: c.global, image: c, imageSetProp: &imageSetPropCmd}
 	cmd.AddCommand(imageUnsetPropCmd.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/image_alias.go
+++ b/lxc/image_alias.go
@@ -41,6 +41,9 @@ func (c *cmdImageAlias) Command() *cobra.Command {
 	imageAliasRenameCmd := cmdImageAliasRename{global: c.global, image: c.image, imageAlias: c}
 	cmd.AddCommand(imageAliasRenameCmd.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/network.go
+++ b/lxc/network.go
@@ -97,6 +97,9 @@ func (c *cmdNetwork) Command() *cobra.Command {
 	networkACLCmd := cmdNetworkACL{global: c.global}
 	cmd.AddCommand(networkACLCmd.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/network_acl.go
+++ b/lxc/network_acl.go
@@ -69,6 +69,9 @@ func (c *cmdNetworkACL) Command() *cobra.Command {
 	networkACLRuleCmd := cmdNetworkACLRule{global: c.global, networkACL: c}
 	cmd.AddCommand(networkACLRuleCmd.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/operation.go
+++ b/lxc/operation.go
@@ -36,6 +36,9 @@ func (c *cmdOperation) Command() *cobra.Command {
 	operationShowCmd := cmdOperationShow{global: c.global, operation: c}
 	cmd.AddCommand(operationShowCmd.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -85,6 +85,9 @@ func (c *cmdProfile) Command() *cobra.Command {
 	profileUnsetCmd := cmdProfileUnset{global: c.global, profile: c, profileSet: &profileSetCmd}
 	cmd.AddCommand(profileUnsetCmd.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -74,6 +74,9 @@ func (c *cmdProject) Command() *cobra.Command {
 	projectSwitchCmd := cmdProjectSwitch{global: c.global, project: c}
 	cmd.AddCommand(projectSwitchCmd.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -61,6 +61,9 @@ func (c *cmdRemote) Command() *cobra.Command {
 	remoteSetURLCmd := cmdRemoteSetURL{global: c.global, remote: c}
 	cmd.AddCommand(remoteSetURLCmd.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/storage.go
+++ b/lxc/storage.go
@@ -73,6 +73,9 @@ func (c *cmdStorage) Command() *cobra.Command {
 	storageVolumeCmd := cmdStorageVolume{global: c.global, storage: c}
 	cmd.AddCommand(storageVolumeCmd.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -125,6 +125,9 @@ Unless specified through a prefix, all volume operations affect "custom" (user c
 	storageVolumeUnsetCmd := cmdStorageVolumeUnset{global: c.global, storage: c.storage, storageVolume: c, storageVolumeSet: &storageVolumeSetCmd}
 	cmd.AddCommand(storageVolumeUnsetCmd.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxc/warning.go
+++ b/lxc/warning.go
@@ -46,6 +46,9 @@ func (c *cmdWarning) Command() *cobra.Command {
 	warningDeleteCmd := cmdWarningDelete{global: c.global, warning: c}
 	cmd.AddCommand(warningDeleteCmd.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxd/db/generate/db.go
+++ b/lxd/db/generate/db.go
@@ -24,6 +24,9 @@ func newDb() *cobra.Command {
 	cmd.AddCommand(newDbSchema())
 	cmd.AddCommand(newDbMapper())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxd/db/generate/root.go
+++ b/lxd/db/generate/root.go
@@ -19,5 +19,8 @@ used in LXD's source code.`,
 	}
 	cmd.AddCommand(newDb())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }

--- a/lxd/main_cluster.go
+++ b/lxd/main_cluster.go
@@ -41,6 +41,9 @@ func (c *cmdCluster) Command() *cobra.Command {
 	removeRaftNode := cmdClusterRemoveRaftNode{global: c.global}
 	cmd.AddCommand(removeRaftNode.Command())
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxd/main_forkfile.go
+++ b/lxd/main_forkfile.go
@@ -500,6 +500,9 @@ func (c *cmdForkfile) Command() *cobra.Command {
 	cmdRemove.RunE = c.Run
 	cmd.AddCommand(cmdRemove)
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxd/main_forkmount.go
+++ b/lxd/main_forkmount.go
@@ -490,6 +490,9 @@ func (c *cmdForkmount) Command() *cobra.Command {
 	cmdLXDUmount.RunE = c.Run
 	cmd.AddCommand(cmdLXDUmount)
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxd/main_forknet.go
+++ b/lxd/main_forknet.go
@@ -150,6 +150,9 @@ func (c *cmdForknet) Command() *cobra.Command {
 	cmdDetach.RunE = c.RunDetach
 	cmd.AddCommand(cmdDetach)
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 

--- a/lxd/main_forkuevent.go
+++ b/lxd/main_forkuevent.go
@@ -237,6 +237,9 @@ func (c *cmdForkuevent) Command() *cobra.Command {
 	cmdInject.RunE = c.Run
 	cmd.AddCommand(cmdInject)
 
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { cmd.Usage() }
 	return cmd
 }
 


### PR DESCRIPTION
Closes #8927

Fix for `spf13/cobra`'s inconsistent handling of errors for sub-commands. This workaround properly returns an error for invalid commands.