### PR TITLE
Instance: Don't fully regenerate VM config driver on start in generateConfigShare

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2107,7 +2107,11 @@ echo "To start it now, unmount this filesystem and run: systemctl start lxd-agen
 	}
 
 	// Templated files.
-	err = os.MkdirAll(filepath.Join(configDrivePath, "files"), 0500)
+	templateFilesPath := filepath.Join(configDrivePath, "files")
+
+	// Clear path and recreate.
+	os.RemoveAll(templateFilesPath)
+	err = os.MkdirAll(templateFilesPath, 0500)
 	if err != nil {
 		return err
 	}
@@ -2116,7 +2120,7 @@ echo "To start it now, unmount this filesystem and run: systemctl start lxd-agen
 	key := "volatile.apply_template"
 	if d.localConfig[key] != "" {
 		// Run any template that needs running.
-		err = d.templateApplyNow(instance.TemplateTrigger(d.localConfig[key]), filepath.Join(configDrivePath, "files"))
+		err = d.templateApplyNow(instance.TemplateTrigger(d.localConfig[key]), templateFilesPath)
 		if err != nil {
 			return err
 		}
@@ -2128,7 +2132,7 @@ echo "To start it now, unmount this filesystem and run: systemctl start lxd-agen
 		}
 	}
 
-	err = d.templateApplyNow("start", filepath.Join(configDrivePath, "files"))
+	err = d.templateApplyNow("start", templateFilesPath)
 	if err != nil {
 		return err
 	}
@@ -2136,7 +2140,7 @@ echo "To start it now, unmount this filesystem and run: systemctl start lxd-agen
 	// Copy the template metadata itself too.
 	metaPath := filepath.Join(d.Path(), "metadata.yaml")
 	if shared.PathExists(metaPath) {
-		err = shared.FileCopy(metaPath, filepath.Join(configDrivePath, "files/metadata.yaml"))
+		err = shared.FileCopy(metaPath, filepath.Join(templateFilesPath, "metadata.yaml"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
And skip installing lxd-agent if existing is same size and same modification time as source.

This significantly reduces the per-snapshot tracking cost (in terms of size used) when creating a snapshot and starting the VM, as it doesn't need to copy a fresh lxd-agent across.

Test:

```
lxc launch images:ubuntu/focal v1 -s zfs --vm

sudo zfs list | grep test_v1
zfs/virtual-machines/test_v1                                                         9.65M  85.7M     9.66M  /var/lib/lxd/storage-pools/zfs/virtual-machines/test_v1
zfs/virtual-machines/test_v1.block                                                      1K   223G      383M  -


lxc snapshot v1
lxc start v1

sudo zfs list | grep test_v1
zfs/virtual-machines/test_v1                                                         10.5M  84.8M     10.5M  /var/lib/lxd/storage-pools/zfs/virtual-machines/test_v1
zfs/virtual-machines/test_v1.block                                                   1.45M   223G      384M  -

lxc stop v1
lxc snapshot v1
lxc start v1

sudo zfs list | grep test_v1
zfs/virtual-machines/test_v1                                                         10.6M  84.8M     10.5M  /var/lib/lxd/storage-pools/zfs/virtual-machines/test_v1
zfs/virtual-machines/test_v1.block                                                   1.45M   223G      384M  -
```

Reported from https://discuss.linuxcontainers.org/t/zfs-quota-set-for-vm-dataset-by-lxd/11417/

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>