### PR TITLE
Support refreshing custom storage volume copies

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -444,6 +444,9 @@ type StoragePoolVolumeCopyArgs struct {
 
 	// API extension: storage_api_volume_snapshots
 	VolumeOnly bool
+
+	// API extension: custom_volume_refresh
+	Refresh bool
 }
 
 // The StoragePoolVolumeMoveArgs struct is used to pass additional options

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -388,6 +388,10 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 		return nil, fmt.Errorf("The target server is missing the required \"storage_api_volume_snapshots\" API extension")
 	}
 
+	if args != nil && args.Refresh && !r.HasExtension("custom_volume_refresh") {
+		return nil, fmt.Errorf("The target server is missing the required \"custom_volume_refresh\" API extension")
+	}
+
 	req := api.StorageVolumesPost{
 		Name: args.Name,
 		Type: volume.Type,

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -400,7 +400,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 			Type:       "copy",
 			Pool:       sourcePool,
 			VolumeOnly: args.VolumeOnly,
-			Fresh:      args.Refresh,
+			Refresh:    args.Refresh,
 		},
 	}
 	req.Config = volume.Config

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -396,6 +396,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 			Type:       "copy",
 			Pool:       sourcePool,
 			VolumeOnly: args.VolumeOnly,
+			Fresh:      args.Fresh
 		},
 	}
 	req.Config = volume.Config

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -400,7 +400,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 			Type:       "copy",
 			Pool:       sourcePool,
 			VolumeOnly: args.VolumeOnly,
-			Fresh:      args.Fresh
+			Fresh:      args.Refresh
 		},
 	}
 	req.Config = volume.Config

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -400,7 +400,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 			Type:       "copy",
 			Pool:       sourcePool,
 			VolumeOnly: args.VolumeOnly,
-			Fresh:      args.Refresh
+			Fresh:      args.Refresh,
 		},
 	}
 	req.Config = volume.Config

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -438,6 +438,7 @@ func (c *cmdStorageVolumeCopy) Run(cmd *cobra.Command, args []string) error {
 		args.Name = dstVolName
 		args.Mode = mode
 		args.VolumeOnly = c.flagVolumeOnly
+		args.Refresh = c.flagRefresh
 
 		if isSnapshot {
 			srcVol.Name = srcVolName

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -315,7 +315,7 @@ type cmdStorageVolumeCopy struct {
 
 	flagMode          string
 	flagVolumeOnly    bool
-	flagFresh         bool
+	flagRefresh       bool
 	flagTargetProject string
 }
 
@@ -331,7 +331,7 @@ func (c *cmdStorageVolumeCopy) Command() *cobra.Command {
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVar(&c.flagVolumeOnly, "volume-only", false, i18n.G("Copy the volume without its snapshots"))
 	cmd.Flags().StringVar(&c.flagTargetProject, "target-project", "", i18n.G("Copy to a project different from the source")+"``")
-	cmd.Flags().BoolVar(&c.flagFresh, "refresh", false, i18n.G("Refresh and update the existing storage volume copies"))
+	cmd.Flags().BoolVar(&c.flagRefresh, "refresh", false, i18n.G("Refresh and update the existing storage volume copies"))
 	cmd.RunE = c.Run
 
 	return cmd

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -315,6 +315,7 @@ type cmdStorageVolumeCopy struct {
 
 	flagMode          string
 	flagVolumeOnly    bool
+	flagFresh         bool
 	flagTargetProject string
 }
 
@@ -330,7 +331,7 @@ func (c *cmdStorageVolumeCopy) Command() *cobra.Command {
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVar(&c.flagVolumeOnly, "volume-only", false, i18n.G("Copy the volume without its snapshots"))
 	cmd.Flags().StringVar(&c.flagTargetProject, "target-project", "", i18n.G("Copy to a project different from the source")+"``")
-	cmd.Flags().BoolVar(&c.flagVolumeOnly, "refresh", false, i18n.G("Refresh and update the existing storage volume copies"))
+	cmd.Flags().BoolVar(&c.flagFresh, "refresh", false, i18n.G("Refresh and update the existing storage volume copies"))
 	cmd.RunE = c.Run
 
 	return cmd

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -330,6 +330,7 @@ func (c *cmdStorageVolumeCopy) Command() *cobra.Command {
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVar(&c.flagVolumeOnly, "volume-only", false, i18n.G("Copy the volume without its snapshots"))
 	cmd.Flags().StringVar(&c.flagTargetProject, "target-project", "", i18n.G("Copy to a project different from the source")+"``")
+	cmd.Flags().BoolVar(&c.flagVolumeOnly, "refresh", false, i18n.G("Refresh and update the existing storage volume copies"))
 	cmd.RunE = c.Run
 
 	return cmd

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -525,7 +525,9 @@ func storagePoolVolumesTypePost(d *Daemon, r *http.Request) response.Response {
 			return response.SmartError(err)
 		}
 
-		return response.Conflict(fmt.Errorf("Volume by that name already exists"))
+		if req.Refresh == false {
+			return response.Conflict(fmt.Errorf("Volume by that name already exists"))
+		}
 	}
 
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {

--- a/shared/api/storage_pool_volume.go
+++ b/shared/api/storage_pool_volume.go
@@ -185,6 +185,12 @@ type StorageVolumeSource struct {
 	// API extension: storage_api_volume_snapshots
 	VolumeOnly bool `json:"volume_only" yaml:"volume_only"`
 
+	// Whether existing copies should be refreshed (for copy and migration)
+	// Example: false
+	//
+	// API extension: custom_volume_refresh
+	Refresh bool `json:"refresh" yaml:"refresh"`
+
 	// Source project name
 	// Example: foo
 	//

--- a/shared/api/storage_pool_volume.go
+++ b/shared/api/storage_pool_volume.go
@@ -60,6 +60,12 @@ type StorageVolumePost struct {
 	//
 	// API extension: storage_api_remote_volume_snapshots
 	VolumeOnly bool `json:"volume_only" yaml:"volume_only"`
+
+	// Whether existing copies should be refreshed (for copy)
+	// Example: false
+	//
+	// API extension: custom_volume_refresh
+	Refresh bool `json:"refresh" yaml:"refresh"`
 }
 
 // StorageVolumePostTarget represents the migration target host and operation
@@ -185,7 +191,7 @@ type StorageVolumeSource struct {
 	// API extension: storage_api_volume_snapshots
 	VolumeOnly bool `json:"volume_only" yaml:"volume_only"`
 
-	// Whether existing copies should be refreshed (for copy and migration)
+	// Whether existing copies should be refreshed (for copy)
 	// Example: false
 	//
 	// API extension: custom_volume_refresh

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -274,6 +274,7 @@ var APIExtensions = []string{
 	"server_trusted_proxy",
 	"clustering_update_cert",
 	"storage_api_project",
+	"custom_volume_refresh",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Add support to refresh/overwrite existing custom storage volume copies for storage volume copy operations.

Resolves #7873

Signed-off-by: Ricky Yu lijierickyyu@gmail.com