### PR TITLE
Fix crash when listener is nil

### DIFF
--- a/lxd/endpoints/network.go
+++ b/lxd/endpoints/network.go
@@ -168,14 +168,14 @@ func (e *Endpoints) NetworkUpdateTrustedProxy(trustedProxy string) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	listener, ok := e.listeners[network]
-	if !ok {
+	if !ok || listener == nil {
 		return
 	}
 	listener.(*networkListener).TrustedProxy(proxies)
 
 	// Update the cluster listener too, if enabled.
 	listener, ok = e.listeners[cluster]
-	if !ok {
+	if !ok || listener == nil {
 		return
 	}
 	listener.(*networkListener).TrustedProxy(proxies)

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -611,7 +611,7 @@ func instancePostClusteringMigrateWithCeph(d *Daemon, r *http.Request, inst inst
 		// Trigger a rename in the Ceph driver.
 		err = pool.MigrateInstance(inst, nil, &args, op)
 		if err != nil {
-			return errors.Wrap(err, "Failed to rename ceph RBD volume")
+			return errors.Wrap(err, "Failed to migrate ceph RBD volume")
 		}
 
 		// Re-link the database entries against the new node name.


### PR DESCRIPTION
I'm not sure exactly in what case we'd have a entry in the map but have it point to a nil listener, though based on the issue we've seen reported, it certainly looks possible and we should handle it.

Fixes #8940