### PR TITLE
API: Wait until LXD fully started before applying API changes in doApi10UpdateTriggers

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -657,6 +657,9 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 }
 
 func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]string, nodeConfig *node.Config, clusterConfig *cluster.Config) error {
+	// Don't apply changes to settings until daemon is full started.
+	<-d.readyChan
+
 	s := d.State()
 
 	maasChanged := false


### PR DESCRIPTION
This should prevent a crash where tasks have not been initialised yet.

Fixes #9006

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>