### PR TITLE
NIC: Apply managed network validation checks when bridged NIC parent is set to a managed network

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -178,6 +178,15 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 			if err != nil {
 				return err
 			}
+		} else {
+			// Check that static IPs are defined when using IP filtering on an unmanaged bridge.
+			if shared.IsTrue(d.config["security.ipv4_filtering"]) && d.config["ipv4.address"] == "" {
+				return fmt.Errorf("IPv4 filtering requires a manually specified ipv4.address when using an unmanaged parent bridge")
+			}
+
+			if shared.IsTrue(d.config["security.ipv6_filtering"]) && d.config["ipv6.address"] == "" {
+				return fmt.Errorf("IPv6 filtering requires a manually specified ipv6.address when using an unmanaged parent bridge")
+			}
 		}
 	}
 

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -92,14 +92,15 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 		if d.config["ipv4.address"] != "" {
 			dhcpv4Subnet := n.DHCPv4Subnet()
 
-			// Check that DHCPv4 is enabled on parent network (needed to use static assigned IPs).
-			if dhcpv4Subnet == nil {
+			// Check that DHCPv4 is enabled on parent network (needed to use static assigned IPs) when
+			// IP filtering isn't enabled (if it is we allow the use of static IPs for this purpose).
+			if dhcpv4Subnet == nil && !shared.IsTrue(d.config["security.ipv4_filtering"]) {
 				return fmt.Errorf(`Cannot specify "ipv4.address" when DHCP is disabled on network %q`, n.Name())
 			}
 
 			// Check the static IP supplied is valid for the linked network. It should be part of the
 			// network's subnet, but not necessarily part of the dynamic allocation ranges.
-			if !dhcpalloc.DHCPValidIP(dhcpv4Subnet, nil, net.ParseIP(d.config["ipv4.address"])) {
+			if dhcpv4Subnet != nil && !dhcpalloc.DHCPValidIP(dhcpv4Subnet, nil, net.ParseIP(d.config["ipv4.address"])) {
 				return fmt.Errorf("Device IP address %q not within network %q subnet", d.config["ipv4.address"], n.Name())
 			}
 		}
@@ -107,14 +108,15 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 		if d.config["ipv6.address"] != "" {
 			dhcpv6Subnet := n.DHCPv6Subnet()
 
-			// Check that DHCPv6 is enabled on parent network (needed to use static assigned IPs).
-			if dhcpv6Subnet == nil || !shared.IsTrue(netConfig["ipv6.dhcp.stateful"]) {
+			// Check that DHCPv6 is enabled on parent network (needed to use static assigned IPs) when
+			// IP filtering isn't enabled (if it is we allow the use of static IPs for this purpose).
+			if (dhcpv6Subnet == nil || !shared.IsTrue(netConfig["ipv6.dhcp.stateful"])) && !shared.IsTrue(d.config["security.ipv6_filtering"]) {
 				return fmt.Errorf(`Cannot specify "ipv6.address" when DHCP or "ipv6.dhcp.stateful" are disabled on network %q`, n.Name())
 			}
 
 			// Check the static IP supplied is valid for the linked network. It should be part of the
 			// network's subnet, but not necessarily part of the dynamic allocation ranges.
-			if !dhcpalloc.DHCPValidIP(dhcpv6Subnet, nil, net.ParseIP(d.config["ipv6.address"])) {
+			if dhcpv6Subnet != nil && !dhcpalloc.DHCPValidIP(dhcpv6Subnet, nil, net.ParseIP(d.config["ipv6.address"])) {
 				return fmt.Errorf("Device IP address %q not within network %q subnet", d.config["ipv6.address"], n.Name())
 			}
 		}

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -77,24 +77,8 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 		"vlan",
 	}
 
-	// Check that if network proeperty is set that conflicting keys are not present.
-	if d.config["network"] != "" {
-		requiredFields = append(requiredFields, "network")
-
-		bannedKeys := []string{"nictype", "parent", "mtu", "maas.subnet.ipv4", "maas.subnet.ipv6"}
-		for _, bannedKey := range bannedKeys {
-			if d.config[bannedKey] != "" {
-				return fmt.Errorf("Cannot use %q property in conjunction with %q property", bannedKey, "network")
-			}
-		}
-
-		// If network property is specified, lookup network settings and apply them to the device's config.
-		// project.Default is used here as bridge networks don't suppprt projects.
-		n, err := network.LoadByName(d.state, project.Default, d.config["network"])
-		if err != nil {
-			return errors.Wrapf(err, "Error loading network config for %q", d.config["network"])
-		}
-
+	// checkWithManagedNetwork validates the device's settings against the managed network.
+	checkWithManagedNetwork := func(n network.Network) error {
 		if n.Status() != api.NetworkStatusCreated {
 			return fmt.Errorf("Specified network is not fully created")
 		}
@@ -110,13 +94,13 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 
 			// Check that DHCPv4 is enabled on parent network (needed to use static assigned IPs).
 			if dhcpv4Subnet == nil {
-				return fmt.Errorf(`Cannot specify "ipv4.address" when DHCP is disabled on network %q`, d.config["network"])
+				return fmt.Errorf(`Cannot specify "ipv4.address" when DHCP is disabled on network %q`, n.Name())
 			}
 
 			// Check the static IP supplied is valid for the linked network. It should be part of the
 			// network's subnet, but not necessarily part of the dynamic allocation ranges.
 			if !dhcpalloc.DHCPValidIP(dhcpv4Subnet, nil, net.ParseIP(d.config["ipv4.address"])) {
-				return fmt.Errorf("Device IP address %q not within network %q subnet", d.config["ipv4.address"], d.config["network"])
+				return fmt.Errorf("Device IP address %q not within network %q subnet", d.config["ipv4.address"], n.Name())
 			}
 		}
 
@@ -125,15 +109,44 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 
 			// Check that DHCPv6 is enabled on parent network (needed to use static assigned IPs).
 			if dhcpv6Subnet == nil || !shared.IsTrue(netConfig["ipv6.dhcp.stateful"]) {
-				return fmt.Errorf(`Cannot specify "ipv6.address" when DHCP or "ipv6.dhcp.stateful" are disabled on network %q`, d.config["network"])
+				return fmt.Errorf(`Cannot specify "ipv6.address" when DHCP or "ipv6.dhcp.stateful" are disabled on network %q`, n.Name())
 			}
 
 			// Check the static IP supplied is valid for the linked network. It should be part of the
 			// network's subnet, but not necessarily part of the dynamic allocation ranges.
 			if !dhcpalloc.DHCPValidIP(dhcpv6Subnet, nil, net.ParseIP(d.config["ipv6.address"])) {
-				return fmt.Errorf("Device IP address %q not within network %q subnet", d.config["ipv6.address"], d.config["network"])
+				return fmt.Errorf("Device IP address %q not within network %q subnet", d.config["ipv6.address"], n.Name())
 			}
 		}
+
+		return nil
+	}
+
+	// Check that if network proeperty is set that conflicting keys are not present.
+	if d.config["network"] != "" {
+		requiredFields = append(requiredFields, "network")
+
+		bannedKeys := []string{"nictype", "parent", "mtu", "maas.subnet.ipv4", "maas.subnet.ipv6"}
+		for _, bannedKey := range bannedKeys {
+			if d.config[bannedKey] != "" {
+				return fmt.Errorf("Cannot use %q property in conjunction with %q property", bannedKey, "network")
+			}
+		}
+
+		// Load managed network. project.Default is used here as bridge networks don't support projects.
+		n, err := network.LoadByName(d.state, project.Default, d.config["network"])
+		if err != nil {
+			return errors.Wrapf(err, "Error loading network config for %q", d.config["network"])
+		}
+
+		// Validate NIC settings with managed network.
+		err = checkWithManagedNetwork(n)
+		if err != nil {
+			return err
+		}
+
+		// Apply network settings to NIC.
+		netConfig := n.Config()
 
 		// Link device to network bridge.
 		d.config["parent"] = d.config["network"]
@@ -153,6 +166,17 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 	} else {
 		// If no network property supplied, then parent property is required.
 		requiredFields = append(requiredFields, "parent")
+
+		// Check if parent is a managed network.
+		// project.Default is used here as bridge networks don't support projects.
+		n, _ := network.LoadByName(d.state, project.Default, d.config["parent"])
+		if n != nil {
+			// Validate NIC settings with managed network.
+			err := checkWithManagedNetwork(n)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	// Check that IP filtering isn't being used with VLAN filtering.

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -850,11 +850,9 @@ test_clustering_network() {
   ! LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net}" --target node2 || false
   LXD_DIR="${LXD_ONE_DIR}" lxc network show "${net}" | grep status: | grep -q Pending
 
-  # A container can't be started when associated with a pending network.
+  # A container can't be created when its NIC is associated with a pending network.
   LXD_DIR="${LXD_TWO_DIR}" ensure_import_testimage
-  LXD_DIR="${LXD_ONE_DIR}" lxc init --target node2 -n "${net}" testimage bar
-  ! LXD_DIR="${LXD_ONE_DIR}" lxc start bar || false
-  LXD_DIR="${LXD_ONE_DIR}" lxc delete bar
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc init --target node2 -n "${net}" testimage bar || false
   LXD_DIR="${LXD_ONE_DIR}" lxc image delete testimage
 
   # The bridge.external_interfaces config key is not legal for the final network creation

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -606,12 +606,12 @@ test_container_devices_nic_bridged_filtering() {
     done
   fi
 
-  # Enable IP filtering and check container won't start without manual IP assigned in LXD config.
-  lxc config device set "${ctPrefix}A" eth0 security.ipv4_filtering=true security.ipv6_filtering=true
-  ! lxc start "${ctPrefix}A" || false
-  lxc config device set "${ctPrefix}A" eth0 ipv4.address=192.0.2.2
-  ! lxc start "${ctPrefix}A" || false
-  lxc config device set "${ctPrefix}A" eth0 ipv6.address=2001:db8::2
+  # Check IP filtering cannot be enabled without manual IP assigned in LXD config.
+  ! lxc config device set "${ctPrefix}A" eth0 security.ipv4_filtering=true || false
+  lxc config device set "${ctPrefix}A" eth0 ipv4.address=192.0.2.2 security.ipv4_filtering=true
+  ! lxc config device set "${ctPrefix}A" eth0 security.ipv6_filtering=true || false
+    lxc config device set "${ctPrefix}A" eth0 ipv6.address=2001:db8::2 security.ipv6_filtering=true
+
   lxc start "${ctPrefix}A"
   lxc exec "${ctPrefix}A" -- ip a add 192.0.2.2/24 dev eth0
   lxc exec "${ctPrefix}A" -- ip a add 2001:db8::2/64 dev eth0


### PR DESCRIPTION
Also allow specifying static IPs when the managed parent network has DHCP disabled if IP filtering is enabled.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>