### PR TITLE
VM: Return Error status code if QEMU process running but QMP socket isn't responsive

### DIFF
--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -636,6 +636,21 @@ func (d *common) isRunningStatusCode(statusCode api.StatusCode) bool {
 	return statusCode != api.Error && statusCode != api.Stopped
 }
 
+// isStartableStatusCode returns an error if the status code means the instance cannot be started currently.
+func (d *common) isStartableStatusCode(statusCode api.StatusCode) error {
+	if d.isRunningStatusCode(statusCode) {
+		return fmt.Errorf("The instance is already running")
+	}
+
+	// If the instance process exists but is crashed, don't allow starting until its been cleaned up, as it
+	// would likely fail to start anyway or leave the old process untracked.
+	if statusCode == api.Error {
+		return fmt.Errorf("The instance cannot be started as in %s status", statusCode)
+	}
+
+	return nil
+}
+
 // startupSnapshot triggers a snapshot if configured.
 func (d *common) startupSnapshot(inst instance.Instance) error {
 	schedule := strings.ToLower(d.expandedConfig["snapshots.schedule"])

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2326,10 +2326,11 @@ func (d *lxc) Start(stateful bool) error {
 	d.logger.Debug("Start started", log.Ctx{"stateful": stateful})
 	defer d.logger.Debug("Start finished", log.Ctx{"stateful": stateful})
 
-	// Check that we're not already running before creating an operation lock, so if the instance is in the
+	// Check that we are startable before creating an operation lock, so if the instance is in the
 	// process of stopping we don't prevent the stop hooks from running due to our start operation lock.
-	if d.IsRunning() {
-		return fmt.Errorf("The instance is already running")
+	err := d.isStartableStatusCode(d.statusCode())
+	if err != nil {
+		return err
 	}
 
 	var ctxMap log.Ctx

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -881,10 +881,11 @@ func (d *qemu) Start(stateful bool) error {
 	d.logger.Debug("Start started", log.Ctx{"stateful": stateful})
 	defer d.logger.Debug("Start finished", log.Ctx{"stateful": stateful})
 
-	// Check that we're not already running before creating an operation lock, so if the instance is in the
+	// Check that we are startable before creating an operation lock, so if the instance is in the
 	// process of stopping we don't prevent the stop hooks from running due to our start operation lock.
-	if d.IsRunning() {
-		return fmt.Errorf("The instance is already running")
+	err := d.isStartableStatusCode(d.statusCode())
+	if err != nil {
+		return err
 	}
 
 	// Check for stateful.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5314,6 +5314,13 @@ func (d *qemu) statusCode() api.StatusCode {
 	status, err := monitor.Status()
 	if err != nil {
 		if err == qmp.ErrMonitorDisconnect {
+			// If cannot connect to monitor, but qemu process in pid file still exists, then likely qemu
+			// has crashed/hung and this instance is in an error state.
+			pid, _ := d.pid()
+			if pid > 0 {
+				return api.Error
+			}
+
 			return api.Stopped
 		}
 


### PR DESCRIPTION
Also prevent trying to start instances that are in Error state to avoid writing over active processes PID file causing to be untracked.

Fixes #8958