### PR TITLE
Cluster and Cluster Member lifecycle events

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1726,6 +1726,9 @@ func clusterCertificatePut(d *Daemon, r *http.Request) response.Response {
 	d.endpoints.NetworkUpdateCert(cert)
 	d.gateway.NetworkUpdateCert(cert)
 
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(projectParam(r), lifecycle.ClusterCertificateUpdated.Event("certificate", requestor, nil))
+
 	return response.EmptySyncResponse
 }
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/request"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/util"
@@ -279,7 +280,7 @@ func clusterPut(d *Daemon, r *http.Request) response.Response {
 
 	// Disable clustering.
 	if !req.Enabled {
-		return clusterPutDisable(d)
+		return clusterPutDisable(d, r, req)
 	}
 
 	// Depending on the provided parameters we either bootstrap a brand new
@@ -696,7 +697,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 }
 
 // Disable clustering on a node.
-func clusterPutDisable(d *Daemon) response.Response {
+func clusterPutDisable(d *Daemon, r *http.Request, req api.ClusterPut) response.Response {
 	// Close the cluster database
 	err := d.cluster.Close()
 	if err != nil {
@@ -749,6 +750,9 @@ func clusterPutDisable(d *Daemon) response.Response {
 
 	// Remove the cluster flag from the agent
 	version.UserAgentFeatures(nil)
+
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(projectParam(r), lifecycle.ClusterDisabled.Event(req.ServerName, requestor, nil))
 
 	return response.EmptySyncResponse
 }

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1202,6 +1202,8 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
+	d.State().Events.SendLifecycle(projectParam(r), lifecycle.ClusterTokenCreated.Event("", op.Requestor(), nil))
+
 	return operations.OperationResponse(op)
 }
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1637,6 +1637,9 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 		logger.Warn("Failed to sync images")
 	}
 
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(projectParam(r), lifecycle.ClusterMemberRemoved.Event(name, requestor, nil))
+
 	return response.EmptySyncResponse
 }
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1475,6 +1475,9 @@ func clusterNodePost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(projectParam(r), lifecycle.ClusterMemberRenamed.Event(req.ServerName, requestor, log.Ctx{"old_name": name}))
+
 	return response.EmptySyncResponse
 }
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lxc/lxd/lxd/cluster"
 	clusterRequest "github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/lifecycle"
 	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/project"
@@ -301,6 +302,8 @@ func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) respons
 			d.stopClusterTasks()
 			return err
 		}
+
+		d.State().Events.SendLifecycle(projectParam(r), lifecycle.ClusterEnabled.Event(req.ServerName, op.Requestor(), nil))
 
 		return nil
 	}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1424,6 +1424,9 @@ func clusterNodePut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	requestor := request.CreateRequestor(r)
+	d.State().Events.SendLifecycle(projectParam(r), lifecycle.ClusterMemberUpdated.Event(name, requestor, nil))
+
 	return response.EmptySyncResponse
 }
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -18,7 +18,7 @@ import (
 
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
-	"github.com/lxc/lxd/lxd/cluster/request"
+	clusterRequest "github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/operations"
@@ -467,7 +467,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		// As ServerAddress field is required to be set it means that we're using the new join API
 		// introduced with the 'clustering_join' extension.
 		// Connect to ourselves to initialize storage pools and networks using the API.
-		localClient, err := lxd.ConnectLXDUnix(d.UnixSocket(), &lxd.ConnectionArgs{UserAgent: request.UserAgentJoiner})
+		localClient, err := lxd.ConnectLXDUnix(d.UnixSocket(), &lxd.ConnectionArgs{UserAgent: clusterRequest.UserAgentJoiner})
 		if err != nil {
 			return errors.Wrap(err, "Failed to connect to local LXD")
 		}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -681,6 +681,8 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 			logger.Warn("Failed to sync images")
 		}
 
+		d.State().Events.SendLifecycle(projectParam(r), lifecycle.ClusterMemberAdded.Event(req.ServerName, op.Requestor(), nil))
+
 		revert.Success()
 		return nil
 	}

--- a/lxd/lifecycle/cluster.go
+++ b/lxd/lifecycle/cluster.go
@@ -1,0 +1,32 @@
+package lifecycle
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/lxc/lxd/shared/api"
+)
+
+// ClusterAction represents a lifecycle event action for clusters.
+type ClusterAction string
+
+// All supported lifecycle events for clusters.
+const (
+	ClusterEnabled            = ClusterAction("enabled")
+	ClusterDisabled           = ClusterAction("disabled")
+	ClusterCertificateUpdated = ClusterAction("certificate-updated")
+	ClusterTokenCreated       = ClusterAction("token-created")
+)
+
+// Event creates the lifecycle event for an action on a cluster.
+func (a ClusterAction) Event(name string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+	eventType := fmt.Sprintf("cluster-%s", a)
+	u := fmt.Sprintf("/1.0/cluster/%s", url.PathEscape(name))
+
+	return api.EventLifecycle{
+		Action:    eventType,
+		Source:    u,
+		Context:   ctx,
+		Requestor: requestor,
+	}
+}

--- a/lxd/lifecycle/cluster_member.go
+++ b/lxd/lifecycle/cluster_member.go
@@ -1,0 +1,35 @@
+package lifecycle
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/lxc/lxd/shared/api"
+)
+
+// ClusterMemberAction represents a lifecycle event action for cluster members.
+type ClusterMemberAction string
+
+// All supported lifecycle events for cluster members.
+const (
+	ClusterMemberAdded   = ClusterMemberAction("added")
+	ClusterMemberRemoved = ClusterMemberAction("removed")
+	ClusterMemberUpdated = ClusterMemberAction("updated")
+	ClusterMemberRenamed = ClusterMemberAction("renamed")
+)
+
+// Event creates the lifecycle event for an action on a cluster member.
+func (a ClusterMemberAction) Event(name string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+	eventType := fmt.Sprintf("cluster-member-%s", a)
+	u := fmt.Sprintf("/1.0/cluster/members")
+	if name != "" {
+		u = fmt.Sprintf("%s/%s", u, url.PathEscape(name))
+	}
+
+	return api.EventLifecycle{
+		Action:    eventType,
+		Source:    u,
+		Context:   ctx,
+		Requestor: requestor,
+	}
+}


### PR DESCRIPTION
* A bit more specific events than just CRUD here.
* `Enabled` -- cluster initialized
* `Disabled` -- turning off clustering
* `CertificateUpdated` -- updating the certificates on all cluster members
* `TokenCreated` -- for creating join tokens

For members:
* Updated, Renamed and Removed, and Added
