### PR TITLE
Storage: Add ability for volume mount to probe block backed volumes for their filesystem type

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -820,7 +820,7 @@ func internalImport(d *Daemon, projectName string, req *internalImportPost, reco
 		Name:         backupConf.Container.Name,
 		Profiles:     backupConf.Container.Profiles,
 		Stateful:     backupConf.Container.Stateful,
-	}, true, revert)
+	}, true, nil, revert)
 	if err != nil {
 		return response.SmartError(errors.Wrap(err, "Failed creating instance record"))
 	}
@@ -915,7 +915,7 @@ func internalImport(d *Daemon, projectName string, req *internalImportPost, reco
 			Name:         snap.Name,
 			Profiles:     snap.Profiles,
 			Stateful:     snap.Stateful,
-		}, true, revert)
+		}, true, nil, revert)
 		if err != nil {
 			return response.SmartError(errors.Wrapf(err, "Failed creating instance snapshot record %q", snap.Name))
 		}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -33,7 +33,7 @@ func instanceCreateAsEmpty(d *Daemon, args db.InstanceArgs) (instance.Instance, 
 	defer revert.Fail()
 
 	// Create the instance record.
-	inst, err := instance.CreateInternal(d.State(), args, true, revert)
+	inst, err := instance.CreateInternal(d.State(), args, true, nil, revert)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed creating instance record")
 	}
@@ -143,7 +143,7 @@ func instanceCreateFromImage(d *Daemon, r *http.Request, args db.InstanceArgs, h
 	args.BaseImage = hash
 
 	// Create the instance.
-	inst, err := instance.CreateInternal(s, args, true, revert)
+	inst, err := instance.CreateInternal(s, args, true, nil, revert)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed creating instance record")
 	}
@@ -206,7 +206,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 	// If we are not in refresh mode, then create a new instance as we are in copy mode.
 	if !opts.refresh {
 		// Create the instance.
-		inst, err = instance.CreateInternal(s, opts.targetInstance, true, revert)
+		inst, err = instance.CreateInternal(s, opts.targetInstance, true, nil, revert)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed creating instance record")
 		}
@@ -326,7 +326,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 			}
 
 			// Create the snapshots.
-			snapInst, err := instance.CreateInternal(s, snapInstArgs, true, revert)
+			snapInst, err := instance.CreateInternal(s, snapInstArgs, true, nil, revert)
 			if err != nil {
 				return nil, errors.Wrapf(err, "Failed creating instance snapshot record %q", newSnapName)
 			}

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -553,7 +553,7 @@ func (d *common) snapshotCommon(inst instance.Instance, name string, expiry time
 	}
 
 	// Create the snapshot.
-	snap, err := instance.CreateInternal(d.state, args, true, revert)
+	snap, err := instance.CreateInternal(d.state, args, true, nil, revert)
 	if err != nil {
 		return errors.Wrapf(err, "Failed creating instance snapshot record %q", name)
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -139,7 +139,7 @@ func lxcStatusCode(state liblxc.State) api.StatusCode {
 // lxcCreate creates the DB storage records and sets up instance devices.
 // Accepts a reverter that revert steps this function does will be added to. It is up to the caller to call the
 // revert's Fail() or Success() function as needed.
-func lxcCreate(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (instance.Instance, error) {
+func lxcCreate(s *state.State, args db.InstanceArgs, volumeConfig map[string]string, revert *revert.Reverter) (instance.Instance, error) {
 	// Create the container struct
 	d := &lxc{
 		common: common{
@@ -258,7 +258,10 @@ func lxcCreate(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (i
 		}
 	} else {
 		// Fill default config for new instances.
-		volumeConfig := map[string]string{}
+		if volumeConfig == nil {
+			volumeConfig = make(map[string]string)
+		}
+
 		err = d.storagePool.FillInstanceConfig(d, volumeConfig)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed filling default config")

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -166,7 +166,7 @@ func qemuInstantiate(s *state.State, args db.InstanceArgs, expandedDevices devic
 // qemuCreate creates a new storage volume record and returns an initialised Instance.
 // Accepts a reverter that revert steps this function does will be added to. It is up to the caller to call the
 // revert's Fail() or Success() function as needed.
-func qemuCreate(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (instance.Instance, error) {
+func qemuCreate(s *state.State, args db.InstanceArgs, volumeConfig map[string]string, revert *revert.Reverter) (instance.Instance, error) {
 	// Create the instance struct.
 	d := &qemu{
 		common: common{
@@ -292,7 +292,10 @@ func qemuCreate(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (
 		}
 	} else {
 		// Fill default config for new instances.
-		volumeConfig := map[string]string{}
+		if volumeConfig == nil {
+			volumeConfig = make(map[string]string)
+		}
+
 		err = d.storagePool.FillInstanceConfig(d, volumeConfig)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed filling default config")

--- a/lxd/instance/drivers/load.go
+++ b/lxd/instance/drivers/load.go
@@ -101,11 +101,11 @@ func validDevices(state *state.State, cluster *db.Cluster, projectName string, i
 	return nil
 }
 
-func create(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (instance.Instance, error) {
+func create(s *state.State, args db.InstanceArgs, volumeConfig map[string]string, revert *revert.Reverter) (instance.Instance, error) {
 	if args.Type == instancetype.Container {
-		return lxcCreate(s, args, revert)
+		return lxcCreate(s, args, volumeConfig, revert)
 	} else if args.Type == instancetype.VM {
-		return qemuCreate(s, args, revert)
+		return qemuCreate(s, args, volumeConfig, revert)
 	}
 
 	return nil, fmt.Errorf("Instance type invalid")

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -42,7 +42,7 @@ var Load func(s *state.State, args db.InstanceArgs, profiles []api.Profile) (Ins
 // Create is linked from instance/drivers.create to allow difference instance types to be created.
 // Accepts a reverter that revert steps this function does will be added to. It is up to the caller to call the
 // revert's Fail() or Success() function as needed.
-var Create func(s *state.State, args db.InstanceArgs, revert *revert.Reverter) (Instance, error)
+var Create func(s *state.State, args db.InstanceArgs, volumeConfig map[string]string, revert *revert.Reverter) (Instance, error)
 
 // CompareSnapshots returns a list of snapshots to sync to the target and a list of
 // snapshots to remove from the target. A snapshot will be marked as "to sync" if it either doesn't

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -917,9 +917,10 @@ func ValidName(instanceName string, isSnapshot bool) error {
 }
 
 // CreateInternal creates an instance record and storage volume record in the database and sets up devices.
-// Accepts a reverter that revert steps this function does will be added to. It is up to the caller to call the
-// revert's Fail() or Success() function as needed.
-func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, revert *revert.Reverter) (Instance, error) {
+// Accepts an (optionally nil) volumeConfig map that can be used to specify extra custom settings for the volume
+// record. Also accepts a reverter that revert steps this function does will be added to. It is up to the caller to
+// call the revert's Fail() or Success() function as needed.
+func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, volumeConfig map[string]string, revert *revert.Reverter) (Instance, error) {
 	// Check instance type requested is supported by this machine.
 	if _, supported := s.InstanceTypes[args.Type]; !supported {
 		return nil, fmt.Errorf("Instance type %q is not supported on this server", args.Type)
@@ -1113,7 +1114,7 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, reve
 	revert.Add(func() { s.Cluster.DeleteInstance(dbInst.Project, dbInst.Name) })
 
 	args = db.InstanceToArgs(&dbInst)
-	inst, err := Create(s, args, revert)
+	inst, err := Create(s, args, volumeConfig, revert)
 	if err != nil {
 		logger.Error("Failed initialising instance", log.Ctx{"project": args.Project, "instance": args.Name, "type": args.Type, "err": err})
 		return nil, errors.Wrap(err, "Failed initialising instance")

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -30,7 +30,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesDefault() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
 	suite.Req.Nil(err)
 	defer c.Delete(true)
 
@@ -74,7 +74,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
 	suite.Req.Nil(err)
 	defer c.Delete(true)
 
@@ -105,7 +105,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesOverwriteDefaultNic() {
 	_, err := suite.d.State().Cluster.CreateNetwork(project.Default, "unknownbr0", "", db.NetworkTypeBridge, nil)
 	suite.Req.Nil(err)
 
-	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
 	suite.Req.Nil(err)
 
 	suite.True(c.IsPrivileged(), "This container should be privileged.")
@@ -140,7 +140,7 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 	suite.Req.Nil(err)
 
 	// Create the container
-	c, err := instance.CreateInternal(state, args, true, revert.New())
+	c, err := instance.CreateInternal(state, args, true, nil, revert.New())
 	suite.Req.Nil(err)
 	defer c.Delete(true)
 
@@ -168,7 +168,7 @@ func (suite *containerTestSuite) TestContainer_Path_Regular() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
 	suite.Req.Nil(err)
 	defer c.Delete(true)
 
@@ -184,7 +184,7 @@ func (suite *containerTestSuite) TestContainer_LogPath() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
 	suite.Req.Nil(err)
 	defer c.Delete(true)
 
@@ -199,7 +199,7 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Privileged() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
 	suite.Req.Nil(err)
 
 	suite.Req.True(c.IsPrivileged(), "This container should be privileged.")
@@ -222,7 +222,7 @@ func (suite *containerTestSuite) TestContainer_AddRoutedNicValidation() {
 		Name: "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
 	suite.Req.NoError(err)
 
 	err = c.Update(db.InstanceArgs{
@@ -271,7 +271,7 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Unprivileged() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
 	suite.Req.Nil(err)
 
 	suite.Req.False(c.IsPrivileged(), "This container should be unprivileged.")
@@ -285,7 +285,7 @@ func (suite *containerTestSuite) TestContainer_Rename() {
 		Name:      "testFoo",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
 	suite.Req.Nil(err)
 	defer c.Delete(true)
 
@@ -300,7 +300,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
 		},
-	}, true, revert.New())
+	}, true, nil, revert.New())
 	suite.Req.Nil(err)
 	defer c1.Delete(true)
 
@@ -310,7 +310,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
 		},
-	}, true, revert.New())
+	}, true, nil, revert.New())
 	suite.Req.Nil(err)
 	defer c2.Delete(true)
 
@@ -341,7 +341,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 		Config: map[string]string{
 			"security.idmap.isolated": "false",
 		},
-	}, true, revert.New())
+	}, true, nil, revert.New())
 	suite.Req.Nil(err)
 	defer c1.Delete(true)
 
@@ -351,7 +351,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
 		},
-	}, true, revert.New())
+	}, true, nil, revert.New())
 	suite.Req.Nil(err)
 	defer c2.Delete(true)
 
@@ -383,7 +383,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_raw() {
 			"security.idmap.isolated": "false",
 			"raw.idmap":               "both 1000 1000",
 		},
-	}, true, revert.New())
+	}, true, nil, revert.New())
 	suite.Req.Nil(err)
 	defer c1.Delete(true)
 
@@ -421,7 +421,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_maxed() {
 			Config: map[string]string{
 				"security.idmap.isolated": "true",
 			},
-		}, true, revert.New())
+		}, true, nil, revert.New())
 
 		/* we should fail if there are no ids left */
 		if i != 6 {

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -301,7 +301,7 @@ func createFromMigration(d *Daemon, r *http.Request, projectName string, req *ap
 		// Note: At this stage we do not yet know if snapshots are going to be received and so we cannot
 		// create their DB records. This will be done if needed in the migrationSink.Do() function called
 		// as part of the operation below.
-		inst, err = instance.CreateInternal(d.State(), args, true, revert)
+		inst, err = instance.CreateInternal(d.State(), args, true, nil, revert)
 		if err != nil {
 			return response.InternalError(errors.Wrap(err, "Failed creating instance record"))
 		}

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -921,7 +921,7 @@ func (c *migrationSink) Do(state *state.State, revert *revert.Reverter, migrateO
 				_, err := instance.LoadByProjectAndName(state, args.Instance.Project(), snapArgs.Name)
 				if err != nil {
 					// Create the snapshot as it doesn't seem to exist.
-					_, err := instance.CreateInternal(state, snapArgs, true, revert)
+					_, err := instance.CreateInternal(state, snapArgs, true, nil, revert)
 					if err != nil {
 						return errors.Wrapf(err, "Failed creating instance snapshot record %q", snapArgs.Name)
 					}

--- a/lxd/snapshot_common_test.go
+++ b/lxd/snapshot_common_test.go
@@ -18,7 +18,7 @@ func (suite *containerTestSuite) TestSnapshotScheduling() {
 		Name:      "hal9000",
 	}
 
-	c, err := instance.CreateInternal(suite.d.State(), args, true, revert.New())
+	c, err := instance.CreateInternal(suite.d.State(), args, true, nil, revert.New())
 	suite.Req.Nil(err)
 	suite.Equal(true, snapshotIsScheduledNow("* * * * *",
 		int64(c.ID())),

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -1001,7 +1001,7 @@ func (d *btrfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWr
 
 			// Override volume's mount path with location of snapshot so genericVFSBackupVolume reads
 			// from there instead of main volume.
-			vol.customMountPath = filepath.Join(tmpDir, vol.name)
+			vol.mountCustomPath = filepath.Join(tmpDir, vol.name)
 
 			// Create the read-only snapshot.
 			mountPath := vol.MountPath()

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -508,13 +508,22 @@ func (d *lvm) MountVolume(vol Volume, op *operations.Operation) error {
 		// Check if already mounted.
 		mountPath := vol.MountPath()
 		if !shared.IsMountPoint(mountPath) {
+			fsType := vol.ConfigBlockFilesystem()
+
+			if vol.mountFilesystemProbe {
+				fsType, err = fsProbe(volDevPath)
+				if err != nil {
+					return errors.Wrapf(err, "Failed probing filesystem")
+				}
+			}
+
 			err = vol.EnsureMountPath()
 			if err != nil {
 				return err
 			}
 
 			mountFlags, mountOptions := resolveMountOptions(vol.ConfigBlockMountOptions())
-			err = TryMount(volDevPath, mountPath, vol.ConfigBlockFilesystem(), mountFlags, mountOptions)
+			err = TryMount(volDevPath, mountPath, fsType, mountFlags, mountOptions)
 			if err != nil {
 				return errors.Wrapf(err, "Failed to mount LVM logical volume")
 			}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1380,7 +1380,7 @@ func (d *zfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWrit
 
 			// Override volume's mount path with location of snapshot so genericVFSBackupVolume reads
 			// from there instead of main volume.
-			vol.customMountPath = tmpDir
+			vol.mountCustomPath = tmpDir
 
 			// Mount the snapshot directly (not possible through ZFS tools), so that the volume is
 			// already mounted by the time genericVFSBackupVolume tries to mount it below,

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -212,8 +212,7 @@ func fsUUID(path string) (string, error) {
 		return "", err
 	}
 
-	val = strings.TrimSpace(val)
-	return val, nil
+	return strings.TrimSpace(val), nil
 }
 
 // hasFilesystem checks if a given path is backed by a specified filesystem.

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -215,6 +215,16 @@ func fsUUID(path string) (string, error) {
 	return strings.TrimSpace(val), nil
 }
 
+// fsProbe returns the filesystem type for the given block path.
+func fsProbe(path string) (string, error) {
+	val, err := shared.RunCommand("blkid", "-s", "TYPE", "-o", "value", path)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(val), nil
+}
+
 // hasFilesystem checks if a given path is backed by a specified filesystem.
 func hasFilesystem(path string, fsType int64) bool {
 	fs := unix.Statfs_t{}

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -103,7 +103,7 @@ func (v Volume) Pool() string {
 	return v.pool
 }
 
-// Config returns the volumes (unexpanded) config.
+// Config returns the volume's (unexpanded) config.
 func (v Volume) Config() map[string]string {
 	return v.config
 }

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -77,7 +77,7 @@ type Volume struct {
 	contentType     ContentType
 	config          map[string]string
 	driver          Driver
-	customMountPath string
+	mountCustomPath string // Mount the filesystem volume at a custom location.
 }
 
 // NewVolume instantiates a new Volume struct.
@@ -135,8 +135,8 @@ func (v Volume) IsSnapshot() bool {
 
 // MountPath returns the path where the volume will be mounted.
 func (v Volume) MountPath() string {
-	if v.customMountPath != "" {
-		return v.customMountPath
+	if v.mountCustomPath != "" {
+		return v.mountCustomPath
 	}
 
 	return GetVolumeMountPath(v.pool, v.volType, v.name)

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -70,14 +70,15 @@ var BaseDirectories = map[VolumeType][]string{
 
 // Volume represents a storage volume, and provides functions to mount and unmount it.
 type Volume struct {
-	name            string
-	pool            string
-	poolConfig      map[string]string
-	volType         VolumeType
-	contentType     ContentType
-	config          map[string]string
-	driver          Driver
-	mountCustomPath string // Mount the filesystem volume at a custom location.
+	name                 string
+	pool                 string
+	poolConfig           map[string]string
+	volType              VolumeType
+	contentType          ContentType
+	config               map[string]string
+	driver               Driver
+	mountCustomPath      string // Mount the filesystem volume at a custom location.
+	mountFilesystemProbe bool   // Probe filesystem type when mounting volume (when needed).
 }
 
 // NewVolume instantiates a new Volume struct.
@@ -125,7 +126,12 @@ func (v Volume) NewSnapshot(snapshotName string) (Volume, error) {
 	}
 
 	fullSnapName := GetSnapshotVolumeName(v.name, snapshotName)
-	return NewVolume(v.driver, v.pool, v.volType, v.contentType, fullSnapName, v.config, v.poolConfig), nil
+	vol := NewVolume(v.driver, v.pool, v.volType, v.contentType, fullSnapName, v.config, v.poolConfig)
+
+	// Propagate filesystem probe mode of parent volume.
+	vol.SetMountFilesystemProbe(v.mountFilesystemProbe)
+
+	return vol, nil
 }
 
 // IsSnapshot indicates if volume is a snapshot.
@@ -355,7 +361,12 @@ func (v Volume) NewVMBlockFilesystemVolume() Volume {
 		newConf["size"] = DefaultVMBlockFilesystemSize
 	}
 
-	return NewVolume(v.driver, v.pool, v.volType, ContentTypeFS, v.name, newConf, v.poolConfig)
+	vol := NewVolume(v.driver, v.pool, v.volType, ContentTypeFS, v.name, newConf, v.poolConfig)
+
+	// Propagate filesystem probe mode of parent volume.
+	vol.SetMountFilesystemProbe(v.mountFilesystemProbe)
+
+	return vol
 }
 
 // SetQuota calls SetVolumeQuota on the Volume's driver.
@@ -475,4 +486,9 @@ func (v Volume) ConfigSizeFromSource(srcVol Volume) (string, error) {
 
 	// Use the default volume size.
 	return volSize, nil
+}
+
+// SetMountFilesystemProbe enables or disables the probing mode when mounting the filesystem volume.
+func (v *Volume) SetMountFilesystemProbe(probe bool) {
+	v.mountFilesystemProbe = probe
 }

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -94,22 +94,6 @@ func VolumeTypeNameToDBType(volumeTypeName string) (int, error) {
 	return -1, fmt.Errorf("Invalid storage volume type name")
 }
 
-// VolumeDBTypeToTypeName converts an internal volume DB type code string to a volume type string.
-func VolumeDBTypeToTypeName(volumeDBType int) (string, error) {
-	switch volumeDBType {
-	case db.StoragePoolVolumeTypeContainer:
-		return db.StoragePoolVolumeTypeNameContainer, nil
-	case db.StoragePoolVolumeTypeVM:
-		return db.StoragePoolVolumeTypeNameVM, nil
-	case db.StoragePoolVolumeTypeImage:
-		return db.StoragePoolVolumeTypeNameImage, nil
-	case db.StoragePoolVolumeTypeCustom:
-		return db.StoragePoolVolumeTypeNameCustom, nil
-	}
-
-	return "", fmt.Errorf("Invalid storage volume type code")
-}
-
 // VolumeTypeToDBType converts volume type to internal volume type DB code.
 func VolumeTypeToDBType(volType drivers.VolumeType) (int, error) {
 	switch volType {


### PR DESCRIPTION
This is enabled via an optional setting on the `Volume` struct, and will be used in the forthcoming `lxd recover` command to allow mounting of block backed volumes (LVM and Ceph) that have a non-default filesystem type.