### PR TITLE
Validate instance config on a per-instance-type basis

### DIFF
--- a/doc/instances.md
+++ b/doc/instances.md
@@ -72,7 +72,7 @@ raw.idmap                                   | blob      | -                 | no
 raw.lxc                                     | blob      | -                 | no            | container                 | Raw LXC configuration to be appended to the generated one
 raw.qemu                                    | blob      | -                 | no            | virtual-machine           | Raw Qemu configuration to be appended to the generated command line
 raw.seccomp                                 | blob      | -                 | no            | container                 | Raw Seccomp configuration
-security.devlxd                             | boolean   | true              | no            | container                 | Controls the presence of /dev/lxd in the instance
+security.devlxd                             | boolean   | true              | no            | -                         | Controls the presence of /dev/lxd in the instance
 security.devlxd.images                      | boolean   | false             | no            | container                 | Controls the availability of the /1.0/images API over devlxd
 security.idmap.base                         | integer   | -                 | no            | unprivileged container    | The base host ID to use for the allocation (overrides auto-detection)
 security.idmap.isolated                     | boolean   | false             | no            | unprivileged container    | Use an idmap for this instance that is unique among instances with isolated set

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -14,6 +14,7 @@ import (
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxc/config"
 	"github.com/lxc/lxd/lxc/utils"
+	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
@@ -561,7 +562,7 @@ func (c *cmdList) parseColumns(clustered bool) ([]column, bool, error) {
 
 			k := cc[0]
 			if colType == configColumnType {
-				if _, err := shared.ConfigKeyChecker(k); err != nil {
+				if _, err := shared.ConfigKeyChecker(k, instancetype.Any); err != nil {
 					return nil, false, fmt.Errorf(i18n.G("Invalid config key '%s' in '%s'"), k, columnEntry)
 				}
 			}

--- a/lxc/list_test.go
+++ b/lxc/list_test.go
@@ -160,10 +160,10 @@ func TestColumns(t *testing.T) {
 	keys := make([]string, 0, len(shared.KnownInstanceConfigKeys))
 	for k := range shared.KnownInstanceConfigKeys {
 		keys = append(keys, k)
-		//Test compatibility with 'config:' prefix
+		// Test compatibility with 'config:' prefix.
 		keys = append(keys, "config:"+k)
 	}
-	//Test with 'devices:'
+	// Test with 'devices:'.
 	keys = append(keys, "devices:eth0.parent.rand")
 	keys = append(keys, "devices:root.path")
 

--- a/lxc/list_test.go
+++ b/lxc/list_test.go
@@ -157,12 +157,28 @@ const shorthand = "46abcdDfFlmMnNpPsStuL"
 const alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 func TestColumns(t *testing.T) {
-	keys := make([]string, 0, len(shared.KnownInstanceConfigKeys))
-	for k := range shared.KnownInstanceConfigKeys {
+	keys := make([]string, 0, len(shared.InstanceConfigKeysAny)+len(shared.InstanceConfigKeysContainer)+len(shared.InstanceConfigKeysVM))
+	for k := range shared.InstanceConfigKeysAny {
 		keys = append(keys, k)
+
 		// Test compatibility with 'config:' prefix.
 		keys = append(keys, "config:"+k)
 	}
+
+	for k := range shared.InstanceConfigKeysContainer {
+		keys = append(keys, k)
+
+		// Test compatibility with 'config:' prefix.
+		keys = append(keys, "config:"+k)
+	}
+
+	for k := range shared.InstanceConfigKeysVM {
+		keys = append(keys, k)
+
+		// Test compatibility with 'config:' prefix.
+		keys = append(keys, "config:"+k)
+	}
+
 	// Test with 'devices:'.
 	keys = append(keys, "devices:eth0.parent.rand")
 	keys = append(keys, "devices:root.path")

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -186,8 +186,8 @@ func lxcCreate(s *state.State, args db.InstanceArgs, volumeConfig map[string]str
 		return nil, errors.Wrap(err, "Failed to expand config")
 	}
 
-	// Validate expanded config.
-	err = instance.ValidConfig(s.OS, d.expandedConfig, false, true)
+	// Validate expanded config (allows mixed instance types for profiles).
+	err = instance.ValidConfig(s.OS, d.expandedConfig, true, instancetype.Any)
 	if err != nil {
 		return nil, errors.Wrap(err, "Invalid config")
 	}
@@ -3886,7 +3886,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 
 	if userRequested {
 		// Validate the new config
-		err := instance.ValidConfig(d.state.OS, args.Config, false, false)
+		err := instance.ValidConfig(d.state.OS, args.Config, false, d.dbType)
 		if err != nil {
 			return errors.Wrap(err, "Invalid config")
 		}
@@ -4055,8 +4055,8 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 	})
 
 	if userRequested {
-		// Do some validation of the config diff
-		err = instance.ValidConfig(d.state.OS, d.expandedConfig, false, true)
+		// Do some validation of the config diff (allows mixed instance types for profiles).
+		err = instance.ValidConfig(d.state.OS, d.expandedConfig, true, instancetype.Any)
 		if err != nil {
 			return errors.Wrap(err, "Invalid expanded config")
 		}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -219,8 +219,8 @@ func qemuCreate(s *state.State, args db.InstanceArgs, volumeConfig map[string]st
 		return nil, errors.Wrap(err, "Failed to expand config")
 	}
 
-	// Validate expanded config.
-	err = instance.ValidConfig(s.OS, d.expandedConfig, false, true)
+	// Validate expanded config (allows mixed instance types for profiles).
+	err = instance.ValidConfig(s.OS, d.expandedConfig, true, instancetype.Any)
 	if err != nil {
 		return nil, errors.Wrap(err, "Invalid config")
 	}
@@ -3814,7 +3814,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 
 	if userRequested {
 		// Validate the new config.
-		err := instance.ValidConfig(d.state.OS, args.Config, false, false)
+		err := instance.ValidConfig(d.state.OS, args.Config, false, d.dbType)
 		if err != nil {
 			return errors.Wrap(err, "Invalid config")
 		}
@@ -3970,8 +3970,8 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 	})
 
 	if userRequested {
-		// Do some validation of the config diff.
-		err = instance.ValidConfig(d.state.OS, d.expandedConfig, false, true)
+		// Do some validation of the config diff (allows mixed instance types for profiles).
+		err = instance.ValidConfig(d.state.OS, d.expandedConfig, true, instancetype.Any)
 		if err != nil {
 			return errors.Wrap(err, "Invalid expanded config")
 		}

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -204,7 +204,7 @@ func ValidConfig(sysOS *sys.OS, config map[string]string, expanded bool, instanc
 }
 
 func validConfigKey(os *sys.OS, key string, value string, instanceType instancetype.Type) error {
-	f, err := shared.ConfigKeyChecker(key)
+	f, err := shared.ConfigKeyChecker(key, instanceType)
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -140,7 +140,7 @@ func ValidConfig(sysOS *sys.OS, config map[string]string, expanded bool, instanc
 			return fmt.Errorf("Image keys can only be set on instances")
 		}
 
-		err := validConfigKey(sysOS, k, v)
+		err := validConfigKey(sysOS, k, v, instanceType)
 		if err != nil {
 			return err
 		}
@@ -203,7 +203,7 @@ func ValidConfig(sysOS *sys.OS, config map[string]string, expanded bool, instanc
 	return nil
 }
 
-func validConfigKey(os *sys.OS, key string, value string) error {
+func validConfigKey(os *sys.OS, key string, value string, instanceType instancetype.Type) error {
 	f, err := shared.ConfigKeyChecker(key)
 	if err != nil {
 		return err

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -126,17 +126,17 @@ func exclusiveConfigKeys(key1 string, key2 string, config map[string]string) (va
 }
 
 // ValidConfig validates an instance's config.
-func ValidConfig(sysOS *sys.OS, config map[string]string, profile bool, expanded bool) error {
+func ValidConfig(sysOS *sys.OS, config map[string]string, expanded bool, instanceType instancetype.Type) error {
 	if config == nil {
 		return nil
 	}
 
 	for k, v := range config {
-		if profile && strings.HasPrefix(k, shared.ConfigVolatilePrefix) {
+		if instanceType == instancetype.Any && !expanded && strings.HasPrefix(k, shared.ConfigVolatilePrefix) {
 			return fmt.Errorf("Volatile keys can only be set on instances")
 		}
 
-		if profile && strings.HasPrefix(k, "image.") {
+		if instanceType == instancetype.Any && !expanded && strings.HasPrefix(k, "image.") {
 			return fmt.Errorf("Image keys can only be set on instances")
 		}
 
@@ -962,7 +962,7 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, volu
 	}
 
 	// Validate container config.
-	err = ValidConfig(s.OS, args.Config, false, false)
+	err = ValidConfig(s.OS, args.Config, false, args.Type)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -230,7 +230,7 @@ func profilesPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Invalid profile name %q", req.Name))
 	}
 
-	err = instance.ValidConfig(d.os, req.Config, true, false)
+	err = instance.ValidConfig(d.os, req.Config, false, instancetype.Any)
 	if err != nil {
 		return response.BadRequest(err)
 	}

--- a/lxd/profiles_utils.go
+++ b/lxd/profiles_utils.go
@@ -24,7 +24,7 @@ func doProfileUpdate(d *Daemon, projectName string, name string, id int64, profi
 	}
 
 	// Quick checks.
-	err = instance.ValidConfig(d.os, req.Config, true, false)
+	err = instance.ValidConfig(d.os, req.Config, false, instancetype.Any)
 	if err != nil {
 		return err
 	}

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/shared/units"
 	"github.com/lxc/lxd/shared/validate"
 )
@@ -266,17 +267,21 @@ var InstanceConfigKeysVM = map[string]func(value string) error{
 // syntactic checking of the value, semantic and usage checking must
 // be done by the caller.  User defined keys are always considered to
 // be valid, e.g. user.* and environment.* keys.
-func ConfigKeyChecker(key string) (func(value string) error, error) {
+func ConfigKeyChecker(key string, instanceType instancetype.Type) (func(value string) error, error) {
 	if f, ok := InstanceConfigKeysAny[key]; ok {
 		return f, nil
 	}
 
-	if f, ok := InstanceConfigKeysContainer[key]; ok {
-		return f, nil
+	if instanceType == instancetype.Any || instanceType == instancetype.Container {
+		if f, ok := InstanceConfigKeysContainer[key]; ok {
+			return f, nil
+		}
 	}
 
-	if f, ok := InstanceConfigKeysVM[key]; ok {
-		return f, nil
+	if instanceType == instancetype.Any || instanceType == instancetype.VM {
+		if f, ok := InstanceConfigKeysVM[key]; ok {
+			return f, nil
+		}
 	}
 
 	if strings.HasPrefix(key, ConfigVolatilePrefix) {

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -267,7 +267,15 @@ var InstanceConfigKeysVM = map[string]func(value string) error{
 // be done by the caller.  User defined keys are always considered to
 // be valid, e.g. user.* and environment.* keys.
 func ConfigKeyChecker(key string) (func(value string) error, error) {
-	if f, ok := KnownInstanceConfigKeys[key]; ok {
+	if f, ok := InstanceConfigKeysAny[key]; ok {
+		return f, nil
+	}
+
+	if f, ok := InstanceConfigKeysContainer[key]; ok {
+		return f, nil
+	}
+
+	if f, ok := InstanceConfigKeysVM[key]; ok {
 		return f, nil
 	}
 

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -131,7 +131,7 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	// Caller is responsible for full validation of any raw.* value.
 	"raw.apparmor": validate.IsAny,
 
-	"security.devlxd":        validate.Optional(validate.IsBool),
+	"security.devlxd":            validate.Optional(validate.IsBool),
 	"security.protection.delete": validate.Optional(validate.IsBool),
 
 	"snapshots.schedule":         validate.Optional(validate.IsCron([]string{"@hourly", "@daily", "@midnight", "@weekly", "@monthly", "@annually", "@yearly", "@startup"})),
@@ -191,7 +191,7 @@ var InstanceConfigKeysContainer = map[string]func(value string) error{
 
 		return nil
 	},
-	"limits.cpu.priority": validate.Optional(validate.IsPriority),
+	"limits.cpu.priority":   validate.Optional(validate.IsPriority),
 	"limits.hugepages.64KB": validate.Optional(validate.IsSize),
 	"limits.hugepages.1MB":  validate.Optional(validate.IsSize),
 	"limits.hugepages.2MB":  validate.Optional(validate.IsSize),
@@ -202,7 +202,7 @@ var InstanceConfigKeysContainer = map[string]func(value string) error{
 
 	"limits.memory.swap":          validate.Optional(validate.IsBool),
 	"limits.memory.swap.priority": validate.Optional(validate.IsPriority),
-	"limits.processes": validate.Optional(validate.IsInt64),
+	"limits.processes":            validate.Optional(validate.IsInt64),
 
 	"linux.kernel_modules": validate.IsAny,
 
@@ -216,9 +216,9 @@ var InstanceConfigKeysContainer = map[string]func(value string) error{
 	"nvidia.require.driver":      validate.IsAny,
 
 	// Caller is responsible for full validation of any raw.* value.
-	"raw.idmap":    validate.IsAny,
-	"raw.lxc":      validate.IsAny,
-	"raw.seccomp":  validate.IsAny,
+	"raw.idmap":   validate.IsAny,
+	"raw.lxc":     validate.IsAny,
+	"raw.seccomp": validate.IsAny,
 
 	"security.devlxd.images": validate.Optional(validate.IsBool),
 
@@ -226,9 +226,9 @@ var InstanceConfigKeysContainer = map[string]func(value string) error{
 	"security.idmap.isolated": validate.Optional(validate.IsBool),
 	"security.idmap.size":     validate.Optional(validate.IsUint32),
 
-	"security.nesting":       validate.Optional(validate.IsBool),
-	"security.privileged":    validate.Optional(validate.IsBool),
-	"security.protection.shift":  validate.Optional(validate.IsBool),
+	"security.nesting":          validate.Optional(validate.IsBool),
+	"security.privileged":       validate.Optional(validate.IsBool),
+	"security.protection.shift": validate.Optional(validate.IsBool),
 
 	"security.syscalls.allow":                   validate.IsAny,
 	"security.syscalls.blacklist_default":       validate.Optional(validate.IsBool),
@@ -250,12 +250,12 @@ var InstanceConfigKeysContainer = map[string]func(value string) error{
 
 // InstanceConfigKeysVM is a map of config key to validator. (keys applying to VM only)
 var InstanceConfigKeysVM = map[string]func(value string) error{
-	"limits.memory.hugepages":     validate.Optional(validate.IsBool),
+	"limits.memory.hugepages": validate.Optional(validate.IsBool),
 
-	"migration.stateful":                      validate.Optional(validate.IsBool),
+	"migration.stateful": validate.Optional(validate.IsBool),
 
 	// Caller is responsible for full validation of any raw.* value.
-	"raw.qemu":     validate.IsAny,
+	"raw.qemu": validate.IsAny,
 
 	"security.secureboot": validate.Optional(validate.IsBool),
 }


### PR DESCRIPTION
Adds all the plumbing to validate based on instanceType.

Based off the work of @my5t3ry in #8970 but changed to reduce per-commit delta and simplify cherry-picks.
We also don't have an actual need to determining whether a config is Any, Container or VM, so reduced the changes a bit to remove that.

Closes #8970
Closes #8912