### PR TITLE
VM: Allow force stop to kill QEMU process if in Error status

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2730,7 +2730,12 @@ func (d *lxc) Shutdown(timeout time.Duration) error {
 	defer d.logger.Debug("Shutdown finished", log.Ctx{"timeout": timeout})
 
 	// Must be run prior to creating the operation lock.
-	if !d.IsRunning() {
+	statusCode := d.statusCode()
+	if !d.isRunningStatusCode(statusCode) {
+		if statusCode == api.Error {
+			return fmt.Errorf("The instance cannot be cleanly shutdown as in %s status", statusCode)
+		}
+
 		return fmt.Errorf("The instance is already stopped")
 	}
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2832,7 +2832,7 @@ func (d *lxc) onStopNS(args map[string]string) error {
 	}
 
 	// Create/pick up operation, but don't complete it as we leave operation running for the onStop hook below.
-	_, err := d.onStopOperationSetup(target)
+	_, _, err := d.onStopOperationSetup(target)
 	if err != nil {
 		return err
 	}
@@ -2855,7 +2855,7 @@ func (d *lxc) onStop(args map[string]string) error {
 	}
 
 	// Create/pick up operation.
-	op, err := d.onStopOperationSetup(target)
+	op, instanceInitiated, err := d.onStopOperationSetup(target)
 	if err != nil {
 		return err
 	}
@@ -2927,7 +2927,7 @@ func (d *lxc) onStop(args map[string]string) error {
 		}
 
 		// Log and emit lifecycle if not user triggered
-		if op == nil {
+		if instanceInitiated {
 			ctxMap := log.Ctx{
 				"action":    target,
 				"created":   d.creationDate,

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3094,8 +3094,8 @@ func (d *lxc) Unfreeze() error {
 	return err
 }
 
-// Get lxc container state, with 1 second timeout
-// If we don't get a reply, assume the lxc monitor is hung
+// Get lxc container state, with 1 second timeout.
+// If we don't get a reply, assume the lxc monitor is unresponsive.
 func (d *lxc) getLxcState() (liblxc.State, error) {
 	if d.IsSnapshot() {
 		return liblxc.StateMap["STOPPED"], nil
@@ -3121,7 +3121,7 @@ func (d *lxc) getLxcState() (liblxc.State, error) {
 	case state := <-monitor:
 		return state, nil
 	case <-time.After(5 * time.Second):
-		return liblxc.StateMap["FROZEN"], fmt.Errorf("Monitor is hung")
+		return liblxc.StateMap["FROZEN"], fmt.Errorf("Monitor is unresponsive")
 	}
 }
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -575,7 +575,7 @@ func (d *qemu) onStop(target string) error {
 	defer d.logger.Debug("onStop hook finished", log.Ctx{"target": target})
 
 	// Create/pick up operation.
-	op, err := d.onStopOperationSetup(target)
+	op, instanceInitiated, err := d.onStopOperationSetup(target)
 	if err != nil {
 		return err
 	}
@@ -647,7 +647,7 @@ func (d *qemu) onStop(target string) error {
 		}
 	}
 
-	if op == nil {
+	if instanceInitiated {
 		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceShutdown.Event(d, nil))
 	}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5322,7 +5322,7 @@ func (d *qemu) statusCode() api.StatusCode {
 	monitor, err := qmp.Connect(d.monitorPath(), qemuSerialChardevName, d.getMonitorEventHandler())
 	if err != nil {
 		// If cannot connect to monitor, but qemu process in pid file still exists, then likely qemu
-		// has crashed/hung and this instance is in an error state.
+		// is unresponsive and this instance is in an error state.
 		pid, _ := d.pid()
 		if pid > 0 {
 			return api.Error
@@ -5335,8 +5335,8 @@ func (d *qemu) statusCode() api.StatusCode {
 	status, err := monitor.Status()
 	if err != nil {
 		if err == qmp.ErrMonitorDisconnect {
-			// If cannot connect to monitor, but qemu process in pid file still exists, then likely qemu
-			// has crashed/hung and this instance is in an error state.
+			// If cannot connect to monitor, but qemu process in pid file still exists, then likely
+			// qemu is unresponsive and this instance is in an error state.
 			pid, _ := d.pid()
 			if pid > 0 {
 				return api.Error

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5352,6 +5352,8 @@ func (d *qemu) statusCode() api.StatusCode {
 		return api.Running
 	} else if status == "paused" {
 		return api.Frozen
+	} else if status == "internal-error" {
+		return api.Error
 	}
 
 	return api.Stopped

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -661,7 +661,12 @@ func (d *qemu) Shutdown(timeout time.Duration) error {
 	defer d.logger.Debug("Shutdown finished", log.Ctx{"timeout": timeout})
 
 	// Must be run prior to creating the operation lock.
-	if !d.IsRunning() {
+	statusCode := d.statusCode()
+	if !d.isRunningStatusCode(statusCode) {
+		if statusCode == api.Error {
+			return fmt.Errorf("The instance cannot be cleanly shutdown as in %s status", statusCode)
+		}
+
 		return fmt.Errorf("The instance is already stopped")
 	}
 


### PR DESCRIPTION
Also fix shutdown lifecycle events for all instance types which was broken for self-initiated shutdowns in https://github.com/lxc/lxd/commit/69ed7f0e091a6652a527667f215e8404bf3b7a93

Also handles "internal-error" from QEMU QMP status request when KVM has crashed.

Behaviour:

```
lxc launch images:ubuntu/focal v1 --vm
lxc ls v1
+------+---------+---------------------+-------------------------------------------------+-----------------+-----------+
| NAME |  STATE  |        IPV4         |                      IPV6                       |      TYPE       | SNAPSHOTS |
+------+---------+---------------------+-------------------------------------------------+-----------------+-----------+
| v1   | RUNNING | 10.98.30.5 (enp5s0) | fd42:f402:8623:5b6b:216:3eff:fe82:72f2 (enp5s0) | VIRTUAL-MACHINE | 0         |
+------+---------+---------------------+-------------------------------------------------+-----------------+-----------+

# Simulate QEMU problem by removing QMP socket file.
sudo rm /var/log/lxd/v1/qemu.monitor
# Reload LXD to clear QMP connection cache

lxc ls v1
+------+-------+------+------+-----------------+-----------+
| NAME | STATE | IPV4 | IPV6 |      TYPE       | SNAPSHOTS |
+------+-------+------+------+-----------------+-----------+
| v1   | ERROR |      |      | VIRTUAL-MACHINE | 0         |
+------+-------+------+------+-----------------+-----------+

mount | grep v1
zfs/virtual-machines/v1 on /var/lib/lxd/storage-pools/zfs/virtual-machines/v1 type zfs (rw,xattr,posixacl)
zfs/virtual-machines/v1 on /var/lib/lxd/storage-pools/zfs/virtual-machines/v1/config.mount type zfs (ro,xattr,posixacl)

lxc start v1
Error: The instance cannot be started as in Error status

lxc stop v1
Error: The instance cannot be cleanly shutdown as in Error status

lxc stop v1 -f
# OK

mount | grep v1
# Nothing

lxc stop v1
Error: The instance is already stopped

lxc start v1
lxc ls v1
+------+---------+---------------------+-------------------------------------------------+-----------------+-----------+
| NAME |  STATE  |        IPV4         |                      IPV6                       |      TYPE       | SNAPSHOTS |
+------+---------+---------------------+-------------------------------------------------+-----------------+-----------+
| v1   | RUNNING | 10.98.30.5 (enp5s0) | fd42:f402:8623:5b6b:216:3eff:fe82:72f2 (enp5s0) | VIRTUAL-MACHINE | 0         |
+------+---------+---------------------+-------------------------------------------------+-----------------+-----------+
```

Fixes #8958

Associated tests: https://github.com/lxc/lxc-ci/pull/339