### PR TITLE
Image & Image Alias lifecycle events

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -4730,6 +4730,11 @@ definitions:
         example: local
         type: string
         x-go-name: Pool
+      project:
+        description: Source project name
+        example: foo
+        type: string
+        x-go-name: Project
       secrets:
         additionalProperties:
           type: string
@@ -6143,6 +6148,29 @@ paths:
       tags:
       - images
   /1.0/images/aliases/{name}:
+    delete:
+      description: Deletes a specific image alias.
+      operationId: image_alias_delete
+      parameters:
+      - description: Project name
+        example: default
+        in: query
+        name: project
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/EmptySyncResponse'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "403":
+          $ref: '#/responses/Forbidden'
+        "500":
+          $ref: '#/responses/InternalServerError'
+      summary: Delete the image alias
+      tags:
+      - images
     get:
       description: Gets a specific image alias.
       operationId: image_alias_get

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2955,6 +2955,9 @@ func imageAliasDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(projectName, lifecycle.ImageAliasDeleted.Event(name, projectName, requestor, nil))
+
 	return response.EmptySyncResponse
 }
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2947,6 +2947,30 @@ func imageAliasGet(d *Daemon, r *http.Request) response.Response {
 	return response.SyncResponseETag(true, alias, alias)
 }
 
+// swagger:operation DELETE /1.0/images/aliases/{name} images image_alias_delete
+//
+// Delete the image alias
+//
+// Deletes a specific image alias.
+//
+// ---
+// produces:
+//   - application/json
+// parameters:
+//   - in: query
+//     name: project
+//     description: Project name
+//     type: string
+//     example: default
+// responses:
+//   "200":
+//     $ref: "#/responses/EmptySyncResponse"
+//   "400":
+//     $ref: "#/responses/BadRequest"
+//   "403":
+//     $ref: "#/responses/Forbidden"
+//   "500":
+//     $ref: "#/responses/InternalServerError"
 func imageAliasDelete(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 	name := mux.Vars(r)["name"]

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3029,6 +3029,9 @@ func imageAliasPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(projectName, lifecycle.ImageAliasUpdated.Event(alias.Name, projectName, requestor, log.Ctx{"target": alias.Target}))
+
 	return response.EmptySyncResponse
 }
 
@@ -3115,6 +3118,9 @@ func imageAliasPatch(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.SmartError(err)
 	}
+
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(projectName, lifecycle.ImageAliasUpdated.Event(alias.Name, projectName, requestor, log.Ctx{"target": alias.Target}))
 
 	return response.EmptySyncResponse
 }

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -38,6 +38,7 @@ import (
 	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/operations"
 	projectutils "github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/request"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/state"
 	storagePools "github.com/lxc/lxd/lxd/storage"
@@ -2544,6 +2545,9 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(projectName, lifecycle.ImageUpdated.Event(info.Fingerprint, projectName, requestor, nil))
+
 	return response.EmptySyncResponse
 }
 
@@ -2644,6 +2648,9 @@ func imagePatch(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.SmartError(err)
 	}
+
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(projectName, lifecycle.ImageUpdated.Event(info.Fingerprint, projectName, requestor, nil))
 
 	return response.EmptySyncResponse
 }

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3831,5 +3831,7 @@ func createTokenResponse(d *Daemon, r *http.Request, projectName string, fingerp
 		return response.InternalError(err)
 	}
 
+	d.State().Events.SendLifecycle(projectName, lifecycle.ImageSecretCreated.Event(fingerprint, projectName, op.Requestor(), nil))
+
 	return operations.OperationResponse(op)
 }

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3182,6 +3182,9 @@ func imageAliasPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(projectName, lifecycle.ImageAliasRenamed.Event(req.Name, projectName, requestor, log.Ctx{"old_name": name}))
+
 	return response.SyncResponseLocation(true, nil, fmt.Sprintf("/%s/images/aliases/%s", version.APIVersion, req.Name))
 }
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2718,6 +2718,9 @@ func imageAliasesPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(projectName, lifecycle.ImageAliasCreated.Event(req.Name, projectName, requestor, log.Ctx{"target": req.Target}))
+
 	return response.SyncResponseLocation(true, nil, fmt.Sprintf("/%s/images/aliases/%s", version.APIVersion, req.Name))
 }
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3332,6 +3332,9 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 	files[0].Path = imagePath
 	files[0].Filename = filename
 
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(projectName, lifecycle.ImageRetrieved.Event(imgInfo.Fingerprint, projectName, requestor, nil))
+
 	return response.FileResponse(r, files, nil, false)
 }
 
@@ -3453,6 +3456,8 @@ func imageExportPost(d *Daemon, r *http.Request) response.Response {
 		if opWaitAPI.Status != "success" {
 			return fmt.Errorf(opWaitAPI.Err)
 		}
+
+		d.State().Events.SendLifecycle(projectName, lifecycle.ImageRetrieved.Event(fingerprint, projectName, op.Requestor(), log.Ctx{"target": req.Target}))
 
 		return nil
 	}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -34,6 +34,7 @@ import (
 	"github.com/lxc/lxd/lxd/filter"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/lxd/lifecycle"
 	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/operations"
 	projectutils "github.com/lxc/lxd/lxd/project"
@@ -1016,6 +1017,8 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 		if err != nil {
 			return errors.Wrapf(err, "Failed syncing image between nodes")
 		}
+
+		d.State().Events.SendLifecycle(projectName, lifecycle.ImageCreated.Event(info.Fingerprint, projectName, op.Requestor(), log.Ctx{"type": info.Type}))
 
 		return nil
 	}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1834,6 +1834,11 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 
 		metadata := map[string]interface{}{"refreshed": result}
 		op.UpdateMetadata(metadata)
+
+		// Sent a lifecycle event if the refresh actually happened.
+		if result {
+			d.State().Events.SendLifecycle(projectName, lifecycle.ImageRefreshed.Event(fingerprint, projectName, op.Requestor(), nil))
+		}
 	}
 
 	// Update the image on each pool where it currently exists.

--- a/lxd/lifecycle/image.go
+++ b/lxd/lifecycle/image.go
@@ -1,0 +1,37 @@
+package lifecycle
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/shared/api"
+)
+
+// ImageAction represents a lifecycle event action for images.
+type ImageAction string
+
+// All supported lifecycle events for images.
+const (
+	ImageCreated       = ImageAction("created")
+	ImageDeleted       = ImageAction("deleted")
+	ImageUpdated       = ImageAction("updated")
+	ImageRetrieved     = ImageAction("retrieved")
+	ImageRefreshed     = ImageAction("refreshed")
+	ImageSecretCreated = ImageAction("secret-created")
+)
+
+// Event creates the lifecycle event for an action on an image.
+func (a ImageAction) Event(image string, projectName string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+	eventType := fmt.Sprintf("image-%s", a)
+	u := fmt.Sprintf("/1.0/images/%s", url.PathEscape(image))
+	if projectName != project.Default {
+		u = fmt.Sprintf("%s?project=%s", u, url.QueryEscape(projectName))
+	}
+	return api.EventLifecycle{
+		Action:    eventType,
+		Source:    u,
+		Context:   ctx,
+		Requestor: requestor,
+	}
+}

--- a/lxd/lifecycle/image_alias.go
+++ b/lxd/lifecycle/image_alias.go
@@ -1,0 +1,35 @@
+package lifecycle
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/shared/api"
+)
+
+// ImageAliasAction represents a lifecycle event action for image aliases.
+type ImageAliasAction string
+
+// All supported lifecycle events for image aliases.
+const (
+	ImageAliasCreated = ImageAliasAction("created")
+	ImageAliasDeleted = ImageAliasAction("deleted")
+	ImageAliasUpdated = ImageAliasAction("updated")
+	ImageAliasRenamed = ImageAliasAction("renamed")
+)
+
+// Event creates the lifecycle event for an action on an image alias.
+func (a ImageAliasAction) Event(image string, projectName string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+	eventType := fmt.Sprintf("image-alias-%s", a)
+	u := fmt.Sprintf("/1.0/images/aliases/%s", url.PathEscape(image))
+	if projectName != project.Default {
+		u = fmt.Sprintf("%s?project=%s", u, url.QueryEscape(projectName))
+	}
+	return api.EventLifecycle{
+		Action:    eventType,
+		Source:    u,
+		Context:   ctx,
+		Requestor: requestor,
+	}
+}


### PR DESCRIPTION
* Created, Deleted, Updated, Retrieved, Pushed, Refreshed, and Secret Created events for Images
* CRUD for Image aliases

* I noticed `imageAliasDeleted` was missing its swagger documentation, so I added it. 