### PR TITLE
Instance: Improve error logging in restartCommon

### DIFF
--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -506,7 +506,7 @@ func (d *common) restartCommon(inst instance.Instance, timeout time.Duration) er
 	// Setup a new operation for the start phase.
 	op, err = operationlock.Create(d.id, "restart", true, true)
 	if err != nil {
-		return errors.Wrap(err, "Create restart operation")
+		return errors.Wrap(err, "Create restart (for start) operation")
 	}
 
 	err = inst.Start(false)

--- a/lxd/instance/operationlock/operationlock.go
+++ b/lxd/instance/operationlock/operationlock.go
@@ -165,7 +165,6 @@ func (op *InstanceOperation) Done(err error) {
 	}
 
 	op.err = err
+	delete(instanceOperations, op.id) // Delete before closing chanDone.
 	close(op.chanDone)
-
-	delete(instanceOperations, op.id)
 }


### PR DESCRIPTION
To try and catch the cause of the intermittent errors during restart:

```
/lxc-ci/build/tmp.pf8Hs5O5mB/go/bin/lxc restart foo --verbose
INFO[06-22|17:52:49] Restarting container                     instanceType=container instance=foo project=default action=shutdown created=2021-06-22T17:52:40+0000 ephemeral=false used=2021-06-22T17:52:48+0000 timeout=-1ns
Error: Create restart operation: Instance is busy running a stop operation
```

Also ensures that the operation lock entry is removed before closing the chanDone channel.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>