### PR TITLE
QMP: Fixes potential crash in QueryPCI

### DIFF
--- a/lxd/instance/drivers/qmp/commands.go
+++ b/lxd/instance/drivers/qmp/commands.go
@@ -384,5 +384,9 @@ func (m *Monitor) QueryPCI() ([]PCIDevice, error) {
 		return nil, errors.Wrapf(err, "Failed querying PCI devices")
 	}
 
-	return resp.Return[0].Devices, nil
+	if len(resp.Return) > 0 {
+		return resp.Return[0].Devices, nil
+	}
+
+	return nil, nil
 }


### PR DESCRIPTION
In some tests the QMP command doesn't return an error, but returns no results, so handle that.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>

Fixes crash:

```
Jul 20 09:52:19 home02 lxd.daemon[142401]: panic: runtime error: index out of range [0] with length 0
Jul 20 09:52:19 home02 lxd.daemon[142401]: goroutine 10261 [running]:
Jul 20 09:52:19 home02 lxd.daemon[142401]: github.com/lxc/lxd/lxd/instance/drivers/qmp.(*Monitor).QueryPCI(0xc0013141c0, 0x7447af, 0xc000010608, 0xc0000cdc00, 0x0, 0x0)
Jul 20 09:52:19 home02 lxd.daemon[142401]:         /build/lxd/parts/lxd/src/.go/src/github.com/lxc/lxd/lxd/instance/drivers/qmp/commands.go:387 +0x145
Jul 20 09:52:19 home02 lxd.daemon[142401]: github.com/lxc/lxd/lxd/instance/drivers.(*qemu).deviceDetachNIC.func1(0xc00066af30, 0xc, 0x25, 0xc00096f780, 0x1)
Jul 20 09:52:19 home02 lxd.daemon[142401]:         /build/lxd/parts/lxd/src/.go/src/github.com/lxc/lxd/lxd/instance/drivers/driver_qemu.go:1823 +0x3f
Jul 20 09:52:19 home02 lxd.daemon[142401]: github.com/lxc/lxd/lxd/instance/drivers.(*qemu).deviceDetachNIC(0xc000012840, 0xc00133d244, 0x4, 0x4, 0xc000093968)
Jul 20 09:52:19 home02 lxd.daemon[142401]:         /build/lxd/parts/lxd/src/.go/src/github.com/lxc/lxd/lxd/instance/drivers/driver_qemu.go:1858 +0x42a
Jul 20 09:52:19 home02 lxd.daemon[142401]: github.com/lxc/lxd/lxd/instance/drivers.(*qemu).deviceStop(0xc000012840, 0xc00133d244, 0x4, 0xc000505c50, 0xc00096eb01, 0x0, 0x0)
Jul 20 09:52:19 home02 lxd.daemon[142401]:         /build/lxd/parts/lxd/src/.go/src/github.com/lxc/lxd/lxd/instance/drivers/driver_qemu.go:1796 +0x53f
Jul 20 09:52:19 home02 lxd.daemon[142401]: github.com/lxc/lxd/lxd/instance/drivers.(*qemu).updateDevices(0xc000012840, 0xc001271d10, 0xc001271d40, 0xc001271d70, 0xc000505290, 0xc001270101, 0x0, 0x0)
Jul 20 09:52:19 home02 lxd.daemon[142401]:         /build/lxd/parts/lxd/src/.go/src/github.com/lxc/lxd/lxd/instance/drivers/driver_qemu.go:4192 +0x145
Jul 20 09:52:19 home02 lxd.daemon[142401]: github.com/lxc/lxd/lxd/instance/drivers.(*qemu).Update(0xc000012840, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1601459, 0x7, 0x0, 0x0, ...)
Jul 20 09:52:19 home02 lxd.daemon[142401]:         /build/lxd/parts/lxd/src/.go/src/github.com/lxc/lxd/lxd/instance/drivers/driver_qemu.go:3987 +0x10b8
Jul 20 09:52:19 home02 lxd.daemon[142401]: main.instancePut.func2(0xc00029eb40, 0x30, 0x4193db)
Jul 20 09:52:19 home02 lxd.daemon[142401]:         /build/lxd/parts/lxd/src/.go/src/github.com/lxc/lxd/lxd/instance_put.go:120 +0x19d
Jul 20 09:52:19 home02 lxd.daemon[142401]: github.com/lxc/lxd/lxd/operations.(*Operation).Run.func1(0xc00029eb40, 0xc000cac4e0)
Jul 20 09:52:19 home02 lxd.daemon[142401]:         /build/lxd/parts/lxd/src/.go/src/github.com/lxc/lxd/lxd/operations/operations.go:270 +0x4a
Jul 20 09:52:19 home02 lxd.daemon[142401]: created by github.com/lxc/lxd/lxd/operations.(*Operation).Run
Jul 20 09:52:19 home02 lxd.daemon[142401]:         /build/lxd/parts/lxd/src/.go/src/github.com/lxc/lxd/lxd/operations/operations.go:269 +0x468
Jul 20 09:52:19 home02 lxd.daemon[142231]: => LXD failed with return code 2

```