### PR TITLE
Generator: Auto-generate all statements from Filter struct

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -501,7 +501,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		}
 
 		// Get a list of projects for networks.
-		var projects []api.Project
+		var projects []db.Project
 
 		err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
 			projects, err = tx.GetProjects(db.ProjectFilter{})

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -153,7 +153,7 @@ func projectsGet(d *Daemon, r *http.Request) response.Response {
 				return err
 			}
 
-			filtered := []api.Project{}
+			filtered := []db.Project{}
 			for _, project := range projects {
 				if !rbac.UserHasPermission(r, project.Name, "view") {
 					continue
@@ -221,7 +221,7 @@ func projectsGet(d *Daemon, r *http.Request) response.Response {
 //     $ref: "#/responses/InternalServerError"
 func projectsPost(d *Daemon, r *http.Request) response.Response {
 	// Parse the request.
-	project := api.ProjectsPost{}
+	project := db.Project{}
 
 	// Set default features.
 	if project.Config == nil {
@@ -525,7 +525,7 @@ func projectPatch(d *Daemon, r *http.Request) response.Response {
 }
 
 // Common logic between PUT and PATCH.
-func projectChange(d *Daemon, project *api.Project, req api.ProjectPut) response.Response {
+func projectChange(d *Daemon, project *db.Project, req api.ProjectPut) response.Response {
 	// Make a list of config keys that have changed.
 	configChanged := []string{}
 	for key := range project.Config {
@@ -829,7 +829,7 @@ func projectStateGet(d *Daemon, r *http.Request) response.Response {
 }
 
 // Check if a project is empty.
-func projectIsEmpty(project *api.Project) bool {
+func projectIsEmpty(project *db.Project) bool {
 	if len(project.UsedBy) > 0 {
 		// Check if the only entity is the default profile.
 		if len(project.UsedBy) == 1 && strings.Contains(project.UsedBy[0], "/profiles/default") {

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -31,7 +31,7 @@ import (
 )
 
 type certificateCache struct {
-	Certificates map[int]map[string]x509.Certificate
+	Certificates map[db.CertificateType]map[string]x509.Certificate
 	Projects     map[string][]string
 	Lock         sync.Mutex
 }
@@ -170,7 +170,7 @@ func certificatesGet(d *Daemon, r *http.Request) response.Response {
 func updateCertificateCache(d *Daemon) {
 	logger.Debug("Refreshing trusted certificate cache")
 
-	newCerts := map[int]map[string]x509.Certificate{}
+	newCerts := map[db.CertificateType]map[string]x509.Certificate{}
 	newProjects := map[string][]string{}
 
 	var dbCerts []db.Certificate
@@ -234,7 +234,7 @@ func updateCertificateCache(d *Daemon) {
 func updateCertificateCacheFromLocal(d *Daemon) error {
 	logger.Debug("Refreshing local trusted certificate cache")
 
-	newCerts := map[int]map[string]x509.Certificate{}
+	newCerts := map[db.CertificateType]map[string]x509.Certificate{}
 
 	var dbCerts []db.Certificate
 	var err error

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -149,7 +149,7 @@ func setDqliteVersionHeader(request *http.Request) {
 // These handlers might return 404, either because this LXD node is a
 // non-clustered node not available over the network or because it is not a
 // database node part of the dqlite cluster.
-func (g *Gateway) HandlerFuncs(nodeRefreshTask func(*APIHeartbeat), trustedCerts func() map[int]map[string]x509.Certificate) map[string]http.HandlerFunc {
+func (g *Gateway) HandlerFuncs(nodeRefreshTask func(*APIHeartbeat), trustedCerts func() map[db.CertificateType]map[string]x509.Certificate) map[string]http.HandlerFunc {
 	database := func(w http.ResponseWriter, r *http.Request) {
 		g.lock.RLock()
 		defer g.lock.RUnlock()

--- a/lxd/cluster/heartbeat_test.go
+++ b/lxd/cluster/heartbeat_test.go
@@ -205,7 +205,7 @@ func (f *heartbeatFixture) node() (*state.State, *cluster.Gateway, string) {
 	mux := http.NewServeMux()
 	server := newServer(serverCert, mux)
 
-	trustedCerts := func() map[int]map[string]x509.Certificate {
+	trustedCerts := func() map[db.CertificateType]map[string]x509.Certificate {
 		return nil
 	}
 

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -958,7 +958,8 @@ func Purge(cluster *db.Cluster, name string) error {
 			return errors.Wrapf(err, "Failed to remove member %q", name)
 		}
 
-		filter := db.CertificateFilter{Name: name, Type: db.CertificateTypeServer}
+		certType := db.CertificateTypeServer
+		filter := db.CertificateFilter{Name: name, Type: &certType}
 		err = tx.DeleteCertificates(filter)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to remove member %q certificate from trust store", name)

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -496,7 +496,7 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 			op := db.Operation{
 				UUID:   operation.UUID,
 				Type:   operation.Type,
-				NodeID: tx.GetNodeID(),
+				NodeID: *tx.GetNodeID(),
 			}
 			_, err := tx.CreateOrReplaceOperation(op)
 			if err != nil {

--- a/lxd/cluster/membership_test.go
+++ b/lxd/cluster/membership_test.go
@@ -126,7 +126,7 @@ func TestBootstrap(t *testing.T) {
 	// The cluster certificate is in place.
 	assert.True(t, shared.PathExists(filepath.Join(state.OS.VarDir, "cluster.crt")))
 
-	trustedCerts := func() map[int]map[string]x509.Certificate {
+	trustedCerts := func() map[db.CertificateType]map[string]x509.Certificate {
 		return nil
 	}
 
@@ -259,8 +259,8 @@ func TestJoin(t *testing.T) {
 	altServerCert := shared.TestingAltKeyPair()
 	trustedAltServerCert, _ := x509.ParseCertificate(altServerCert.KeyPair().Certificate[0])
 
-	trustedCerts := func() map[int]map[string]x509.Certificate {
-		return map[int]map[string]x509.Certificate{
+	trustedCerts := func() map[db.CertificateType]map[string]x509.Certificate {
+		return map[db.CertificateType]map[string]x509.Certificate{
 			db.CertificateTypeServer: {
 				altServerCert.Fingerprint(): *trustedAltServerCert,
 			},

--- a/lxd/cluster/tls.go
+++ b/lxd/cluster/tls.go
@@ -52,7 +52,7 @@ func tlsClientConfig(networkCert *shared.CertInfo, serverCert *shared.CertInfo) 
 }
 
 // tlsCheckCert checks certificate access, returns true if certificate is trusted.
-func tlsCheckCert(r *http.Request, networkCert *shared.CertInfo, serverCert *shared.CertInfo, trustedCerts map[int]map[string]x509.Certificate) bool {
+func tlsCheckCert(r *http.Request, networkCert *shared.CertInfo, serverCert *shared.CertInfo, trustedCerts map[db.CertificateType]map[string]x509.Certificate) bool {
 	_, err := x509.ParseCertificate(networkCert.KeyPair().Certificate[0])
 	if err != nil {
 		// Since we have already loaded this certificate, typically

--- a/lxd/cluster/upgrade_test.go
+++ b/lxd/cluster/upgrade_test.go
@@ -139,7 +139,7 @@ func TestUpgradeMembersWithoutRole(t *testing.T) {
 	gateway := newGateway(t, state.Node, serverCert, serverCert)
 	defer gateway.Shutdown()
 
-	trustedCerts := func() map[int]map[string]x509.Certificate {
+	trustedCerts := func() map[db.CertificateType]map[string]x509.Certificate {
 		return nil
 	}
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -267,7 +267,7 @@ func (d *Daemon) checkTrustedClient(r *http.Request) error {
 }
 
 // getTrustedCertificates returns trusted certificates key on DB type and fingerprint.
-func (d *Daemon) getTrustedCertificates() map[int]map[string]x509.Certificate {
+func (d *Daemon) getTrustedCertificates() map[db.CertificateType]map[string]x509.Certificate {
 	d.clientCerts.Lock.Lock()
 	defer d.clientCerts.Lock.Unlock()
 

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -17,7 +17,6 @@ import (
 //
 //go:generate mapper stmt -p db -e certificate objects
 //go:generate mapper stmt -p db -e certificate projects-ref
-//go:generate mapper stmt -p db -e certificate projects-ref-by-Fingerprint
 //go:generate mapper stmt -p db -e certificate id
 //go:generate mapper stmt -p db -e certificate create struct=Certificate
 //go:generate mapper stmt -p db -e certificate create-projects-ref
@@ -119,9 +118,9 @@ func (c *ClusterTx) UpdateCertificateProjects(id int, projects []string) error {
 
 // CertificateFilter specifies potential query parameter fields.
 type CertificateFilter struct {
-	Fingerprint string // Matched with LIKE
-	Name        string
-	Type        *CertificateType // CertificateType is a pointer so it can be omitted.
+	Fingerprint string           // Matched with LIKE
+	Name        string           `db:"omit=projects-ref"`
+	Type        *CertificateType `db:"omit=projects-ref"` // CertificateType is a pointer so it can be omitted.
 }
 
 // GetCertificate gets an CertBaseInfo object from the database.

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -35,14 +35,17 @@ import (
 //go:generate mapper method -p db -e certificate DeleteMany
 //go:generate mapper method -p db -e certificate Update struct=Certificate
 
+// CertificateType indicates the type of the certificate.
+type CertificateType int
+
 // CertificateTypeClient indicates a client certificate type.
-const CertificateTypeClient = 1
+const CertificateTypeClient = CertificateType(1)
 
 // CertificateTypeServer indicates a server certificate type.
-const CertificateTypeServer = 2
+const CertificateTypeServer = CertificateType(2)
 
 // CertificateAPITypeToDBType converts an API type to the equivalent DB type.
-func CertificateAPITypeToDBType(apiType string) (int, error) {
+func CertificateAPITypeToDBType(apiType string) (CertificateType, error) {
 	switch apiType {
 	case api.CertificateTypeClient:
 		return CertificateTypeClient, nil
@@ -57,7 +60,7 @@ func CertificateAPITypeToDBType(apiType string) (int, error) {
 type Certificate struct {
 	ID          int
 	Fingerprint string `db:"primary=yes&comparison=like"`
-	Type        int
+	Type        CertificateType
 	Name        string
 	Certificate string
 	Restricted  bool
@@ -119,7 +122,7 @@ func (c *ClusterTx) UpdateCertificateProjects(id int, projects []string) error {
 type CertificateFilter struct {
 	Fingerprint string // Matched with LIKE
 	Name        string
-	Type        int
+	Type        *CertificateType // CertificateType is a pointer so it can be omitted.
 }
 
 // GetCertificate gets an CertBaseInfo object from the database.
@@ -186,14 +189,14 @@ func (c *Cluster) UpdateCertificateProjects(id int, projects []string) error {
 func (n *NodeTx) GetCertificates() ([]Certificate, error) {
 	dbCerts := []struct {
 		fingerprint string
-		certType    int
+		certType    CertificateType
 		name        string
 		certificate string
 	}{}
 	dest := func(i int) []interface{} {
 		dbCerts = append(dbCerts, struct {
 			fingerprint string
-			certType    int
+			certType    CertificateType
 			name        string
 			certificate string
 		}{})

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -21,8 +21,7 @@ import (
 //go:generate mapper stmt -p db -e certificate id
 //go:generate mapper stmt -p db -e certificate create struct=Certificate
 //go:generate mapper stmt -p db -e certificate create-projects-ref
-//go:generate mapper stmt -p db -e certificate delete-by-Fingerprint
-//go:generate mapper stmt -p db -e certificate delete-by-Name-and-Type
+//go:generate mapper stmt -p db -e certificate delete
 //go:generate mapper stmt -p db -e certificate update struct=Certificate
 //
 //go:generate mapper method -p db -e certificate List

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -16,7 +16,6 @@ import (
 //go:generate mapper reset
 //
 //go:generate mapper stmt -p db -e certificate objects
-//go:generate mapper stmt -p db -e certificate objects-by-Fingerprint
 //go:generate mapper stmt -p db -e certificate projects-ref
 //go:generate mapper stmt -p db -e certificate projects-ref-by-Fingerprint
 //go:generate mapper stmt -p db -e certificate id

--- a/lxd/db/certificates.mapper.go
+++ b/lxd/db/certificates.mapper.go
@@ -78,9 +78,23 @@ INSERT INTO certificates (fingerprint, type, name, certificate, restricted)
 var certificateDeleteByFingerprint = cluster.RegisterStmt(`
 DELETE FROM certificates WHERE fingerprint = ?
 `)
-
+var certificateDeleteByName = cluster.RegisterStmt(`
+DELETE FROM certificates WHERE name = ?
+`)
+var certificateDeleteByFingerprintAndName = cluster.RegisterStmt(`
+DELETE FROM certificates WHERE fingerprint = ? AND name = ?
+`)
+var certificateDeleteByType = cluster.RegisterStmt(`
+DELETE FROM certificates WHERE type = ?
+`)
+var certificateDeleteByFingerprintAndType = cluster.RegisterStmt(`
+DELETE FROM certificates WHERE fingerprint = ? AND type = ?
+`)
 var certificateDeleteByNameAndType = cluster.RegisterStmt(`
 DELETE FROM certificates WHERE name = ? AND type = ?
+`)
+var certificateDeleteByFingerprintAndNameAndType = cluster.RegisterStmt(`
+DELETE FROM certificates WHERE fingerprint = ? AND name = ? AND type = ?
 `)
 
 var certificateUpdate = cluster.RegisterStmt(`
@@ -372,11 +386,40 @@ func (c *ClusterTx) DeleteCertificate(filter CertificateFilter) error {
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Name"] != nil && criteria["Type"] != nil {
+	if criteria["Fingerprint"] != nil && criteria["Name"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(certificateDeleteByFingerprintAndNameAndType)
+		args = []interface{}{
+			filter.Fingerprint,
+			filter.Name,
+			filter.Type,
+		}
+	} else if criteria["Name"] != nil && criteria["Type"] != nil {
 		stmt = c.stmt(certificateDeleteByNameAndType)
 		args = []interface{}{
 			filter.Name,
 			filter.Type,
+		}
+	} else if criteria["Fingerprint"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(certificateDeleteByFingerprintAndType)
+		args = []interface{}{
+			filter.Fingerprint,
+			filter.Type,
+		}
+	} else if criteria["Fingerprint"] != nil && criteria["Name"] != nil {
+		stmt = c.stmt(certificateDeleteByFingerprintAndName)
+		args = []interface{}{
+			filter.Fingerprint,
+			filter.Name,
+		}
+	} else if criteria["Type"] != nil {
+		stmt = c.stmt(certificateDeleteByType)
+		args = []interface{}{
+			filter.Type,
+		}
+	} else if criteria["Name"] != nil {
+		stmt = c.stmt(certificateDeleteByName)
+		args = []interface{}{
+			filter.Name,
 		}
 	} else if criteria["Fingerprint"] != nil {
 		stmt = c.stmt(certificateDeleteByFingerprint)
@@ -420,11 +463,40 @@ func (c *ClusterTx) DeleteCertificates(filter CertificateFilter) error {
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Name"] != nil && criteria["Type"] != nil {
+	if criteria["Fingerprint"] != nil && criteria["Name"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(certificateDeleteByFingerprintAndNameAndType)
+		args = []interface{}{
+			filter.Fingerprint,
+			filter.Name,
+			filter.Type,
+		}
+	} else if criteria["Name"] != nil && criteria["Type"] != nil {
 		stmt = c.stmt(certificateDeleteByNameAndType)
 		args = []interface{}{
 			filter.Name,
 			filter.Type,
+		}
+	} else if criteria["Fingerprint"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(certificateDeleteByFingerprintAndType)
+		args = []interface{}{
+			filter.Fingerprint,
+			filter.Type,
+		}
+	} else if criteria["Fingerprint"] != nil && criteria["Name"] != nil {
+		stmt = c.stmt(certificateDeleteByFingerprintAndName)
+		args = []interface{}{
+			filter.Fingerprint,
+			filter.Name,
+		}
+	} else if criteria["Type"] != nil {
+		stmt = c.stmt(certificateDeleteByType)
+		args = []interface{}{
+			filter.Type,
+		}
+	} else if criteria["Name"] != nil {
+		stmt = c.stmt(certificateDeleteByName)
+		args = []interface{}{
+			filter.Name,
 		}
 	} else if criteria["Fingerprint"] != nil {
 		stmt = c.stmt(certificateDeleteByFingerprint)

--- a/lxd/db/certificates.mapper.go
+++ b/lxd/db/certificates.mapper.go
@@ -60,7 +60,6 @@ SELECT certificates.id, certificates.fingerprint, certificates.type, certificate
 var certificateProjectsRef = cluster.RegisterStmt(`
 SELECT fingerprint, value FROM certificates_projects_ref ORDER BY fingerprint
 `)
-
 var certificateProjectsRefByFingerprint = cluster.RegisterStmt(`
 SELECT fingerprint, value FROM certificates_projects_ref WHERE fingerprint = ? ORDER BY fingerprint
 `)

--- a/lxd/db/certificates.mapper.go
+++ b/lxd/db/certificates.mapper.go
@@ -16,87 +16,87 @@ import (
 
 var _ = api.ServerEnvironment{}
 
-var certificateObjects = cluster.RegisterStmt(`
+const certificateObjects = cluster.RegisterStmt(`
 SELECT certificates.id, certificates.fingerprint, certificates.type, certificates.name, certificates.certificate, certificates.restricted
   FROM certificates
   ORDER BY certificates.fingerprint
 `)
-var certificateObjectsByFingerprint = cluster.RegisterStmt(`
+const certificateObjectsByFingerprint = cluster.RegisterStmt(`
 SELECT certificates.id, certificates.fingerprint, certificates.type, certificates.name, certificates.certificate, certificates.restricted
   FROM certificates
   WHERE certificates.fingerprint LIKE ? ORDER BY certificates.fingerprint
 `)
-var certificateObjectsByName = cluster.RegisterStmt(`
+const certificateObjectsByName = cluster.RegisterStmt(`
 SELECT certificates.id, certificates.fingerprint, certificates.type, certificates.name, certificates.certificate, certificates.restricted
   FROM certificates
   WHERE certificates.name = ? ORDER BY certificates.fingerprint
 `)
-var certificateObjectsByFingerprintAndName = cluster.RegisterStmt(`
+const certificateObjectsByFingerprintAndName = cluster.RegisterStmt(`
 SELECT certificates.id, certificates.fingerprint, certificates.type, certificates.name, certificates.certificate, certificates.restricted
   FROM certificates
   WHERE certificates.fingerprint LIKE ? AND certificates.name = ? ORDER BY certificates.fingerprint
 `)
-var certificateObjectsByType = cluster.RegisterStmt(`
+const certificateObjectsByType = cluster.RegisterStmt(`
 SELECT certificates.id, certificates.fingerprint, certificates.type, certificates.name, certificates.certificate, certificates.restricted
   FROM certificates
   WHERE certificates.type = ? ORDER BY certificates.fingerprint
 `)
-var certificateObjectsByFingerprintAndType = cluster.RegisterStmt(`
+const certificateObjectsByFingerprintAndType = cluster.RegisterStmt(`
 SELECT certificates.id, certificates.fingerprint, certificates.type, certificates.name, certificates.certificate, certificates.restricted
   FROM certificates
   WHERE certificates.fingerprint LIKE ? AND certificates.type = ? ORDER BY certificates.fingerprint
 `)
-var certificateObjectsByNameAndType = cluster.RegisterStmt(`
+const certificateObjectsByNameAndType = cluster.RegisterStmt(`
 SELECT certificates.id, certificates.fingerprint, certificates.type, certificates.name, certificates.certificate, certificates.restricted
   FROM certificates
   WHERE certificates.name = ? AND certificates.type = ? ORDER BY certificates.fingerprint
 `)
-var certificateObjectsByFingerprintAndNameAndType = cluster.RegisterStmt(`
+const certificateObjectsByFingerprintAndNameAndType = cluster.RegisterStmt(`
 SELECT certificates.id, certificates.fingerprint, certificates.type, certificates.name, certificates.certificate, certificates.restricted
   FROM certificates
   WHERE certificates.fingerprint LIKE ? AND certificates.name = ? AND certificates.type = ? ORDER BY certificates.fingerprint
 `)
 
-var certificateProjectsRef = cluster.RegisterStmt(`
+const certificateProjectsRef = cluster.RegisterStmt(`
 SELECT fingerprint, value FROM certificates_projects_ref ORDER BY fingerprint
 `)
-var certificateProjectsRefByFingerprint = cluster.RegisterStmt(`
+const certificateProjectsRefByFingerprint = cluster.RegisterStmt(`
 SELECT fingerprint, value FROM certificates_projects_ref WHERE fingerprint = ? ORDER BY fingerprint
 `)
 
-var certificateID = cluster.RegisterStmt(`
+const certificateID = cluster.RegisterStmt(`
 SELECT certificates.id FROM certificates
   WHERE certificates.fingerprint = ?
 `)
 
-var certificateCreate = cluster.RegisterStmt(`
+const certificateCreate = cluster.RegisterStmt(`
 INSERT INTO certificates (fingerprint, type, name, certificate, restricted)
   VALUES (?, ?, ?, ?, ?)
 `)
 
-var certificateDeleteByFingerprint = cluster.RegisterStmt(`
+const certificateDeleteByFingerprint = cluster.RegisterStmt(`
 DELETE FROM certificates WHERE fingerprint = ?
 `)
-var certificateDeleteByName = cluster.RegisterStmt(`
+const certificateDeleteByName = cluster.RegisterStmt(`
 DELETE FROM certificates WHERE name = ?
 `)
-var certificateDeleteByFingerprintAndName = cluster.RegisterStmt(`
+const certificateDeleteByFingerprintAndName = cluster.RegisterStmt(`
 DELETE FROM certificates WHERE fingerprint = ? AND name = ?
 `)
-var certificateDeleteByType = cluster.RegisterStmt(`
+const certificateDeleteByType = cluster.RegisterStmt(`
 DELETE FROM certificates WHERE type = ?
 `)
-var certificateDeleteByFingerprintAndType = cluster.RegisterStmt(`
+const certificateDeleteByFingerprintAndType = cluster.RegisterStmt(`
 DELETE FROM certificates WHERE fingerprint = ? AND type = ?
 `)
-var certificateDeleteByNameAndType = cluster.RegisterStmt(`
+const certificateDeleteByNameAndType = cluster.RegisterStmt(`
 DELETE FROM certificates WHERE name = ? AND type = ?
 `)
-var certificateDeleteByFingerprintAndNameAndType = cluster.RegisterStmt(`
+const certificateDeleteByFingerprintAndNameAndType = cluster.RegisterStmt(`
 DELETE FROM certificates WHERE fingerprint = ? AND name = ? AND type = ?
 `)
 
-var certificateUpdate = cluster.RegisterStmt(`
+const certificateUpdate = cluster.RegisterStmt(`
 UPDATE certificates
   SET fingerprint = ?, type = ?, name = ?, certificate = ?, restricted = ?
  WHERE id = ?

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -286,7 +286,7 @@ func OpenCluster(name string, store driver.NodeStore, address, dir string, timeo
 		cluster.NodeID(nodeID)
 
 		// Delete any operation tied to this node
-		filter := OperationFilter{NodeID: nodeID}
+		filter := OperationFilter{NodeID: &nodeID}
 		err = tx.DeleteOperations(filter)
 		if err != nil {
 			return err

--- a/lxd/db/entity.go
+++ b/lxd/db/entity.go
@@ -254,7 +254,8 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 		var op Operation
 
 		err = c.transaction(func(tx *ClusterTx) error {
-			filter := OperationFilter{ID: int64(entityID)}
+			id := int64(entityID)
+			filter := OperationFilter{ID: &id}
 			ops, err := tx.GetOperations(filter)
 			if err != nil {
 				return err

--- a/lxd/db/generate/db/mapping.go
+++ b/lxd/db/generate/db/mapping.go
@@ -237,7 +237,7 @@ func (f *Field) ZeroValue() string {
 	switch f.Type.Name {
 	case "string":
 		return `""`
-	case "int", "instancetype.Type", "int64", "OperationType":
+	case "int", "instancetype.Type", "int64", "OperationType", "CertificateType":
 		// FIXME: we use -1 since at the moment integer criteria are
 		// required to be positive.
 		return "-1"
@@ -319,6 +319,7 @@ var columnarTypeNames = []string{
 	"int",
 	"int64",
 	"OperationType",
+	"CertificateType",
 	"string",
 	"time.Time",
 }

--- a/lxd/db/generate/db/mapping.go
+++ b/lxd/db/generate/db/mapping.go
@@ -239,6 +239,10 @@ func (f *Field) ZeroValue() string {
 		panic("attempt to get zero value of non-column field")
 	}
 
+	if f.Type.IsPointer {
+		return "nil"
+	}
+
 	switch f.Type.Name {
 	case "string":
 		return `""`
@@ -301,8 +305,9 @@ func FieldCriteria(fields []*Field) string {
 // Type holds all information about a field in a field type that is relevant
 // for database code generation.
 type Type struct {
-	Name string
-	Code int
+	Name      string
+	Code      int
+	IsPointer bool
 }
 
 // Possible type code.

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -99,9 +99,9 @@ func (m *Method) uris(buf *file.Buffer) error {
 		if name == "Parent" {
 			continue
 		}
-		field := mapping.FieldByName(name)
-		if field == nil {
-			return fmt.Errorf("No field named %q in filter struct", name)
+		field, err := mapping.FilterFieldByName(name)
+		if err != nil {
+			return err
 		}
 		buf.L("if filter.%s != %s {", name, field.ZeroValue())
 		buf.L("        criteria[%q] = filter.%s", name, name)
@@ -183,9 +183,9 @@ func (m *Method) list(buf *file.Buffer) error {
 		if name == "Parent" {
 			zero = `""`
 		} else {
-			field := mapping.FieldByName(name)
-			if field == nil {
-				return fmt.Errorf("No field named %q in filter struct", name)
+			field, err := mapping.FilterFieldByName(name)
+			if err != nil {
+				return err
 			}
 			zero = field.ZeroValue()
 		}
@@ -961,9 +961,9 @@ func (m *Method) delete(buf *file.Buffer, deleteOne bool) error {
 		if name == "Parent" {
 			zero = `""`
 		} else {
-			field := mapping.FieldByName(name)
-			if field == nil {
-				return fmt.Errorf("No field named %q in filter struct", name)
+			field, err := mapping.FilterFieldByName(name)
+			if err != nil {
+				return err
 			}
 			zero = field.ZeroValue()
 		}

--- a/lxd/db/generate/db/parse_test.go
+++ b/lxd/db/generate/db/parse_test.go
@@ -41,6 +41,9 @@ type Teacher struct {
 	Classes      []Class
 }
 
+type TeacherFilter struct {
+}
+
 func TestParse(t *testing.T) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "parse_test.go", nil, parser.ParseComments)

--- a/lxd/db/generate/db/stmt.go
+++ b/lxd/db/generate/db/stmt.go
@@ -438,7 +438,7 @@ func (s *Stmt) createRef(buf *file.Buffer) error {
 		sql = fmt.Sprintf(stmts["create"], table+"_config", columns, params)
 
 		kind := fmt.Sprintf("Create%sConfigRef", field.Name)
-		buf.L("var %s = %s.RegisterStmt(`\n%s\n`)", stmtCodeVar(s.entity, kind), s.db, sql)
+		buf.L("const %s = %s.RegisterStmt(`\n%s\n`)", stmtCodeVar(s.entity, kind), s.db, sql)
 	}
 
 	return nil
@@ -653,7 +653,7 @@ func (s *Stmt) register(buf *file.Buffer, sql string, filters ...string) {
 	if kind == "id" {
 		kind = "ID" // silence go lints
 	}
-	buf.L("var %s = %s.RegisterStmt(`\n%s\n`)", stmtCodeVar(s.entity, kind, filters...), s.db, sql)
+	buf.L("const %s = %s.RegisterStmt(`\n%s\n`)", stmtCodeVar(s.entity, kind, filters...), s.db, sql)
 }
 
 // Map of boilerplate statements.

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -23,14 +23,6 @@ import (
 //go:generate mapper reset
 //
 //go:generate mapper stmt -p db -e image objects
-//go:generate mapper stmt -p db -e image objects-by-Project
-//go:generate mapper stmt -p db -e image objects-by-Project-and-Cached
-//go:generate mapper stmt -p db -e image objects-by-Project-and-Public
-//go:generate mapper stmt -p db -e image objects-by-Project-and-Fingerprint
-//go:generate mapper stmt -p db -e image objects-by-Project-and-Fingerprint-and-Public
-//go:generate mapper stmt -p db -e image objects-by-Fingerprint
-//go:generate mapper stmt -p db -e image objects-by-Cached
-//go:generate mapper stmt -p db -e image objects-by-AutoUpdate
 //
 //go:generate mapper method -p db -e image List
 //go:generate mapper method -p db -e image Get

--- a/lxd/db/images.mapper.go
+++ b/lxd/db/images.mapper.go
@@ -16,162 +16,162 @@ import (
 
 var _ = api.ServerEnvironment{}
 
-var imageObjects = cluster.RegisterStmt(`
+const imageObjects = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByProject = cluster.RegisterStmt(`
+const imageObjectsByProject = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE project = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByFingerprint = cluster.RegisterStmt(`
+const imageObjectsByFingerprint = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE images.fingerprint LIKE ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByProjectAndFingerprint = cluster.RegisterStmt(`
+const imageObjectsByProjectAndFingerprint = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE project = ? AND images.fingerprint LIKE ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByPublic = cluster.RegisterStmt(`
+const imageObjectsByPublic = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE images.public = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByProjectAndPublic = cluster.RegisterStmt(`
+const imageObjectsByProjectAndPublic = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE project = ? AND images.public = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByFingerprintAndPublic = cluster.RegisterStmt(`
+const imageObjectsByFingerprintAndPublic = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE images.fingerprint LIKE ? AND images.public = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByProjectAndFingerprintAndPublic = cluster.RegisterStmt(`
+const imageObjectsByProjectAndFingerprintAndPublic = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE project = ? AND images.fingerprint LIKE ? AND images.public = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByCached = cluster.RegisterStmt(`
+const imageObjectsByCached = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE images.cached = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByProjectAndCached = cluster.RegisterStmt(`
+const imageObjectsByProjectAndCached = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE project = ? AND images.cached = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByFingerprintAndCached = cluster.RegisterStmt(`
+const imageObjectsByFingerprintAndCached = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE images.fingerprint LIKE ? AND images.cached = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByProjectAndFingerprintAndCached = cluster.RegisterStmt(`
+const imageObjectsByProjectAndFingerprintAndCached = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE project = ? AND images.fingerprint LIKE ? AND images.cached = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByPublicAndCached = cluster.RegisterStmt(`
+const imageObjectsByPublicAndCached = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE images.public = ? AND images.cached = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByProjectAndPublicAndCached = cluster.RegisterStmt(`
+const imageObjectsByProjectAndPublicAndCached = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE project = ? AND images.public = ? AND images.cached = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByFingerprintAndPublicAndCached = cluster.RegisterStmt(`
+const imageObjectsByFingerprintAndPublicAndCached = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE images.fingerprint LIKE ? AND images.public = ? AND images.cached = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByProjectAndFingerprintAndPublicAndCached = cluster.RegisterStmt(`
+const imageObjectsByProjectAndFingerprintAndPublicAndCached = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE project = ? AND images.fingerprint LIKE ? AND images.public = ? AND images.cached = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByAutoUpdate = cluster.RegisterStmt(`
+const imageObjectsByAutoUpdate = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE images.auto_update = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByProjectAndAutoUpdate = cluster.RegisterStmt(`
+const imageObjectsByProjectAndAutoUpdate = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE project = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByFingerprintAndAutoUpdate = cluster.RegisterStmt(`
+const imageObjectsByFingerprintAndAutoUpdate = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE images.fingerprint LIKE ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByProjectAndFingerprintAndAutoUpdate = cluster.RegisterStmt(`
+const imageObjectsByProjectAndFingerprintAndAutoUpdate = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE project = ? AND images.fingerprint LIKE ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByPublicAndAutoUpdate = cluster.RegisterStmt(`
+const imageObjectsByPublicAndAutoUpdate = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE images.public = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByProjectAndPublicAndAutoUpdate = cluster.RegisterStmt(`
+const imageObjectsByProjectAndPublicAndAutoUpdate = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE project = ? AND images.public = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByFingerprintAndPublicAndAutoUpdate = cluster.RegisterStmt(`
+const imageObjectsByFingerprintAndPublicAndAutoUpdate = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE images.fingerprint LIKE ? AND images.public = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByProjectAndFingerprintAndPublicAndAutoUpdate = cluster.RegisterStmt(`
+const imageObjectsByProjectAndFingerprintAndPublicAndAutoUpdate = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE project = ? AND images.fingerprint LIKE ? AND images.public = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByCachedAndAutoUpdate = cluster.RegisterStmt(`
+const imageObjectsByCachedAndAutoUpdate = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE images.cached = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByProjectAndCachedAndAutoUpdate = cluster.RegisterStmt(`
+const imageObjectsByProjectAndCachedAndAutoUpdate = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE project = ? AND images.cached = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByFingerprintAndCachedAndAutoUpdate = cluster.RegisterStmt(`
+const imageObjectsByFingerprintAndCachedAndAutoUpdate = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE images.fingerprint LIKE ? AND images.cached = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByProjectAndFingerprintAndCachedAndAutoUpdate = cluster.RegisterStmt(`
+const imageObjectsByProjectAndFingerprintAndCachedAndAutoUpdate = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE project = ? AND images.fingerprint LIKE ? AND images.cached = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByPublicAndCachedAndAutoUpdate = cluster.RegisterStmt(`
+const imageObjectsByPublicAndCachedAndAutoUpdate = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE images.public = ? AND images.cached = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByProjectAndPublicAndCachedAndAutoUpdate = cluster.RegisterStmt(`
+const imageObjectsByProjectAndPublicAndCachedAndAutoUpdate = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE project = ? AND images.public = ? AND images.cached = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByFingerprintAndPublicAndCachedAndAutoUpdate = cluster.RegisterStmt(`
+const imageObjectsByFingerprintAndPublicAndCachedAndAutoUpdate = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE images.fingerprint LIKE ? AND images.public = ? AND images.cached = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
 `)
-var imageObjectsByProjectAndFingerprintAndPublicAndCachedAndAutoUpdate = cluster.RegisterStmt(`
+const imageObjectsByProjectAndFingerprintAndPublicAndCachedAndAutoUpdate = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE project = ? AND images.fingerprint LIKE ? AND images.public = ? AND images.cached = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint

--- a/lxd/db/images.mapper.go
+++ b/lxd/db/images.mapper.go
@@ -21,53 +21,160 @@ SELECT images.id, projects.name AS project, images.fingerprint, images.type, ima
   FROM images JOIN projects ON images.project_id = projects.id
   ORDER BY projects.id, images.fingerprint
 `)
-
 var imageObjectsByProject = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE project = ? ORDER BY projects.id, images.fingerprint
 `)
-
-var imageObjectsByProjectAndCached = cluster.RegisterStmt(`
-SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
-  FROM images JOIN projects ON images.project_id = projects.id
-  WHERE project = ? AND images.cached = ? ORDER BY projects.id, images.fingerprint
-`)
-
-var imageObjectsByProjectAndPublic = cluster.RegisterStmt(`
-SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
-  FROM images JOIN projects ON images.project_id = projects.id
-  WHERE project = ? AND images.public = ? ORDER BY projects.id, images.fingerprint
-`)
-
-var imageObjectsByProjectAndFingerprint = cluster.RegisterStmt(`
-SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
-  FROM images JOIN projects ON images.project_id = projects.id
-  WHERE project = ? AND images.fingerprint LIKE ? ORDER BY projects.id, images.fingerprint
-`)
-
-var imageObjectsByProjectAndFingerprintAndPublic = cluster.RegisterStmt(`
-SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
-  FROM images JOIN projects ON images.project_id = projects.id
-  WHERE project = ? AND images.fingerprint LIKE ? AND images.public = ? ORDER BY projects.id, images.fingerprint
-`)
-
 var imageObjectsByFingerprint = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE images.fingerprint LIKE ? ORDER BY projects.id, images.fingerprint
 `)
-
+var imageObjectsByProjectAndFingerprint = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE project = ? AND images.fingerprint LIKE ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByPublic = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE images.public = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByProjectAndPublic = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE project = ? AND images.public = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByFingerprintAndPublic = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE images.fingerprint LIKE ? AND images.public = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByProjectAndFingerprintAndPublic = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE project = ? AND images.fingerprint LIKE ? AND images.public = ? ORDER BY projects.id, images.fingerprint
+`)
 var imageObjectsByCached = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE images.cached = ? ORDER BY projects.id, images.fingerprint
 `)
-
+var imageObjectsByProjectAndCached = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE project = ? AND images.cached = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByFingerprintAndCached = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE images.fingerprint LIKE ? AND images.cached = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByProjectAndFingerprintAndCached = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE project = ? AND images.fingerprint LIKE ? AND images.cached = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByPublicAndCached = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE images.public = ? AND images.cached = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByProjectAndPublicAndCached = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE project = ? AND images.public = ? AND images.cached = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByFingerprintAndPublicAndCached = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE images.fingerprint LIKE ? AND images.public = ? AND images.cached = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByProjectAndFingerprintAndPublicAndCached = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE project = ? AND images.fingerprint LIKE ? AND images.public = ? AND images.cached = ? ORDER BY projects.id, images.fingerprint
+`)
 var imageObjectsByAutoUpdate = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
   FROM images JOIN projects ON images.project_id = projects.id
   WHERE images.auto_update = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByProjectAndAutoUpdate = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE project = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByFingerprintAndAutoUpdate = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE images.fingerprint LIKE ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByProjectAndFingerprintAndAutoUpdate = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE project = ? AND images.fingerprint LIKE ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByPublicAndAutoUpdate = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE images.public = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByProjectAndPublicAndAutoUpdate = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE project = ? AND images.public = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByFingerprintAndPublicAndAutoUpdate = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE images.fingerprint LIKE ? AND images.public = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByProjectAndFingerprintAndPublicAndAutoUpdate = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE project = ? AND images.fingerprint LIKE ? AND images.public = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByCachedAndAutoUpdate = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE images.cached = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByProjectAndCachedAndAutoUpdate = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE project = ? AND images.cached = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByFingerprintAndCachedAndAutoUpdate = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE images.fingerprint LIKE ? AND images.cached = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByProjectAndFingerprintAndCachedAndAutoUpdate = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE project = ? AND images.fingerprint LIKE ? AND images.cached = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByPublicAndCachedAndAutoUpdate = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE images.public = ? AND images.cached = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByProjectAndPublicAndCachedAndAutoUpdate = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE project = ? AND images.public = ? AND images.cached = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByFingerprintAndPublicAndCachedAndAutoUpdate = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE images.fingerprint LIKE ? AND images.public = ? AND images.cached = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
+`)
+var imageObjectsByProjectAndFingerprintAndPublicAndCachedAndAutoUpdate = cluster.RegisterStmt(`
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+  FROM images JOIN projects ON images.project_id = projects.id
+  WHERE project = ? AND images.fingerprint LIKE ? AND images.public = ? AND images.cached = ? AND images.auto_update = ? ORDER BY projects.id, images.fingerprint
 `)
 
 // GetImages returns all available images.
@@ -97,18 +204,148 @@ func (c *ClusterTx) GetImages(filter ImageFilter) ([]Image, error) {
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Project"] != nil && criteria["Fingerprint"] != nil && criteria["Public"] != nil {
+	if criteria["Project"] != nil && criteria["Fingerprint"] != nil && criteria["Public"] != nil && criteria["Cached"] != nil && criteria["AutoUpdate"] != nil {
+		stmt = c.stmt(imageObjectsByProjectAndFingerprintAndPublicAndCachedAndAutoUpdate)
+		args = []interface{}{
+			filter.Project,
+			filter.Fingerprint,
+			filter.Public,
+			filter.Cached,
+			filter.AutoUpdate,
+		}
+	} else if criteria["Project"] != nil && criteria["Fingerprint"] != nil && criteria["Public"] != nil && criteria["Cached"] != nil {
+		stmt = c.stmt(imageObjectsByProjectAndFingerprintAndPublicAndCached)
+		args = []interface{}{
+			filter.Project,
+			filter.Fingerprint,
+			filter.Public,
+			filter.Cached,
+		}
+	} else if criteria["Project"] != nil && criteria["Fingerprint"] != nil && criteria["Public"] != nil && criteria["AutoUpdate"] != nil {
+		stmt = c.stmt(imageObjectsByProjectAndFingerprintAndPublicAndAutoUpdate)
+		args = []interface{}{
+			filter.Project,
+			filter.Fingerprint,
+			filter.Public,
+			filter.AutoUpdate,
+		}
+	} else if criteria["Project"] != nil && criteria["Public"] != nil && criteria["Cached"] != nil && criteria["AutoUpdate"] != nil {
+		stmt = c.stmt(imageObjectsByProjectAndPublicAndCachedAndAutoUpdate)
+		args = []interface{}{
+			filter.Project,
+			filter.Public,
+			filter.Cached,
+			filter.AutoUpdate,
+		}
+	} else if criteria["Fingerprint"] != nil && criteria["Public"] != nil && criteria["Cached"] != nil && criteria["AutoUpdate"] != nil {
+		stmt = c.stmt(imageObjectsByFingerprintAndPublicAndCachedAndAutoUpdate)
+		args = []interface{}{
+			filter.Fingerprint,
+			filter.Public,
+			filter.Cached,
+			filter.AutoUpdate,
+		}
+	} else if criteria["Project"] != nil && criteria["Fingerprint"] != nil && criteria["Cached"] != nil && criteria["AutoUpdate"] != nil {
+		stmt = c.stmt(imageObjectsByProjectAndFingerprintAndCachedAndAutoUpdate)
+		args = []interface{}{
+			filter.Project,
+			filter.Fingerprint,
+			filter.Cached,
+			filter.AutoUpdate,
+		}
+	} else if criteria["Project"] != nil && criteria["Fingerprint"] != nil && criteria["Public"] != nil {
 		stmt = c.stmt(imageObjectsByProjectAndFingerprintAndPublic)
 		args = []interface{}{
 			filter.Project,
 			filter.Fingerprint,
 			filter.Public,
 		}
+	} else if criteria["Project"] != nil && criteria["Public"] != nil && criteria["Cached"] != nil {
+		stmt = c.stmt(imageObjectsByProjectAndPublicAndCached)
+		args = []interface{}{
+			filter.Project,
+			filter.Public,
+			filter.Cached,
+		}
+	} else if criteria["Project"] != nil && criteria["Public"] != nil && criteria["AutoUpdate"] != nil {
+		stmt = c.stmt(imageObjectsByProjectAndPublicAndAutoUpdate)
+		args = []interface{}{
+			filter.Project,
+			filter.Public,
+			filter.AutoUpdate,
+		}
+	} else if criteria["Fingerprint"] != nil && criteria["Public"] != nil && criteria["Cached"] != nil {
+		stmt = c.stmt(imageObjectsByFingerprintAndPublicAndCached)
+		args = []interface{}{
+			filter.Fingerprint,
+			filter.Public,
+			filter.Cached,
+		}
+	} else if criteria["Fingerprint"] != nil && criteria["Public"] != nil && criteria["AutoUpdate"] != nil {
+		stmt = c.stmt(imageObjectsByFingerprintAndPublicAndAutoUpdate)
+		args = []interface{}{
+			filter.Fingerprint,
+			filter.Public,
+			filter.AutoUpdate,
+		}
+	} else if criteria["Public"] != nil && criteria["Cached"] != nil && criteria["AutoUpdate"] != nil {
+		stmt = c.stmt(imageObjectsByPublicAndCachedAndAutoUpdate)
+		args = []interface{}{
+			filter.Public,
+			filter.Cached,
+			filter.AutoUpdate,
+		}
+	} else if criteria["Project"] != nil && criteria["Fingerprint"] != nil && criteria["Cached"] != nil {
+		stmt = c.stmt(imageObjectsByProjectAndFingerprintAndCached)
+		args = []interface{}{
+			filter.Project,
+			filter.Fingerprint,
+			filter.Cached,
+		}
+	} else if criteria["Project"] != nil && criteria["Fingerprint"] != nil && criteria["AutoUpdate"] != nil {
+		stmt = c.stmt(imageObjectsByProjectAndFingerprintAndAutoUpdate)
+		args = []interface{}{
+			filter.Project,
+			filter.Fingerprint,
+			filter.AutoUpdate,
+		}
+	} else if criteria["Project"] != nil && criteria["Cached"] != nil && criteria["AutoUpdate"] != nil {
+		stmt = c.stmt(imageObjectsByProjectAndCachedAndAutoUpdate)
+		args = []interface{}{
+			filter.Project,
+			filter.Cached,
+			filter.AutoUpdate,
+		}
+	} else if criteria["Fingerprint"] != nil && criteria["Cached"] != nil && criteria["AutoUpdate"] != nil {
+		stmt = c.stmt(imageObjectsByFingerprintAndCachedAndAutoUpdate)
+		args = []interface{}{
+			filter.Fingerprint,
+			filter.Cached,
+			filter.AutoUpdate,
+		}
 	} else if criteria["Project"] != nil && criteria["Public"] != nil {
 		stmt = c.stmt(imageObjectsByProjectAndPublic)
 		args = []interface{}{
 			filter.Project,
 			filter.Public,
+		}
+	} else if criteria["Fingerprint"] != nil && criteria["Public"] != nil {
+		stmt = c.stmt(imageObjectsByFingerprintAndPublic)
+		args = []interface{}{
+			filter.Fingerprint,
+			filter.Public,
+		}
+	} else if criteria["Public"] != nil && criteria["Cached"] != nil {
+		stmt = c.stmt(imageObjectsByPublicAndCached)
+		args = []interface{}{
+			filter.Public,
+			filter.Cached,
+		}
+	} else if criteria["Public"] != nil && criteria["AutoUpdate"] != nil {
+		stmt = c.stmt(imageObjectsByPublicAndAutoUpdate)
+		args = []interface{}{
+			filter.Public,
+			filter.AutoUpdate,
 		}
 	} else if criteria["Project"] != nil && criteria["Fingerprint"] != nil {
 		stmt = c.stmt(imageObjectsByProjectAndFingerprint)
@@ -121,6 +358,35 @@ func (c *ClusterTx) GetImages(filter ImageFilter) ([]Image, error) {
 		args = []interface{}{
 			filter.Project,
 			filter.Cached,
+		}
+	} else if criteria["Project"] != nil && criteria["AutoUpdate"] != nil {
+		stmt = c.stmt(imageObjectsByProjectAndAutoUpdate)
+		args = []interface{}{
+			filter.Project,
+			filter.AutoUpdate,
+		}
+	} else if criteria["Fingerprint"] != nil && criteria["Cached"] != nil {
+		stmt = c.stmt(imageObjectsByFingerprintAndCached)
+		args = []interface{}{
+			filter.Fingerprint,
+			filter.Cached,
+		}
+	} else if criteria["Fingerprint"] != nil && criteria["AutoUpdate"] != nil {
+		stmt = c.stmt(imageObjectsByFingerprintAndAutoUpdate)
+		args = []interface{}{
+			filter.Fingerprint,
+			filter.AutoUpdate,
+		}
+	} else if criteria["Cached"] != nil && criteria["AutoUpdate"] != nil {
+		stmt = c.stmt(imageObjectsByCachedAndAutoUpdate)
+		args = []interface{}{
+			filter.Cached,
+			filter.AutoUpdate,
+		}
+	} else if criteria["Public"] != nil {
+		stmt = c.stmt(imageObjectsByPublic)
+		args = []interface{}{
+			filter.Public,
 		}
 	} else if criteria["Project"] != nil {
 		stmt = c.stmt(imageObjectsByProject)

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -45,7 +45,7 @@ import (
 //go:generate mapper stmt -p db -e instance create-config-ref
 //go:generate mapper stmt -p db -e instance create-devices-ref
 //go:generate mapper stmt -p db -e instance rename
-//go:generate mapper stmt -p db -e instance delete-by-Project-and-Name
+//go:generate mapper stmt -p db -e instance delete
 //go:generate mapper stmt -p db -e instance delete-config-ref
 //go:generate mapper stmt -p db -e instance delete-devices-ref
 //go:generate mapper stmt -p db -e instance delete-profiles-ref

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -26,20 +26,8 @@ import (
 //
 //go:generate mapper stmt -p db -e instance objects
 //go:generate mapper stmt -p db -e instance profiles-ref
-//go:generate mapper stmt -p db -e instance profiles-ref-by-Project
-//go:generate mapper stmt -p db -e instance profiles-ref-by-Node
-//go:generate mapper stmt -p db -e instance profiles-ref-by-Project-and-Node
-//go:generate mapper stmt -p db -e instance profiles-ref-by-Project-and-Name
 //go:generate mapper stmt -p db -e instance config-ref
-//go:generate mapper stmt -p db -e instance config-ref-by-Project
-//go:generate mapper stmt -p db -e instance config-ref-by-Node
-//go:generate mapper stmt -p db -e instance config-ref-by-Project-and-Node
-//go:generate mapper stmt -p db -e instance config-ref-by-Project-and-Name
 //go:generate mapper stmt -p db -e instance devices-ref
-//go:generate mapper stmt -p db -e instance devices-ref-by-Project
-//go:generate mapper stmt -p db -e instance devices-ref-by-Node
-//go:generate mapper stmt -p db -e instance devices-ref-by-Project-and-Node
-//go:generate mapper stmt -p db -e instance devices-ref-by-Project-and-Name
 //go:generate mapper stmt -p db -e instance id
 //go:generate mapper stmt -p db -e instance create struct=Instance
 //go:generate mapper stmt -p db -e instance create-config-ref
@@ -88,7 +76,7 @@ type InstanceFilter struct {
 	Project string
 	Name    string
 	Node    string
-	Type    instancetype.Type
+	Type    instancetype.Type `db:"omit=profiles-ref,config-ref"`
 }
 
 // InstanceFilterAllInstances returns a predefined filter for returning all instances.

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -25,21 +25,6 @@ import (
 //go:generate mapper reset
 //
 //go:generate mapper stmt -p db -e instance objects
-//go:generate mapper stmt -p db -e instance objects-by-Project
-//go:generate mapper stmt -p db -e instance objects-by-Project-and-Type
-//go:generate mapper stmt -p db -e instance objects-by-Project-and-Type-and-Node
-//go:generate mapper stmt -p db -e instance objects-by-Project-and-Type-and-Node-and-Name
-//go:generate mapper stmt -p db -e instance objects-by-Project-and-Type-and-Name
-//go:generate mapper stmt -p db -e instance objects-by-Project-and-Name
-//go:generate mapper stmt -p db -e instance objects-by-Project-and-Name-and-Node
-//go:generate mapper stmt -p db -e instance objects-by-Project-and-Node
-//go:generate mapper stmt -p db -e instance objects-by-Type
-//go:generate mapper stmt -p db -e instance objects-by-Type-and-Name
-//go:generate mapper stmt -p db -e instance objects-by-Type-and-Name-and-Node
-//go:generate mapper stmt -p db -e instance objects-by-Type-and-Node
-//go:generate mapper stmt -p db -e instance objects-by-Node
-//go:generate mapper stmt -p db -e instance objects-by-Node-and-Name
-//go:generate mapper stmt -p db -e instance objects-by-Name
 //go:generate mapper stmt -p db -e instance profiles-ref
 //go:generate mapper stmt -p db -e instance profiles-ref-by-Project
 //go:generate mapper stmt -p db -e instance profiles-ref-by-Node

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -332,9 +332,9 @@ var ErrInstanceListStop = fmt.Errorf("search stopped")
 
 // InstanceList loads all instances across all projects and for each instance runs the instanceFunc passing in the
 // instance and it's project and profiles. Accepts optional filter argument to specify a subset of instances.
-func (c *Cluster) InstanceList(filter *InstanceFilter, instanceFunc func(inst Instance, project api.Project, profiles []api.Profile) error) error {
+func (c *Cluster) InstanceList(filter *InstanceFilter, instanceFunc func(inst Instance, project Project, profiles []api.Profile) error) error {
 	var instances []Instance
-	projectMap := map[string]api.Project{}
+	projectMap := map[string]Project{}
 	projectHasProfiles := map[string]bool{}
 	profilesByProjectAndName := map[string]map[string]Profile{}
 

--- a/lxd/db/instances.mapper.go
+++ b/lxd/db/instances.mapper.go
@@ -100,61 +100,100 @@ SELECT instances.id, projects.name AS project, instances.name, nodes.name AS nod
 var instanceProfilesRef = cluster.RegisterStmt(`
 SELECT project, name, value FROM instances_profiles_ref ORDER BY project, name
 `)
-
 var instanceProfilesRefByProject = cluster.RegisterStmt(`
 SELECT project, name, value FROM instances_profiles_ref WHERE project = ? ORDER BY project, name
 `)
-
+var instanceProfilesRefByName = cluster.RegisterStmt(`
+SELECT project, name, value FROM instances_profiles_ref WHERE name = ? ORDER BY project, name
+`)
+var instanceProfilesRefByProjectAndName = cluster.RegisterStmt(`
+SELECT project, name, value FROM instances_profiles_ref WHERE project = ? AND name = ? ORDER BY project, name
+`)
 var instanceProfilesRefByNode = cluster.RegisterStmt(`
 SELECT project, name, value FROM instances_profiles_ref WHERE node = ? ORDER BY project, name
 `)
-
 var instanceProfilesRefByProjectAndNode = cluster.RegisterStmt(`
 SELECT project, name, value FROM instances_profiles_ref WHERE project = ? AND node = ? ORDER BY project, name
 `)
-
-var instanceProfilesRefByProjectAndName = cluster.RegisterStmt(`
-SELECT project, name, value FROM instances_profiles_ref WHERE project = ? AND name = ? ORDER BY project, name
+var instanceProfilesRefByNameAndNode = cluster.RegisterStmt(`
+SELECT project, name, value FROM instances_profiles_ref WHERE name = ? AND node = ? ORDER BY project, name
+`)
+var instanceProfilesRefByProjectAndNameAndNode = cluster.RegisterStmt(`
+SELECT project, name, value FROM instances_profiles_ref WHERE project = ? AND name = ? AND node = ? ORDER BY project, name
 `)
 
 var instanceConfigRef = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM instances_config_ref ORDER BY project, name
 `)
-
 var instanceConfigRefByProject = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM instances_config_ref WHERE project = ? ORDER BY project, name
 `)
-
+var instanceConfigRefByName = cluster.RegisterStmt(`
+SELECT project, name, key, value FROM instances_config_ref WHERE name = ? ORDER BY project, name
+`)
+var instanceConfigRefByProjectAndName = cluster.RegisterStmt(`
+SELECT project, name, key, value FROM instances_config_ref WHERE project = ? AND name = ? ORDER BY project, name
+`)
 var instanceConfigRefByNode = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM instances_config_ref WHERE node = ? ORDER BY project, name
 `)
-
 var instanceConfigRefByProjectAndNode = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM instances_config_ref WHERE project = ? AND node = ? ORDER BY project, name
 `)
-
-var instanceConfigRefByProjectAndName = cluster.RegisterStmt(`
-SELECT project, name, key, value FROM instances_config_ref WHERE project = ? AND name = ? ORDER BY project, name
+var instanceConfigRefByNameAndNode = cluster.RegisterStmt(`
+SELECT project, name, key, value FROM instances_config_ref WHERE name = ? AND node = ? ORDER BY project, name
+`)
+var instanceConfigRefByProjectAndNameAndNode = cluster.RegisterStmt(`
+SELECT project, name, key, value FROM instances_config_ref WHERE project = ? AND name = ? AND node = ? ORDER BY project, name
 `)
 
 var instanceDevicesRef = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref ORDER BY project, name
 `)
-
 var instanceDevicesRefByProject = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE project = ? ORDER BY project, name
 `)
-
+var instanceDevicesRefByName = cluster.RegisterStmt(`
+SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE name = ? ORDER BY project, name
+`)
+var instanceDevicesRefByProjectAndName = cluster.RegisterStmt(`
+SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE project = ? AND name = ? ORDER BY project, name
+`)
 var instanceDevicesRefByNode = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE node = ? ORDER BY project, name
 `)
-
 var instanceDevicesRefByProjectAndNode = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE project = ? AND node = ? ORDER BY project, name
 `)
-
-var instanceDevicesRefByProjectAndName = cluster.RegisterStmt(`
-SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE project = ? AND name = ? ORDER BY project, name
+var instanceDevicesRefByNameAndNode = cluster.RegisterStmt(`
+SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE name = ? AND node = ? ORDER BY project, name
+`)
+var instanceDevicesRefByProjectAndNameAndNode = cluster.RegisterStmt(`
+SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE project = ? AND name = ? AND node = ? ORDER BY project, name
+`)
+var instanceDevicesRefByType = cluster.RegisterStmt(`
+SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE type = ? ORDER BY project, name
+`)
+var instanceDevicesRefByProjectAndType = cluster.RegisterStmt(`
+SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE project = ? AND type = ? ORDER BY project, name
+`)
+var instanceDevicesRefByNameAndType = cluster.RegisterStmt(`
+SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE name = ? AND type = ? ORDER BY project, name
+`)
+var instanceDevicesRefByProjectAndNameAndType = cluster.RegisterStmt(`
+SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE project = ? AND name = ? AND type = ? ORDER BY project, name
+`)
+var instanceDevicesRefByNodeAndType = cluster.RegisterStmt(`
+SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE node = ? AND type = ? ORDER BY project, name
+`)
+var instanceDevicesRefByProjectAndNodeAndType = cluster.RegisterStmt(`
+SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE project = ? AND node = ? AND type = ? ORDER BY project, name
+`)
+var instanceDevicesRefByNameAndNodeAndType = cluster.RegisterStmt(`
+SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE name = ? AND node = ? AND type = ? ORDER BY project, name
+`)
+var instanceDevicesRefByProjectAndNameAndNodeAndType = cluster.RegisterStmt(`
+SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE project = ? AND name = ? AND node = ? AND type = ? ORDER BY project, name
 `)
 
 var instanceID = cluster.RegisterStmt(`
@@ -629,7 +668,14 @@ func (c *ClusterTx) InstanceProfilesRef(filter InstanceFilter) (map[string]map[s
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Project"] != nil && criteria["Node"] != nil {
+	if criteria["Project"] != nil && criteria["Name"] != nil && criteria["Node"] != nil {
+		stmt = c.stmt(instanceProfilesRefByProjectAndNameAndNode)
+		args = []interface{}{
+			filter.Project,
+			filter.Name,
+			filter.Node,
+		}
+	} else if criteria["Project"] != nil && criteria["Node"] != nil {
 		stmt = c.stmt(instanceProfilesRefByProjectAndNode)
 		args = []interface{}{
 			filter.Project,
@@ -641,6 +687,12 @@ func (c *ClusterTx) InstanceProfilesRef(filter InstanceFilter) (map[string]map[s
 			filter.Project,
 			filter.Name,
 		}
+	} else if criteria["Name"] != nil && criteria["Node"] != nil {
+		stmt = c.stmt(instanceProfilesRefByNameAndNode)
+		args = []interface{}{
+			filter.Name,
+			filter.Node,
+		}
 	} else if criteria["Project"] != nil {
 		stmt = c.stmt(instanceProfilesRefByProject)
 		args = []interface{}{
@@ -650,6 +702,11 @@ func (c *ClusterTx) InstanceProfilesRef(filter InstanceFilter) (map[string]map[s
 		stmt = c.stmt(instanceProfilesRefByNode)
 		args = []interface{}{
 			filter.Node,
+		}
+	} else if criteria["Name"] != nil {
+		stmt = c.stmt(instanceProfilesRefByName)
+		args = []interface{}{
+			filter.Name,
 		}
 	} else {
 		stmt = c.stmt(instanceProfilesRef)
@@ -720,7 +777,14 @@ func (c *ClusterTx) InstanceConfigRef(filter InstanceFilter) (map[string]map[str
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Project"] != nil && criteria["Node"] != nil {
+	if criteria["Project"] != nil && criteria["Name"] != nil && criteria["Node"] != nil {
+		stmt = c.stmt(instanceConfigRefByProjectAndNameAndNode)
+		args = []interface{}{
+			filter.Project,
+			filter.Name,
+			filter.Node,
+		}
+	} else if criteria["Project"] != nil && criteria["Node"] != nil {
 		stmt = c.stmt(instanceConfigRefByProjectAndNode)
 		args = []interface{}{
 			filter.Project,
@@ -732,6 +796,12 @@ func (c *ClusterTx) InstanceConfigRef(filter InstanceFilter) (map[string]map[str
 			filter.Project,
 			filter.Name,
 		}
+	} else if criteria["Name"] != nil && criteria["Node"] != nil {
+		stmt = c.stmt(instanceConfigRefByNameAndNode)
+		args = []interface{}{
+			filter.Name,
+			filter.Node,
+		}
 	} else if criteria["Project"] != nil {
 		stmt = c.stmt(instanceConfigRefByProject)
 		args = []interface{}{
@@ -741,6 +811,11 @@ func (c *ClusterTx) InstanceConfigRef(filter InstanceFilter) (map[string]map[str
 		stmt = c.stmt(instanceConfigRefByNode)
 		args = []interface{}{
 			filter.Node,
+		}
+	} else if criteria["Name"] != nil {
+		stmt = c.stmt(instanceConfigRefByName)
+		args = []interface{}{
+			filter.Name,
 		}
 	} else {
 		stmt = c.stmt(instanceConfigRef)
@@ -816,7 +891,61 @@ func (c *ClusterTx) InstanceDevicesRef(filter InstanceFilter) (map[string]map[st
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Project"] != nil && criteria["Node"] != nil {
+	if criteria["Project"] != nil && criteria["Name"] != nil && criteria["Node"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceDevicesRefByProjectAndNameAndNodeAndType)
+		args = []interface{}{
+			filter.Project,
+			filter.Name,
+			filter.Node,
+			filter.Type,
+		}
+	} else if criteria["Project"] != nil && criteria["Node"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceDevicesRefByProjectAndNodeAndType)
+		args = []interface{}{
+			filter.Project,
+			filter.Node,
+			filter.Type,
+		}
+	} else if criteria["Project"] != nil && criteria["Name"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceDevicesRefByProjectAndNameAndType)
+		args = []interface{}{
+			filter.Project,
+			filter.Name,
+			filter.Type,
+		}
+	} else if criteria["Name"] != nil && criteria["Node"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceDevicesRefByNameAndNodeAndType)
+		args = []interface{}{
+			filter.Name,
+			filter.Node,
+			filter.Type,
+		}
+	} else if criteria["Project"] != nil && criteria["Name"] != nil && criteria["Node"] != nil {
+		stmt = c.stmt(instanceDevicesRefByProjectAndNameAndNode)
+		args = []interface{}{
+			filter.Project,
+			filter.Name,
+			filter.Node,
+		}
+	} else if criteria["Project"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceDevicesRefByProjectAndType)
+		args = []interface{}{
+			filter.Project,
+			filter.Type,
+		}
+	} else if criteria["Node"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceDevicesRefByNodeAndType)
+		args = []interface{}{
+			filter.Node,
+			filter.Type,
+		}
+	} else if criteria["Name"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceDevicesRefByNameAndType)
+		args = []interface{}{
+			filter.Name,
+			filter.Type,
+		}
+	} else if criteria["Project"] != nil && criteria["Node"] != nil {
 		stmt = c.stmt(instanceDevicesRefByProjectAndNode)
 		args = []interface{}{
 			filter.Project,
@@ -828,6 +957,17 @@ func (c *ClusterTx) InstanceDevicesRef(filter InstanceFilter) (map[string]map[st
 			filter.Project,
 			filter.Name,
 		}
+	} else if criteria["Name"] != nil && criteria["Node"] != nil {
+		stmt = c.stmt(instanceDevicesRefByNameAndNode)
+		args = []interface{}{
+			filter.Name,
+			filter.Node,
+		}
+	} else if criteria["Type"] != nil {
+		stmt = c.stmt(instanceDevicesRefByType)
+		args = []interface{}{
+			filter.Type,
+		}
 	} else if criteria["Project"] != nil {
 		stmt = c.stmt(instanceDevicesRefByProject)
 		args = []interface{}{
@@ -837,6 +977,11 @@ func (c *ClusterTx) InstanceDevicesRef(filter InstanceFilter) (map[string]map[st
 		stmt = c.stmt(instanceDevicesRefByNode)
 		args = []interface{}{
 			filter.Node,
+		}
+	} else if criteria["Name"] != nil {
+		stmt = c.stmt(instanceDevicesRefByName)
+		args = []interface{}{
+			filter.Name,
 		}
 	} else {
 		stmt = c.stmt(instanceDevicesRef)

--- a/lxd/db/instances.mapper.go
+++ b/lxd/db/instances.mapper.go
@@ -185,8 +185,50 @@ var instanceRename = cluster.RegisterStmt(`
 UPDATE instances SET name = ? WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND name = ?
 `)
 
+var instanceDeleteByProject = cluster.RegisterStmt(`
+DELETE FROM instances WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?)
+`)
+var instanceDeleteByName = cluster.RegisterStmt(`
+DELETE FROM instances WHERE name = ?
+`)
 var instanceDeleteByProjectAndName = cluster.RegisterStmt(`
 DELETE FROM instances WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND name = ?
+`)
+var instanceDeleteByNode = cluster.RegisterStmt(`
+DELETE FROM instances WHERE node_id = (SELECT nodes.id FROM nodes WHERE nodes.name = ?)
+`)
+var instanceDeleteByProjectAndNode = cluster.RegisterStmt(`
+DELETE FROM instances WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND node_id = (SELECT nodes.id FROM nodes WHERE nodes.name = ?)
+`)
+var instanceDeleteByNameAndNode = cluster.RegisterStmt(`
+DELETE FROM instances WHERE name = ? AND node_id = (SELECT nodes.id FROM nodes WHERE nodes.name = ?)
+`)
+var instanceDeleteByProjectAndNameAndNode = cluster.RegisterStmt(`
+DELETE FROM instances WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND name = ? AND node_id = (SELECT nodes.id FROM nodes WHERE nodes.name = ?)
+`)
+var instanceDeleteByType = cluster.RegisterStmt(`
+DELETE FROM instances WHERE type = ?
+`)
+var instanceDeleteByProjectAndType = cluster.RegisterStmt(`
+DELETE FROM instances WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND type = ?
+`)
+var instanceDeleteByNameAndType = cluster.RegisterStmt(`
+DELETE FROM instances WHERE name = ? AND type = ?
+`)
+var instanceDeleteByProjectAndNameAndType = cluster.RegisterStmt(`
+DELETE FROM instances WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND name = ? AND type = ?
+`)
+var instanceDeleteByNodeAndType = cluster.RegisterStmt(`
+DELETE FROM instances WHERE node_id = (SELECT nodes.id FROM nodes WHERE nodes.name = ?) AND type = ?
+`)
+var instanceDeleteByProjectAndNodeAndType = cluster.RegisterStmt(`
+DELETE FROM instances WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND node_id = (SELECT nodes.id FROM nodes WHERE nodes.name = ?) AND type = ?
+`)
+var instanceDeleteByNameAndNodeAndType = cluster.RegisterStmt(`
+DELETE FROM instances WHERE name = ? AND node_id = (SELECT nodes.id FROM nodes WHERE nodes.name = ?) AND type = ?
+`)
+var instanceDeleteByProjectAndNameAndNodeAndType = cluster.RegisterStmt(`
+DELETE FROM instances WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND name = ? AND node_id = (SELECT nodes.id FROM nodes WHERE nodes.name = ?) AND type = ?
 `)
 
 var instanceDeleteConfigRef = cluster.RegisterStmt(`
@@ -903,10 +945,96 @@ func (c *ClusterTx) DeleteInstance(filter InstanceFilter) error {
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Project"] != nil && criteria["Name"] != nil {
+	if criteria["Project"] != nil && criteria["Name"] != nil && criteria["Node"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceDeleteByProjectAndNameAndNodeAndType)
+		args = []interface{}{
+			filter.Project,
+			filter.Name,
+			filter.Node,
+			filter.Type,
+		}
+	} else if criteria["Project"] != nil && criteria["Node"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceDeleteByProjectAndNodeAndType)
+		args = []interface{}{
+			filter.Project,
+			filter.Node,
+			filter.Type,
+		}
+	} else if criteria["Project"] != nil && criteria["Name"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceDeleteByProjectAndNameAndType)
+		args = []interface{}{
+			filter.Project,
+			filter.Name,
+			filter.Type,
+		}
+	} else if criteria["Name"] != nil && criteria["Node"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceDeleteByNameAndNodeAndType)
+		args = []interface{}{
+			filter.Name,
+			filter.Node,
+			filter.Type,
+		}
+	} else if criteria["Project"] != nil && criteria["Name"] != nil && criteria["Node"] != nil {
+		stmt = c.stmt(instanceDeleteByProjectAndNameAndNode)
+		args = []interface{}{
+			filter.Project,
+			filter.Name,
+			filter.Node,
+		}
+	} else if criteria["Project"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceDeleteByProjectAndType)
+		args = []interface{}{
+			filter.Project,
+			filter.Type,
+		}
+	} else if criteria["Node"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceDeleteByNodeAndType)
+		args = []interface{}{
+			filter.Node,
+			filter.Type,
+		}
+	} else if criteria["Name"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceDeleteByNameAndType)
+		args = []interface{}{
+			filter.Name,
+			filter.Type,
+		}
+	} else if criteria["Project"] != nil && criteria["Node"] != nil {
+		stmt = c.stmt(instanceDeleteByProjectAndNode)
+		args = []interface{}{
+			filter.Project,
+			filter.Node,
+		}
+	} else if criteria["Project"] != nil && criteria["Name"] != nil {
 		stmt = c.stmt(instanceDeleteByProjectAndName)
 		args = []interface{}{
 			filter.Project,
+			filter.Name,
+		}
+	} else if criteria["Name"] != nil && criteria["Node"] != nil {
+		stmt = c.stmt(instanceDeleteByNameAndNode)
+		args = []interface{}{
+			filter.Name,
+			filter.Node,
+		}
+	} else if criteria["Type"] != nil {
+		stmt = c.stmt(instanceDeleteByType)
+		args = []interface{}{
+			filter.Type,
+		}
+	} else if criteria["Project"] != nil {
+		stmt = c.stmt(instanceDeleteByProject)
+		args = []interface{}{
+			filter.Project,
+		}
+	} else if criteria["Node"] != nil {
+		stmt = c.stmt(instanceDeleteByNode)
+		args = []interface{}{
+			filter.Node,
+		}
+	} else if criteria["Name"] != nil {
+		stmt = c.stmt(instanceDeleteByName)
+		args = []interface{}{
 			filter.Name,
 		}
 	} else {

--- a/lxd/db/instances.mapper.go
+++ b/lxd/db/instances.mapper.go
@@ -21,95 +21,80 @@ SELECT instances.id, projects.name AS project, instances.name, nodes.name AS nod
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   ORDER BY projects.id, instances.name
 `)
-
 var instanceObjectsByProject = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE project = ? ORDER BY projects.id, instances.name
 `)
-
-var instanceObjectsByProjectAndType = cluster.RegisterStmt(`
+var instanceObjectsByName = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE project = ? AND instances.type = ? ORDER BY projects.id, instances.name
+  WHERE instances.name = ? ORDER BY projects.id, instances.name
 `)
-
-var instanceObjectsByProjectAndTypeAndNode = cluster.RegisterStmt(`
-SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
-  FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE project = ? AND instances.type = ? AND node = ? ORDER BY projects.id, instances.name
-`)
-
-var instanceObjectsByProjectAndTypeAndNodeAndName = cluster.RegisterStmt(`
-SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
-  FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE project = ? AND instances.type = ? AND node = ? AND instances.name = ? ORDER BY projects.id, instances.name
-`)
-
-var instanceObjectsByProjectAndTypeAndName = cluster.RegisterStmt(`
-SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
-  FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE project = ? AND instances.type = ? AND instances.name = ? ORDER BY projects.id, instances.name
-`)
-
 var instanceObjectsByProjectAndName = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE project = ? AND instances.name = ? ORDER BY projects.id, instances.name
 `)
-
-var instanceObjectsByProjectAndNameAndNode = cluster.RegisterStmt(`
-SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
-  FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE project = ? AND instances.name = ? AND node = ? ORDER BY projects.id, instances.name
-`)
-
-var instanceObjectsByProjectAndNode = cluster.RegisterStmt(`
-SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
-  FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE project = ? AND node = ? ORDER BY projects.id, instances.name
-`)
-
-var instanceObjectsByType = cluster.RegisterStmt(`
-SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
-  FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE instances.type = ? ORDER BY projects.id, instances.name
-`)
-
-var instanceObjectsByTypeAndName = cluster.RegisterStmt(`
-SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
-  FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE instances.type = ? AND instances.name = ? ORDER BY projects.id, instances.name
-`)
-
-var instanceObjectsByTypeAndNameAndNode = cluster.RegisterStmt(`
-SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
-  FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE instances.type = ? AND instances.name = ? AND node = ? ORDER BY projects.id, instances.name
-`)
-
-var instanceObjectsByTypeAndNode = cluster.RegisterStmt(`
-SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
-  FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE instances.type = ? AND node = ? ORDER BY projects.id, instances.name
-`)
-
 var instanceObjectsByNode = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE node = ? ORDER BY projects.id, instances.name
 `)
-
-var instanceObjectsByNodeAndName = cluster.RegisterStmt(`
+var instanceObjectsByProjectAndNode = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE node = ? AND instances.name = ? ORDER BY projects.id, instances.name
+  WHERE project = ? AND node = ? ORDER BY projects.id, instances.name
 `)
-
-var instanceObjectsByName = cluster.RegisterStmt(`
+var instanceObjectsByNameAndNode = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
-  WHERE instances.name = ? ORDER BY projects.id, instances.name
+  WHERE instances.name = ? AND node = ? ORDER BY projects.id, instances.name
+`)
+var instanceObjectsByProjectAndNameAndNode = cluster.RegisterStmt(`
+SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
+  FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
+  WHERE project = ? AND instances.name = ? AND node = ? ORDER BY projects.id, instances.name
+`)
+var instanceObjectsByType = cluster.RegisterStmt(`
+SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
+  FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
+  WHERE instances.type = ? ORDER BY projects.id, instances.name
+`)
+var instanceObjectsByProjectAndType = cluster.RegisterStmt(`
+SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
+  FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
+  WHERE project = ? AND instances.type = ? ORDER BY projects.id, instances.name
+`)
+var instanceObjectsByNameAndType = cluster.RegisterStmt(`
+SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
+  FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
+  WHERE instances.name = ? AND instances.type = ? ORDER BY projects.id, instances.name
+`)
+var instanceObjectsByProjectAndNameAndType = cluster.RegisterStmt(`
+SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
+  FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
+  WHERE project = ? AND instances.name = ? AND instances.type = ? ORDER BY projects.id, instances.name
+`)
+var instanceObjectsByNodeAndType = cluster.RegisterStmt(`
+SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
+  FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
+  WHERE node = ? AND instances.type = ? ORDER BY projects.id, instances.name
+`)
+var instanceObjectsByProjectAndNodeAndType = cluster.RegisterStmt(`
+SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
+  FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
+  WHERE project = ? AND node = ? AND instances.type = ? ORDER BY projects.id, instances.name
+`)
+var instanceObjectsByNameAndNodeAndType = cluster.RegisterStmt(`
+SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
+  FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
+  WHERE instances.name = ? AND node = ? AND instances.type = ? ORDER BY projects.id, instances.name
+`)
+var instanceObjectsByProjectAndNameAndNodeAndType = cluster.RegisterStmt(`
+SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
+  FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
+  WHERE project = ? AND instances.name = ? AND node = ? AND instances.type = ? ORDER BY projects.id, instances.name
 `)
 
 var instanceProfilesRef = cluster.RegisterStmt(`
@@ -246,34 +231,34 @@ func (c *ClusterTx) GetInstances(filter InstanceFilter) ([]Instance, error) {
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Project"] != nil && criteria["Type"] != nil && criteria["Node"] != nil && criteria["Name"] != nil {
-		stmt = c.stmt(instanceObjectsByProjectAndTypeAndNodeAndName)
+	if criteria["Project"] != nil && criteria["Name"] != nil && criteria["Node"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceObjectsByProjectAndNameAndNodeAndType)
 		args = []interface{}{
 			filter.Project,
-			filter.Type,
-			filter.Node,
 			filter.Name,
+			filter.Node,
+			filter.Type,
 		}
-	} else if criteria["Project"] != nil && criteria["Type"] != nil && criteria["Node"] != nil {
-		stmt = c.stmt(instanceObjectsByProjectAndTypeAndNode)
+	} else if criteria["Project"] != nil && criteria["Node"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceObjectsByProjectAndNodeAndType)
 		args = []interface{}{
 			filter.Project,
-			filter.Type,
 			filter.Node,
+			filter.Type,
 		}
-	} else if criteria["Project"] != nil && criteria["Type"] != nil && criteria["Name"] != nil {
-		stmt = c.stmt(instanceObjectsByProjectAndTypeAndName)
+	} else if criteria["Project"] != nil && criteria["Name"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceObjectsByProjectAndNameAndType)
 		args = []interface{}{
 			filter.Project,
-			filter.Type,
 			filter.Name,
-		}
-	} else if criteria["Type"] != nil && criteria["Name"] != nil && criteria["Node"] != nil {
-		stmt = c.stmt(instanceObjectsByTypeAndNameAndNode)
-		args = []interface{}{
 			filter.Type,
+		}
+	} else if criteria["Name"] != nil && criteria["Node"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceObjectsByNameAndNodeAndType)
+		args = []interface{}{
 			filter.Name,
 			filter.Node,
+			filter.Type,
 		}
 	} else if criteria["Project"] != nil && criteria["Name"] != nil && criteria["Node"] != nil {
 		stmt = c.stmt(instanceObjectsByProjectAndNameAndNode)
@@ -288,17 +273,17 @@ func (c *ClusterTx) GetInstances(filter InstanceFilter) ([]Instance, error) {
 			filter.Project,
 			filter.Type,
 		}
-	} else if criteria["Type"] != nil && criteria["Node"] != nil {
-		stmt = c.stmt(instanceObjectsByTypeAndNode)
+	} else if criteria["Node"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceObjectsByNodeAndType)
 		args = []interface{}{
-			filter.Type,
 			filter.Node,
-		}
-	} else if criteria["Type"] != nil && criteria["Name"] != nil {
-		stmt = c.stmt(instanceObjectsByTypeAndName)
-		args = []interface{}{
 			filter.Type,
+		}
+	} else if criteria["Name"] != nil && criteria["Type"] != nil {
+		stmt = c.stmt(instanceObjectsByNameAndType)
+		args = []interface{}{
 			filter.Name,
+			filter.Type,
 		}
 	} else if criteria["Project"] != nil && criteria["Node"] != nil {
 		stmt = c.stmt(instanceObjectsByProjectAndNode)
@@ -312,11 +297,11 @@ func (c *ClusterTx) GetInstances(filter InstanceFilter) ([]Instance, error) {
 			filter.Project,
 			filter.Name,
 		}
-	} else if criteria["Node"] != nil && criteria["Name"] != nil {
-		stmt = c.stmt(instanceObjectsByNodeAndName)
+	} else if criteria["Name"] != nil && criteria["Node"] != nil {
+		stmt = c.stmt(instanceObjectsByNameAndNode)
 		args = []interface{}{
-			filter.Node,
 			filter.Name,
+			filter.Node,
 		}
 	} else if criteria["Type"] != nil {
 		stmt = c.stmt(instanceObjectsByType)

--- a/lxd/db/instances.mapper.go
+++ b/lxd/db/instances.mapper.go
@@ -16,273 +16,273 @@ import (
 
 var _ = api.ServerEnvironment{}
 
-var instanceObjects = cluster.RegisterStmt(`
+const instanceObjects = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   ORDER BY projects.id, instances.name
 `)
-var instanceObjectsByProject = cluster.RegisterStmt(`
+const instanceObjectsByProject = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE project = ? ORDER BY projects.id, instances.name
 `)
-var instanceObjectsByName = cluster.RegisterStmt(`
+const instanceObjectsByName = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE instances.name = ? ORDER BY projects.id, instances.name
 `)
-var instanceObjectsByProjectAndName = cluster.RegisterStmt(`
+const instanceObjectsByProjectAndName = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE project = ? AND instances.name = ? ORDER BY projects.id, instances.name
 `)
-var instanceObjectsByNode = cluster.RegisterStmt(`
+const instanceObjectsByNode = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE node = ? ORDER BY projects.id, instances.name
 `)
-var instanceObjectsByProjectAndNode = cluster.RegisterStmt(`
+const instanceObjectsByProjectAndNode = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE project = ? AND node = ? ORDER BY projects.id, instances.name
 `)
-var instanceObjectsByNameAndNode = cluster.RegisterStmt(`
+const instanceObjectsByNameAndNode = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE instances.name = ? AND node = ? ORDER BY projects.id, instances.name
 `)
-var instanceObjectsByProjectAndNameAndNode = cluster.RegisterStmt(`
+const instanceObjectsByProjectAndNameAndNode = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE project = ? AND instances.name = ? AND node = ? ORDER BY projects.id, instances.name
 `)
-var instanceObjectsByType = cluster.RegisterStmt(`
+const instanceObjectsByType = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE instances.type = ? ORDER BY projects.id, instances.name
 `)
-var instanceObjectsByProjectAndType = cluster.RegisterStmt(`
+const instanceObjectsByProjectAndType = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE project = ? AND instances.type = ? ORDER BY projects.id, instances.name
 `)
-var instanceObjectsByNameAndType = cluster.RegisterStmt(`
+const instanceObjectsByNameAndType = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE instances.name = ? AND instances.type = ? ORDER BY projects.id, instances.name
 `)
-var instanceObjectsByProjectAndNameAndType = cluster.RegisterStmt(`
+const instanceObjectsByProjectAndNameAndType = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE project = ? AND instances.name = ? AND instances.type = ? ORDER BY projects.id, instances.name
 `)
-var instanceObjectsByNodeAndType = cluster.RegisterStmt(`
+const instanceObjectsByNodeAndType = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE node = ? AND instances.type = ? ORDER BY projects.id, instances.name
 `)
-var instanceObjectsByProjectAndNodeAndType = cluster.RegisterStmt(`
+const instanceObjectsByProjectAndNodeAndType = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE project = ? AND node = ? AND instances.type = ? ORDER BY projects.id, instances.name
 `)
-var instanceObjectsByNameAndNodeAndType = cluster.RegisterStmt(`
+const instanceObjectsByNameAndNodeAndType = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE instances.name = ? AND node = ? AND instances.type = ? ORDER BY projects.id, instances.name
 `)
-var instanceObjectsByProjectAndNameAndNodeAndType = cluster.RegisterStmt(`
+const instanceObjectsByProjectAndNameAndNodeAndType = cluster.RegisterStmt(`
 SELECT instances.id, projects.name AS project, instances.name, nodes.name AS node, instances.type, instances.architecture, instances.ephemeral, instances.creation_date, instances.stateful, instances.last_use_date, coalesce(instances.description, ''), instances.expiry_date
   FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE project = ? AND instances.name = ? AND node = ? AND instances.type = ? ORDER BY projects.id, instances.name
 `)
 
-var instanceProfilesRef = cluster.RegisterStmt(`
+const instanceProfilesRef = cluster.RegisterStmt(`
 SELECT project, name, value FROM instances_profiles_ref ORDER BY project, name
 `)
-var instanceProfilesRefByProject = cluster.RegisterStmt(`
+const instanceProfilesRefByProject = cluster.RegisterStmt(`
 SELECT project, name, value FROM instances_profiles_ref WHERE project = ? ORDER BY project, name
 `)
-var instanceProfilesRefByName = cluster.RegisterStmt(`
+const instanceProfilesRefByName = cluster.RegisterStmt(`
 SELECT project, name, value FROM instances_profiles_ref WHERE name = ? ORDER BY project, name
 `)
-var instanceProfilesRefByProjectAndName = cluster.RegisterStmt(`
+const instanceProfilesRefByProjectAndName = cluster.RegisterStmt(`
 SELECT project, name, value FROM instances_profiles_ref WHERE project = ? AND name = ? ORDER BY project, name
 `)
-var instanceProfilesRefByNode = cluster.RegisterStmt(`
+const instanceProfilesRefByNode = cluster.RegisterStmt(`
 SELECT project, name, value FROM instances_profiles_ref WHERE node = ? ORDER BY project, name
 `)
-var instanceProfilesRefByProjectAndNode = cluster.RegisterStmt(`
+const instanceProfilesRefByProjectAndNode = cluster.RegisterStmt(`
 SELECT project, name, value FROM instances_profiles_ref WHERE project = ? AND node = ? ORDER BY project, name
 `)
-var instanceProfilesRefByNameAndNode = cluster.RegisterStmt(`
+const instanceProfilesRefByNameAndNode = cluster.RegisterStmt(`
 SELECT project, name, value FROM instances_profiles_ref WHERE name = ? AND node = ? ORDER BY project, name
 `)
-var instanceProfilesRefByProjectAndNameAndNode = cluster.RegisterStmt(`
+const instanceProfilesRefByProjectAndNameAndNode = cluster.RegisterStmt(`
 SELECT project, name, value FROM instances_profiles_ref WHERE project = ? AND name = ? AND node = ? ORDER BY project, name
 `)
 
-var instanceConfigRef = cluster.RegisterStmt(`
+const instanceConfigRef = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM instances_config_ref ORDER BY project, name
 `)
-var instanceConfigRefByProject = cluster.RegisterStmt(`
+const instanceConfigRefByProject = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM instances_config_ref WHERE project = ? ORDER BY project, name
 `)
-var instanceConfigRefByName = cluster.RegisterStmt(`
+const instanceConfigRefByName = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM instances_config_ref WHERE name = ? ORDER BY project, name
 `)
-var instanceConfigRefByProjectAndName = cluster.RegisterStmt(`
+const instanceConfigRefByProjectAndName = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM instances_config_ref WHERE project = ? AND name = ? ORDER BY project, name
 `)
-var instanceConfigRefByNode = cluster.RegisterStmt(`
+const instanceConfigRefByNode = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM instances_config_ref WHERE node = ? ORDER BY project, name
 `)
-var instanceConfigRefByProjectAndNode = cluster.RegisterStmt(`
+const instanceConfigRefByProjectAndNode = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM instances_config_ref WHERE project = ? AND node = ? ORDER BY project, name
 `)
-var instanceConfigRefByNameAndNode = cluster.RegisterStmt(`
+const instanceConfigRefByNameAndNode = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM instances_config_ref WHERE name = ? AND node = ? ORDER BY project, name
 `)
-var instanceConfigRefByProjectAndNameAndNode = cluster.RegisterStmt(`
+const instanceConfigRefByProjectAndNameAndNode = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM instances_config_ref WHERE project = ? AND name = ? AND node = ? ORDER BY project, name
 `)
 
-var instanceDevicesRef = cluster.RegisterStmt(`
+const instanceDevicesRef = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref ORDER BY project, name
 `)
-var instanceDevicesRefByProject = cluster.RegisterStmt(`
+const instanceDevicesRefByProject = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE project = ? ORDER BY project, name
 `)
-var instanceDevicesRefByName = cluster.RegisterStmt(`
+const instanceDevicesRefByName = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE name = ? ORDER BY project, name
 `)
-var instanceDevicesRefByProjectAndName = cluster.RegisterStmt(`
+const instanceDevicesRefByProjectAndName = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE project = ? AND name = ? ORDER BY project, name
 `)
-var instanceDevicesRefByNode = cluster.RegisterStmt(`
+const instanceDevicesRefByNode = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE node = ? ORDER BY project, name
 `)
-var instanceDevicesRefByProjectAndNode = cluster.RegisterStmt(`
+const instanceDevicesRefByProjectAndNode = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE project = ? AND node = ? ORDER BY project, name
 `)
-var instanceDevicesRefByNameAndNode = cluster.RegisterStmt(`
+const instanceDevicesRefByNameAndNode = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE name = ? AND node = ? ORDER BY project, name
 `)
-var instanceDevicesRefByProjectAndNameAndNode = cluster.RegisterStmt(`
+const instanceDevicesRefByProjectAndNameAndNode = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE project = ? AND name = ? AND node = ? ORDER BY project, name
 `)
-var instanceDevicesRefByType = cluster.RegisterStmt(`
+const instanceDevicesRefByType = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE type = ? ORDER BY project, name
 `)
-var instanceDevicesRefByProjectAndType = cluster.RegisterStmt(`
+const instanceDevicesRefByProjectAndType = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE project = ? AND type = ? ORDER BY project, name
 `)
-var instanceDevicesRefByNameAndType = cluster.RegisterStmt(`
+const instanceDevicesRefByNameAndType = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE name = ? AND type = ? ORDER BY project, name
 `)
-var instanceDevicesRefByProjectAndNameAndType = cluster.RegisterStmt(`
+const instanceDevicesRefByProjectAndNameAndType = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE project = ? AND name = ? AND type = ? ORDER BY project, name
 `)
-var instanceDevicesRefByNodeAndType = cluster.RegisterStmt(`
+const instanceDevicesRefByNodeAndType = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE node = ? AND type = ? ORDER BY project, name
 `)
-var instanceDevicesRefByProjectAndNodeAndType = cluster.RegisterStmt(`
+const instanceDevicesRefByProjectAndNodeAndType = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE project = ? AND node = ? AND type = ? ORDER BY project, name
 `)
-var instanceDevicesRefByNameAndNodeAndType = cluster.RegisterStmt(`
+const instanceDevicesRefByNameAndNodeAndType = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE name = ? AND node = ? AND type = ? ORDER BY project, name
 `)
-var instanceDevicesRefByProjectAndNameAndNodeAndType = cluster.RegisterStmt(`
+const instanceDevicesRefByProjectAndNameAndNodeAndType = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM instances_devices_ref WHERE project = ? AND name = ? AND node = ? AND type = ? ORDER BY project, name
 `)
 
-var instanceID = cluster.RegisterStmt(`
+const instanceID = cluster.RegisterStmt(`
 SELECT instances.id FROM instances JOIN projects ON instances.project_id = projects.id JOIN nodes ON instances.node_id = nodes.id
   WHERE projects.name = ? AND instances.name = ?
 `)
 
-var instanceCreate = cluster.RegisterStmt(`
+const instanceCreate = cluster.RegisterStmt(`
 INSERT INTO instances (project_id, name, node_id, type, architecture, ephemeral, creation_date, stateful, last_use_date, description, expiry_date)
   VALUES ((SELECT projects.id FROM projects WHERE projects.name = ?), ?, (SELECT nodes.id FROM nodes WHERE nodes.name = ?), ?, ?, ?, ?, ?, ?, ?, ?)
 `)
 
-var instanceCreateConfigRef = cluster.RegisterStmt(`
+const instanceCreateConfigRef = cluster.RegisterStmt(`
 INSERT INTO instances_config (instance_id, key, value)
   VALUES (?, ?, ?)
 `)
 
-var instanceCreateDevicesRef = cluster.RegisterStmt(`
+const instanceCreateDevicesRef = cluster.RegisterStmt(`
 INSERT INTO instances_devices (instance_id, name, type)
   VALUES (?, ?, ?)
 `)
-var instanceCreateDevicesConfigRef = cluster.RegisterStmt(`
+const instanceCreateDevicesConfigRef = cluster.RegisterStmt(`
 INSERT INTO instances_devices_config (instance_device_id, key, value)
   VALUES (?, ?, ?)
 `)
 
-var instanceRename = cluster.RegisterStmt(`
+const instanceRename = cluster.RegisterStmt(`
 UPDATE instances SET name = ? WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND name = ?
 `)
 
-var instanceDeleteByProject = cluster.RegisterStmt(`
+const instanceDeleteByProject = cluster.RegisterStmt(`
 DELETE FROM instances WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?)
 `)
-var instanceDeleteByName = cluster.RegisterStmt(`
+const instanceDeleteByName = cluster.RegisterStmt(`
 DELETE FROM instances WHERE name = ?
 `)
-var instanceDeleteByProjectAndName = cluster.RegisterStmt(`
+const instanceDeleteByProjectAndName = cluster.RegisterStmt(`
 DELETE FROM instances WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND name = ?
 `)
-var instanceDeleteByNode = cluster.RegisterStmt(`
+const instanceDeleteByNode = cluster.RegisterStmt(`
 DELETE FROM instances WHERE node_id = (SELECT nodes.id FROM nodes WHERE nodes.name = ?)
 `)
-var instanceDeleteByProjectAndNode = cluster.RegisterStmt(`
+const instanceDeleteByProjectAndNode = cluster.RegisterStmt(`
 DELETE FROM instances WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND node_id = (SELECT nodes.id FROM nodes WHERE nodes.name = ?)
 `)
-var instanceDeleteByNameAndNode = cluster.RegisterStmt(`
+const instanceDeleteByNameAndNode = cluster.RegisterStmt(`
 DELETE FROM instances WHERE name = ? AND node_id = (SELECT nodes.id FROM nodes WHERE nodes.name = ?)
 `)
-var instanceDeleteByProjectAndNameAndNode = cluster.RegisterStmt(`
+const instanceDeleteByProjectAndNameAndNode = cluster.RegisterStmt(`
 DELETE FROM instances WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND name = ? AND node_id = (SELECT nodes.id FROM nodes WHERE nodes.name = ?)
 `)
-var instanceDeleteByType = cluster.RegisterStmt(`
+const instanceDeleteByType = cluster.RegisterStmt(`
 DELETE FROM instances WHERE type = ?
 `)
-var instanceDeleteByProjectAndType = cluster.RegisterStmt(`
+const instanceDeleteByProjectAndType = cluster.RegisterStmt(`
 DELETE FROM instances WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND type = ?
 `)
-var instanceDeleteByNameAndType = cluster.RegisterStmt(`
+const instanceDeleteByNameAndType = cluster.RegisterStmt(`
 DELETE FROM instances WHERE name = ? AND type = ?
 `)
-var instanceDeleteByProjectAndNameAndType = cluster.RegisterStmt(`
+const instanceDeleteByProjectAndNameAndType = cluster.RegisterStmt(`
 DELETE FROM instances WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND name = ? AND type = ?
 `)
-var instanceDeleteByNodeAndType = cluster.RegisterStmt(`
+const instanceDeleteByNodeAndType = cluster.RegisterStmt(`
 DELETE FROM instances WHERE node_id = (SELECT nodes.id FROM nodes WHERE nodes.name = ?) AND type = ?
 `)
-var instanceDeleteByProjectAndNodeAndType = cluster.RegisterStmt(`
+const instanceDeleteByProjectAndNodeAndType = cluster.RegisterStmt(`
 DELETE FROM instances WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND node_id = (SELECT nodes.id FROM nodes WHERE nodes.name = ?) AND type = ?
 `)
-var instanceDeleteByNameAndNodeAndType = cluster.RegisterStmt(`
+const instanceDeleteByNameAndNodeAndType = cluster.RegisterStmt(`
 DELETE FROM instances WHERE name = ? AND node_id = (SELECT nodes.id FROM nodes WHERE nodes.name = ?) AND type = ?
 `)
-var instanceDeleteByProjectAndNameAndNodeAndType = cluster.RegisterStmt(`
+const instanceDeleteByProjectAndNameAndNodeAndType = cluster.RegisterStmt(`
 DELETE FROM instances WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND name = ? AND node_id = (SELECT nodes.id FROM nodes WHERE nodes.name = ?) AND type = ?
 `)
 
-var instanceDeleteConfigRef = cluster.RegisterStmt(`
+const instanceDeleteConfigRef = cluster.RegisterStmt(`
 DELETE FROM instances_config WHERE instance_id = ?
 `)
 
-var instanceDeleteDevicesRef = cluster.RegisterStmt(`
+const instanceDeleteDevicesRef = cluster.RegisterStmt(`
 DELETE FROM instances_devices WHERE instance_id = ?
 `)
 
-var instanceDeleteProfilesRef = cluster.RegisterStmt(`
+const instanceDeleteProfilesRef = cluster.RegisterStmt(`
 DELETE FROM instances_profiles WHERE instance_id = ?
 `)
 
-var instanceUpdate = cluster.RegisterStmt(`
+const instanceUpdate = cluster.RegisterStmt(`
 UPDATE instances
   SET project_id = (SELECT id FROM projects WHERE name = ?), name = ?, node_id = (SELECT id FROM nodes WHERE name = ?), type = ?, architecture = ?, ephemeral = ?, creation_date = ?, stateful = ?, last_use_date = ?, description = ?, expiry_date = ?
  WHERE id = ?

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -199,7 +199,7 @@ func TestInstanceList(t *testing.T) {
 	require.NoError(t, err)
 
 	var instances []db.Instance
-	err = cluster.InstanceList(nil, func(dbInst db.Instance, p api.Project, profiles []api.Profile) error {
+	err = cluster.InstanceList(nil, func(dbInst db.Instance, p db.Project, profiles []api.Profile) error {
 		dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, profiles)
 		dbInst.Devices = db.ExpandInstanceDevices(deviceConfig.NewDevices(dbInst.Devices), profiles).CloneNative()
 		instances = append(instances, dbInst)

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -98,13 +98,13 @@ func TestInstanceList_ContainerWithSameNameInDifferentProjects(t *testing.T) {
 	defer cleanup()
 
 	// Create a project with no features
-	project1 := api.ProjectsPost{}
+	project1 := db.Project{}
 	project1.Name = "blah"
 	_, err := tx.CreateProject(project1)
 	require.NoError(t, err)
 
 	// Create a project with the profiles feature and a custom profile.
-	project2 := api.ProjectsPost{}
+	project2 := db.Project{}
 	project2.Name = "test"
 	project2.Config = map[string]string{"features.profiles": "true"}
 	_, err = tx.CreateProject(project2)

--- a/lxd/db/migration_test.go
+++ b/lxd/db/migration_test.go
@@ -70,7 +70,7 @@ func TestImportPreClusteringData(t *testing.T) {
 		cert := certs[0]
 		assert.Equal(t, 1, cert.ID)
 		assert.Equal(t, "abcd:efgh", cert.Fingerprint)
-		assert.Equal(t, 1, cert.Type)
+		assert.Equal(t, db.CertificateTypeClient, cert.Type)
 		assert.Equal(t, "foo", cert.Name)
 		assert.Equal(t, "FOO", cert.Certificate)
 		return nil

--- a/lxd/db/operations.go
+++ b/lxd/db/operations.go
@@ -10,9 +10,6 @@ import (
 //go:generate -command mapper lxd-generate db mapper -t operations.mapper.go
 //go:generate mapper reset
 //go:generate mapper stmt -p db -e operation objects
-//go:generate mapper stmt -p db -e operation objects-by-NodeID
-//go:generate mapper stmt -p db -e operation objects-by-ID
-//go:generate mapper stmt -p db -e operation objects-by-UUID
 //go:generate mapper stmt -p db -e operation create-or-replace struct=Operation
 //go:generate mapper stmt -p db -e operation delete-by-UUID
 //go:generate mapper stmt -p db -e operation delete-by-NodeID

--- a/lxd/db/operations.go
+++ b/lxd/db/operations.go
@@ -25,15 +25,15 @@ type Operation struct {
 	ID          int64         `db:"primary=yes"`                               // Stable database identifier
 	UUID        string        `db:"primary=yes"`                               // User-visible identifier
 	NodeAddress string        `db:"join=nodes.address&omit=create-or-replace"` // Address of the node the operation is running on
-	ProjectID   *int64        `db:"omit=objects"`                              // ID of the project for the operation.
+	ProjectID   *int64        // ID of the project for the operation.
 	NodeID      int64         // ID of the node the operation is running on
 	Type        OperationType // Type of the operation
 }
 
 // OperationFilter specifies potential query parameter fields.
 type OperationFilter struct {
-	ID     int64
-	NodeID int64
+	ID     *int64 // ID is a pointer so it can be omitted.
+	NodeID *int64 // NodeID is a pointer so it can be omitted.
 	UUID   string
 }
 

--- a/lxd/db/operations.go
+++ b/lxd/db/operations.go
@@ -11,8 +11,7 @@ import (
 //go:generate mapper reset
 //go:generate mapper stmt -p db -e operation objects
 //go:generate mapper stmt -p db -e operation create-or-replace struct=Operation
-//go:generate mapper stmt -p db -e operation delete-by-UUID
-//go:generate mapper stmt -p db -e operation delete-by-NodeID
+//go:generate mapper stmt -p db -e operation delete
 
 //go:generate mapper method -p db -e operation List
 //go:generate mapper method -p db -e operation CreateOrReplace struct=Operation

--- a/lxd/db/operations.mapper.go
+++ b/lxd/db/operations.mapper.go
@@ -16,71 +16,71 @@ import (
 
 var _ = api.ServerEnvironment{}
 
-var operationObjects = cluster.RegisterStmt(`
+const operationObjects = cluster.RegisterStmt(`
 SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type
   FROM operations JOIN nodes ON operations.node_id = nodes.id
   ORDER BY operations.id, operations.uuid
 `)
-var operationObjectsByID = cluster.RegisterStmt(`
+const operationObjectsByID = cluster.RegisterStmt(`
 SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type
   FROM operations JOIN nodes ON operations.node_id = nodes.id
   WHERE operations.id = ? ORDER BY operations.id, operations.uuid
 `)
-var operationObjectsByNodeID = cluster.RegisterStmt(`
+const operationObjectsByNodeID = cluster.RegisterStmt(`
 SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type
   FROM operations JOIN nodes ON operations.node_id = nodes.id
   WHERE operations.node_id = ? ORDER BY operations.id, operations.uuid
 `)
-var operationObjectsByIDAndNodeID = cluster.RegisterStmt(`
+const operationObjectsByIDAndNodeID = cluster.RegisterStmt(`
 SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type
   FROM operations JOIN nodes ON operations.node_id = nodes.id
   WHERE operations.id = ? AND operations.node_id = ? ORDER BY operations.id, operations.uuid
 `)
-var operationObjectsByUUID = cluster.RegisterStmt(`
+const operationObjectsByUUID = cluster.RegisterStmt(`
 SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type
   FROM operations JOIN nodes ON operations.node_id = nodes.id
   WHERE operations.uuid = ? ORDER BY operations.id, operations.uuid
 `)
-var operationObjectsByIDAndUUID = cluster.RegisterStmt(`
+const operationObjectsByIDAndUUID = cluster.RegisterStmt(`
 SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type
   FROM operations JOIN nodes ON operations.node_id = nodes.id
   WHERE operations.id = ? AND operations.uuid = ? ORDER BY operations.id, operations.uuid
 `)
-var operationObjectsByNodeIDAndUUID = cluster.RegisterStmt(`
+const operationObjectsByNodeIDAndUUID = cluster.RegisterStmt(`
 SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type
   FROM operations JOIN nodes ON operations.node_id = nodes.id
   WHERE operations.node_id = ? AND operations.uuid = ? ORDER BY operations.id, operations.uuid
 `)
-var operationObjectsByIDAndNodeIDAndUUID = cluster.RegisterStmt(`
+const operationObjectsByIDAndNodeIDAndUUID = cluster.RegisterStmt(`
 SELECT operations.id, operations.uuid, nodes.address AS node_address, operations.project_id, operations.node_id, operations.type
   FROM operations JOIN nodes ON operations.node_id = nodes.id
   WHERE operations.id = ? AND operations.node_id = ? AND operations.uuid = ? ORDER BY operations.id, operations.uuid
 `)
 
-var operationCreateOrReplace = cluster.RegisterStmt(`
+const operationCreateOrReplace = cluster.RegisterStmt(`
 INSERT OR REPLACE INTO operations (uuid, project_id, node_id, type)
  VALUES (?, ?, ?, ?)
 `)
 
-var operationDeleteByID = cluster.RegisterStmt(`
+const operationDeleteByID = cluster.RegisterStmt(`
 DELETE FROM operations WHERE id = ?
 `)
-var operationDeleteByNodeID = cluster.RegisterStmt(`
+const operationDeleteByNodeID = cluster.RegisterStmt(`
 DELETE FROM operations WHERE node_id = ?
 `)
-var operationDeleteByIDAndNodeID = cluster.RegisterStmt(`
+const operationDeleteByIDAndNodeID = cluster.RegisterStmt(`
 DELETE FROM operations WHERE id = ? AND node_id = ?
 `)
-var operationDeleteByUUID = cluster.RegisterStmt(`
+const operationDeleteByUUID = cluster.RegisterStmt(`
 DELETE FROM operations WHERE uuid = ?
 `)
-var operationDeleteByIDAndUUID = cluster.RegisterStmt(`
+const operationDeleteByIDAndUUID = cluster.RegisterStmt(`
 DELETE FROM operations WHERE id = ? AND uuid = ?
 `)
-var operationDeleteByNodeIDAndUUID = cluster.RegisterStmt(`
+const operationDeleteByNodeIDAndUUID = cluster.RegisterStmt(`
 DELETE FROM operations WHERE node_id = ? AND uuid = ?
 `)
-var operationDeleteByIDAndNodeIDAndUUID = cluster.RegisterStmt(`
+const operationDeleteByIDAndNodeIDAndUUID = cluster.RegisterStmt(`
 DELETE FROM operations WHERE id = ? AND node_id = ? AND uuid = ?
 `)
 

--- a/lxd/db/operations.mapper.go
+++ b/lxd/db/operations.mapper.go
@@ -62,12 +62,26 @@ INSERT OR REPLACE INTO operations (uuid, project_id, node_id, type)
  VALUES (?, ?, ?, ?)
 `)
 
+var operationDeleteByID = cluster.RegisterStmt(`
+DELETE FROM operations WHERE id = ?
+`)
+var operationDeleteByNodeID = cluster.RegisterStmt(`
+DELETE FROM operations WHERE node_id = ?
+`)
+var operationDeleteByIDAndNodeID = cluster.RegisterStmt(`
+DELETE FROM operations WHERE id = ? AND node_id = ?
+`)
 var operationDeleteByUUID = cluster.RegisterStmt(`
 DELETE FROM operations WHERE uuid = ?
 `)
-
-var operationDeleteByNodeID = cluster.RegisterStmt(`
-DELETE FROM operations WHERE node_id = ?
+var operationDeleteByIDAndUUID = cluster.RegisterStmt(`
+DELETE FROM operations WHERE id = ? AND uuid = ?
+`)
+var operationDeleteByNodeIDAndUUID = cluster.RegisterStmt(`
+DELETE FROM operations WHERE node_id = ? AND uuid = ?
+`)
+var operationDeleteByIDAndNodeIDAndUUID = cluster.RegisterStmt(`
+DELETE FROM operations WHERE id = ? AND node_id = ? AND uuid = ?
 `)
 
 // GetOperations returns all available operations.
@@ -203,7 +217,32 @@ func (c *ClusterTx) DeleteOperation(filter OperationFilter) error {
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["UUID"] != nil {
+	if criteria["ID"] != nil && criteria["NodeID"] != nil && criteria["UUID"] != nil {
+		stmt = c.stmt(operationDeleteByIDAndNodeIDAndUUID)
+		args = []interface{}{
+			filter.ID,
+			filter.NodeID,
+			filter.UUID,
+		}
+	} else if criteria["NodeID"] != nil && criteria["UUID"] != nil {
+		stmt = c.stmt(operationDeleteByNodeIDAndUUID)
+		args = []interface{}{
+			filter.NodeID,
+			filter.UUID,
+		}
+	} else if criteria["ID"] != nil && criteria["UUID"] != nil {
+		stmt = c.stmt(operationDeleteByIDAndUUID)
+		args = []interface{}{
+			filter.ID,
+			filter.UUID,
+		}
+	} else if criteria["ID"] != nil && criteria["NodeID"] != nil {
+		stmt = c.stmt(operationDeleteByIDAndNodeID)
+		args = []interface{}{
+			filter.ID,
+			filter.NodeID,
+		}
+	} else if criteria["UUID"] != nil {
 		stmt = c.stmt(operationDeleteByUUID)
 		args = []interface{}{
 			filter.UUID,
@@ -212,6 +251,11 @@ func (c *ClusterTx) DeleteOperation(filter OperationFilter) error {
 		stmt = c.stmt(operationDeleteByNodeID)
 		args = []interface{}{
 			filter.NodeID,
+		}
+	} else if criteria["ID"] != nil {
+		stmt = c.stmt(operationDeleteByID)
+		args = []interface{}{
+			filter.ID,
 		}
 	} else {
 		return fmt.Errorf("No valid filter for operation delete")
@@ -250,7 +294,32 @@ func (c *ClusterTx) DeleteOperations(filter OperationFilter) error {
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["UUID"] != nil {
+	if criteria["ID"] != nil && criteria["NodeID"] != nil && criteria["UUID"] != nil {
+		stmt = c.stmt(operationDeleteByIDAndNodeIDAndUUID)
+		args = []interface{}{
+			filter.ID,
+			filter.NodeID,
+			filter.UUID,
+		}
+	} else if criteria["NodeID"] != nil && criteria["UUID"] != nil {
+		stmt = c.stmt(operationDeleteByNodeIDAndUUID)
+		args = []interface{}{
+			filter.NodeID,
+			filter.UUID,
+		}
+	} else if criteria["ID"] != nil && criteria["UUID"] != nil {
+		stmt = c.stmt(operationDeleteByIDAndUUID)
+		args = []interface{}{
+			filter.ID,
+			filter.UUID,
+		}
+	} else if criteria["ID"] != nil && criteria["NodeID"] != nil {
+		stmt = c.stmt(operationDeleteByIDAndNodeID)
+		args = []interface{}{
+			filter.ID,
+			filter.NodeID,
+		}
+	} else if criteria["UUID"] != nil {
 		stmt = c.stmt(operationDeleteByUUID)
 		args = []interface{}{
 			filter.UUID,
@@ -259,6 +328,11 @@ func (c *ClusterTx) DeleteOperations(filter OperationFilter) error {
 		stmt = c.stmt(operationDeleteByNodeID)
 		args = []interface{}{
 			filter.NodeID,
+		}
+	} else if criteria["ID"] != nil {
+		stmt = c.stmt(operationDeleteByID)
+		args = []interface{}{
+			filter.ID,
 		}
 	} else {
 		return fmt.Errorf("No valid filter for operation delete")

--- a/lxd/db/operations_test.go
+++ b/lxd/db/operations_test.go
@@ -20,7 +20,7 @@ func TestOperation(t *testing.T) {
 	require.NoError(t, err)
 
 	opInfo := db.Operation{
-		NodeID:    tx.GetNodeID(),
+		NodeID:    *tx.GetNodeID(),
 		Type:      db.OperationInstanceCreate,
 		UUID:      "abcd",
 		ProjectID: &projectID,
@@ -64,7 +64,7 @@ func TestOperationNoProject(t *testing.T) {
 	defer cleanup()
 
 	opInfo := db.Operation{
-		NodeID: tx.GetNodeID(),
+		NodeID: *tx.GetNodeID(),
 		Type:   db.OperationInstanceCreate,
 		UUID:   "abcd",
 	}

--- a/lxd/db/profiles.go
+++ b/lxd/db/profiles.go
@@ -20,8 +20,6 @@ import (
 //go:generate mapper stmt -p db -e profile names-by-Project
 //go:generate mapper stmt -p db -e profile names-by-Project-and-Name
 //go:generate mapper stmt -p db -e profile objects
-//go:generate mapper stmt -p db -e profile objects-by-Project
-//go:generate mapper stmt -p db -e profile objects-by-Project-and-Name
 //go:generate mapper stmt -p db -e profile config-ref
 //go:generate mapper stmt -p db -e profile config-ref-by-Project
 //go:generate mapper stmt -p db -e profile config-ref-by-Project-and-Name

--- a/lxd/db/profiles.go
+++ b/lxd/db/profiles.go
@@ -34,7 +34,7 @@ import (
 //go:generate mapper stmt -p db -e profile create-config-ref
 //go:generate mapper stmt -p db -e profile create-devices-ref
 //go:generate mapper stmt -p db -e profile rename
-//go:generate mapper stmt -p db -e profile delete-by-Project-and-Name
+//go:generate mapper stmt -p db -e profile delete
 //go:generate mapper stmt -p db -e profile delete-config-ref
 //go:generate mapper stmt -p db -e profile delete-devices-ref
 //go:generate mapper stmt -p db -e profile update struct=Profile

--- a/lxd/db/profiles.go
+++ b/lxd/db/profiles.go
@@ -17,8 +17,6 @@ import (
 //go:generate mapper reset
 //
 //go:generate mapper stmt -p db -e profile names
-//go:generate mapper stmt -p db -e profile names-by-Project
-//go:generate mapper stmt -p db -e profile names-by-Project-and-Name
 //go:generate mapper stmt -p db -e profile objects
 //go:generate mapper stmt -p db -e profile config-ref
 //go:generate mapper stmt -p db -e profile devices-ref

--- a/lxd/db/profiles.go
+++ b/lxd/db/profiles.go
@@ -21,14 +21,8 @@ import (
 //go:generate mapper stmt -p db -e profile names-by-Project-and-Name
 //go:generate mapper stmt -p db -e profile objects
 //go:generate mapper stmt -p db -e profile config-ref
-//go:generate mapper stmt -p db -e profile config-ref-by-Project
-//go:generate mapper stmt -p db -e profile config-ref-by-Project-and-Name
 //go:generate mapper stmt -p db -e profile devices-ref
-//go:generate mapper stmt -p db -e profile devices-ref-by-Project
-//go:generate mapper stmt -p db -e profile devices-ref-by-Project-and-Name
 //go:generate mapper stmt -p db -e profile used-by-ref
-//go:generate mapper stmt -p db -e profile used-by-ref-by-Project
-//go:generate mapper stmt -p db -e profile used-by-ref-by-Project-and-Name
 //go:generate mapper stmt -p db -e profile id
 //go:generate mapper stmt -p db -e profile create struct=Profile
 //go:generate mapper stmt -p db -e profile create-config-ref

--- a/lxd/db/profiles.mapper.go
+++ b/lxd/db/profiles.mapper.go
@@ -21,13 +21,16 @@ SELECT projects.name AS project, profiles.name
   FROM profiles JOIN projects ON profiles.project_id = projects.id
   ORDER BY projects.id, profiles.name
 `)
-
 var profileNamesByProject = cluster.RegisterStmt(`
 SELECT projects.name AS project, profiles.name
   FROM profiles JOIN projects ON profiles.project_id = projects.id
   WHERE project = ? ORDER BY projects.id, profiles.name
 `)
-
+var profileNamesByName = cluster.RegisterStmt(`
+SELECT projects.name AS project, profiles.name
+  FROM profiles JOIN projects ON profiles.project_id = projects.id
+  WHERE profiles.name = ? ORDER BY projects.id, profiles.name
+`)
 var profileNamesByProjectAndName = cluster.RegisterStmt(`
 SELECT projects.name AS project, profiles.name
   FROM profiles JOIN projects ON profiles.project_id = projects.id

--- a/lxd/db/profiles.mapper.go
+++ b/lxd/db/profiles.mapper.go
@@ -119,6 +119,12 @@ var profileRename = cluster.RegisterStmt(`
 UPDATE profiles SET name = ? WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND name = ?
 `)
 
+var profileDeleteByProject = cluster.RegisterStmt(`
+DELETE FROM profiles WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?)
+`)
+var profileDeleteByName = cluster.RegisterStmt(`
+DELETE FROM profiles WHERE name = ?
+`)
 var profileDeleteByProjectAndName = cluster.RegisterStmt(`
 DELETE FROM profiles WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND name = ?
 `)
@@ -744,6 +750,16 @@ func (c *ClusterTx) DeleteProfile(filter ProfileFilter) error {
 		stmt = c.stmt(profileDeleteByProjectAndName)
 		args = []interface{}{
 			filter.Project,
+			filter.Name,
+		}
+	} else if criteria["Project"] != nil {
+		stmt = c.stmt(profileDeleteByProject)
+		args = []interface{}{
+			filter.Project,
+		}
+	} else if criteria["Name"] != nil {
+		stmt = c.stmt(profileDeleteByName)
+		args = []interface{}{
 			filter.Name,
 		}
 	} else {

--- a/lxd/db/profiles.mapper.go
+++ b/lxd/db/profiles.mapper.go
@@ -58,11 +58,12 @@ SELECT profiles.id, projects.name AS project, profiles.name, coalesce(profiles.d
 var profileConfigRef = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM profiles_config_ref ORDER BY project, name
 `)
-
 var profileConfigRefByProject = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM profiles_config_ref WHERE project = ? ORDER BY project, name
 `)
-
+var profileConfigRefByName = cluster.RegisterStmt(`
+SELECT project, name, key, value FROM profiles_config_ref WHERE name = ? ORDER BY project, name
+`)
 var profileConfigRefByProjectAndName = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM profiles_config_ref WHERE project = ? AND name = ? ORDER BY project, name
 `)
@@ -70,11 +71,12 @@ SELECT project, name, key, value FROM profiles_config_ref WHERE project = ? AND 
 var profileDevicesRef = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM profiles_devices_ref ORDER BY project, name
 `)
-
 var profileDevicesRefByProject = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM profiles_devices_ref WHERE project = ? ORDER BY project, name
 `)
-
+var profileDevicesRefByName = cluster.RegisterStmt(`
+SELECT project, name, device, type, key, value FROM profiles_devices_ref WHERE name = ? ORDER BY project, name
+`)
 var profileDevicesRefByProjectAndName = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM profiles_devices_ref WHERE project = ? AND name = ? ORDER BY project, name
 `)
@@ -82,11 +84,12 @@ SELECT project, name, device, type, key, value FROM profiles_devices_ref WHERE p
 var profileUsedByRef = cluster.RegisterStmt(`
 SELECT project, name, value FROM profiles_used_by_ref ORDER BY project, name
 `)
-
 var profileUsedByRefByProject = cluster.RegisterStmt(`
 SELECT project, name, value FROM profiles_used_by_ref WHERE project = ? ORDER BY project, name
 `)
-
+var profileUsedByRefByName = cluster.RegisterStmt(`
+SELECT project, name, value FROM profiles_used_by_ref WHERE name = ? ORDER BY project, name
+`)
 var profileUsedByRefByProjectAndName = cluster.RegisterStmt(`
 SELECT project, name, value FROM profiles_used_by_ref WHERE project = ? AND name = ? ORDER BY project, name
 `)
@@ -409,6 +412,11 @@ func (c *ClusterTx) ProfileConfigRef(filter ProfileFilter) (map[string]map[strin
 		args = []interface{}{
 			filter.Project,
 		}
+	} else if criteria["Name"] != nil {
+		stmt = c.stmt(profileConfigRefByName)
+		args = []interface{}{
+			filter.Name,
+		}
 	} else {
 		stmt = c.stmt(profileConfigRef)
 		args = []interface{}{}
@@ -493,6 +501,11 @@ func (c *ClusterTx) ProfileDevicesRef(filter ProfileFilter) (map[string]map[stri
 		stmt = c.stmt(profileDevicesRefByProject)
 		args = []interface{}{
 			filter.Project,
+		}
+	} else if criteria["Name"] != nil {
+		stmt = c.stmt(profileDevicesRefByName)
+		args = []interface{}{
+			filter.Name,
 		}
 	} else {
 		stmt = c.stmt(profileDevicesRef)
@@ -594,6 +607,11 @@ func (c *ClusterTx) ProfileUsedByRef(filter ProfileFilter) (map[string]map[strin
 		stmt = c.stmt(profileUsedByRefByProject)
 		args = []interface{}{
 			filter.Project,
+		}
+	} else if criteria["Name"] != nil {
+		stmt = c.stmt(profileUsedByRefByName)
+		args = []interface{}{
+			filter.Name,
 		}
 	} else {
 		stmt = c.stmt(profileUsedByRef)

--- a/lxd/db/profiles.mapper.go
+++ b/lxd/db/profiles.mapper.go
@@ -16,134 +16,134 @@ import (
 
 var _ = api.ServerEnvironment{}
 
-var profileNames = cluster.RegisterStmt(`
+const profileNames = cluster.RegisterStmt(`
 SELECT projects.name AS project, profiles.name
   FROM profiles JOIN projects ON profiles.project_id = projects.id
   ORDER BY projects.id, profiles.name
 `)
-var profileNamesByProject = cluster.RegisterStmt(`
+const profileNamesByProject = cluster.RegisterStmt(`
 SELECT projects.name AS project, profiles.name
   FROM profiles JOIN projects ON profiles.project_id = projects.id
   WHERE project = ? ORDER BY projects.id, profiles.name
 `)
-var profileNamesByName = cluster.RegisterStmt(`
+const profileNamesByName = cluster.RegisterStmt(`
 SELECT projects.name AS project, profiles.name
   FROM profiles JOIN projects ON profiles.project_id = projects.id
   WHERE profiles.name = ? ORDER BY projects.id, profiles.name
 `)
-var profileNamesByProjectAndName = cluster.RegisterStmt(`
+const profileNamesByProjectAndName = cluster.RegisterStmt(`
 SELECT projects.name AS project, profiles.name
   FROM profiles JOIN projects ON profiles.project_id = projects.id
   WHERE project = ? AND profiles.name = ? ORDER BY projects.id, profiles.name
 `)
 
-var profileObjects = cluster.RegisterStmt(`
+const profileObjects = cluster.RegisterStmt(`
 SELECT profiles.id, projects.name AS project, profiles.name, coalesce(profiles.description, '')
   FROM profiles JOIN projects ON profiles.project_id = projects.id
   ORDER BY projects.id, profiles.name
 `)
-var profileObjectsByProject = cluster.RegisterStmt(`
+const profileObjectsByProject = cluster.RegisterStmt(`
 SELECT profiles.id, projects.name AS project, profiles.name, coalesce(profiles.description, '')
   FROM profiles JOIN projects ON profiles.project_id = projects.id
   WHERE project = ? ORDER BY projects.id, profiles.name
 `)
-var profileObjectsByName = cluster.RegisterStmt(`
+const profileObjectsByName = cluster.RegisterStmt(`
 SELECT profiles.id, projects.name AS project, profiles.name, coalesce(profiles.description, '')
   FROM profiles JOIN projects ON profiles.project_id = projects.id
   WHERE profiles.name = ? ORDER BY projects.id, profiles.name
 `)
-var profileObjectsByProjectAndName = cluster.RegisterStmt(`
+const profileObjectsByProjectAndName = cluster.RegisterStmt(`
 SELECT profiles.id, projects.name AS project, profiles.name, coalesce(profiles.description, '')
   FROM profiles JOIN projects ON profiles.project_id = projects.id
   WHERE project = ? AND profiles.name = ? ORDER BY projects.id, profiles.name
 `)
 
-var profileConfigRef = cluster.RegisterStmt(`
+const profileConfigRef = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM profiles_config_ref ORDER BY project, name
 `)
-var profileConfigRefByProject = cluster.RegisterStmt(`
+const profileConfigRefByProject = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM profiles_config_ref WHERE project = ? ORDER BY project, name
 `)
-var profileConfigRefByName = cluster.RegisterStmt(`
+const profileConfigRefByName = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM profiles_config_ref WHERE name = ? ORDER BY project, name
 `)
-var profileConfigRefByProjectAndName = cluster.RegisterStmt(`
+const profileConfigRefByProjectAndName = cluster.RegisterStmt(`
 SELECT project, name, key, value FROM profiles_config_ref WHERE project = ? AND name = ? ORDER BY project, name
 `)
 
-var profileDevicesRef = cluster.RegisterStmt(`
+const profileDevicesRef = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM profiles_devices_ref ORDER BY project, name
 `)
-var profileDevicesRefByProject = cluster.RegisterStmt(`
+const profileDevicesRefByProject = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM profiles_devices_ref WHERE project = ? ORDER BY project, name
 `)
-var profileDevicesRefByName = cluster.RegisterStmt(`
+const profileDevicesRefByName = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM profiles_devices_ref WHERE name = ? ORDER BY project, name
 `)
-var profileDevicesRefByProjectAndName = cluster.RegisterStmt(`
+const profileDevicesRefByProjectAndName = cluster.RegisterStmt(`
 SELECT project, name, device, type, key, value FROM profiles_devices_ref WHERE project = ? AND name = ? ORDER BY project, name
 `)
 
-var profileUsedByRef = cluster.RegisterStmt(`
+const profileUsedByRef = cluster.RegisterStmt(`
 SELECT project, name, value FROM profiles_used_by_ref ORDER BY project, name
 `)
-var profileUsedByRefByProject = cluster.RegisterStmt(`
+const profileUsedByRefByProject = cluster.RegisterStmt(`
 SELECT project, name, value FROM profiles_used_by_ref WHERE project = ? ORDER BY project, name
 `)
-var profileUsedByRefByName = cluster.RegisterStmt(`
+const profileUsedByRefByName = cluster.RegisterStmt(`
 SELECT project, name, value FROM profiles_used_by_ref WHERE name = ? ORDER BY project, name
 `)
-var profileUsedByRefByProjectAndName = cluster.RegisterStmt(`
+const profileUsedByRefByProjectAndName = cluster.RegisterStmt(`
 SELECT project, name, value FROM profiles_used_by_ref WHERE project = ? AND name = ? ORDER BY project, name
 `)
 
-var profileID = cluster.RegisterStmt(`
+const profileID = cluster.RegisterStmt(`
 SELECT profiles.id FROM profiles JOIN projects ON profiles.project_id = projects.id
   WHERE projects.name = ? AND profiles.name = ?
 `)
 
-var profileCreate = cluster.RegisterStmt(`
+const profileCreate = cluster.RegisterStmt(`
 INSERT INTO profiles (project_id, name, description)
   VALUES ((SELECT projects.id FROM projects WHERE projects.name = ?), ?, ?)
 `)
 
-var profileCreateConfigRef = cluster.RegisterStmt(`
+const profileCreateConfigRef = cluster.RegisterStmt(`
 INSERT INTO profiles_config (profile_id, key, value)
   VALUES (?, ?, ?)
 `)
 
-var profileCreateDevicesRef = cluster.RegisterStmt(`
+const profileCreateDevicesRef = cluster.RegisterStmt(`
 INSERT INTO profiles_devices (profile_id, name, type)
   VALUES (?, ?, ?)
 `)
-var profileCreateDevicesConfigRef = cluster.RegisterStmt(`
+const profileCreateDevicesConfigRef = cluster.RegisterStmt(`
 INSERT INTO profiles_devices_config (profile_device_id, key, value)
   VALUES (?, ?, ?)
 `)
 
-var profileRename = cluster.RegisterStmt(`
+const profileRename = cluster.RegisterStmt(`
 UPDATE profiles SET name = ? WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND name = ?
 `)
 
-var profileDeleteByProject = cluster.RegisterStmt(`
+const profileDeleteByProject = cluster.RegisterStmt(`
 DELETE FROM profiles WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?)
 `)
-var profileDeleteByName = cluster.RegisterStmt(`
+const profileDeleteByName = cluster.RegisterStmt(`
 DELETE FROM profiles WHERE name = ?
 `)
-var profileDeleteByProjectAndName = cluster.RegisterStmt(`
+const profileDeleteByProjectAndName = cluster.RegisterStmt(`
 DELETE FROM profiles WHERE project_id = (SELECT projects.id FROM projects WHERE projects.name = ?) AND name = ?
 `)
 
-var profileDeleteConfigRef = cluster.RegisterStmt(`
+const profileDeleteConfigRef = cluster.RegisterStmt(`
 DELETE FROM profiles_config WHERE profile_id = ?
 `)
 
-var profileDeleteDevicesRef = cluster.RegisterStmt(`
+const profileDeleteDevicesRef = cluster.RegisterStmt(`
 DELETE FROM profiles_devices WHERE profile_id = ?
 `)
 
-var profileUpdate = cluster.RegisterStmt(`
+const profileUpdate = cluster.RegisterStmt(`
 UPDATE profiles
   SET project_id = (SELECT id FROM projects WHERE name = ?), name = ?, description = ?
  WHERE id = ?

--- a/lxd/db/projects.go
+++ b/lxd/db/projects.go
@@ -31,7 +31,7 @@ import (
 //go:generate mapper stmt -p db -e project id
 //go:generate mapper stmt -p db -e project rename
 //go:generate mapper stmt -p db -e project update struct=Project
-//go:generate mapper stmt -p db -e project delete-by-Name
+//go:generate mapper stmt -p db -e project delete
 //
 //go:generate mapper method -p db -e project URIs
 //go:generate mapper method -p db -e project List

--- a/lxd/db/projects.go
+++ b/lxd/db/projects.go
@@ -19,31 +19,39 @@ import (
 //go:generate -command mapper lxd-generate db mapper -t projects.mapper.go
 //go:generate mapper reset
 //
-//go:generate mapper stmt -e project names
-//go:generate mapper stmt -e project names-by-Name
-//go:generate mapper stmt -e project objects
-//go:generate mapper stmt -e project objects-by-Name
-//go:generate mapper stmt -e project used-by-ref
-//go:generate mapper stmt -e project used-by-ref-by-Name
-//go:generate mapper stmt -e project config-ref
-//go:generate mapper stmt -e project config-ref-by-Name
-//go:generate mapper stmt -e project create
-//go:generate mapper stmt -e project create-config-ref
-//go:generate mapper stmt -e project id
-//go:generate mapper stmt -e project rename
-//go:generate mapper stmt -e project update
-//go:generate mapper stmt -e project delete-by-Name
+//go:generate mapper stmt -p db -e project names
+//go:generate mapper stmt -p db -e project names-by-Name
+//go:generate mapper stmt -p db -e project objects
+//go:generate mapper stmt -p db -e project objects-by-Name
+//go:generate mapper stmt -p db -e project used-by-ref
+//go:generate mapper stmt -p db -e project used-by-ref-by-Name
+//go:generate mapper stmt -p db -e project config-ref
+//go:generate mapper stmt -p db -e project config-ref-by-Name
+//go:generate mapper stmt -p db -e project create struct=Project
+//go:generate mapper stmt -p db -e project create-config-ref
+//go:generate mapper stmt -p db -e project id
+//go:generate mapper stmt -p db -e project rename
+//go:generate mapper stmt -p db -e project update struct=Project
+//go:generate mapper stmt -p db -e project delete-by-Name
 //
-//go:generate mapper method -e project URIs
-//go:generate mapper method -e project List
-//go:generate mapper method -e project Get
-//go:generate mapper method -e project ConfigRef
-//go:generate mapper method -e project Exists
-//go:generate mapper method -e project Create
-//go:generate mapper method -e project UsedByRef
-//go:generate mapper method -e project ID
-//go:generate mapper method -e project Rename
-//go:generate mapper method -e project DeleteOne
+//go:generate mapper method -p db -e project URIs
+//go:generate mapper method -p db -e project List
+//go:generate mapper method -p db -e project Get struct=Project
+//go:generate mapper method -p db -e project ConfigRef
+//go:generate mapper method -p db -e project Exists struct=Project
+//go:generate mapper method -p db -e project Create struct=Project
+//go:generate mapper method -p db -e project UsedByRef
+//go:generate mapper method -p db -e project ID struct=Project
+//go:generate mapper method -p db -e project Rename
+//go:generate mapper method -p db -e project DeleteOne
+
+// Project represents a LXD project
+type Project struct {
+	Description string
+	Name        string
+	UsedBy      []string `db:"omit=create"`
+	Config      map[string]string
+}
 
 // ProjectFilter specifies potential query parameter fields.
 type ProjectFilter struct {

--- a/lxd/db/projects.go
+++ b/lxd/db/projects.go
@@ -20,7 +20,6 @@ import (
 //go:generate mapper reset
 //
 //go:generate mapper stmt -p db -e project names
-//go:generate mapper stmt -p db -e project names-by-Name
 //go:generate mapper stmt -p db -e project objects
 //go:generate mapper stmt -p db -e project used-by-ref
 //go:generate mapper stmt -p db -e project config-ref

--- a/lxd/db/projects.go
+++ b/lxd/db/projects.go
@@ -200,9 +200,9 @@ func (c *ClusterTx) InitProjectWithoutImages(project string) error {
 }
 
 // GetProject returns the project with the given key.
-func (c *Cluster) GetProject(projectName string) (*api.Project, error) {
+func (c *Cluster) GetProject(projectName string) (*Project, error) {
 	var err error
-	var p *api.Project
+	var p *Project
 	err = c.Transaction(func(tx *ClusterTx) error {
 		p, err = tx.GetProject(projectName)
 		if err != nil {

--- a/lxd/db/projects.go
+++ b/lxd/db/projects.go
@@ -23,9 +23,7 @@ import (
 //go:generate mapper stmt -p db -e project names-by-Name
 //go:generate mapper stmt -p db -e project objects
 //go:generate mapper stmt -p db -e project used-by-ref
-//go:generate mapper stmt -p db -e project used-by-ref-by-Name
 //go:generate mapper stmt -p db -e project config-ref
-//go:generate mapper stmt -p db -e project config-ref-by-Name
 //go:generate mapper stmt -p db -e project create struct=Project
 //go:generate mapper stmt -p db -e project create-config-ref
 //go:generate mapper stmt -p db -e project id

--- a/lxd/db/projects.go
+++ b/lxd/db/projects.go
@@ -22,7 +22,6 @@ import (
 //go:generate mapper stmt -p db -e project names
 //go:generate mapper stmt -p db -e project names-by-Name
 //go:generate mapper stmt -p db -e project objects
-//go:generate mapper stmt -p db -e project objects-by-Name
 //go:generate mapper stmt -p db -e project used-by-ref
 //go:generate mapper stmt -p db -e project used-by-ref-by-Name
 //go:generate mapper stmt -p db -e project config-ref

--- a/lxd/db/projects.mapper.go
+++ b/lxd/db/projects.mapper.go
@@ -16,68 +16,68 @@ import (
 
 var _ = api.ServerEnvironment{}
 
-var projectNames = cluster.RegisterStmt(`
+const projectNames = cluster.RegisterStmt(`
 SELECT projects.name
   FROM projects
   ORDER BY projects.name
 `)
-var projectNamesByName = cluster.RegisterStmt(`
+const projectNamesByName = cluster.RegisterStmt(`
 SELECT projects.name
   FROM projects
   WHERE projects.name = ? ORDER BY projects.name
 `)
 
-var projectObjects = cluster.RegisterStmt(`
+const projectObjects = cluster.RegisterStmt(`
 SELECT projects.description, projects.name
   FROM projects
   ORDER BY projects.name
 `)
-var projectObjectsByName = cluster.RegisterStmt(`
+const projectObjectsByName = cluster.RegisterStmt(`
 SELECT projects.description, projects.name
   FROM projects
   WHERE projects.name = ? ORDER BY projects.name
 `)
 
-var projectUsedByRef = cluster.RegisterStmt(`
+const projectUsedByRef = cluster.RegisterStmt(`
 SELECT name, value FROM projects_used_by_ref ORDER BY name
 `)
-var projectUsedByRefByName = cluster.RegisterStmt(`
+const projectUsedByRefByName = cluster.RegisterStmt(`
 SELECT name, value FROM projects_used_by_ref WHERE name = ? ORDER BY name
 `)
 
-var projectConfigRef = cluster.RegisterStmt(`
+const projectConfigRef = cluster.RegisterStmt(`
 SELECT name, key, value FROM projects_config_ref ORDER BY name
 `)
-var projectConfigRefByName = cluster.RegisterStmt(`
+const projectConfigRefByName = cluster.RegisterStmt(`
 SELECT name, key, value FROM projects_config_ref WHERE name = ? ORDER BY name
 `)
 
-var projectCreate = cluster.RegisterStmt(`
+const projectCreate = cluster.RegisterStmt(`
 INSERT INTO projects (description, name)
   VALUES (?, ?)
 `)
 
-var projectCreateConfigRef = cluster.RegisterStmt(`
+const projectCreateConfigRef = cluster.RegisterStmt(`
 INSERT INTO projects_config (project_id, key, value)
   VALUES (?, ?, ?)
 `)
 
-var projectID = cluster.RegisterStmt(`
+const projectID = cluster.RegisterStmt(`
 SELECT projects.id FROM projects
   WHERE projects.name = ?
 `)
 
-var projectRename = cluster.RegisterStmt(`
+const projectRename = cluster.RegisterStmt(`
 UPDATE projects SET name = ? WHERE name = ?
 `)
 
-var projectUpdate = cluster.RegisterStmt(`
+const projectUpdate = cluster.RegisterStmt(`
 UPDATE projects
   SET description = ?, name = ?
  WHERE id = ?
 `)
 
-var projectDeleteByName = cluster.RegisterStmt(`
+const projectDeleteByName = cluster.RegisterStmt(`
 DELETE FROM projects WHERE name = ?
 `)
 

--- a/lxd/db/projects.mapper.go
+++ b/lxd/db/projects.mapper.go
@@ -42,7 +42,6 @@ SELECT projects.description, projects.name
 var projectUsedByRef = cluster.RegisterStmt(`
 SELECT name, value FROM projects_used_by_ref ORDER BY name
 `)
-
 var projectUsedByRefByName = cluster.RegisterStmt(`
 SELECT name, value FROM projects_used_by_ref WHERE name = ? ORDER BY name
 `)
@@ -50,7 +49,6 @@ SELECT name, value FROM projects_used_by_ref WHERE name = ? ORDER BY name
 var projectConfigRef = cluster.RegisterStmt(`
 SELECT name, key, value FROM projects_config_ref ORDER BY name
 `)
-
 var projectConfigRefByName = cluster.RegisterStmt(`
 SELECT name, key, value FROM projects_config_ref WHERE name = ? ORDER BY name
 `)

--- a/lxd/db/projects.mapper.go
+++ b/lxd/db/projects.mapper.go
@@ -21,7 +21,6 @@ SELECT projects.name
   FROM projects
   ORDER BY projects.name
 `)
-
 var projectNamesByName = cluster.RegisterStmt(`
 SELECT projects.name
   FROM projects

--- a/lxd/db/snapshots.go
+++ b/lxd/db/snapshots.go
@@ -18,11 +18,7 @@ import (
 //go:generate mapper stmt -p db -e instance_snapshot objects
 //go:generate mapper stmt -p db -e instance_snapshot id
 //go:generate mapper stmt -p db -e instance_snapshot config-ref
-//go:generate mapper stmt -p db -e instance_snapshot config-ref-by-Project-and-Instance
-//go:generate mapper stmt -p db -e instance_snapshot config-ref-by-Project-and-Instance-and-Name
 //go:generate mapper stmt -p db -e instance_snapshot devices-ref
-//go:generate mapper stmt -p db -e instance_snapshot devices-ref-by-Project-and-Instance
-//go:generate mapper stmt -p db -e instance_snapshot devices-ref-by-Project-and-Instance-and-Name
 //go:generate mapper stmt -p db -e instance_snapshot create struct=InstanceSnapshot
 //go:generate mapper stmt -p db -e instance_snapshot create-config-ref
 //go:generate mapper stmt -p db -e instance_snapshot create-devices-ref

--- a/lxd/db/snapshots.go
+++ b/lxd/db/snapshots.go
@@ -27,7 +27,7 @@ import (
 //go:generate mapper stmt -p db -e instance_snapshot create-config-ref
 //go:generate mapper stmt -p db -e instance_snapshot create-devices-ref
 //go:generate mapper stmt -p db -e instance_snapshot rename
-//go:generate mapper stmt -p db -e instance_snapshot delete-by-Project-and-Instance-and-Name
+//go:generate mapper stmt -p db -e instance_snapshot delete
 //
 //go:generate mapper method -p db -e instance_snapshot List
 //go:generate mapper method -p db -e instance_snapshot Get

--- a/lxd/db/snapshots.go
+++ b/lxd/db/snapshots.go
@@ -16,8 +16,6 @@ import (
 //go:generate mapper reset
 //
 //go:generate mapper stmt -p db -e instance_snapshot objects
-//go:generate mapper stmt -p db -e instance_snapshot objects-by-Project-and-Instance
-//go:generate mapper stmt -p db -e instance_snapshot objects-by-Project-and-Instance-and-Name
 //go:generate mapper stmt -p db -e instance_snapshot id
 //go:generate mapper stmt -p db -e instance_snapshot config-ref
 //go:generate mapper stmt -p db -e instance_snapshot config-ref-by-Project-and-Instance

--- a/lxd/db/snapshots.mapper.go
+++ b/lxd/db/snapshots.mapper.go
@@ -16,116 +16,116 @@ import (
 
 var _ = api.ServerEnvironment{}
 
-var instanceSnapshotObjects = cluster.RegisterStmt(`
+const instanceSnapshotObjects = cluster.RegisterStmt(`
 SELECT instances_snapshots.id, projects.name AS project, instances.name AS instance, instances_snapshots.name, instances_snapshots.creation_date, instances_snapshots.stateful, coalesce(instances_snapshots.description, ''), instances_snapshots.expiry_date
   FROM instances_snapshots JOIN projects ON instances.project_id = projects.id JOIN instances ON instances_snapshots.instance_id = instances.id
   ORDER BY projects.id, instances.id, instances_snapshots.name
 `)
-var instanceSnapshotObjectsByInstance = cluster.RegisterStmt(`
+const instanceSnapshotObjectsByInstance = cluster.RegisterStmt(`
 SELECT instances_snapshots.id, projects.name AS project, instances.name AS instance, instances_snapshots.name, instances_snapshots.creation_date, instances_snapshots.stateful, coalesce(instances_snapshots.description, ''), instances_snapshots.expiry_date
   FROM instances_snapshots JOIN projects ON instances.project_id = projects.id JOIN instances ON instances_snapshots.instance_id = instances.id
   WHERE instance = ? ORDER BY projects.id, instances.id, instances_snapshots.name
 `)
-var instanceSnapshotObjectsByProjectAndInstance = cluster.RegisterStmt(`
+const instanceSnapshotObjectsByProjectAndInstance = cluster.RegisterStmt(`
 SELECT instances_snapshots.id, projects.name AS project, instances.name AS instance, instances_snapshots.name, instances_snapshots.creation_date, instances_snapshots.stateful, coalesce(instances_snapshots.description, ''), instances_snapshots.expiry_date
   FROM instances_snapshots JOIN projects ON instances.project_id = projects.id JOIN instances ON instances_snapshots.instance_id = instances.id
   WHERE project = ? AND instance = ? ORDER BY projects.id, instances.id, instances_snapshots.name
 `)
-var instanceSnapshotObjectsByName = cluster.RegisterStmt(`
+const instanceSnapshotObjectsByName = cluster.RegisterStmt(`
 SELECT instances_snapshots.id, projects.name AS project, instances.name AS instance, instances_snapshots.name, instances_snapshots.creation_date, instances_snapshots.stateful, coalesce(instances_snapshots.description, ''), instances_snapshots.expiry_date
   FROM instances_snapshots JOIN projects ON instances.project_id = projects.id JOIN instances ON instances_snapshots.instance_id = instances.id
   WHERE instances_snapshots.name = ? ORDER BY projects.id, instances.id, instances_snapshots.name
 `)
-var instanceSnapshotObjectsByInstanceAndName = cluster.RegisterStmt(`
+const instanceSnapshotObjectsByInstanceAndName = cluster.RegisterStmt(`
 SELECT instances_snapshots.id, projects.name AS project, instances.name AS instance, instances_snapshots.name, instances_snapshots.creation_date, instances_snapshots.stateful, coalesce(instances_snapshots.description, ''), instances_snapshots.expiry_date
   FROM instances_snapshots JOIN projects ON instances.project_id = projects.id JOIN instances ON instances_snapshots.instance_id = instances.id
   WHERE instance = ? AND instances_snapshots.name = ? ORDER BY projects.id, instances.id, instances_snapshots.name
 `)
-var instanceSnapshotObjectsByProjectAndInstanceAndName = cluster.RegisterStmt(`
+const instanceSnapshotObjectsByProjectAndInstanceAndName = cluster.RegisterStmt(`
 SELECT instances_snapshots.id, projects.name AS project, instances.name AS instance, instances_snapshots.name, instances_snapshots.creation_date, instances_snapshots.stateful, coalesce(instances_snapshots.description, ''), instances_snapshots.expiry_date
   FROM instances_snapshots JOIN projects ON instances.project_id = projects.id JOIN instances ON instances_snapshots.instance_id = instances.id
   WHERE project = ? AND instance = ? AND instances_snapshots.name = ? ORDER BY projects.id, instances.id, instances_snapshots.name
 `)
 
-var instanceSnapshotID = cluster.RegisterStmt(`
+const instanceSnapshotID = cluster.RegisterStmt(`
 SELECT instances_snapshots.id FROM instances_snapshots JOIN projects ON instances.project_id = projects.id JOIN instances ON instances_snapshots.instance_id = instances.id
   WHERE projects.name = ? AND instances.name = ? AND instances_snapshots.name = ?
 `)
 
-var instanceSnapshotConfigRef = cluster.RegisterStmt(`
+const instanceSnapshotConfigRef = cluster.RegisterStmt(`
 SELECT project, instance, name, key, value FROM instances_snapshots_config_ref ORDER BY project, instance, name
 `)
-var instanceSnapshotConfigRefByInstance = cluster.RegisterStmt(`
+const instanceSnapshotConfigRefByInstance = cluster.RegisterStmt(`
 SELECT project, instance, name, key, value FROM instances_snapshots_config_ref WHERE instance = ? ORDER BY project, instance, name
 `)
-var instanceSnapshotConfigRefByProjectAndInstance = cluster.RegisterStmt(`
+const instanceSnapshotConfigRefByProjectAndInstance = cluster.RegisterStmt(`
 SELECT project, instance, name, key, value FROM instances_snapshots_config_ref WHERE project = ? AND instance = ? ORDER BY project, instance, name
 `)
-var instanceSnapshotConfigRefByName = cluster.RegisterStmt(`
+const instanceSnapshotConfigRefByName = cluster.RegisterStmt(`
 SELECT project, instance, name, key, value FROM instances_snapshots_config_ref WHERE name = ? ORDER BY project, instance, name
 `)
-var instanceSnapshotConfigRefByInstanceAndName = cluster.RegisterStmt(`
+const instanceSnapshotConfigRefByInstanceAndName = cluster.RegisterStmt(`
 SELECT project, instance, name, key, value FROM instances_snapshots_config_ref WHERE instance = ? AND name = ? ORDER BY project, instance, name
 `)
-var instanceSnapshotConfigRefByProjectAndInstanceAndName = cluster.RegisterStmt(`
+const instanceSnapshotConfigRefByProjectAndInstanceAndName = cluster.RegisterStmt(`
 SELECT project, instance, name, key, value FROM instances_snapshots_config_ref WHERE project = ? AND instance = ? AND name = ? ORDER BY project, instance, name
 `)
 
-var instanceSnapshotDevicesRef = cluster.RegisterStmt(`
+const instanceSnapshotDevicesRef = cluster.RegisterStmt(`
 SELECT project, instance, name, device, type, key, value FROM instances_snapshots_devices_ref ORDER BY project, instance, name
 `)
-var instanceSnapshotDevicesRefByInstance = cluster.RegisterStmt(`
+const instanceSnapshotDevicesRefByInstance = cluster.RegisterStmt(`
 SELECT project, instance, name, device, type, key, value FROM instances_snapshots_devices_ref WHERE instance = ? ORDER BY project, instance, name
 `)
-var instanceSnapshotDevicesRefByProjectAndInstance = cluster.RegisterStmt(`
+const instanceSnapshotDevicesRefByProjectAndInstance = cluster.RegisterStmt(`
 SELECT project, instance, name, device, type, key, value FROM instances_snapshots_devices_ref WHERE project = ? AND instance = ? ORDER BY project, instance, name
 `)
-var instanceSnapshotDevicesRefByName = cluster.RegisterStmt(`
+const instanceSnapshotDevicesRefByName = cluster.RegisterStmt(`
 SELECT project, instance, name, device, type, key, value FROM instances_snapshots_devices_ref WHERE name = ? ORDER BY project, instance, name
 `)
-var instanceSnapshotDevicesRefByInstanceAndName = cluster.RegisterStmt(`
+const instanceSnapshotDevicesRefByInstanceAndName = cluster.RegisterStmt(`
 SELECT project, instance, name, device, type, key, value FROM instances_snapshots_devices_ref WHERE instance = ? AND name = ? ORDER BY project, instance, name
 `)
-var instanceSnapshotDevicesRefByProjectAndInstanceAndName = cluster.RegisterStmt(`
+const instanceSnapshotDevicesRefByProjectAndInstanceAndName = cluster.RegisterStmt(`
 SELECT project, instance, name, device, type, key, value FROM instances_snapshots_devices_ref WHERE project = ? AND instance = ? AND name = ? ORDER BY project, instance, name
 `)
 
-var instanceSnapshotCreate = cluster.RegisterStmt(`
+const instanceSnapshotCreate = cluster.RegisterStmt(`
 INSERT INTO instances_snapshots (instance_id, name, creation_date, stateful, description, expiry_date)
   VALUES ((SELECT instances.id FROM instances JOIN projects ON projects.id = instances.project_id WHERE projects.name = ? AND instances.name = ?), ?, ?, ?, ?, ?)
 `)
 
-var instanceSnapshotCreateConfigRef = cluster.RegisterStmt(`
+const instanceSnapshotCreateConfigRef = cluster.RegisterStmt(`
 INSERT INTO instances_snapshots_config (instance_snapshot_id, key, value)
   VALUES (?, ?, ?)
 `)
 
-var instanceSnapshotCreateDevicesRef = cluster.RegisterStmt(`
+const instanceSnapshotCreateDevicesRef = cluster.RegisterStmt(`
 INSERT INTO instances_snapshots_devices (instance_snapshot_id, name, type)
   VALUES (?, ?, ?)
 `)
-var instanceSnapshotCreateDevicesConfigRef = cluster.RegisterStmt(`
+const instanceSnapshotCreateDevicesConfigRef = cluster.RegisterStmt(`
 INSERT INTO instances_snapshots_devices_config (instance_snapshot_device_id, key, value)
   VALUES (?, ?, ?)
 `)
 
-var instanceSnapshotRename = cluster.RegisterStmt(`
+const instanceSnapshotRename = cluster.RegisterStmt(`
 UPDATE instances_snapshots SET name = ? WHERE instance_id = (SELECT instances.id FROM instances JOIN projects ON projects.id = instances.project_id WHERE projects.name = ? AND instances.name = ?) AND name = ?
 `)
 
-var instanceSnapshotDeleteByInstance = cluster.RegisterStmt(`
+const instanceSnapshotDeleteByInstance = cluster.RegisterStmt(`
 DELETE FROM instances_snapshots WHERE instance_id = (SELECT instances.id FROM instances WHERE instances.name = ?)
 `)
-var instanceSnapshotDeleteByProjectAndInstance = cluster.RegisterStmt(`
+const instanceSnapshotDeleteByProjectAndInstance = cluster.RegisterStmt(`
 DELETE FROM instances_snapshots WHERE instance_id = (SELECT instances.id FROM instances JOIN projects ON projects.id = instances.project_id WHERE projects.name = ? AND instances.name = ?)
 `)
-var instanceSnapshotDeleteByName = cluster.RegisterStmt(`
+const instanceSnapshotDeleteByName = cluster.RegisterStmt(`
 DELETE FROM instances_snapshots WHERE name = ?
 `)
-var instanceSnapshotDeleteByInstanceAndName = cluster.RegisterStmt(`
+const instanceSnapshotDeleteByInstanceAndName = cluster.RegisterStmt(`
 DELETE FROM instances_snapshots WHERE instance_id = (SELECT instances.id FROM instances WHERE instances.name = ?) AND name = ?
 `)
-var instanceSnapshotDeleteByProjectAndInstanceAndName = cluster.RegisterStmt(`
+const instanceSnapshotDeleteByProjectAndInstanceAndName = cluster.RegisterStmt(`
 DELETE FROM instances_snapshots WHERE instance_id = (SELECT instances.id FROM instances JOIN projects ON projects.id = instances.project_id WHERE projects.name = ? AND instances.name = ?) AND name = ?
 `)
 

--- a/lxd/db/snapshots_test.go
+++ b/lxd/db/snapshots_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
-	"github.com/lxc/lxd/shared/api"
 )
 
 func TestGetInstanceSnapshots(t *testing.T) {
@@ -90,7 +89,7 @@ func TestGetInstanceSnapshots_SameNameInDifferentProjects(t *testing.T) {
 	defer cleanup()
 
 	// Create an additional project
-	project1 := api.ProjectsPost{}
+	project1 := db.Project{}
 	project1.Name = "p1"
 	_, err := tx.CreateProject(project1)
 	require.NoError(t, err)

--- a/lxd/db/transaction.go
+++ b/lxd/db/transaction.go
@@ -42,8 +42,8 @@ func (c *ClusterTx) NodeID(id int64) {
 }
 
 // GetNodeID gets the ID of the node associated with this cluster transaction.
-func (c *ClusterTx) GetNodeID() int64 {
-	return c.nodeID
+func (c *ClusterTx) GetNodeID() *int64 {
+	return &c.nodeID
 }
 
 func (c *ClusterTx) stmt(code int) *sql.Stmt {

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1247,7 +1247,7 @@ func (d *disk) storagePoolVolumeAttachShift(projectName, poolName, volumeName st
 
 		if !shared.IsTrue(poolVolumePut.Config["security.shifted"]) {
 			volumeUsedBy := []instance.Instance{}
-			err = storagePools.VolumeUsedByInstanceDevices(d.state, poolName, projectName, volume, true, func(dbInst db.Instance, project api.Project, profiles []api.Profile, usedByDevices []string) error {
+			err = storagePools.VolumeUsedByInstanceDevices(d.state, poolName, projectName, volume, true, func(dbInst db.Instance, project db.Project, profiles []api.Profile, usedByDevices []string) error {
 				inst, err := instance.Load(d.state, db.InstanceToArgs(&dbInst), profiles)
 				if err != nil {
 					return err

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -217,7 +217,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 			ourNICMAC, _ = net.ParseMAC(v["hwaddr"])
 		}
 
-		err := d.state.Cluster.InstanceList(&filter, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+		err := d.state.Cluster.InstanceList(&filter, func(inst db.Instance, p db.Project, profiles []api.Profile) error {
 			// Get the instance's effective network project name.
 			instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2031,7 +2031,7 @@ func pruneLeftoverImages(d *Daemon) {
 }
 
 func pruneExpiredImages(ctx context.Context, d *Daemon, op *operations.Operation) error {
-	var projects []api.Project
+	var projects []db.Project
 	err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
 		var err error
 		projects, err = tx.GetProjects(db.ProjectFilter{})
@@ -2055,7 +2055,7 @@ func pruneExpiredImages(ctx context.Context, d *Daemon, op *operations.Operation
 	return nil
 }
 
-func pruneExpiredImagesInProject(ctx context.Context, d *Daemon, project api.Project, op *operations.Operation) error {
+func pruneExpiredImagesInProject(ctx context.Context, d *Daemon, project db.Project, op *operations.Operation) error {
 	var expiry int64
 	var err error
 	if project.Config["images.remote_cache_expiry"] != "" {

--- a/lxd/network/acl/acl_load.go
+++ b/lxd/network/acl/acl_load.go
@@ -198,7 +198,7 @@ func UsedBy(s *state.State, aclProjectName string, usageFunc func(matchedACLName
 	}
 
 	// Find instances using the ACLs. Most expensive to do.
-	err = s.Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+	err = s.Cluster.InstanceList(nil, func(inst db.Instance, p db.Project, profiles []api.Profile) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -68,7 +68,7 @@ func RandomDevName(prefix string) string {
 
 // usedByInstanceDevices looks for instance NIC devices using the network and runs the supplied usageFunc for each.
 func usedByInstanceDevices(s *state.State, networkProjectName string, networkName string, usageFunc func(inst db.Instance, nicName string, nicConfig map[string]string) error) error {
-	return s.Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+	return s.Cluster.InstanceList(nil, func(inst db.Instance, p db.Project, profiles []api.Profile) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 
@@ -175,7 +175,7 @@ func UsedBy(s *state.State, networkProjectName string, networkName string, first
 	}
 
 	// Look at instances. Most expensive to do.
-	err = s.Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+	err = s.Cluster.InstanceList(nil, func(inst db.Instance, p db.Project, profiles []api.Profile) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/network/network_utils_sriov.go
+++ b/lxd/network/network_utils_sriov.go
@@ -65,7 +65,7 @@ func SRIOVGetHostDevicesInUse(s *state.State) (map[string]struct{}, error) {
 	reservedDevices := map[string]struct{}{}
 
 	// Check if any instances are using the VF device.
-	err = s.Cluster.InstanceList(&filter, func(dbInst db.Instance, p api.Project, profiles []api.Profile) error {
+	err = s.Cluster.InstanceList(&filter, func(dbInst db.Instance, p db.Project, profiles []api.Profile) error {
 		// Expand configs so we take into account profile devices.
 		dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, profiles)
 		dbInst.Devices = db.ExpandInstanceDevices(deviceConfig.NewDevices(dbInst.Devices), profiles).CloneNative()

--- a/lxd/operations/linux.go
+++ b/lxd/operations/linux.go
@@ -18,7 +18,7 @@ func registerDBOperation(op *Operation, opType db.OperationType) error {
 		opInfo := db.Operation{
 			UUID:   op.id,
 			Type:   opType,
-			NodeID: tx.GetNodeID(),
+			NodeID: *tx.GetNodeID(),
 		}
 
 		if op.projectName != "" {

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -441,7 +441,7 @@ func patchVMRenameUUIDKey(name string, d *Daemon) error {
 	oldUUIDKey := "volatile.vm.uuid"
 	newUUIDKey := "volatile.uuid"
 
-	return d.State().Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+	return d.State().Cluster.InstanceList(nil, func(inst db.Instance, p db.Project, profiles []api.Profile) error {
 		if inst.Type != instancetype.VM {
 			return nil
 		}

--- a/lxd/project/permissions_test.go
+++ b/lxd/project/permissions_test.go
@@ -29,12 +29,10 @@ func TestAllowInstanceCreation_Below(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	_, err := tx.CreateProject(api.ProjectsPost{
+	_, err := tx.CreateProject(db.Project{
 		Name: "p1",
-		ProjectPut: api.ProjectPut{
-			Config: map[string]string{
-				"limits.containers": "5",
-			},
+		Config: map[string]string{
+			"limits.containers": "5",
 		},
 	})
 	require.NoError(t, err)
@@ -63,12 +61,10 @@ func TestAllowInstanceCreation_Above(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	_, err := tx.CreateProject(api.ProjectsPost{
+	_, err := tx.CreateProject(db.Project{
 		Name: "p1",
-		ProjectPut: api.ProjectPut{
-			Config: map[string]string{
-				"limits.containers": "1",
-			},
+		Config: map[string]string{
+			"limits.containers": "1",
 		},
 	})
 	require.NoError(t, err)
@@ -97,12 +93,10 @@ func TestAllowInstanceCreation_DifferentType(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	_, err := tx.CreateProject(api.ProjectsPost{
+	_, err := tx.CreateProject(db.Project{
 		Name: "p1",
-		ProjectPut: api.ProjectPut{
-			Config: map[string]string{
-				"limits.containers": "1",
-			},
+		Config: map[string]string{
+			"limits.containers": "1",
 		},
 	})
 	require.NoError(t, err)
@@ -131,13 +125,11 @@ func TestAllowInstanceCreation_AboveInstances(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	_, err := tx.CreateProject(api.ProjectsPost{
+	_, err := tx.CreateProject(db.Project{
 		Name: "p1",
-		ProjectPut: api.ProjectPut{
-			Config: map[string]string{
-				"limits.containers": "5",
-				"limits.instances":  "1",
-			},
+		Config: map[string]string{
+			"limits.containers": "5",
+			"limits.instances":  "1",
 		},
 	})
 	require.NoError(t, err)

--- a/lxd/project/project.go
+++ b/lxd/project/project.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
-	"github.com/lxc/lxd/shared/api"
 )
 
 // Default is the string used for a default project.
@@ -86,7 +85,7 @@ func StorageVolumeProject(c *db.Cluster, projectName string, volumeType int) (st
 // For custom volume type, if the project supplied has the "features.storage.volumes" flag enabled then the
 // project name is returned, otherwise the default project name is returned. For all other volume types the
 // supplied project's name is returned.
-func StorageVolumeProjectFromRecord(p *api.Project, volumeType int) string {
+func StorageVolumeProjectFromRecord(p *db.Project, volumeType int) string {
 	// Non-custom volumes always use the project specified.
 	if volumeType != db.StoragePoolVolumeTypeCustom {
 		return p.Name
@@ -123,7 +122,7 @@ func NetworkProject(c *db.Cluster, projectName string) (string, map[string]strin
 // NetworkProjectFromRecord returns the project name to use for the network based on the supplied project.
 // If the project supplied has the "features.networks" flag enabled then the project name is returned,
 // otherwise the default project name is returned.
-func NetworkProjectFromRecord(p *api.Project) string {
+func NetworkProjectFromRecord(p *db.Project) string {
 	// Networks only use the project specified if the project has the features.networks feature enabled,
 	// otherwise the legacy behaviour of using the default project for networks is used.
 	if shared.IsTrue(p.Config["features.networks"]) {
@@ -155,7 +154,7 @@ func ProfileProject(c *db.Cluster, projectName string) (string, map[string]strin
 // ProfileProjectFromRecord returns the project name to use for the profile based on the supplied project.
 // If the project supplied has the "features.profiles" flag enabled then the project name is returned,
 // otherwise the default project name is returned.
-func ProfileProjectFromRecord(p *api.Project) string {
+func ProfileProjectFromRecord(p *db.Project) string {
 	// Profiles only use the project specified if the project has the features.profiles feature enabled,
 	// otherwise the default project for profiles is used.
 	if shared.IsTrue(p.Config["features.profiles"]) {

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3087,7 +3087,7 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 
 		// Check for config changing that is not allowed when running instances are using it.
 		if changedConfig["security.shifted"] != "" {
-			err = VolumeUsedByInstanceDevices(b.state, b.name, projectName, curVol, true, func(dbInst db.Instance, project api.Project, profiles []api.Profile, usedByDevices []string) error {
+			err = VolumeUsedByInstanceDevices(b.state, b.name, projectName, curVol, true, func(dbInst db.Instance, project db.Project, profiles []api.Profile, usedByDevices []string) error {
 				inst, err := instance.Load(b.state, db.InstanceToArgs(&dbInst), profiles)
 				if err != nil {
 					return err
@@ -3528,7 +3528,7 @@ func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotNa
 	}
 
 	// Check that the volume isn't in use by running instances.
-	err = VolumeUsedByInstanceDevices(b.state, b.Name(), projectName, curVol, true, func(dbInst db.Instance, project api.Project, profiles []api.Profile, usedByDevices []string) error {
+	err = VolumeUsedByInstanceDevices(b.state, b.Name(), projectName, curVol, true, func(dbInst db.Instance, project db.Project, profiles []api.Profile, usedByDevices []string) error {
 		inst, err := instance.Load(b.state, db.InstanceToArgs(&dbInst), profiles)
 		if err != nil {
 			return err

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -605,14 +605,14 @@ func InstanceContentType(inst instance.Instance) drivers.ContentType {
 // VolumeUsedByProfileDevices finds profiles using a volume and passes them to profileFunc for evaluation.
 // The profileFunc is provided with a profile config, project config and a list of device names that are using
 // the volume.
-func VolumeUsedByProfileDevices(s *state.State, poolName string, projectName string, vol *api.StorageVolume, profileFunc func(profile db.Profile, project api.Project, usedByDevices []string) error) error {
+func VolumeUsedByProfileDevices(s *state.State, poolName string, projectName string, vol *api.StorageVolume, profileFunc func(profile db.Profile, project db.Project, usedByDevices []string) error) error {
 	// Convert the volume type name to our internal integer representation.
 	volumeType, err := VolumeTypeNameToDBType(vol.Type)
 	if err != nil {
 		return err
 	}
 
-	projectMap := map[string]api.Project{}
+	projectMap := map[string]db.Project{}
 	var profiles []db.Profile
 
 	// Retrieve required info from the database in single transaction for performance.
@@ -690,14 +690,14 @@ func VolumeUsedByProfileDevices(s *state.State, poolName string, projectName str
 // is returned immediately. The instanceFunc is executed during a DB transaction, so DB queries are not permitted.
 // The instanceFunc is provided with a instance config, project config, instance's profiles and a list of device
 // names that are using the volume.
-func VolumeUsedByInstanceDevices(s *state.State, poolName string, projectName string, vol *api.StorageVolume, expandDevices bool, instanceFunc func(inst db.Instance, project api.Project, profiles []api.Profile, usedByDevices []string) error) error {
+func VolumeUsedByInstanceDevices(s *state.State, poolName string, projectName string, vol *api.StorageVolume, expandDevices bool, instanceFunc func(inst db.Instance, project db.Project, profiles []api.Profile, usedByDevices []string) error) error {
 	// Convert the volume type name to our internal integer representation.
 	volumeType, err := VolumeTypeNameToDBType(vol.Type)
 	if err != nil {
 		return err
 	}
 
-	return s.Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+	return s.Cluster.InstanceList(nil, func(inst db.Instance, p db.Project, profiles []api.Profile) error {
 		// If the volume has a specific cluster member which is different than the instance then skip as
 		// instance cannot be using this volume.
 		if vol.Location != "" && inst.Node != vol.Location {
@@ -784,7 +784,7 @@ func VolumeUsedByExclusiveRemoteInstancesWithProfiles(s *state.State, poolName s
 
 	// Find if volume is attached to a remote instance.
 	var remoteInstance *db.Instance
-	err = VolumeUsedByInstanceDevices(s, poolName, projectName, vol, true, func(dbInst db.Instance, project api.Project, profiles []api.Profile, usedByDevices []string) error {
+	err = VolumeUsedByInstanceDevices(s, poolName, projectName, vol, true, func(dbInst db.Instance, project db.Project, profiles []api.Profile, usedByDevices []string) error {
 		if dbInst.Node != localNode {
 			remoteInstance = &dbInst
 			return db.ErrInstanceListStop // Stop the search, this volume is attached to a remote instance.

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -940,7 +940,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Check if a running instance is using it.
-	err = storagePools.VolumeUsedByInstanceDevices(d.State(), srcPoolName, projectName, vol, true, func(dbInst db.Instance, project api.Project, profiles []api.Profile, usedByDevices []string) error {
+	err = storagePools.VolumeUsedByInstanceDevices(d.State(), srcPoolName, projectName, vol, true, func(dbInst db.Instance, project db.Project, profiles []api.Profile, usedByDevices []string) error {
 		inst, err := instance.Load(d.State(), db.InstanceToArgs(&dbInst), profiles)
 		if err != nil {
 			return err

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -22,7 +22,7 @@ func storagePoolVolumeUpdateUsers(d *Daemon, projectName string, oldPoolName str
 	s := d.State()
 
 	// Update all instances that are using the volume with a local (non-expanded) device.
-	err := storagePools.VolumeUsedByInstanceDevices(s, oldPoolName, projectName, oldVol, false, func(dbInst db.Instance, project api.Project, profiles []api.Profile, usedByDevices []string) error {
+	err := storagePools.VolumeUsedByInstanceDevices(s, oldPoolName, projectName, oldVol, false, func(dbInst db.Instance, project db.Project, profiles []api.Profile, usedByDevices []string) error {
 		inst, err := instance.Load(s, db.InstanceToArgs(&dbInst), profiles)
 		if err != nil {
 			return err
@@ -60,7 +60,7 @@ func storagePoolVolumeUpdateUsers(d *Daemon, projectName string, oldPoolName str
 	}
 
 	// Update all profiles that are using the volume with a device.
-	err = storagePools.VolumeUsedByProfileDevices(s, oldPoolName, projectName, oldVol, func(profile db.Profile, p api.Project, usedByDevices []string) error {
+	err = storagePools.VolumeUsedByProfileDevices(s, oldPoolName, projectName, oldVol, func(profile db.Profile, p db.Project, usedByDevices []string) error {
 		for _, devName := range usedByDevices {
 			if _, exists := profile.Devices[devName]; exists {
 				profile.Devices[devName]["pool"] = newPoolName
@@ -131,7 +131,7 @@ func storagePoolVolumeUsedByGet(s *state.State, projectName string, poolName str
 
 	// Pass false to expandDevices, as we only want to see instances directly using a volume, rather than their
 	// profiles using a volume.
-	err = storagePools.VolumeUsedByInstanceDevices(s, poolName, projectName, vol, false, func(inst db.Instance, p api.Project, profiles []api.Profile, usedByDevices []string) error {
+	err = storagePools.VolumeUsedByInstanceDevices(s, poolName, projectName, vol, false, func(inst db.Instance, p db.Project, profiles []api.Profile, usedByDevices []string) error {
 		if inst.Project == project.Default {
 			volumeUsedBy = append(volumeUsedBy, fmt.Sprintf("/%s/instances/%s", version.APIVersion, inst.Name))
 		} else {
@@ -144,7 +144,7 @@ func storagePoolVolumeUsedByGet(s *state.State, projectName string, poolName str
 		return []string{}, err
 	}
 
-	err = storagePools.VolumeUsedByProfileDevices(s, poolName, projectName, vol, func(profile db.Profile, p api.Project, usedByDevices []string) error {
+	err = storagePools.VolumeUsedByProfileDevices(s, poolName, projectName, vol, func(profile db.Profile, p db.Project, usedByDevices []string) error {
 		if profile.Project == project.Default {
 			volumeUsedBy = append(volumeUsedBy, fmt.Sprintf("/%s/profiles/%s", version.APIVersion, profile.Name))
 		} else {


### PR DESCRIPTION
91 commits! It's quite hard to break up, as it's a whole bunch of minuscule changes in a ton of files that all depend on each other....

The main goal of this PR is to remove all the filter-by keywords from the generator calls. Now, simply calling `objects` or `delete`, for example, will produce all possible filter combinations as well.

Notable changes:
* Added a `FilterCombinations` function, which effectively returns the power set of the fields in the Filter structs for each of the generated classes.
* Removed all the `-by-` statements from `go:generate` comments, as all filters are now automatically generated.
* I had to create a `db.Project` struct based on `api.ProjectPost`, as there previously was not a `ProjectFilter` struct.
* Filter structs are now required for the generator to function.
* I ran into a bit of an issue with zero values for integers. Currently we are using `-1`, which works fine as long as the value was explicitly set in the Filter struct, but with the new `FilterCombinations`, several more integers were being passed, and I felt using `-1`'s everywhere wasn't the best. My solution was to just use `*int` for all `int` fields that do not have a default `-1` value already defined. This is to allow the `int` fields to be omitted outright.
* Added a `CertificateType` int value to allow taking a pointer of a `const`.

An alternative approach to the zero value issue could be to simply pass a `db:"zero=0"` tag, and not use pointers at all.