### PR TITLE
VM: Introduce volatile.last_state.vsock_id key

### DIFF
--- a/doc/instances.md
+++ b/doc/instances.md
@@ -111,6 +111,7 @@ volatile.idmap.current                      | string    | -             | The id
 volatile.idmap.next                         | string    | -             | The idmap to use next time the instance starts
 volatile.last\_state.idmap                  | string    | -             | Serialized instance uid/gid map
 volatile.last\_state.power                  | string    | -             | Instance state as of last host shutdown
+volatile.last\_state.vsock\_id              | string    | -             | Instance vsock ID used as of last start
 volatile.uuid                               | string    | -             | Instance UUID
 volatile.\<name\>.apply\_quota              | string    | -             | Disk quota to be applied on next instance start
 volatile.\<name\>.ceph\_rbd                 | string    | -             | RBD device path for Ceph disk devices

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -239,15 +239,16 @@ var KnownInstanceConfigKeys = map[string]func(value string) error{
 	"raw.qemu":     validate.IsAny,
 	"raw.seccomp":  validate.IsAny,
 
-	"volatile.apply_template":   validate.IsAny,
-	"volatile.base_image":       validate.IsAny,
-	"volatile.last_state.idmap": validate.IsAny,
-	"volatile.last_state.power": validate.IsAny,
-	"volatile.idmap.base":       validate.IsAny,
-	"volatile.idmap.current":    validate.IsAny,
-	"volatile.idmap.next":       validate.IsAny,
-	"volatile.apply_quota":      validate.IsAny,
-	"volatile.uuid":             validate.Optional(validate.IsUUID),
+	"volatile.apply_template":      validate.IsAny,
+	"volatile.base_image":          validate.IsAny,
+	"volatile.last_state.idmap":    validate.IsAny,
+	"volatile.last_state.power":    validate.IsAny,
+	"volatile.idmap.base":          validate.IsAny,
+	"volatile.idmap.current":       validate.IsAny,
+	"volatile.idmap.next":          validate.IsAny,
+	"volatile.apply_quota":         validate.IsAny,
+	"volatile.uuid":                validate.Optional(validate.IsUUID),
+	"volatile.last_state.vsock_id": validate.Optional(validate.IsInt64),
 }
 
 // ConfigKeyChecker returns a function that will check whether or not


### PR DESCRIPTION
Set `volatile.last_state.vsock_id` on each VM start (if VM's DB ID has changed or if key is missing).

This will enable lxd-agent connections to still work after a running VM is recovered after removing its DB records (using future recovery tool) which will cause the instance DB record's ID to change.