### PR TITLE
Warnings: Delete instance related warnings when instance deleted

### DIFF
--- a/lxd/db/entity.go
+++ b/lxd/db/entity.go
@@ -138,7 +138,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 		var instances []Instance
 
 		err = c.transaction(func(tx *ClusterTx) error {
-			instances, err = tx.GetInstances(InstanceFilter{})
+			instances, err = tx.GetInstances(*InstanceFilterAllInstances())
 			if err != nil {
 				return err
 			}
@@ -170,7 +170,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 		var instances []Instance
 
 		err = c.transaction(func(tx *ClusterTx) error {
-			instances, err = tx.GetInstances(InstanceFilter{})
+			instances, err = tx.GetInstances(*InstanceFilterAllInstances())
 			if err != nil {
 				return err
 			}

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -106,6 +106,11 @@ type InstanceFilter struct {
 	Type    instancetype.Type
 }
 
+// InstanceFilterAllInstances returns a predefined filter for returning all instances.
+func InstanceFilterAllInstances() *InstanceFilter {
+	return &InstanceFilter{Type: instancetype.Any}
+}
+
 // InstanceToArgs is a convenience to convert an Instance db struct into the legacy InstanceArgs.
 func InstanceToArgs(inst *Instance) InstanceArgs {
 	args := InstanceArgs{
@@ -335,7 +340,7 @@ func (c *Cluster) InstanceList(filter *InstanceFilter, instanceFunc func(inst In
 
 	// Default to listing all instances if no filter provided.
 	if filter == nil {
-		filter = &InstanceFilter{Type: instancetype.Any}
+		filter = InstanceFilterAllInstances()
 	}
 
 	// Retrieve required info from the database in single transaction for performance.

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -147,7 +147,7 @@ func TestInstanceList_ContainerWithSameNameInDifferentProjects(t *testing.T) {
 	_, err = tx.CreateInstance(c1p2)
 	require.NoError(t, err)
 
-	containers, err := tx.GetInstances(db.InstanceFilter{})
+	containers, err := tx.GetInstances(*db.InstanceFilterAllInstances())
 	require.NoError(t, err)
 
 	assert.Len(t, containers, 2)

--- a/lxd/db/warnings.go
+++ b/lxd/db/warnings.go
@@ -83,7 +83,7 @@ func (c *Cluster) UpsertWarning(nodeName string, projectName string, entityTypeC
 	// Validate
 	_, err := c.GetURIFromEntity(entityTypeCode, entityID)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to get URI for entity type code %d", entityTypeCode)
+		return errors.Wrapf(err, "Failed to get URI for entity ID %d with entity type code %d", entityID, entityTypeCode)
 	}
 
 	_, ok := WarningTypeNames[typeCode]

--- a/lxd/db/warnings.go
+++ b/lxd/db/warnings.go
@@ -14,6 +14,8 @@ import (
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	log "github.com/lxc/lxd/shared/log15"
+	"github.com/lxc/lxd/shared/logger"
 )
 
 // Warning is a value object holding db-related details about a warning.
@@ -463,7 +465,7 @@ func (w Warning) ToAPI(c *Cluster) (api.Warning, error) {
 
 	entity, err := c.GetURIFromEntity(w.EntityTypeCode, w.EntityID)
 	if err != nil {
-		return api.Warning{}, errors.Wrapf(err, "Failed to get URI for entity type code %d", w.EntityTypeCode)
+		logger.Warn("Failed to get entity URI for warning", log.Ctx{"ID": w.UUID, "entityID": w.EntityID, "entityTypeCode": w.EntityTypeCode, "err": err})
 	}
 
 	return api.Warning{

--- a/lxd/db/warnings.go
+++ b/lxd/db/warnings.go
@@ -459,6 +459,12 @@ func (c *ClusterTx) DeleteWarningsByStatus(status WarningStatus) error {
 	return nil
 }
 
+// DeleteWarningsByEntity deletes all warnings with the given entity type and entity ID.
+func (c *ClusterTx) DeleteWarningsByEntity(entityTypeCode int, entityID int) error {
+	_, err := c.tx.Exec(`DELETE FROM warnings WHERE entity_type_code = ? AND entity_id = ?`, entityTypeCode, entityID)
+	return err
+}
+
 // ToAPI returns a LXD API entry.
 func (w Warning) ToAPI(c *Cluster) (api.Warning, error) {
 	typeCode := WarningType(w.TypeCode)

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lxc/lxd/lxd/backup"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
+	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/query"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/device/nictype"
@@ -882,4 +883,16 @@ func (d *common) onStopOperationSetup(target string) (*operationlock.InstanceOpe
 	}
 
 	return op, instanceInitiated, nil
+}
+
+// warningsDelete deletes any persistent warnings for the instance.
+func (d *common) warningsDelete() error {
+	err := d.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
+		return tx.DeleteWarningsByEntity(dbCluster.TypeInstance, d.ID())
+	})
+	if err != nil {
+		return errors.Wrapf(err, "Failed deleting persistent warnings")
+	}
+
+	return nil
 }

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3549,6 +3549,12 @@ func (d *lxc) Delete(force bool) error {
 		return err
 	}
 
+	// Delete any persistent warnings for instance.
+	err := d.warningsDelete()
+	if err != nil {
+		return err
+	}
+
 	isImport := false
 	pool, err := storagePools.GetPoolByInstance(d.state, d)
 	if err != nil && errors.Cause(err) != db.ErrNoSuchObject {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4343,6 +4343,12 @@ func (d *qemu) Delete(force bool) error {
 		return fmt.Errorf("Instance is protected")
 	}
 
+	// Delete any persistent warnings for instance.
+	err := d.warningsDelete()
+	if err != nil {
+		return err
+	}
+
 	// Check if we're dealing with "lxd import".
 	// TODO consider lxd import detection for VMs.
 	isImport := false


### PR DESCRIPTION
Also:
- Add support for generating warnings for VMs (The use of `GetInstances()` didn't have the correct filter on it and was only considering containers).
- Don't make generating the entity URL an absolute requirement for displaying the persistent warnings (just log a warning on failure).