### PR TITLE
Instance: Check instance is actually stopped, and not in an error state when stopping

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2715,9 +2715,17 @@ func (d *lxc) Stop(stateful bool) error {
 		return err
 	}
 
+	// Wait for onStop and liblxc to stop.
 	err = op.Wait()
-	if err != nil && d.IsRunning() {
-		return err
+	status := d.statusCode()
+	if status != api.Stopped {
+		errPrefix := fmt.Errorf("Failed stopping instance, status is %q", status)
+
+		if err != nil {
+			return errors.Wrap(err, errPrefix.Error())
+		}
+
+		return errPrefix
 	}
 
 	if op.Action() == "stop" {


### PR DESCRIPTION
Otherwise consider stop action failed.

This is part of an ongoing investigation into intermittent stop & delete failures in our integration network tests.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>