### PR TITLE
LXC: Improvements to default config handling

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 
 	"github.com/lxc/lxd/shared"
+	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/simplestreams"
 )
@@ -184,7 +185,7 @@ func ConnectPublicLXD(url string, args *ConnectionArgs) (ImageServer, error) {
 //
 // Unless the remote server is trusted by the system CA, the remote certificate must be provided (TLSServerCert).
 func ConnectSimpleStreams(url string, args *ConnectionArgs) (ImageServer, error) {
-	logger.Debugf("Connecting to a remote simplestreams server")
+	logger.Debug("Connecting to a remote simplestreams server", log.Ctx{"URL": url})
 
 	// Cleanup URL
 	url = strings.TrimSuffix(url, "/")

--- a/client/connection.go
+++ b/client/connection.go
@@ -216,7 +216,7 @@ func ConnectSimpleStreams(url string, args *ConnectionArgs) (ImageServer, error)
 	// Setup the cache
 	if args.CachePath != "" {
 		if !shared.PathExists(args.CachePath) {
-			return nil, fmt.Errorf("Cache directory '%s' doesn't exist", args.CachePath)
+			return nil, fmt.Errorf("Cache directory %q doesn't exist", args.CachePath)
 		}
 
 		hashedURL := fmt.Sprintf("%x", sha256.Sum256([]byte(url)))

--- a/lxc/config/config.go
+++ b/lxc/config/config.go
@@ -81,8 +81,8 @@ func (c *Config) SaveCookies() {
 func NewConfig(configDir string, defaults bool) *Config {
 	config := &Config{ConfigDir: configDir}
 	if defaults {
-		config.Remotes = DefaultRemotes
-		config.DefaultRemote = "local"
+		config.Remotes = DefaultConfig.Remotes
+		config.DefaultRemote = DefaultConfig.DefaultRemote
 	}
 
 	return config

--- a/lxc/config/file.go
+++ b/lxc/config/file.go
@@ -64,6 +64,11 @@ func LoadConfig(path string) (*Config, error) {
 		c.Remotes[k] = v
 	}
 
+	// Set default remote if not defined.
+	if c.DefaultRemote == "" {
+		c.DefaultRemote = DefaultConfig.DefaultRemote
+	}
+
 	// NOTE: Remove this once we only see a small fraction of non-simplestreams users
 	// Upgrade users to the "simplestreams" protocol
 	images, ok := c.Remotes["images"]

--- a/lxc/config/file.go
+++ b/lxc/config/file.go
@@ -98,7 +98,7 @@ func (c *Config) SaveConfig(path string) error {
 
 	// Remove the static remotes
 	for k := range StaticRemotes {
-		if k == "local" {
+		if k == DefaultConfig.DefaultRemote {
 			continue
 		}
 

--- a/test/godeps.list
+++ b/test/godeps.list
@@ -5,6 +5,7 @@ github.com/lxc/lxd/shared
 github.com/lxc/lxd/shared/api
 github.com/lxc/lxd/shared/cancel
 github.com/lxc/lxd/shared/ioprogress
+github.com/lxc/lxd/shared/log15
 github.com/lxc/lxd/shared/logger
 github.com/lxc/lxd/shared/simplestreams
 github.com/lxc/lxd/shared/units


### PR DESCRIPTION
- If `.config/lxc/config.yml` exists, but is empty, then use default remote.
- Reference `DefaultConfig` which exists, but wasn't being used, to avoid duplication of default values in code base.