### PR TITLE
Client: Only retry remote operation on a different URL if the last attempt failed to connect

### DIFF
--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -177,7 +177,7 @@ func (r *ProtocolLXD) tryCreateContainer(req api.ContainersPost, urls []string) 
 	// Forward targetOp to remote op
 	go func() {
 		success := false
-		errors := map[string]error{}
+		var errors []remoteOperationResult
 		for _, serverURL := range urls {
 			if operation == "" {
 				req.Source.Server = serverURL
@@ -187,7 +187,7 @@ func (r *ProtocolLXD) tryCreateContainer(req api.ContainersPost, urls []string) 
 
 			op, err := r.CreateContainer(req)
 			if err != nil {
-				errors[serverURL] = err
+				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 
@@ -199,7 +199,7 @@ func (r *ProtocolLXD) tryCreateContainer(req api.ContainersPost, urls []string) 
 
 			err = rop.targetOp.Wait()
 			if err != nil {
-				errors[serverURL] = err
+				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 
@@ -535,13 +535,13 @@ func (r *ProtocolLXD) tryMigrateContainer(source InstanceServer, name string, re
 	// Forward targetOp to remote op
 	go func() {
 		success := false
-		errors := map[string]error{}
+		var errors []remoteOperationResult
 		for _, serverURL := range urls {
 			req.Target.Operation = fmt.Sprintf("%s/1.0/operations/%s", serverURL, url.PathEscape(operation))
 
 			op, err := source.MigrateContainer(name, req)
 			if err != nil {
-				errors[serverURL] = err
+				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 
@@ -553,7 +553,7 @@ func (r *ProtocolLXD) tryMigrateContainer(source InstanceServer, name string, re
 
 			err = rop.targetOp.Wait()
 			if err != nil {
-				errors[serverURL] = err
+				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 
@@ -1201,13 +1201,13 @@ func (r *ProtocolLXD) tryMigrateContainerSnapshot(source InstanceServer, contain
 	// Forward targetOp to remote op
 	go func() {
 		success := false
-		errors := map[string]error{}
+		var errors []remoteOperationResult
 		for _, serverURL := range urls {
 			req.Target.Operation = fmt.Sprintf("%s/1.0/operations/%s", serverURL, url.PathEscape(operation))
 
 			op, err := source.MigrateContainerSnapshot(containerName, name, req)
 			if err != nil {
-				errors[serverURL] = err
+				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 
@@ -1219,7 +1219,7 @@ func (r *ProtocolLXD) tryMigrateContainerSnapshot(source InstanceServer, contain
 
 			err = rop.targetOp.Wait()
 			if err != nil {
-				errors[serverURL] = err
+				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 

--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -200,7 +200,12 @@ func (r *ProtocolLXD) tryCreateContainer(req api.ContainersPost, urls []string) 
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
-				continue
+
+				if shared.IsConnectionError(err) {
+					continue
+				}
+
+				break
 			}
 
 			success = true
@@ -554,7 +559,12 @@ func (r *ProtocolLXD) tryMigrateContainer(source InstanceServer, name string, re
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
-				continue
+
+				if shared.IsConnectionError(err) {
+					continue
+				}
+
+				break
 			}
 
 			success = true
@@ -1220,7 +1230,12 @@ func (r *ProtocolLXD) tryMigrateContainerSnapshot(source InstanceServer, contain
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
-				continue
+
+				if shared.IsConnectionError(err) {
+					continue
+				}
+
+				break
 			}
 
 			success = true

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -600,7 +600,12 @@ func (r *ProtocolLXD) tryCopyImage(req api.ImagesPost, urls []string) (RemoteOpe
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
-				continue
+
+				if shared.IsConnectionError(err) {
+					continue
+				}
+
+				break
 			}
 
 			success = true

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -579,13 +579,13 @@ func (r *ProtocolLXD) tryCopyImage(req api.ImagesPost, urls []string) (RemoteOpe
 	// Forward targetOp to remote op
 	go func() {
 		success := false
-		errors := map[string]error{}
+		var errors []remoteOperationResult
 		for _, serverURL := range urls {
 			req.Source.Server = serverURL
 
 			op, err := r.CreateImage(req, nil)
 			if err != nil {
-				errors[serverURL] = err
+				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 
@@ -599,7 +599,7 @@ func (r *ProtocolLXD) tryCopyImage(req api.ImagesPost, urls []string) (RemoteOpe
 
 			err = rop.targetOp.Wait()
 			if err != nil {
-				errors[serverURL] = err
+				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -265,7 +265,7 @@ func (r *ProtocolLXD) tryCreateInstance(req api.InstancesPost, urls []string, op
 	// Forward targetOp to remote op
 	go func() {
 		success := false
-		errors := map[string]error{}
+		var errors []remoteOperationResult
 		for _, serverURL := range urls {
 			if operation == "" {
 				req.Source.Server = serverURL
@@ -275,7 +275,7 @@ func (r *ProtocolLXD) tryCreateInstance(req api.InstancesPost, urls []string, op
 
 			op, err := r.CreateInstance(req)
 			if err != nil {
-				errors[serverURL] = err
+				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 
@@ -289,7 +289,7 @@ func (r *ProtocolLXD) tryCreateInstance(req api.InstancesPost, urls []string, op
 
 			err = rop.targetOp.Wait()
 			if err != nil {
-				errors[serverURL] = err
+				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 
@@ -641,13 +641,13 @@ func (r *ProtocolLXD) tryMigrateInstance(source InstanceServer, name string, req
 	// Forward targetOp to remote op
 	go func() {
 		success := false
-		errors := map[string]error{}
+		var errors []remoteOperationResult
 		for _, serverURL := range urls {
 			req.Target.Operation = fmt.Sprintf("%s/1.0/operations/%s", serverURL, url.PathEscape(operation))
 
 			op, err := source.MigrateInstance(name, req)
 			if err != nil {
-				errors[serverURL] = err
+				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 
@@ -659,7 +659,7 @@ func (r *ProtocolLXD) tryMigrateInstance(source InstanceServer, name string, req
 
 			err = rop.targetOp.Wait()
 			if err != nil {
-				errors[serverURL] = err
+				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 
@@ -1415,13 +1415,13 @@ func (r *ProtocolLXD) tryMigrateInstanceSnapshot(source InstanceServer, instance
 	// Forward targetOp to remote op
 	go func() {
 		success := false
-		errors := map[string]error{}
+		var errors []remoteOperationResult
 		for _, serverURL := range urls {
 			req.Target.Operation = fmt.Sprintf("%s/1.0/operations/%s", serverURL, url.PathEscape(operation))
 
 			op, err := source.MigrateInstanceSnapshot(instanceName, name, req)
 			if err != nil {
-				errors[serverURL] = err
+				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 
@@ -1433,7 +1433,7 @@ func (r *ProtocolLXD) tryMigrateInstanceSnapshot(source InstanceServer, instance
 
 			err = rop.targetOp.Wait()
 			if err != nil {
-				errors[serverURL] = err
+				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -290,7 +290,12 @@ func (r *ProtocolLXD) tryCreateInstance(req api.InstancesPost, urls []string, op
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
-				continue
+
+				if shared.IsConnectionError(err) {
+					continue
+				}
+
+				break
 			}
 
 			success = true
@@ -660,7 +665,12 @@ func (r *ProtocolLXD) tryMigrateInstance(source InstanceServer, name string, req
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
-				continue
+
+				if shared.IsConnectionError(err) {
+					continue
+				}
+
+				break
 			}
 
 			success = true
@@ -1434,7 +1444,12 @@ func (r *ProtocolLXD) tryMigrateInstanceSnapshot(source InstanceServer, instance
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
-				continue
+
+				if shared.IsConnectionError(err) {
+					continue
+				}
+
+				break
 			}
 
 			success = true

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -283,14 +283,14 @@ func (r *ProtocolLXD) tryMigrateStoragePoolVolume(source InstanceServer, pool st
 	// Forward targetOp to remote op
 	go func() {
 		success := false
-		errors := map[string]error{}
+		var errors []remoteOperationResult
 		for _, serverURL := range urls {
 			req.Target.Operation = fmt.Sprintf("%s/1.0/operations/%s", serverURL, url.PathEscape(operation))
 
 			// Send the request
 			top, err := source.MigrateStoragePoolVolume(pool, req)
 			if err != nil {
-				errors[serverURL] = err
+				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 
@@ -305,7 +305,7 @@ func (r *ProtocolLXD) tryMigrateStoragePoolVolume(source InstanceServer, pool st
 
 			err = rop.targetOp.Wait()
 			if err != nil {
-				errors[serverURL] = err
+				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 
@@ -337,7 +337,7 @@ func (r *ProtocolLXD) tryCreateStoragePoolVolume(pool string, req api.StorageVol
 	// Forward targetOp to remote op
 	go func() {
 		success := false
-		errors := map[string]error{}
+		var errors []remoteOperationResult
 		for _, serverURL := range urls {
 			req.Source.Operation = fmt.Sprintf("%s/1.0/operations/%s", serverURL, url.PathEscape(operation))
 
@@ -345,7 +345,7 @@ func (r *ProtocolLXD) tryCreateStoragePoolVolume(pool string, req api.StorageVol
 			path := fmt.Sprintf("/storage-pools/%s/volumes/%s", url.PathEscape(pool), url.PathEscape(req.Type))
 			top, _, err := r.queryOperation("POST", path, req, "")
 			if err != nil {
-				errors[serverURL] = err
+				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 
@@ -360,7 +360,7 @@ func (r *ProtocolLXD) tryCreateStoragePoolVolume(pool string, req api.StorageVol
 
 			err = rop.targetOp.Wait()
 			if err != nil {
-				errors[serverURL] = err
+				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
 			}
 

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/cancel"
 	"github.com/lxc/lxd/shared/ioprogress"
@@ -306,7 +307,12 @@ func (r *ProtocolLXD) tryMigrateStoragePoolVolume(source InstanceServer, pool st
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
-				continue
+
+				if shared.IsConnectionError(err) {
+					continue
+				}
+
+				break
 			}
 
 			success = true
@@ -361,7 +367,12 @@ func (r *ProtocolLXD) tryCreateStoragePoolVolume(pool string, req api.StorageVol
 			err = rop.targetOp.Wait()
 			if err != nil {
 				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
-				continue
+
+				if shared.IsConnectionError(err) {
+					continue
+				}
+
+				break
 			}
 
 			success = true

--- a/lxd/cluster/notify.go
+++ b/lxd/cluster/notify.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -109,12 +108,11 @@ func NewNotifier(state *state.State, networkCert *shared.CertInfo, serverCert *s
 		// TODO: aggregate all errors?
 		for i, err := range errs {
 			if err != nil {
-				// FIXME: unfortunately the LXD client currently does not
-				//        provide a way to differentiate between errors
-				if isClientConnectionError(err) && policy == NotifyAlive {
+				if shared.IsConnectionError(err) && policy == NotifyAlive {
 					logger.Warnf("Could not notify node %s", peers[i])
 					continue
 				}
+
 				return err
 			}
 		}
@@ -122,12 +120,4 @@ func NewNotifier(state *state.State, networkCert *shared.CertInfo, serverCert *s
 	}
 
 	return notifier, nil
-}
-
-// Return true if the given error is due to the LXD Go client not being able to
-// connect to the target LXD node.
-func isClientConnectionError(err error) bool {
-	// FIXME: unfortunately the LXD client currently does not
-	//        provide a way to differentiate between errors
-	return strings.Contains(err.Error(), "Unable to connect to")
 }

--- a/shared/network.go
+++ b/shared/network.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,7 +18,12 @@ import (
 	"github.com/lxc/lxd/shared/logger"
 )
 
-func RFC3493Dialer(network, address string) (net.Conn, error) {
+// connectErrorPrefix used as prefix to error returned from RFC3493Dialer.
+const connectErrorPrefix = "Unable to connect to"
+
+// RFC3493Dialer connects to the specified server and returns the connection.
+// If the connection cannot be established then an error with the connectErrorPrefix is returned.
+func RFC3493Dialer(network string, address string) (net.Conn, error) {
 	host, port, err := net.SplitHostPort(address)
 	if err != nil {
 		return nil, err
@@ -42,7 +48,14 @@ func RFC3493Dialer(network, address string) (net.Conn, error) {
 		return c, err
 	}
 
-	return nil, fmt.Errorf("Unable to connect to: " + address)
+	return nil, fmt.Errorf("%s: %s", connectErrorPrefix, address)
+}
+
+// IsConnectionError returns true if the given error is due to the dialer not being able to connect to the target
+// LXD server.
+func IsConnectionError(err error) bool {
+	// FIXME: unfortunately the LXD client currently does not provide a way to differentiate between errors.
+	return strings.Contains(err.Error(), connectErrorPrefix)
 }
 
 // InitTLSConfig returns a tls.Config populated with default encryption

--- a/shared/network.go
+++ b/shared/network.go
@@ -27,17 +27,21 @@ func RFC3493Dialer(network, address string) (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	for _, a := range addrs {
 		c, err := net.DialTimeout(network, net.JoinHostPort(a, port), 10*time.Second)
 		if err != nil {
 			continue
 		}
+
 		if tc, ok := c.(*net.TCPConn); ok {
 			tc.SetKeepAlive(true)
 			tc.SetKeepAlivePeriod(3 * time.Second)
 		}
+
 		return c, err
 	}
+
 	return nil, fmt.Errorf("Unable to connect to: " + address)
 }
 


### PR DESCRIPTION
Don't try next address if the initial operation creation succeeds, but then the actual operation fails.

This suggests that the error is internal to the server and retrying the same operation just on a different address for the same target can potentially exacerbate the problem.

In one example #8900 the instance copy to a remote target node failed on the target due to insufficient pool size.
This error was successfully being returned to the client, but because it subsequently retried, and the original operation was not cleaned up, it caused a hang.

There was no reason to retry as this could not have succeeded on a different address.

Also updates the error returned when multiple errors do occur so they are listed in order rather than randomly.

Fixes #8900