### PR TITLE
Daemon: Remove duplicate VM monitor re-connection on start up

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1233,7 +1233,7 @@ func (d *Daemon) init() error {
 
 		go device.InotifyHandler(d.State())
 
-		// Register devices on running instances to receive events.
+		// Register devices on running instances to receive events and reconnect to VM monitor sockets.
 		// This should come after the event handler go routines have been started.
 		devicesRegister(d.State())
 
@@ -1403,9 +1403,6 @@ func (d *Daemon) Ready() error {
 
 	// Restore containers
 	instancesRestart(s)
-
-	// Start monitoring VMs again
-	vmMonitor(s)
 
 	// Re-balance in case things changed while LXD was down
 	deviceTaskBalance(s)

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -582,7 +582,10 @@ func deviceEventListener(s *state.State) {
 }
 
 // devicesRegister calls the Register() function on all supported devices so they receive events.
+// This also has the effect of actively reconnecting to any running VM monitor sockets.
 func devicesRegister(s *state.State) {
+	logger.Debug("Registering running instances")
+
 	instances, err := instance.LoadNodeAll(s, instancetype.Any)
 	if err != nil {
 		logger.Error("Problem loading instances list", log.Ctx{"err": err})

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -295,21 +295,6 @@ func instancesRestart(s *state.State) error {
 	return nil
 }
 
-func vmMonitor(s *state.State) error {
-	// Get all the instances
-	insts, err := instance.LoadNodeAll(s, instancetype.VM)
-	if err != nil {
-		return err
-	}
-
-	for _, inst := range insts {
-		// Retrieve running state, this will re-connect to QMP
-		inst.IsRunning()
-	}
-
-	return nil
-}
-
 type containerStopList []instance.Instance
 
 func (slice containerStopList) Len() int {


### PR DESCRIPTION
Doing this twice is unnecessary and inefficient.