### PR TITLE
Storage volume, snapshot, and backup lifecycle events

### DIFF
--- a/lxd/lifecycle/storage_volume.go
+++ b/lxd/lifecycle/storage_volume.go
@@ -1,0 +1,56 @@
+package lifecycle
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/lxc/lxd/lxd/operations"
+	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/shared/api"
+)
+
+// Internal copy of the volume interface.
+type volume interface {
+	Name() string
+	Pool() string
+}
+
+// StorageVolumeAction represents a lifecycle event action for storage volumes.
+type StorageVolumeAction string
+
+// All supported lifecycle events for storage volumes.
+const (
+	StorageVolumeCreated  = StorageVolumeAction("created")
+	StorageVolumeDeleted  = StorageVolumeAction("deleted")
+	StorageVolumeUpdated  = StorageVolumeAction("updated")
+	StorageVolumeRenamed  = StorageVolumeAction("renamed")
+	StorageVolumeRestored = StorageVolumeAction("restored")
+)
+
+// Event creates the lifecycle event for an action on a storage volume.
+func (a StorageVolumeAction) Event(v volume, volumeType string, projectName string, op *operations.Operation, ctx map[string]interface{}) api.EventLifecycle {
+	eventType := fmt.Sprintf("storage-volume-%s", a)
+	u := fmt.Sprintf("/1.0/storage-pools/%s/volumes", url.PathEscape(v.Pool()))
+	if volumeType != "" {
+		u = fmt.Sprintf("%s/%s", u, url.PathEscape(volumeType))
+	}
+	if v.Name() != "" {
+		u = fmt.Sprintf("%s/%s", u, url.PathEscape(v.Name()))
+	}
+
+	if projectName != project.Default {
+		u = fmt.Sprintf("%s?project=%s", u, url.QueryEscape(projectName))
+	}
+
+	var requestor *api.EventLifecycleRequestor
+	if op != nil {
+		requestor = op.Requestor()
+	}
+
+	return api.EventLifecycle{
+		Action:    eventType,
+		Source:    u,
+		Context:   ctx,
+		Requestor: requestor,
+	}
+}

--- a/lxd/lifecycle/storage_volume_backup.go
+++ b/lxd/lifecycle/storage_volume_backup.go
@@ -1,0 +1,42 @@
+package lifecycle
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+)
+
+// StorageVolumeBackupAction represents a lifecycle event action for storage volume backups.
+type StorageVolumeBackupAction string
+
+// All supported lifecycle events for storage volume backups.
+const (
+	StorageVolumeBackupCreated   = StorageVolumeBackupAction("created")
+	StorageVolumeBackupDeleted   = StorageVolumeBackupAction("deleted")
+	StorageVolumeBackupRetrieved = StorageVolumeBackupAction("retrieved")
+	StorageVolumeBackupRenamed   = StorageVolumeBackupAction("renamed")
+)
+
+// Event creates the lifecycle event for an action on a storage volume backup.
+func (a StorageVolumeBackupAction) Event(poolName string, volumeType string, volumeName string, projectName string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
+	eventType := fmt.Sprintf("storage-volume-backup-%s", a)
+	parentName, backupName, _ := shared.InstanceGetParentAndSnapshotName(volumeName)
+	u := fmt.Sprintf("/1.0/storage-pools/%s/volumes/%s/%s/backups", url.PathEscape(poolName), url.PathEscape(volumeType), url.PathEscape(parentName))
+	if backupName != "" {
+		u = fmt.Sprintf("%s/%s", u, backupName)
+	}
+
+	if projectName != project.Default {
+		u = fmt.Sprintf("%s?project=%s", u, url.QueryEscape(projectName))
+	}
+
+	return api.EventLifecycle{
+		Action:    eventType,
+		Source:    u,
+		Context:   ctx,
+		Requestor: requestor,
+	}
+}

--- a/lxd/lifecycle/storage_volume_snapshot.go
+++ b/lxd/lifecycle/storage_volume_snapshot.go
@@ -1,0 +1,48 @@
+package lifecycle
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/lxc/lxd/lxd/operations"
+	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+)
+
+// StorageVolumeSnapshotAction represents a lifecycle event action for storage volume snapshots.
+type StorageVolumeSnapshotAction string
+
+// All supported lifecycle events for storage volume snapshots.
+const (
+	StorageVolumeSnapshotCreated = StorageVolumeSnapshotAction("created")
+	StorageVolumeSnapshotDeleted = StorageVolumeSnapshotAction("deleted")
+	StorageVolumeSnapshotUpdated = StorageVolumeSnapshotAction("updated")
+	StorageVolumeSnapshotRenamed = StorageVolumeSnapshotAction("renamed")
+)
+
+// Event creates the lifecycle event for an action on a storage volume snapshot.
+func (a StorageVolumeSnapshotAction) Event(v volume, volumeType string, projectName string, op *operations.Operation, ctx map[string]interface{}) api.EventLifecycle {
+	eventType := fmt.Sprintf("storage-volume-snapshot-%s", a)
+	parentName, snapshotName, _ := shared.InstanceGetParentAndSnapshotName(v.Name())
+	u := fmt.Sprintf("/1.0/storage-pools/%s/volumes/%s/%s/snapshots", url.PathEscape(v.Pool()), url.PathEscape(volumeType), url.PathEscape(parentName))
+	if snapshotName != "" {
+		u = fmt.Sprintf("%s/%s", u, snapshotName)
+	}
+
+	if projectName != project.Default {
+		u = fmt.Sprintf("%s?project=%s", u, url.QueryEscape(projectName))
+	}
+
+	var requestor *api.EventLifecycleRequestor
+	if op != nil {
+		requestor = op.Requestor()
+	}
+
+	return api.EventLifecycle{
+		Action:    eventType,
+		Source:    u,
+		Context:   ctx,
+		Requestor: requestor,
+	}
+}

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -181,7 +181,7 @@ func OperationCreate(s *state.State, projectName string, opClass OperationClass,
 
 	// Set requestor if request was provided.
 	if r != nil {
-		op.requestor = request.CreateRequestor(r)
+		op.SetRequestor(r)
 	}
 
 	operationsLock.Lock()
@@ -206,6 +206,11 @@ func OperationCreate(s *state.State, projectName string, opClass OperationClass,
 // SetEventServer allows injection of event server.
 func (op *Operation) SetEventServer(events *events.Server) {
 	op.events = events
+}
+
+// SetRequestor sets a requestor for this operation from an http.Request.
+func (op *Operation) SetRequestor(r *http.Request) {
+	op.requestor = request.CreateRequestor(r)
 }
 
 // Requestor returns the initial requestor for this operation.

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3490,6 +3490,8 @@ func (b *lxdBackend) DeleteCustomVolumeSnapshot(projectName, volName string, op 
 		return err
 	}
 
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeSnapshotDeleted.Event(vol, string(vol.Type()), projectName, op, nil))
+
 	return nil
 }
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3577,6 +3577,8 @@ func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotNa
 		return err
 	}
 
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeRestored.Event(vol, string(vol.Type()), projectName, op, log.Ctx{"snapshot": snapshotName}))
+
 	return nil
 }
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3435,6 +3435,8 @@ func (b *lxdBackend) RenameCustomVolumeSnapshot(projectName, volName string, new
 		return err
 	}
 
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeSnapshotRenamed.Event(vol, string(vol.Type()), projectName, op, log.Ctx{"old_name": oldSnapshotName}))
+
 	return nil
 }
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/lxd/lifecycle"
 	"github.com/lxc/lxd/lxd/locking"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
@@ -2513,6 +2514,8 @@ func (b *lxdBackend) CreateCustomVolume(projectName string, volName string, desc
 		return err
 	}
 
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeCreated.Event(vol, string(vol.Type()), projectName, op, log.Ctx{"type": vol.Type()}))
+
 	revertDB = false
 	return nil
 }
@@ -2664,6 +2667,8 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 		if err != nil {
 			return err
 		}
+
+		b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeCreated.Event(vol, string(vol.Type()), projectName, op, log.Ctx{"type": vol.Type()}))
 
 		revertDBVolumes = nil
 		return nil
@@ -2875,6 +2880,8 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io
 		conn.Close()
 		return err
 	}
+
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeCreated.Event(vol, string(vol.Type()), projectName, op, log.Ctx{"type": vol.Type()}))
 
 	revertDBVolumes = nil
 	return nil
@@ -3887,6 +3894,8 @@ func (b *lxdBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData
 	if volPostHook != nil {
 		return fmt.Errorf("Custom volume restore doesn't support post hooks")
 	}
+
+	b.state.Events.SendLifecycle(srcBackup.Project, lifecycle.StorageVolumeCreated.Event(vol, string(vol.Type()), srcBackup.Project, op, log.Ctx{"type": vol.Type()}))
 
 	revert.Success()
 	return nil

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2990,6 +2990,9 @@ func (b *lxdBackend) RenameCustomVolume(projectName string, volName string, newV
 		return err
 	}
 
+	vol = b.newVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), newVolStorageName, nil)
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeRenamed.Event(vol, string(vol.Type()), projectName, op, log.Ctx{"old_name": volName}))
+
 	revert.Success()
 	return nil
 }

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3386,6 +3386,8 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 		return err
 	}
 
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeSnapshotCreated.Event(vol, string(vol.Type()), projectName, op, log.Ctx{"type": vol.Type()}))
+
 	revertDB = false
 	return nil
 }

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2469,7 +2469,11 @@ func (b *lxdBackend) updateVolumeDescriptionOnly(project string, volName string,
 	// Validate config.
 	vol := b.newVolume(drivers.VolumeType(curVol.Type), contentType, volName, newConfig)
 
-	b.state.Events.SendLifecycle(project, lifecycle.StorageVolumeUpdated.Event(vol, string(vol.Type()), project, op, nil))
+	if !vol.IsSnapshot() {
+		b.state.Events.SendLifecycle(project, lifecycle.StorageVolumeUpdated.Event(vol, string(vol.Type()), project, op, nil))
+	} else {
+		b.state.Events.SendLifecycle(project, lifecycle.StorageVolumeSnapshotUpdated.Event(vol, string(vol.Type()), project, op, nil))
+	}
 
 	return nil
 }
@@ -3169,6 +3173,9 @@ func (b *lxdBackend) UpdateCustomVolumeSnapshot(projectName string, volName stri
 			return err
 		}
 	}
+
+	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentType(curVol.ContentType), curVol.Name, curVol.Config)
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeSnapshotUpdated.Event(vol, string(vol.Type()), projectName, op, nil))
 
 	return nil
 }

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2421,6 +2421,8 @@ func (b *lxdBackend) DeleteImage(fingerprint string, op *operations.Operation) e
 		return err
 	}
 
+	b.state.Events.SendLifecycle(project.Default, lifecycle.StorageVolumeDeleted.Event(vol, string(vol.Type()), project.Default, op, nil))
+
 	return nil
 }
 
@@ -3238,6 +3240,8 @@ func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *
 	if err != nil {
 		return err
 	}
+
+	b.state.Events.SendLifecycle(projectName, lifecycle.StorageVolumeDeleted.Event(vol, string(vol.Type()), projectName, op, nil))
 
 	return nil
 }

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -98,6 +98,11 @@ func (v Volume) Name() string {
 	return v.name
 }
 
+// Pool returns the volume's pool name.
+func (v Volume) Pool() string {
+	return v.pool
+}
+
 // Config returns the volumes (unexpanded) config.
 func (v Volume) Config() map[string]string {
 	return v.config

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -591,6 +591,8 @@ func storagePoolVolumeTypeCustomBackupPost(d *Daemon, r *http.Request) response.
 			return err
 		}
 
+		d.State().Events.SendLifecycle(projectName, lifecycle.StorageVolumeBackupRenamed.Event(poolName, volumeTypeName, volumeName, projectName, op.Requestor(), log.Ctx{"old_name": backupName}))
+
 		return nil
 	}
 

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/lxc/lxd/lxd/backup"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/lifecycle"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/response"
@@ -17,6 +18,7 @@ import (
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/version"
 	"github.com/pkg/errors"
 )
@@ -381,6 +383,8 @@ func storagePoolVolumeTypeCustomBackupsPost(d *Daemon, r *http.Request) response
 		if err != nil {
 			return errors.Wrap(err, "Create volume backup")
 		}
+
+		d.State().Events.SendLifecycle(projectName, lifecycle.StorageVolumeBackupCreated.Event(poolName, volumeTypeName, volumeName, projectName, op.Requestor(), log.Ctx{"type": volumeTypeName}))
 
 		return nil
 	}

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -687,6 +687,8 @@ func storagePoolVolumeTypeCustomBackupDelete(d *Daemon, r *http.Request) respons
 			return err
 		}
 
+		d.State().Events.SendLifecycle(projectName, lifecycle.StorageVolumeBackupDeleted.Event(poolName, volumeTypeName, volumeName, projectName, op.Requestor(), nil))
+
 		return nil
 	}
 

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lxc/lxd/lxd/lifecycle"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/request"
 	"github.com/lxc/lxd/lxd/response"
 	storagePools "github.com/lxc/lxd/lxd/storage"
 	"github.com/lxc/lxd/lxd/util"
@@ -777,6 +778,8 @@ func storagePoolVolumeTypeCustomBackupExportGet(d *Daemon, r *http.Request) resp
 	ent := response.FileResponseEntry{
 		Path: shared.VarPath("backups", "custom", poolName, project.StorageVolume(projectName, fullName)),
 	}
+
+	d.State().Events.SendLifecycle(projectName, lifecycle.StorageVolumeBackupRetrieved.Event(poolName, volumeTypeName, volumeName, projectName, request.CreateRequestor(r), nil))
 
 	return response.FileResponse(r, []response.FileResponseEntry{ent}, nil, false)
 }

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -723,7 +723,7 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 		return response.BadRequest(err)
 	}
 
-	return doStoragePoolVolumeSnapshotUpdate(d, poolName, projectName, vol.Name, volumeType, req)
+	return doStoragePoolVolumeSnapshotUpdate(d, r, poolName, projectName, vol.Name, volumeType, req)
 }
 
 // swagger:operation PATCH /1.0/storage-pools/{name}/volumes/{type}/{volume}/snapshots/{snapshot} storage storage_pool_volumes_type_snapshot_patch
@@ -835,10 +835,10 @@ func storagePoolVolumeSnapshotTypePatch(d *Daemon, r *http.Request) response.Res
 		return response.BadRequest(err)
 	}
 
-	return doStoragePoolVolumeSnapshotUpdate(d, poolName, projectName, vol.Name, volumeType, req)
+	return doStoragePoolVolumeSnapshotUpdate(d, r, poolName, projectName, vol.Name, volumeType, req)
 }
 
-func doStoragePoolVolumeSnapshotUpdate(d *Daemon, poolName string, projectName string, volName string, volumeType int, req api.StorageVolumeSnapshotPut) response.Response {
+func doStoragePoolVolumeSnapshotUpdate(d *Daemon, r *http.Request, poolName string, projectName string, volName string, volumeType int, req api.StorageVolumeSnapshotPut) response.Response {
 	expiry := time.Time{}
 	if req.ExpiresAt != nil {
 		expiry = *req.ExpiresAt
@@ -849,9 +849,13 @@ func doStoragePoolVolumeSnapshotUpdate(d *Daemon, poolName string, projectName s
 		return response.SmartError(err)
 	}
 
+	// Use an empty operation for this sync response to pass the requestor
+	op := &operations.Operation{}
+	op.SetRequestor(r)
+
 	// Update the database.
 	if volumeType == db.StoragePoolVolumeTypeCustom {
-		err = pool.UpdateCustomVolumeSnapshot(projectName, volName, req.Description, nil, expiry, nil)
+		err = pool.UpdateCustomVolumeSnapshot(projectName, volName, req.Description, nil, expiry, op)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -861,7 +865,7 @@ func doStoragePoolVolumeSnapshotUpdate(d *Daemon, poolName string, projectName s
 			return response.NotFound(err)
 		}
 
-		err = pool.UpdateInstanceSnapshot(inst, req.Description, nil, nil)
+		err = pool.UpdateInstanceSnapshot(inst, req.Description, nil, op)
 		if err != nil {
 			return response.SmartError(err)
 		}


### PR DESCRIPTION
This is a long one :)

* Added SetRequestor to allow setting the requestor on an operation. I mainly used this with empty operations to pass around the requestor easily for both sync and async operations.

* Nil operation parameters replaced with empty structs that contain the requestor

* Created a `VolumeInterface` file that is basically a copy of all the signatures for `drivers/volume.go`. I used this to reduce the number of parameters I was passing around, because there are a lot for volumes. Open to renaming suggestions other than just `VolumeInterface` :)

* Basic CRUD Volume events -- the context mentions the type of volume.

* I tried to limit the changes to `storage/backend_lxd`, but this wasn't an option for backups as they aren't handled by `backend_lxd`.