### PR TITLE
Revert "client: Only retry target addresses if initial connection fails"

### DIFF
--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -200,11 +200,7 @@ func (r *ProtocolLXD) tryCreateContainer(req api.ContainersPost, urls []string) 
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors[serverURL] = err
-
-				// If we were able to connect and then operation failed, don't attempt another
-				// endpoint address as it was not a connection error, and we may end up
-				// exacerbating the problem by trying again via another address.
-				break
+				continue
 			}
 
 			success = true
@@ -558,11 +554,7 @@ func (r *ProtocolLXD) tryMigrateContainer(source InstanceServer, name string, re
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors[serverURL] = err
-
-				// If we were able to connect and then operation failed, don't attempt another
-				// endpoint address as it was not a connection error, and we may end up
-				// exacerbating the problem by trying again via another address.
-				break
+				continue
 			}
 
 			success = true
@@ -1228,11 +1220,7 @@ func (r *ProtocolLXD) tryMigrateContainerSnapshot(source InstanceServer, contain
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors[serverURL] = err
-
-				// If we were able to connect and then operation failed, don't attempt another
-				// endpoint address as it was not a connection error, and we may end up
-				// exacerbating the problem by trying again via another address.
-				break
+				continue
 			}
 
 			success = true

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -600,11 +600,7 @@ func (r *ProtocolLXD) tryCopyImage(req api.ImagesPost, urls []string) (RemoteOpe
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors[serverURL] = err
-
-				// If we were able to connect and then operation failed, don't attempt another
-				// endpoint address as it was not a connection error, and we may end up
-				// exacerbating the problem by trying again via another address.
-				break
+				continue
 			}
 
 			success = true

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -290,11 +290,7 @@ func (r *ProtocolLXD) tryCreateInstance(req api.InstancesPost, urls []string, op
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors[serverURL] = err
-
-				// If we were able to connect and then operation failed, don't attempt another
-				// endpoint address as it was not a connection error, and we may end up
-				// exacerbating the problem by trying again via another address.
-				break
+				continue
 			}
 
 			success = true
@@ -664,11 +660,7 @@ func (r *ProtocolLXD) tryMigrateInstance(source InstanceServer, name string, req
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors[serverURL] = err
-
-				// If we were able to connect and then operation failed, don't attempt another
-				// endpoint address as it was not a connection error, and we may end up
-				// exacerbating the problem by trying again via another address.
-				break
+				continue
 			}
 
 			success = true
@@ -1442,11 +1434,7 @@ func (r *ProtocolLXD) tryMigrateInstanceSnapshot(source InstanceServer, instance
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors[serverURL] = err
-
-				// If we were able to connect and then operation failed, don't attempt another
-				// endpoint address as it was not a connection error, and we may end up
-				// exacerbating the problem by trying again via another address.
-				break
+				continue
 			}
 
 			success = true

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -306,11 +306,7 @@ func (r *ProtocolLXD) tryMigrateStoragePoolVolume(source InstanceServer, pool st
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors[serverURL] = err
-
-				// If we were able to connect and then operation failed, don't attempt another
-				// endpoint address as it was not a connection error, and we may end up
-				// exacerbating the problem by trying again via another address.
-				break
+				continue
 			}
 
 			success = true
@@ -365,11 +361,7 @@ func (r *ProtocolLXD) tryCreateStoragePoolVolume(pool string, req api.StorageVol
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors[serverURL] = err
-
-				// If we were able to connect and then operation failed, don't attempt another
-				// endpoint address as it was not a connection error, and we may end up
-				// exacerbating the problem by trying again via another address.
-				break
+				continue
 			}
 
 			success = true


### PR DESCRIPTION
This reverts commit 46fe2f1685113a81c0027b67b9081c90dd3400eb.

It seems the retry mechanism is more complicated than I realised and has caused issues:

https://discuss.linuxcontainers.org/t/lxc-copy-to-internal-ip-instead-of-public-ip/11437

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>