### PR TITLE
Instance: Add clearLogDir argument to CreateInternal

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -820,7 +820,7 @@ func internalImport(d *Daemon, projectName string, req *internalImportPost, reco
 		Name:         backupConf.Container.Name,
 		Profiles:     backupConf.Container.Profiles,
 		Stateful:     backupConf.Container.Stateful,
-	}, revert)
+	}, true, revert)
 	if err != nil {
 		return response.SmartError(errors.Wrap(err, "Failed creating instance record"))
 	}
@@ -915,7 +915,7 @@ func internalImport(d *Daemon, projectName string, req *internalImportPost, reco
 			Name:         snap.Name,
 			Profiles:     snap.Profiles,
 			Stateful:     snap.Stateful,
-		}, revert)
+		}, true, revert)
 		if err != nil {
 			return response.SmartError(errors.Wrapf(err, "Failed creating instance snapshot record %q", snap.Name))
 		}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -33,7 +33,7 @@ func instanceCreateAsEmpty(d *Daemon, args db.InstanceArgs) (instance.Instance, 
 	defer revert.Fail()
 
 	// Create the instance record.
-	inst, err := instance.CreateInternal(d.State(), args, revert)
+	inst, err := instance.CreateInternal(d.State(), args, true, revert)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed creating instance record")
 	}
@@ -143,7 +143,7 @@ func instanceCreateFromImage(d *Daemon, r *http.Request, args db.InstanceArgs, h
 	args.BaseImage = hash
 
 	// Create the instance.
-	inst, err := instance.CreateInternal(s, args, revert)
+	inst, err := instance.CreateInternal(s, args, true, revert)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed creating instance record")
 	}
@@ -206,7 +206,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 	// If we are not in refresh mode, then create a new instance as we are in copy mode.
 	if !opts.refresh {
 		// Create the instance.
-		inst, err = instance.CreateInternal(s, opts.targetInstance, revert)
+		inst, err = instance.CreateInternal(s, opts.targetInstance, true, revert)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed creating instance record")
 		}
@@ -326,7 +326,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 			}
 
 			// Create the snapshots.
-			snapInst, err := instance.CreateInternal(s, snapInstArgs, revert)
+			snapInst, err := instance.CreateInternal(s, snapInstArgs, true, revert)
 			if err != nil {
 				return nil, errors.Wrapf(err, "Failed creating instance snapshot record %q", newSnapName)
 			}

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -553,7 +553,7 @@ func (d *common) snapshotCommon(inst instance.Instance, name string, expiry time
 	}
 
 	// Create the snapshot.
-	snap, err := instance.CreateInternal(d.state, args, revert)
+	snap, err := instance.CreateInternal(d.state, args, true, revert)
 	if err != nil {
 		return errors.Wrapf(err, "Failed creating instance snapshot record %q", name)
 	}

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -919,7 +919,7 @@ func ValidName(instanceName string, isSnapshot bool) error {
 // CreateInternal creates an instance record and storage volume record in the database and sets up devices.
 // Accepts a reverter that revert steps this function does will be added to. It is up to the caller to call the
 // revert's Fail() or Success() function as needed.
-func CreateInternal(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (Instance, error) {
+func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, revert *revert.Reverter) (Instance, error) {
 	// Check instance type requested is supported by this machine.
 	if _, supported := s.InstanceTypes[args.Type]; !supported {
 		return nil, fmt.Errorf("Instance type %q is not supported on this server", args.Type)
@@ -1120,7 +1120,9 @@ func CreateInternal(s *state.State, args db.InstanceArgs, revert *revert.Reverte
 	}
 
 	// Wipe any existing log for this instance name.
-	os.RemoveAll(inst.LogPath())
+	if clearLogDir {
+		os.RemoveAll(inst.LogPath())
+	}
 
 	return inst, nil
 }

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -30,7 +30,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesDefault() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.Nil(err)
 	defer c.Delete(true)
 
@@ -73,7 +73,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.Nil(err)
 	defer c.Delete(true)
 
@@ -104,7 +104,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesOverwriteDefaultNic() {
 	_, err := suite.d.State().Cluster.CreateNetwork(project.Default, "unknownbr0", "", db.NetworkTypeBridge, nil)
 	suite.Req.Nil(err)
 
-	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.Nil(err)
 
 	suite.True(c.IsPrivileged(), "This container should be privileged.")
@@ -139,7 +139,7 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 	suite.Req.Nil(err)
 
 	// Create the container
-	c, err := instance.CreateInternal(state, args, revert.New())
+	c, err := instance.CreateInternal(state, args, true, revert.New())
 	suite.Req.Nil(err)
 	defer c.Delete(true)
 
@@ -167,7 +167,7 @@ func (suite *containerTestSuite) TestContainer_Path_Regular() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.Nil(err)
 	defer c.Delete(true)
 
@@ -183,7 +183,7 @@ func (suite *containerTestSuite) TestContainer_LogPath() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.Nil(err)
 	defer c.Delete(true)
 
@@ -198,7 +198,7 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Privileged() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.Nil(err)
 
 	suite.Req.True(c.IsPrivileged(), "This container should be privileged.")
@@ -221,7 +221,7 @@ func (suite *containerTestSuite) TestContainer_AddRoutedNicValidation() {
 		Name: "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.NoError(err)
 
 	err = c.Update(db.InstanceArgs{
@@ -270,7 +270,7 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Unprivileged() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.Nil(err)
 
 	suite.Req.False(c.IsPrivileged(), "This container should be unprivileged.")
@@ -284,7 +284,7 @@ func (suite *containerTestSuite) TestContainer_Rename() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.Nil(err)
 	defer c.Delete(true)
 
@@ -299,7 +299,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
 		},
-	}, revert.New())
+	}, true, revert.New())
 	suite.Req.Nil(err)
 	defer c1.Delete(true)
 
@@ -309,7 +309,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
 		},
-	}, revert.New())
+	}, true, revert.New())
 	suite.Req.Nil(err)
 	defer c2.Delete(true)
 
@@ -340,7 +340,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 		Config: map[string]string{
 			"security.idmap.isolated": "false",
 		},
-	}, revert.New())
+	}, true, revert.New())
 	suite.Req.Nil(err)
 	defer c1.Delete(true)
 
@@ -350,7 +350,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
 		},
-	}, revert.New())
+	}, true, revert.New())
 	suite.Req.Nil(err)
 	defer c2.Delete(true)
 
@@ -382,7 +382,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_raw() {
 			"security.idmap.isolated": "false",
 			"raw.idmap":               "both 1000 1000",
 		},
-	}, revert.New())
+	}, true, revert.New())
 	suite.Req.Nil(err)
 	defer c1.Delete(true)
 
@@ -420,7 +420,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_maxed() {
 			Config: map[string]string{
 				"security.idmap.isolated": "true",
 			},
-		}, revert.New())
+		}, true, revert.New())
 
 		/* we should fail if there are no ids left */
 		if i != 6 {

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -301,7 +301,7 @@ func createFromMigration(d *Daemon, r *http.Request, projectName string, req *ap
 		// Note: At this stage we do not yet know if snapshots are going to be received and so we cannot
 		// create their DB records. This will be done if needed in the migrationSink.Do() function called
 		// as part of the operation below.
-		inst, err = instance.CreateInternal(d.State(), args, revert)
+		inst, err = instance.CreateInternal(d.State(), args, true, revert)
 		if err != nil {
 			return response.InternalError(errors.Wrap(err, "Failed creating instance record"))
 		}

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -921,7 +921,7 @@ func (c *migrationSink) Do(state *state.State, revert *revert.Reverter, migrateO
 				_, err := instance.LoadByProjectAndName(state, args.Instance.Project(), snapArgs.Name)
 				if err != nil {
 					// Create the snapshot as it doesn't seem to exist.
-					_, err := instance.CreateInternal(state, snapArgs, revert)
+					_, err := instance.CreateInternal(state, snapArgs, true, revert)
 					if err != nil {
 						return errors.Wrapf(err, "Failed creating instance snapshot record %q", snapArgs.Name)
 					}

--- a/lxd/snapshot_common_test.go
+++ b/lxd/snapshot_common_test.go
@@ -18,7 +18,7 @@ func (suite *containerTestSuite) TestSnapshotScheduling() {
 		Name:      "hal9000",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
 	suite.Req.Nil(err)
 	suite.Equal(true, snapshotIsScheduledNow("* * * * *",
 		int64(c.ID())),


### PR DESCRIPTION
This will be used (set to `false`) in the future recovery tool to avoid clearing the log dir of the instances being recovered.

This will allow running instance config and socket files to be maintained after recovery.

But for now keep all existing usage of this function passing `true` to get the old behaviour.