### PR TITLE
VM: Renames volatile.last_state.vsock_id to volatile.vsock_id

### DIFF
--- a/doc/instances.md
+++ b/doc/instances.md
@@ -111,7 +111,7 @@ volatile.idmap.current                      | string    | -             | The id
 volatile.idmap.next                         | string    | -             | The idmap to use next time the instance starts
 volatile.last\_state.idmap                  | string    | -             | Serialized instance uid/gid map
 volatile.last\_state.power                  | string    | -             | Instance state as of last host shutdown
-volatile.last\_state.vsock\_id              | string    | -             | Instance vsock ID used as of last start
+volatile.vsock\_id                          | string    | -             | Instance vsock ID used as of last start
 volatile.uuid                               | string    | -             | Instance UUID
 volatile.\<name\>.apply\_quota              | string    | -             | Disk quota to be applied on next instance start
 volatile.\<name\>.ceph\_rbd                 | string    | -             | RBD device path for Ceph disk devices

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -371,8 +371,8 @@ func (d *qemu) getAgentClient() (*http.Client, error) {
 	// But if vsock ID from last VM start is present in volatie, then use that.
 	// This allows a running VM to be recovered after DB record deletion and that agent connection still work
 	// after the VM's instance ID has changed.
-	if d.localConfig["volatile.last_state.vsock_id"] != "" {
-		volatileVsockID, err := strconv.Atoi(d.localConfig["volatile.last_state.vsock_id"])
+	if d.localConfig["volatile.vsock_id"] != "" {
+		volatileVsockID, err := strconv.Atoi(d.localConfig["volatile.vsock_id"])
 		if err == nil {
 			vsockID = volatileVsockID
 		}
@@ -1021,10 +1021,10 @@ func (d *qemu) Start(stateful bool) error {
 	volatileSet := make(map[string]string)
 
 	// Update vsock ID in volatile if needed (for recovery).
-	oldVsockID := d.localConfig["volatile.last_state.vsock_id"]
+	oldVsockID := d.localConfig["volatile.vsock_id"]
 	newVsockID := strconv.Itoa(d.vsockID())
 	if oldVsockID != newVsockID {
-		volatileSet["volatile.last_state.vsock_id"] = newVsockID
+		volatileSet["volatile.vsock_id"] = newVsockID
 	}
 
 	// Generate UUID if not present.

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -239,16 +239,16 @@ var KnownInstanceConfigKeys = map[string]func(value string) error{
 	"raw.qemu":     validate.IsAny,
 	"raw.seccomp":  validate.IsAny,
 
-	"volatile.apply_template":      validate.IsAny,
-	"volatile.base_image":          validate.IsAny,
-	"volatile.last_state.idmap":    validate.IsAny,
-	"volatile.last_state.power":    validate.IsAny,
-	"volatile.idmap.base":          validate.IsAny,
-	"volatile.idmap.current":       validate.IsAny,
-	"volatile.idmap.next":          validate.IsAny,
-	"volatile.apply_quota":         validate.IsAny,
-	"volatile.uuid":                validate.Optional(validate.IsUUID),
-	"volatile.last_state.vsock_id": validate.Optional(validate.IsInt64),
+	"volatile.apply_template":   validate.IsAny,
+	"volatile.base_image":       validate.IsAny,
+	"volatile.last_state.idmap": validate.IsAny,
+	"volatile.last_state.power": validate.IsAny,
+	"volatile.idmap.base":       validate.IsAny,
+	"volatile.idmap.current":    validate.IsAny,
+	"volatile.idmap.next":       validate.IsAny,
+	"volatile.apply_quota":      validate.IsAny,
+	"volatile.uuid":             validate.Optional(validate.IsUUID),
+	"volatile.vsock_id":         validate.Optional(validate.IsInt64),
 }
 
 // ConfigKeyChecker returns a function that will check whether or not


### PR DESCRIPTION
As per conversation: https://github.com/lxc/lxd/pull/9010#issuecomment-877470119