### PR TITLE
Info: Return supported storage driver info in /1.0

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1394,3 +1394,6 @@ This adds support for copy/move custom storage volumes between projects.
 # server\_instance\_driver\_operational
 This modifies the `driver` output for the `/1.0` endpoint to only include drivers which are actually supported and
 operational on the server (as opposed to being included in LXD but not operational on the server).
+
+## server\_supported\_storage\_drivers
+This adds supported storage driver info to server environment info.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -4233,6 +4233,12 @@ definitions:
         example: dir | zfs
         type: string
         x-go-name: Storage
+      storage_supported_drivers:
+        description: List of supported storage drivers
+        items:
+          $ref: '#/definitions/ServerStorageDriverInfo'
+        type: array
+        x-go-name: StorageSupportedDrivers
       storage_version:
         description: List of active storage driver versions (separate by " | ")
         example: 1 | 0.8.4-1ubuntu11
@@ -4252,6 +4258,24 @@ definitions:
           core.trust_password: true
         type: object
         x-go-name: Config
+    type: object
+    x-go-package: github.com/lxc/lxd/shared/api
+  ServerStorageDriverInfo:
+    description: ServerStorageDriverInfo represents the read-only info about a storage
+      driver
+    properties:
+      Name:
+        description: Name of the driver
+        example: zfs
+        type: string
+      Remote:
+        description: Whether the driver has remote volumes
+        example: false
+        type: boolean
+      Version:
+        description: Version of the driver
+        example: 0.8.4-1ubuntu11
+        type: string
     type: object
     x-go-package: github.com/lxc/lxd/shared/api
   ServerUntrusted:

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -331,8 +331,8 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	drivers := readStoragePoolDriversCache()
-	for driver, version := range drivers {
+	supportedStorageDrivers, usedStorageDrivers := readStoragePoolDriversCache()
+	for driver, version := range usedStorageDrivers {
 		if env.Storage != "" {
 			env.Storage = env.Storage + " | " + driver
 		} else {
@@ -346,6 +346,8 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 			env.StorageVersion = version
 		}
 	}
+
+	env.StorageSupportedDrivers = supportedStorageDrivers
 
 	fullSrv := api.Server{ServerUntrusted: srv}
 	fullSrv.Environment = env

--- a/lxd/main_init_auto.go
+++ b/lxd/main_init_auto.go
@@ -14,13 +14,13 @@ import (
 	"github.com/lxc/lxd/shared/api"
 )
 
-func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServer) (*cmdInitData, error) {
+func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServer, server *api.Server) (*cmdInitData, error) {
 	// Quick checks.
 	if c.flagStorageBackend != "" && !shared.StringInSlice(c.flagStorageBackend, storageDrivers.AllDriverNames()) {
 		return nil, fmt.Errorf("The requested backend '%s' isn't supported by lxd init", c.flagStorageBackend)
 	}
 
-	if c.flagStorageBackend != "" && !shared.StringInSlice(c.flagStorageBackend, c.availableStorageDrivers(poolTypeAny)) {
+	if c.flagStorageBackend != "" && !shared.StringInSlice(c.flagStorageBackend, c.availableStorageDrivers(server.Environment.StorageSupportedDrivers, poolTypeAny)) {
 		return nil, fmt.Errorf("The requested backend '%s' isn't available on your system (missing tools)", c.flagStorageBackend)
 	}
 

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -28,7 +28,7 @@ import (
 	"github.com/lxc/lxd/shared/version"
 )
 
-func (c *cmdInit) RunInteractive(cmd *cobra.Command, args []string, d lxd.InstanceServer) (*cmdInitData, error) {
+func (c *cmdInit) RunInteractive(cmd *cobra.Command, args []string, d lxd.InstanceServer, server *api.Server) (*cmdInitData, error) {
 	// Initialize config
 	config := cmdInitData{}
 	config.Node.Config = map[string]interface{}{}
@@ -45,7 +45,7 @@ func (c *cmdInit) RunInteractive(cmd *cobra.Command, args []string, d lxd.Instan
 	}
 
 	// Clustering
-	err := c.askClustering(&config, d)
+	err := c.askClustering(&config, d, server)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (c *cmdInit) RunInteractive(cmd *cobra.Command, args []string, d lxd.Instan
 	// Ask all the other questions
 	if config.Cluster == nil || config.Cluster.ClusterAddress == "" {
 		// Storage
-		err = c.askStorage(&config, d)
+		err = c.askStorage(&config, d, server)
 		if err != nil {
 			return nil, err
 		}
@@ -71,7 +71,7 @@ func (c *cmdInit) RunInteractive(cmd *cobra.Command, args []string, d lxd.Instan
 		}
 
 		// Daemon config
-		err = c.askDaemon(&config, d)
+		err = c.askDaemon(&config, d, server)
 		if err != nil {
 			return nil, err
 		}
@@ -102,7 +102,7 @@ func (c *cmdInit) RunInteractive(cmd *cobra.Command, args []string, d lxd.Instan
 	return &config, nil
 }
 
-func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer) error {
+func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer, server *api.Server) error {
 	if cli.AskBool("Would you like to use LXD clustering? (yes/no) [default=no]: ", "no") {
 		config.Cluster = &initDataCluster{}
 		config.Cluster.Enabled = true
@@ -128,9 +128,8 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer) error
 				return fmt.Errorf("Invalid IP address or DNS name")
 			}
 
-			s, _, err := d.GetServer()
 			if err == nil {
-				if s.Config["cluster.https_address"] == address || s.Config["core.https_address"] == address {
+				if server.Config["cluster.https_address"] == address || server.Config["core.https_address"] == address {
 					// We already own the address, just move on.
 					return nil
 				}
@@ -522,17 +521,17 @@ func (c *cmdInit) askNetworking(config *cmdInitData, d lxd.InstanceServer) error
 	return nil
 }
 
-func (c *cmdInit) askStorage(config *cmdInitData, d lxd.InstanceServer) error {
+func (c *cmdInit) askStorage(config *cmdInitData, d lxd.InstanceServer, server *api.Server) error {
 	if config.Cluster != nil {
 		if cli.AskBool("Do you want to configure a new local storage pool? (yes/no) [default=yes]: ", "yes") {
-			err := c.askStoragePool(config, d, poolTypeLocal)
+			err := c.askStoragePool(config, d, server, poolTypeLocal)
 			if err != nil {
 				return err
 			}
 		}
 
 		if cli.AskBool("Do you want to configure a new remote storage pool? (yes/no) [default=no]: ", "no") {
-			err := c.askStoragePool(config, d, poolTypeRemote)
+			err := c.askStoragePool(config, d, server, poolTypeRemote)
 			if err != nil {
 				return err
 			}
@@ -545,12 +544,12 @@ func (c *cmdInit) askStorage(config *cmdInitData, d lxd.InstanceServer) error {
 		return nil
 	}
 
-	return c.askStoragePool(config, d, poolTypeAny)
+	return c.askStoragePool(config, d, server, poolTypeAny)
 }
 
-func (c *cmdInit) askStoragePool(config *cmdInitData, d lxd.InstanceServer, poolType poolType) error {
+func (c *cmdInit) askStoragePool(config *cmdInitData, d lxd.InstanceServer, server *api.Server, poolType poolType) error {
 	// Figure out the preferred storage driver
-	availableBackends := c.availableStorageDrivers(poolType)
+	availableBackends := c.availableStorageDrivers(server.Environment.StorageSupportedDrivers, poolType)
 
 	if len(availableBackends) == 0 {
 		if poolType != poolTypeAny {
@@ -752,7 +751,7 @@ your Linux distribution and run "lxd init" again afterwards.
 	return nil
 }
 
-func (c *cmdInit) askDaemon(config *cmdInitData, d lxd.InstanceServer) error {
+func (c *cmdInit) askDaemon(config *cmdInitData, d lxd.InstanceServer, server *api.Server) error {
 	// Detect lack of uid/gid
 	idmapset, err := idmap.DefaultIdmapSet("", "")
 	if (err != nil || len(idmapset.Idmap) == 0 || idmapset.Usable() != nil) && shared.RunningInUserNS() {
@@ -795,9 +794,8 @@ they otherwise would.
 		netPort := cli.AskInt(fmt.Sprintf("Port to bind LXD to [default=%d]: ", shared.DefaultPort), 1, 65535, fmt.Sprintf("%d", shared.DefaultPort), func(netPort int64) error {
 			address := util.CanonicalNetworkAddressFromAddressAndPort(netAddr, int(netPort))
 
-			s, _, err := d.GetServer()
 			if err == nil {
-				if s.Config["cluster.https_address"] == address || s.Config["core.https_address"] == address {
+				if server.Config["cluster.https_address"] == address || server.Config["core.https_address"] == address {
 					// We already own the address, just move on.
 					return nil
 				}

--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -105,6 +105,34 @@ type ServerEnvironment struct {
 	// List of active storage driver versions (separate by " | ")
 	// Example: 1 | 0.8.4-1ubuntu11
 	StorageVersion string `json:"storage_version" yaml:"storage_version"`
+
+	// List of supported storage drivers
+	StorageSupportedDrivers []ServerStorageDriverInfo `json:"storage_supported_drivers" yaml:"storage_supported_drivers"`
+}
+
+// ServerStorageDriverInfo represents the read-only info about a storage driver
+//
+// swagger:model
+//
+// API extension: server_supported_storage_drivers
+type ServerStorageDriverInfo struct {
+	// Name of the driver
+	// Example: zfs
+	//
+	// API extension: server_supported_storage_drivers
+	Name string
+
+	// Version of the driver
+	// Example: 0.8.4-1ubuntu11
+	//
+	// API extension: server_supported_storage_drivers
+	Version string
+
+	// Whether the driver has remote volumes
+	// Example: false
+	//
+	// API extension: server_supported_storage_drivers
+	Remote bool
 }
 
 // ServerPut represents the modifiable fields of a LXD server configuration

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -275,6 +275,7 @@ var APIExtensions = []string{
 	"clustering_update_cert",
 	"storage_api_project",
 	"server_instance_driver_operational",
+	"server_supported_storage_drivers",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
And update `lxd init` to use it rather than querying the storage layer directly from the client.

Includes #8990 (to avoid conflicts).

Fixes #5955