### PR TITLE
Add requestors for all lifecycle events

### DIFF
--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lxc/lxd/lxd/project"
 	projecthelpers "github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/rbac"
+	"github.com/lxc/lxd/lxd/request"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/util"
@@ -284,7 +285,8 @@ func projectsPost(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	d.State().Events.SendLifecycle(project.Name, lifecycle.ProjectCreated.Event(project.Name, nil))
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(project.Name, lifecycle.ProjectCreated.Event(project.Name, requestor, nil))
 
 	return response.SyncResponseLocation(true, nil, fmt.Sprintf("/%s/projects/%s", version.APIVersion, project.Name))
 }
@@ -421,7 +423,8 @@ func projectPut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	d.State().Events.SendLifecycle(project.Name, lifecycle.ProjectUpdated.Event(project.Name, nil))
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(project.Name, lifecycle.ProjectUpdated.Event(project.Name, requestor, nil))
 
 	return projectChange(d, project, req)
 }
@@ -515,7 +518,8 @@ func projectPatch(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	d.State().Events.SendLifecycle(project.Name, lifecycle.ProjectUpdated.Event(project.Name, nil))
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(project.Name, lifecycle.ProjectUpdated.Event(project.Name, requestor, nil))
 
 	return projectChange(d, project, req)
 }
@@ -686,7 +690,8 @@ func projectPost(d *Daemon, r *http.Request) response.Response {
 			}
 		}
 
-		d.State().Events.SendLifecycle(req.Name, lifecycle.ProjectRenamed.Event(req.Name, log.Ctx{"old_name": name}))
+		requestor := request.CreateRequestor(r)
+		d.State().Events.SendLifecycle(req.Name, lifecycle.ProjectRenamed.Event(req.Name, requestor, log.Ctx{"old_name": name}))
 
 		return nil
 	}
@@ -754,7 +759,8 @@ func projectDelete(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	d.State().Events.SendLifecycle(name, lifecycle.ProjectDeleted.Event(name, nil))
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(name, lifecycle.ProjectDeleted.Event(name, requestor, nil))
 
 	return response.EmptySyncResponse
 }

--- a/lxd/lifecycle/network.go
+++ b/lxd/lifecycle/network.go
@@ -26,7 +26,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a network device.
-func (a NetworkAction) Event(n network, ctx map[string]interface{}) api.EventLifecycle {
+func (a NetworkAction) Event(n network, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
 	eventType := fmt.Sprintf("network-%s", a)
 	u := fmt.Sprintf("/1.0/networks/%s", url.PathEscape(n.Name()))
 	if n.Project() != project.Default {
@@ -36,6 +36,6 @@ func (a NetworkAction) Event(n network, ctx map[string]interface{}) api.EventLif
 		Action:    eventType,
 		Source:    u,
 		Context:   ctx,
-		Requestor: nil,
+		Requestor: requestor,
 	}
 }

--- a/lxd/lifecycle/profile.go
+++ b/lxd/lifecycle/profile.go
@@ -8,10 +8,10 @@ import (
 	"github.com/lxc/lxd/shared/api"
 )
 
-// ProfileAction represents a lifecycle event action for profile devices.
+// ProfileAction represents a lifecycle event action for profiles.
 type ProfileAction string
 
-// All supported lifecycle events for profile devices.
+// All supported lifecycle events for profiles.
 const (
 	ProfileCreated = ProfileAction("created")
 	ProfileDeleted = ProfileAction("deleted")
@@ -19,7 +19,7 @@ const (
 	ProfileRenamed = ProfileAction("renamed")
 )
 
-// Event creates the lifecycle event for an action on a profile device.
+// Event creates the lifecycle event for an action on a profile.
 func (a ProfileAction) Event(name string, projectName string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
 	eventType := fmt.Sprintf("profile-%s", a)
 	u := fmt.Sprintf("/1.0/profiles/%s", url.PathEscape(name))

--- a/lxd/lifecycle/profile.go
+++ b/lxd/lifecycle/profile.go
@@ -20,7 +20,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a profile device.
-func (a ProfileAction) Event(name string, projectName string, ctx map[string]interface{}) api.EventLifecycle {
+func (a ProfileAction) Event(name string, projectName string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
 	eventType := fmt.Sprintf("profile-%s", a)
 	u := fmt.Sprintf("/1.0/profiles/%s", url.PathEscape(name))
 	if projectName != project.Default {
@@ -30,6 +30,6 @@ func (a ProfileAction) Event(name string, projectName string, ctx map[string]int
 		Action:    eventType,
 		Source:    u,
 		Context:   ctx,
-		Requestor: nil,
+		Requestor: requestor,
 	}
 }

--- a/lxd/lifecycle/project.go
+++ b/lxd/lifecycle/project.go
@@ -7,10 +7,10 @@ import (
 	"github.com/lxc/lxd/shared/api"
 )
 
-// ProjectAction represents a lifecycle event action for project devices.
+// ProjectAction represents a lifecycle event action for projects.
 type ProjectAction string
 
-// All supported lifecycle events for project devices.
+// All supported lifecycle events for projects.
 const (
 	ProjectCreated = ProjectAction("created")
 	ProjectDeleted = ProjectAction("deleted")
@@ -18,7 +18,7 @@ const (
 	ProjectRenamed = ProjectAction("renamed")
 )
 
-// Event creates the lifecycle event for an action on a project device.
+// Event creates the lifecycle event for an action on a project.
 func (a ProjectAction) Event(name string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
 	eventType := fmt.Sprintf("project-%s", a)
 	u := fmt.Sprintf("/1.0/projects/%s", url.PathEscape(name))

--- a/lxd/lifecycle/project.go
+++ b/lxd/lifecycle/project.go
@@ -19,7 +19,7 @@ const (
 )
 
 // Event creates the lifecycle event for an action on a project device.
-func (a ProjectAction) Event(name string, ctx map[string]interface{}) api.EventLifecycle {
+func (a ProjectAction) Event(name string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
 	eventType := fmt.Sprintf("project-%s", a)
 	u := fmt.Sprintf("/1.0/projects/%s", url.PathEscape(name))
 
@@ -27,6 +27,6 @@ func (a ProjectAction) Event(name string, ctx map[string]interface{}) api.EventL
 		Action:    eventType,
 		Source:    u,
 		Context:   ctx,
-		Requestor: nil,
+		Requestor: requestor,
 	}
 }

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -472,7 +472,7 @@ func (n *bridge) Create(clientType request.ClientType) error {
 		return fmt.Errorf("Network interface %q already exists", n.name)
 	}
 
-	return n.common.create(clientType)
+	return nil
 }
 
 // isRunning returns whether the network is up.

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -12,7 +12,6 @@ import (
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
-	"github.com/lxc/lxd/lxd/lifecycle"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
@@ -274,7 +273,6 @@ func (n *common) update(applyNetwork api.NetworkPut, targetNode string, clientTy
 			return err
 		}
 
-		n.state.Events.SendLifecycle(n.project, lifecycle.NetworkUpdated.Event(n, nil))
 	}
 
 	return nil
@@ -350,10 +348,8 @@ func (n *common) rename(newName string) error {
 	}
 
 	// Reinitialise internal name variable and logger context with new name.
-	oldName := n.name
 	n.name = newName
 
-	n.state.Events.SendLifecycle(n.project, lifecycle.NetworkRenamed.Event(n, map[string]interface{}{"old_name": oldName}))
 	return nil
 }
 
@@ -362,11 +358,6 @@ func (n *common) delete(clientType request.ClientType) error {
 	// Cleanup storage.
 	if shared.PathExists(shared.VarPath("networks", n.name)) {
 		os.RemoveAll(shared.VarPath("networks", n.name))
-	}
-
-	// Generate lifecycle event if not notification.
-	if clientType != request.ClientTypeNotifier {
-		n.state.Events.SendLifecycle(n.project, lifecycle.NetworkDeleted.Event(n, nil))
 	}
 
 	return nil

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -328,15 +328,6 @@ func (n *common) configChanged(newNetwork api.NetworkPut) (bool, []string, api.N
 	return dbUpdateNeeded, changedKeys, oldNetwork, nil
 }
 
-// create just sends the needed lifecycle event.
-func (n *common) create(clientType request.ClientType) error {
-	if clientType == request.ClientTypeNormal {
-		n.state.Events.SendLifecycle(n.project, lifecycle.NetworkCreated.Event(n, nil))
-	}
-
-	return nil
-}
-
 // rename the network directory, update database record and update internal variables.
 func (n *common) rename(newName string) error {
 	// Clear new directory if exists.
@@ -384,8 +375,7 @@ func (n *common) delete(clientType request.ClientType) error {
 // Create is a no-op.
 func (n *common) Create(clientType request.ClientType) error {
 	n.logger.Debug("Create", log.Ctx{"clientType": clientType, "config": n.config})
-
-	return n.create(clientType)
+	return nil
 }
 
 // HandleHeartbeat is a no-op.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1401,7 +1401,7 @@ func (n *ovn) Create(clientType request.ClientType) error {
 		}
 	}
 
-	return n.common.create(clientType)
+	return nil
 }
 
 // allowedUplinkNetworks returns a list of allowed networks to use as uplinks based on project restrictions.

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -120,7 +120,7 @@ func (n *physical) Create(clientType request.ClientType) error {
 		}
 	}
 
-	return n.common.create(clientType)
+	return nil
 }
 
 // Delete deletes a network.

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -181,32 +181,7 @@ func OperationCreate(s *state.State, projectName string, opClass OperationClass,
 
 	// Set requestor if request was provided.
 	if r != nil {
-		ctx := r.Context()
-		requestor := api.EventLifecycleRequestor{}
-
-		// Normal requestor.
-		val, ok := ctx.Value(request.CtxUsername).(string)
-		if ok {
-			requestor.Username = val
-		}
-
-		val, ok = ctx.Value(request.CtxProtocol).(string)
-		if ok {
-			requestor.Protocol = val
-		}
-
-		// Forwarded requestor override.
-		val, ok = ctx.Value(request.CtxForwardedUsername).(string)
-		if ok {
-			requestor.Username = val
-		}
-
-		val, ok = ctx.Value(request.CtxForwardedProtocol).(string)
-		if ok {
-			requestor.Protocol = val
-		}
-
-		op.requestor = &requestor
+		op.requestor = request.CreateRequestor(r)
 	}
 
 	operationsLock.Lock()

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/lifecycle"
 	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/request"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -261,7 +262,8 @@ func profilesPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(errors.Wrapf(err, "Error inserting %q into database", req.Name))
 	}
 
-	d.State().Events.SendLifecycle(projectName, lifecycle.ProfileCreated.Event(req.Name, projectName, nil))
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(projectName, lifecycle.ProfileCreated.Event(req.Name, projectName, requestor, nil))
 
 	return response.SyncResponseLocation(true, nil, fmt.Sprintf("/%s/profiles/%s", version.APIVersion, req.Name))
 }
@@ -437,7 +439,8 @@ func profilePut(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	d.State().Events.SendLifecycle(projectName, lifecycle.ProfileUpdated.Event(name, projectName, nil))
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(projectName, lifecycle.ProfileUpdated.Event(name, projectName, requestor, nil))
 
 	return response.SmartError(err)
 }
@@ -557,7 +560,8 @@ func profilePatch(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	d.State().Events.SendLifecycle(projectName, lifecycle.ProfileUpdated.Event(name, projectName, nil))
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(projectName, lifecycle.ProfileUpdated.Event(name, projectName, requestor, nil))
 
 	return response.SmartError(doProfileUpdate(d, projectName, name, id, profile, req))
 }
@@ -636,7 +640,8 @@ func profilePost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	d.State().Events.SendLifecycle(projectName, lifecycle.ProfileRenamed.Event(req.Name, projectName, log.Ctx{"old_name": name}))
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(projectName, lifecycle.ProfileRenamed.Event(req.Name, projectName, requestor, log.Ctx{"old_name": name}))
 
 	return response.SyncResponseLocation(true, nil, fmt.Sprintf("/%s/profiles/%s", version.APIVersion, req.Name))
 }
@@ -691,7 +696,8 @@ func profileDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	d.State().Events.SendLifecycle(projectName, lifecycle.ProfileDeleted.Event(name, projectName, nil))
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(projectName, lifecycle.ProfileDeleted.Event(name, projectName, requestor, nil))
 
 	return response.EmptySyncResponse
 }

--- a/lxd/request/request.go
+++ b/lxd/request/request.go
@@ -1,0 +1,36 @@
+package request
+
+import (
+	"net/http"
+
+	"github.com/lxc/lxd/shared/api"
+)
+
+// CreateRequestor extracts the lifecycle event requestor data from an http.Request context
+func CreateRequestor(r *http.Request) *api.EventLifecycleRequestor {
+	ctx := r.Context()
+	requestor := &api.EventLifecycleRequestor{}
+
+	// Normal requestor.
+	val, ok := ctx.Value(CtxUsername).(string)
+	if ok {
+		requestor.Username = val
+	}
+
+	val, ok = ctx.Value(CtxProtocol).(string)
+	if ok {
+		requestor.Protocol = val
+	}
+
+	// Forwarded requestor override.
+	val, ok = ctx.Value(CtxForwardedUsername).(string)
+	if ok {
+		requestor.Username = val
+	}
+
+	val, ok = ctx.Value(CtxForwardedProtocol).(string)
+	if ok {
+		requestor.Protocol = val
+	}
+	return requestor
+}


### PR DESCRIPTION
This one's a messier one!

* CreateRequestor function in lxd/request takes an http request and creates a requestor for lifecycles.
* `lifecycle.Event` will now accept a requestor as a parameter if there is no operation
* Network lifecycles have been moved from `lxd/network/driver_common` to `lxd/networks` to access the requestor
    * As a result, the `create` function in `lxd/network/driver_common` and its references were removed