### PR TITLE
Generator: Generate delete-by statements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ update-schema:
 	cd lxd/db/generate && go build -o lxd-generate -tags "$(TAG_SQLITE3)" $(DEBUG) && cd -
 	mv lxd/db/generate/lxd-generate $(GOPATH)/bin
 	go generate ./...
+	gofmt -s -w ./lxd/db/
 	@echo "Code generation completed"
 
 .PHONY: update-api

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -746,7 +746,7 @@ func projectDelete(d *Daemon, r *http.Request) response.Response {
 			return errors.Wrapf(err, "Fetch project id %q", name)
 		}
 
-		return tx.DeleteProject(name)
+		return tx.DeleteProject(db.ProjectFilter{Name: name})
 	})
 
 	if err != nil {

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -585,7 +585,8 @@ func projectChange(d *Daemon, project *api.Project, req api.ProjectPut) response
 				}
 			} else {
 				// Delete the project-specific default profile.
-				err = tx.DeleteProfile(project.Name, projecthelpers.Default)
+				filter := db.ProfileFilter{Project: project.Name, Name: projecthelpers.Default}
+				err = tx.DeleteProfile(filter)
 				if err != nil {
 					return errors.Wrap(err, "Delete project default profile")
 				}

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -952,7 +952,8 @@ func Purge(cluster *db.Cluster, name string) error {
 			return errors.Wrapf(err, "Failed to remove member %q", name)
 		}
 
-		err = tx.DeleteCertificateByNameAndType(name, db.CertificateTypeServer)
+		filter := db.CertificateFilter{Name: name, Type: db.CertificateTypeServer}
+		err = tx.DeleteCertificates(filter)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to remove member %q certificate from trust store", name)
 		}

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -121,10 +121,11 @@ func (c *ClusterTx) DeleteCertificateByNameAndType(name string, certType int) er
 	_, err := c.tx.Exec("DELETE FROM certificates WHERE name = ? and type = ?", name, certType)
 	return err
 }
-
-// CertificateFilter can be used to filter results yielded by GetCertInfos
+// CertificateFilter specifies potential query parameter fields.
 type CertificateFilter struct {
 	Fingerprint string // Matched with LIKE
+	Name        string
+	Type        int
 }
 
 // GetCertificate gets an CertBaseInfo object from the database.

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -116,11 +116,6 @@ func (c *ClusterTx) UpdateCertificateProjects(id int, projects []string) error {
 	return nil
 }
 
-// DeleteCertificateByNameAndType deletes the certificate(s) matching the given name and certificate type.
-func (c *ClusterTx) DeleteCertificateByNameAndType(name string, certType int) error {
-	_, err := c.tx.Exec("DELETE FROM certificates WHERE name = ? and type = ?", name, certType)
-	return err
-}
 // CertificateFilter specifies potential query parameter fields.
 type CertificateFilter struct {
 	Fingerprint string // Matched with LIKE

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -162,7 +162,7 @@ func (c *Cluster) CreateCertificate(cert Certificate) (int64, error) {
 // DeleteCertificate deletes a certificate from the db.
 func (c *Cluster) DeleteCertificate(fingerprint string) error {
 	err := c.Transaction(func(tx *ClusterTx) error {
-		return tx.DeleteCertificate(fingerprint)
+		return tx.DeleteCertificate(CertificateFilter{Fingerprint: fingerprint})
 	})
 	return err
 }

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -22,7 +22,8 @@ import (
 //go:generate mapper stmt -p db -e certificate id
 //go:generate mapper stmt -p db -e certificate create struct=Certificate
 //go:generate mapper stmt -p db -e certificate create-projects-ref
-//go:generate mapper stmt -p db -e certificate delete
+//go:generate mapper stmt -p db -e certificate delete-by-Fingerprint
+//go:generate mapper stmt -p db -e certificate delete-by-Name-and-Type
 //go:generate mapper stmt -p db -e certificate update struct=Certificate
 //
 //go:generate mapper method -p db -e certificate List
@@ -31,7 +32,8 @@ import (
 //go:generate mapper method -p db -e certificate Exists struct=Certificate
 //go:generate mapper method -p db -e certificate Create struct=Certificate
 //go:generate mapper method -p db -e certificate ProjectsRef
-//go:generate mapper method -p db -e certificate Delete
+//go:generate mapper method -p db -e certificate DeleteOne
+//go:generate mapper method -p db -e certificate DeleteMany
 //go:generate mapper method -p db -e certificate Update struct=Certificate
 
 // CertificateTypeClient indicates a client certificate type.

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -79,7 +79,7 @@ func (m *Method) uris(buf *file.Buffer) error {
 		return errors.Wrap(err, "Parse filter struct")
 	}
 
-	filters := Filters(m.packages["db"], m.entity)
+	filters := Filters(m.packages["db"], "objects", m.entity)
 
 	comment := fmt.Sprintf("returns all available %s URIs.", m.entity)
 	args := fmt.Sprintf("filter %s", entityFilter(m.entity))
@@ -156,7 +156,7 @@ func (m *Method) list(buf *file.Buffer) error {
 		return errors.Wrap(err, "Parse filter struct")
 	}
 
-	filters := Filters(m.packages["db"], m.entity)
+	filters := Filters(m.packages["db"], "objects", m.entity)
 
 	// Go type name the objects to return (e.g. api.Foo).
 	typ := entityType(m.pkg, m.entity)

--- a/lxd/db/generate/db/parse.go
+++ b/lxd/db/generate/db/parse.go
@@ -37,11 +37,11 @@ var defaultPackages = []string{
 
 // Filters parses all filtering statement defined for the given entity. It
 // returns all supported combinations of filters, sorted by number of criteria.
-func Filters(pkg *ast.Package, entity string) [][]string {
+func Filters(pkg *ast.Package, kind string, entity string) [][]string {
 	objects := pkg.Scope.Objects
 	filters := [][]string{}
 
-	prefix := fmt.Sprintf("%sObjectsBy", lex.Minuscule(lex.Camel(entity)))
+	prefix := fmt.Sprintf("%s%sBy", lex.Minuscule(lex.Camel(entity)), lex.Camel(kind))
 
 	for name := range objects {
 		if !strings.HasPrefix(name, prefix) {

--- a/lxd/db/generate/db/stmt.go
+++ b/lxd/db/generate/db/stmt.go
@@ -459,7 +459,7 @@ func (s *Stmt) rename(buf *file.Buffer) error {
 	}
 
 	table := entityTable(s.entity)
-	where := naturalKeyWhere(mapping)
+	where := whereClause(mapping.NaturalKey())
 
 	sql := fmt.Sprintf(stmts[s.kind], table, where)
 	s.register(buf, sql)
@@ -507,7 +507,7 @@ func (s *Stmt) delete(buf *file.Buffer) error {
 	}
 
 	table := entityTable(s.entity)
-	where := naturalKeyWhere(mapping)
+	where := whereClause(mapping.NaturalKey())
 
 	sql := fmt.Sprintf(stmts[s.kind], table, where)
 	s.register(buf, sql)
@@ -542,26 +542,24 @@ func (s *Stmt) deleteRef(buf *file.Buffer) error {
 	return nil
 }
 
-// Return a where clause that filters an entity by natural key.
-func naturalKeyWhere(mapping *Mapping) string {
-	nk := mapping.NaturalKey()
-
+// Return a where clause that filters an entity by the given fields
+func whereClause(fields []*Field) string {
 	via := map[string][]*Field{} // Map scalar fields to their additional indirect fields
 
 	// Filter out indirect fields
-	fields := []*Field{}
-	for _, field := range nk {
+	directFields := []*Field{}
+	for _, field := range fields {
 		if field.IsIndirect() {
 			entity := field.Config.Get("via")
 			via[entity] = append(via[entity], field)
 			continue
 		}
-		fields = append(fields, field)
+		directFields = append(directFields, field)
 	}
 
-	where := make([]string, len(fields))
+	where := make([]string, len(directFields))
 
-	for i, field := range fields {
+	for i, field := range directFields {
 		if field.IsScalar() {
 			ref := lex.Snake(field.Name)
 			refTable := entityTable(ref)

--- a/lxd/db/generate/file/write.go
+++ b/lxd/db/generate/file/write.go
@@ -10,7 +10,8 @@ import (
 
 // Reset an auto-generated source file, writing a new empty file header.
 func Reset(path string, imports []string) error {
-	content := fmt.Sprintf(`// +build linux,cgo,!agent
+	content := fmt.Sprintf(`//go:build linux && cgo && !agent
+// +build linux,cgo,!agent
 
 package %s
 

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -60,7 +60,7 @@ import (
 //go:generate mapper stmt -p db -e instance create-config-ref
 //go:generate mapper stmt -p db -e instance create-devices-ref
 //go:generate mapper stmt -p db -e instance rename
-//go:generate mapper stmt -p db -e instance delete
+//go:generate mapper stmt -p db -e instance delete-by-Project-and-Name
 //go:generate mapper stmt -p db -e instance delete-config-ref
 //go:generate mapper stmt -p db -e instance delete-devices-ref
 //go:generate mapper stmt -p db -e instance delete-profiles-ref
@@ -75,7 +75,7 @@ import (
 //go:generate mapper method -p db -e instance ConfigRef
 //go:generate mapper method -p db -e instance DevicesRef
 //go:generate mapper method -p db -e instance Rename
-//go:generate mapper method -p db -e instance Delete
+//go:generate mapper method -p db -e instance DeleteOne
 //go:generate mapper method -p db -e instance Update struct=Instance
 
 // Instance is a value object holding db-related details about an instance.

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -98,7 +98,7 @@ type Instance struct {
 	ExpiryDate   time.Time
 }
 
-// InstanceFilter can be used to filter results yielded by InstanceList.
+// InstanceFilter specifies potential query parameter fields.
 type InstanceFilter struct {
 	Project string
 	Name    string
@@ -726,12 +726,22 @@ SELECT storage_pools.name FROM storage_pools
 func (c *Cluster) DeleteInstance(project, name string) error {
 	if strings.Contains(name, shared.SnapshotDelimiter) {
 		parts := strings.SplitN(name, shared.SnapshotDelimiter, 2)
+		filter := InstanceSnapshotFilter{
+			Project:  project,
+			Instance: parts[0],
+			Name:     parts[1],
+		}
 		return c.Transaction(func(tx *ClusterTx) error {
-			return tx.DeleteInstanceSnapshot(project, parts[0], parts[1])
+			return tx.DeleteInstanceSnapshot(filter)
 		})
 	}
+
+	filter := InstanceFilter{
+		Project: project,
+		Name:    name,
+	}
 	return c.Transaction(func(tx *ClusterTx) error {
-		return tx.DeleteInstance(project, name)
+		return tx.DeleteInstance(filter)
 	})
 }
 

--- a/lxd/db/instances.mapper.go
+++ b/lxd/db/instances.mapper.go
@@ -200,7 +200,7 @@ var instanceRename = cluster.RegisterStmt(`
 UPDATE instances SET name = ? WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND name = ?
 `)
 
-var instanceDelete = cluster.RegisterStmt(`
+var instanceDeleteByProjectAndName = cluster.RegisterStmt(`
 DELETE FROM instances WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND name = ?
 `)
 
@@ -898,9 +898,36 @@ func (c *ClusterTx) RenameInstance(project string, name string, to string) error
 }
 
 // DeleteInstance deletes the instance matching the given key parameters.
-func (c *ClusterTx) DeleteInstance(project string, name string) error {
-	stmt := c.stmt(instanceDelete)
-	result, err := stmt.Exec(project, name)
+func (c *ClusterTx) DeleteInstance(filter InstanceFilter) error {
+	// Check which filter criteria are active.
+	criteria := map[string]interface{}{}
+	if filter.Project != "" {
+		criteria["Project"] = filter.Project
+	}
+	if filter.Name != "" {
+		criteria["Name"] = filter.Name
+	}
+	if filter.Node != "" {
+		criteria["Node"] = filter.Node
+	}
+	if filter.Type != -1 {
+		criteria["Type"] = filter.Type
+	}
+
+	// Pick the prepared statement and arguments to use based on active criteria.
+	var stmt *sql.Stmt
+	var args []interface{}
+
+	if criteria["Project"] != nil && criteria["Name"] != nil {
+		stmt = c.stmt(instanceDeleteByProjectAndName)
+		args = []interface{}{
+			filter.Project,
+			filter.Name,
+		}
+	} else {
+		return fmt.Errorf("No valid filter for instance delete")
+	}
+	result, err := stmt.Exec(args...)
 	if err != nil {
 		return errors.Wrap(err, "Delete instance")
 	}

--- a/lxd/db/profiles.go
+++ b/lxd/db/profiles.go
@@ -36,7 +36,7 @@ import (
 //go:generate mapper stmt -p db -e profile create-config-ref
 //go:generate mapper stmt -p db -e profile create-devices-ref
 //go:generate mapper stmt -p db -e profile rename
-//go:generate mapper stmt -p db -e profile delete
+//go:generate mapper stmt -p db -e profile delete-by-Project-and-Name
 //go:generate mapper stmt -p db -e profile delete-config-ref
 //go:generate mapper stmt -p db -e profile delete-devices-ref
 //go:generate mapper stmt -p db -e profile update struct=Profile
@@ -51,7 +51,7 @@ import (
 //go:generate mapper method -p db -e profile UsedByRef
 //go:generate mapper method -p db -e profile Create struct=Profile
 //go:generate mapper method -p db -e profile Rename
-//go:generate mapper method -p db -e profile Delete
+//go:generate mapper method -p db -e profile DeleteOne
 //go:generate mapper method -p db -e profile Update struct=Profile
 
 // Profile is a value object holding db-related details about a profile.
@@ -79,7 +79,7 @@ func ProfileToAPI(profile *Profile) *api.Profile {
 	return p
 }
 
-// ProfileFilter can be used to filter results yielded by ProfileList.
+// ProfileFilter specifies potential query parameter fields.
 type ProfileFilter struct {
 	Project string
 	Name    string

--- a/lxd/db/projects.go
+++ b/lxd/db/projects.go
@@ -32,7 +32,7 @@ import (
 //go:generate mapper stmt -e project id
 //go:generate mapper stmt -e project rename
 //go:generate mapper stmt -e project update
-//go:generate mapper stmt -e project delete
+//go:generate mapper stmt -e project delete-by-Name
 //
 //go:generate mapper method -e project URIs
 //go:generate mapper method -e project List
@@ -43,9 +43,9 @@ import (
 //go:generate mapper method -e project UsedByRef
 //go:generate mapper method -e project ID
 //go:generate mapper method -e project Rename
-//go:generate mapper method -e project Delete
+//go:generate mapper method -e project DeleteOne
 
-// ProjectFilter can be used to filter results yielded by ProjectList.
+// ProjectFilter specifies potential query parameter fields.
 type ProjectFilter struct {
 	Name string // If non-empty, return only the project with this name.
 }

--- a/lxd/db/snapshots.go
+++ b/lxd/db/snapshots.go
@@ -29,7 +29,7 @@ import (
 //go:generate mapper stmt -p db -e instance_snapshot create-config-ref
 //go:generate mapper stmt -p db -e instance_snapshot create-devices-ref
 //go:generate mapper stmt -p db -e instance_snapshot rename
-//go:generate mapper stmt -p db -e instance_snapshot delete
+//go:generate mapper stmt -p db -e instance_snapshot delete-by-Project-and-Instance-and-Name
 //
 //go:generate mapper method -p db -e instance_snapshot List
 //go:generate mapper method -p db -e instance_snapshot Get
@@ -39,7 +39,7 @@ import (
 //go:generate mapper method -p db -e instance_snapshot ConfigRef
 //go:generate mapper method -p db -e instance_snapshot DevicesRef
 //go:generate mapper method -p db -e instance_snapshot Rename
-//go:generate mapper method -p db -e instance_snapshot Delete
+//go:generate mapper method -p db -e instance_snapshot DeleteOne
 
 // InstanceSnapshot is a value object holding db-related details about a snapshot.
 type InstanceSnapshot struct {
@@ -55,7 +55,7 @@ type InstanceSnapshot struct {
 	ExpiryDate   time.Time
 }
 
-// InstanceSnapshotFilter can be used to filter results yielded by GetInstanceSnapshots.
+// InstanceSnapshotFilter specifies potential query parameter fields.
 type InstanceSnapshotFilter struct {
 	Project  string
 	Instance string

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -62,7 +62,8 @@ func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 	suite.Req.Nil(err, "Failed to create the unprivileged profile.")
 	defer func() {
 		suite.d.cluster.Transaction(func(tx *db.ClusterTx) error {
-			return tx.DeleteProfile("default", "unpriviliged")
+			filter := db.ProfileFilter{Project: "default", Name: "unprivileged"}
+			return tx.DeleteProfile(filter)
 		})
 	}()
 

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -858,7 +858,8 @@ func patchInvalidProfileNames(name string, d *Daemon) error {
 		if strings.Contains(profile, "/") || shared.StringInSlice(profile, []string{".", ".."}) {
 			logger.Info("Removing unreachable profile (invalid name)", log.Ctx{"name": profile})
 			err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
-				return tx.DeleteProfile("default", profile)
+				filter := db.ProfileFilter{Project: project.Default, Name: profile}
+				return tx.DeleteProfile(filter)
 			})
 			if err != nil {
 				return err

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -690,7 +690,8 @@ func profileDelete(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Profile is currently in use")
 		}
 
-		return tx.DeleteProfile(projectName, name)
+		filter := db.ProfileFilter{Project: projectName, Name: name}
+		return tx.DeleteProfile(filter)
 	})
 	if err != nil {
 		return response.SmartError(err)


### PR DESCRIPTION
Lots of repetitive commits here :)

This PR extends `DELETE` generation to allow deleting by more than just ID, and to allow deleting many rows at once.

Changes:
* Added `gofmt -s -w ./lxd/db/` to `Makefile` under `update-schema` for file consistency.
* Added `//go:build linux && cgo && !agent` comment as part of the generator. 
* statement generation for delete now requires the field to delete by to be specified, ie: `delete-by-name-and-project`
* method generation can now be one of `DeleteOne` or `DeleteMany`. The difference is just an if-statement that returns an error in the former case.
* the generated `Delete` method now takes the `Filter` struct for its corresponding object as its argument. 

Next up will be operations, since I have that done already. 

After that will be automatic generation of all possible statement combinations for a Filter struct, so that the `-by-` will not need to be directly specified.