### PR TITLE
Add the mechanism of retrying instance autostart when autostart fails

### DIFF
--- a/lxd/db/warnings_types.go
+++ b/lxd/db/warnings_types.go
@@ -51,6 +51,8 @@ const (
 	WarningNetworkStartupFailure
 	// WarningOfflineClusterMember represents the offline cluster members warning
 	WarningOfflineClusterMember
+	// WarningInstanceAutostartFailure represents the failure of instance autostart process after three retries
+	WarningInstanceAutostartFailure
 )
 
 // WarningTypeNames associates a warning code to its name.
@@ -77,6 +79,7 @@ var WarningTypeNames = map[WarningType]string{
 	WarningProxyBridgeNetfilterNotEnabled:         "Proxy bridge netfilter not enabled",
 	WarningNetworkStartupFailure:                  "Failed to start network",
 	WarningOfflineClusterMember:                   "Offline cluster member",
+	WarningInstanceAutostartFailure:               "Failed to autostart instance",
 }
 
 // WarningTypes associates a warning type to its type code.
@@ -134,6 +137,8 @@ func (t WarningType) Severity() WarningSeverity {
 	case WarningNetworkStartupFailure:
 		return WarningSeverityLow
 	case WarningOfflineClusterMember:
+		return WarningSeverityLow
+	case WarningInstanceAutostartFailure:
 		return WarningSeverityLow
 	}
 

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -234,14 +234,24 @@ func instancesRestart(s *state.State) error {
 				continue
 			}
 
-			err = c.Start(false)
-			if err != nil {
-				logger.Errorf("Failed to start instance '%s': %v", c.Name(), err)
+			var err error
+			for retry := 0; retry < 3; retry++ {
+				err = c.Start(false)
+				if err != nil {
+					logger.Errorf("Failed to start instance '%q': %v", c.Name(), err)
+					time.Sleep(5 * time.Second)
+				} else {
+					break
+				}
 			}
 
-			autoStartDelayInt, err := strconv.Atoi(autoStartDelay)
-			if err == nil {
-				time.Sleep(time.Duration(autoStartDelayInt) * time.Second)
+			if err != nil {
+				logger.Errorf("Failed to start instance '%s': %v", c.Name(), err)
+			} else {
+				autoStartDelayInt, err := strconv.Atoi(autoStartDelay)
+				if err == nil {
+					time.Sleep(time.Duration(autoStartDelayInt) * time.Second)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
A rework on the previous PR as I was completely wrong about the contributing rules and messed up the commit messages.

NOTE: The current approach of retrying instance autostart will encounter significant scalability issue if users have scheduled **LOTS** instances autostart. One of the solutions to this issue is by implementing WaitGroup and goroutines to speed up the autostart retries in the backgrounds, however that will contradict with the purpose of **boot.autostart.delay**. Please let me know your thoughts on this :)

Resolves #8858.

Signed-off-by: Ricky Yu lijierickyyu@gmail.com