### PR TITLE
Fix up lifecycle event context fields

### DIFF
--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -284,7 +284,7 @@ func projectsPost(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	d.State().Events.SendLifecycle(project.Name, lifecycle.ProjectCreated.Event(project.Name, log.Ctx{"project": project}))
+	d.State().Events.SendLifecycle(project.Name, lifecycle.ProjectCreated.Event(project.Name, nil))
 
 	return response.SyncResponseLocation(true, nil, fmt.Sprintf("/%s/projects/%s", version.APIVersion, project.Name))
 }
@@ -421,7 +421,7 @@ func projectPut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	d.State().Events.SendLifecycle(project.Name, lifecycle.ProjectUpdated.Event(project.Name, log.Ctx{"project": project}))
+	d.State().Events.SendLifecycle(project.Name, lifecycle.ProjectUpdated.Event(project.Name, nil))
 
 	return projectChange(d, project, req)
 }
@@ -515,7 +515,7 @@ func projectPatch(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	d.State().Events.SendLifecycle(project.Name, lifecycle.ProjectUpdated.Event(project.Name, log.Ctx{"project": project}))
+	d.State().Events.SendLifecycle(project.Name, lifecycle.ProjectUpdated.Event(project.Name, nil))
 
 	return projectChange(d, project, req)
 }

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -686,7 +686,7 @@ func projectPost(d *Daemon, r *http.Request) response.Response {
 			}
 		}
 
-		d.State().Events.SendLifecycle(req.Name, lifecycle.ProjectRenamed.Event(req.Name, log.Ctx{"old-name": name, "new-name": req.Name}))
+		d.State().Events.SendLifecycle(req.Name, lifecycle.ProjectRenamed.Event(req.Name, log.Ctx{"old_name": name, "new_name": req.Name}))
 
 		return nil
 	}

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -437,7 +437,7 @@ func profilePut(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	d.State().Events.SendLifecycle(projectName, lifecycle.ProfileUpdated.Event(name, projectName, log.Ctx{"profile": req}))
+	d.State().Events.SendLifecycle(projectName, lifecycle.ProfileUpdated.Event(name, projectName, nil))
 
 	return response.SmartError(err)
 }
@@ -557,7 +557,7 @@ func profilePatch(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	d.State().Events.SendLifecycle(projectName, lifecycle.ProfileUpdated.Event(name, projectName, log.Ctx{"profile": req}))
+	d.State().Events.SendLifecycle(projectName, lifecycle.ProfileUpdated.Event(name, projectName, nil))
 
 	return response.SmartError(doProfileUpdate(d, projectName, name, id, profile, req))
 }

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -636,7 +636,7 @@ func profilePost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	d.State().Events.SendLifecycle(projectName, lifecycle.ProfileRenamed.Event(req.Name, projectName, log.Ctx{"old-name": name, "new-name": req.Name}))
+	d.State().Events.SendLifecycle(projectName, lifecycle.ProfileRenamed.Event(req.Name, projectName, log.Ctx{"old_name": name, "new_name": req.Name}))
 
 	return response.SyncResponseLocation(true, nil, fmt.Sprintf("/%s/profiles/%s", version.APIVersion, req.Name))
 }


### PR DESCRIPTION
* Use nils instead of the whole struct for created/updated events
* Use `_` instead of `-` for renamed event context field names, for consistency