### PR TITLE
Always pass O_CLOEXEC in cgo open

### DIFF
--- a/lxd/storage/drivers/utils_cgo.go
+++ b/lxd/storage/drivers/utils_cgo.go
@@ -106,7 +106,7 @@ static int find_associated_loop_device(const char *loop_file,
 			continue;
 
 		// Open fd to loop device.
-		return open(loop_dev_name, O_RDWR);
+		return open(loop_dev_name, O_RDWR | O_CLOEXEC);
 	}
 
 	return -1;

--- a/shared/idmap/shift_linux.go
+++ b/shared/idmap/shift_linux.go
@@ -156,7 +156,7 @@ int shiftowner(char *basepath, char *path, int uid, int gid)
 	char fdpath[PATH_MAX], realpath[PATH_MAX];
 	struct stat sb;
 
-	fd = open(path, O_PATH | O_NOFOLLOW);
+	fd = open(path, O_PATH | O_NOFOLLOW | O_CLOEXEC);
 	if (fd < 0) {
 		perror("Failed open");
 		return 1;


### PR DESCRIPTION
We've seen some fd leakage recently when LXD spawns subprocesses at the same time as it's working on shifting instances.
This seems to be because of a missing O_CLOEXEC in the shifting logic. Doing a full audit of all our cgo open calls, I noticed another one in the storage logic too and this PR also fixes it.