### PR TITLE
NIC: Add mutex to SRIOVFindFreeVirtualFunction to prevent concurrent start races

### DIFF
--- a/lxd/network/network_utils_sriov.go
+++ b/lxd/network/network_utils_sriov.go
@@ -25,6 +25,9 @@ import (
 // sriovReservedDevicesMutex used to coordinate access for checking reserved devices.
 var sriovReservedDevicesMutex sync.Mutex
 
+// sriovFindFreeVirtualFunctionMutex used to coordinate access for finding free virtual functions.
+var sriovFindFreeVirtualFunctionMutex sync.Mutex
+
 // SRIOVGetHostDevicesInUse returns a map of host device names that have been used by devices in other instances
 // and networks on the local node. Used when selecting physical and SR-IOV VF devices to avoid conflicts.
 func SRIOVGetHostDevicesInUse(s *state.State) (map[string]struct{}, error) {
@@ -104,6 +107,9 @@ func SRIOVGetHostDevicesInUse(s *state.State) (map[string]struct{}, error) {
 // SRIOVFindFreeVirtualFunction looks on the specified parent device for an unused virtual function.
 // Returns the name of the interface and virtual function index ID if found, error if not.
 func SRIOVFindFreeVirtualFunction(s *state.State, parentDev string) (string, int, error) {
+	sriovFindFreeVirtualFunctionMutex.Lock()
+	defer sriovFindFreeVirtualFunctionMutex.Unlock()
+
 	reservedDevices, err := SRIOVGetHostDevicesInUse(s)
 	if err != nil {
 		return "", -1, errors.Wrapf(err, "Failed getting in use device list")


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>

Before (some instances were trying to use the same VF):

```
lxc init images:ubuntu/focal c1 -s zfs
lxc init images:ubuntu/focal c2 -s zfs
lxc init images:ubuntu/focal c3 -s zfs
lxc init images:ubuntu/focal c4 -s zfs
lxc init images:ubuntu/focal c5 -s zfs
lxc init images:ubuntu/focal c6 -s zfs

lxc config device add c1 eth0 nic nictype=sriov parent=enp1s0f0
lxc config device add c2 eth0 nic nictype=sriov parent=enp1s0f0
lxc config device add c3 eth0 nic nictype=sriov parent=enp1s0f0
lxc config device add c4 eth0 nic nictype=sriov parent=enp1s0f0
lxc config device add c5 eth0 nic nictype=sriov parent=enp1s0f0
lxc config device add c6 eth0 nic nictype=sriov parent=enp1s0f0

lxc start --all
Error: local: The following instances failed to update state:
 - Instance: c5: Failed preparing container for start: Failed to start device "eth0": open /sys/class/net/enp1s0f0v0/mtu: no such file or directory
 - Instance: c4: Failed preparing container for start: Failed to start device "eth0": open /sys/class/net/enp1s0f0v0/mtu: no such file or directory
```

After (all start OK):

```
lxc stop --all
reboot # To reset SR-IOV module status
lxc start --all
```