### PR TITLE
NIC: Add detection of duplicate bridged NIC MAC address assignments

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -200,16 +200,18 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 	// Check there isn't another NIC with the any of the same addresses specified on the same cluster member.
 	// Can only validate this when the instance is supplied (and not doing profile validation).
 	if d.inst != nil && (d.config["ipv4.address"] != "" || d.config["ipv6.address"] != "") {
-		err := d.state.Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+		filter := db.InstanceFilter{
+			Project: "",                // All projects.
+			Node:    d.inst.Location(), // Managed bridge networks have a per-server DHCP daemon.
+			Type:    instancetype.Any,
+		}
+
+		err := d.state.Cluster.InstanceList(&filter, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
 			// Get the instance's effective network project name.
 			instNetworkProject := project.NetworkProjectFromRecord(&p)
 
 			if instNetworkProject != project.Default {
 				return nil // Managed bridge networks can only exist in default project.
-			}
-
-			if inst.Node != d.inst.Location() {
-				return nil // Managed bridge networks have a DHCP server on each cluster member.
 			}
 
 			devices := db.ExpandInstanceDevices(deviceConfig.NewDevices(inst.Devices), profiles)

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -955,6 +955,11 @@ test_clustering_network() {
   LXD_DIR="${LXD_ONE_DIR}" lxc config device set c1 "${net}" ipv4.address=192.0.2.2
   LXD_DIR="${LXD_ONE_DIR}" lxc config device set c1 "${net}" ipv6.address=2001:db8::2
 
+  # Check duplicate MAC address assignment detection is working.
+  c1MAC=$(LXD_DIR="${LXD_ONE_DIR}" lxc config get c1 volatile."${net}".hwaddr)
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc config device set c2 "${net}" hwaddr="${c1MAC}" || false
+  LXD_DIR="${LXD_ONE_DIR}" lxc config device set c3 "${net}" hwaddr="${c1MAC}"
+
   # Cleanup instances and image.
   LXD_DIR="${LXD_ONE_DIR}" lxc delete -f c1 c2 c3
   LXD_DIR="${LXD_ONE_DIR}" lxc image delete testimage


### PR DESCRIPTION
Also improve performance of duplicate bridged NIC IP check in `validateConfig` by filtering for local instances at the DB level.

And adds tests for duplicate IP address assignment detection.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>