### PR TITLE
lxd/device: Fix duplicate MAC test

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -240,7 +240,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 				}
 
 				// Skip NICs connected to other networks.
-				if d.config["parent"] != devConfig["parent"] && d.config["network"] != devConfig["network"] {
+				if d.config["parent"] != devConfig["parent"] || d.config["network"] != devConfig["network"] || d.config["vlan"] != devConfig["vlan"] {
 					continue
 				}
 


### PR DESCRIPTION
The current check would require BOTH the parent and network properties
to differ for the MAC check to be skipped. This is effectively
impossible and was clearly meant to be an OR instead.

Additionally, if two interfaces share the same parent but are on
different VLANs, they also should skip the MAC duplication check.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>