### PR TITLE
Lifecycles: Fix Created source urls. 

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1204,7 +1204,7 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
-	d.State().Events.SendLifecycle(projectParam(r), lifecycle.ClusterTokenCreated.Event("", op.Requestor(), nil))
+	d.State().Events.SendLifecycle(projectParam(r), lifecycle.ClusterTokenCreated.Event("members", op.Requestor(), nil))
 
 	return operations.OperationResponse(op)
 }

--- a/lxd/lifecycle/certificate.go
+++ b/lxd/lifecycle/certificate.go
@@ -21,10 +21,7 @@ const (
 func (a CertificateAction) Event(fingerprint string, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
 	eventType := fmt.Sprintf("certificate-%s", a)
 
-	u := fmt.Sprintf("/1.0/certificates")
-	if a != CertificateCreated {
-		u = fmt.Sprintf("%s/%s", u, url.PathEscape(fingerprint))
-	}
+	u := fmt.Sprintf("/1.0/certificates/%s", url.PathEscape(fingerprint))
 
 	return api.EventLifecycle{
 		Action:    eventType,

--- a/lxd/lifecycle/network_acl.go
+++ b/lxd/lifecycle/network_acl.go
@@ -29,14 +29,11 @@ const (
 func (a NetworkACLAction) Event(n networkACL, requestor *api.EventLifecycleRequestor, ctx map[string]interface{}) api.EventLifecycle {
 	eventType := fmt.Sprintf("network-acl-%s", a)
 
-	u := fmt.Sprintf("/1.0/network-acls")
-
-	if a != NetworkACLCreated {
-		u = fmt.Sprintf("%s/%s", u, url.PathEscape(n.Info().Name))
-	}
+	u := fmt.Sprintf("/1.0/network-acls/%s", url.PathEscape(n.Info().Name))
 	if n.Project() != project.Default {
 		u = fmt.Sprintf("%s?project=%s", u, url.QueryEscape(n.Project()))
 	}
+
 	return api.EventLifecycle{
 		Action:    eventType,
 		Source:    u,


### PR DESCRIPTION
I noticed I wasn't consistently omitting the ID from the lifecycle event when the event was a Created/POST event.

Also noticed CertificateTokenCreated had the wrong source entirely.