### PR TITLE
Add USB GPU support

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1400,3 +1400,6 @@ This adds supported storage driver info to server environment info.
 
 ## event\_lifecycle\_requestor\_address
 Adds a new address field to lifecycle requestor.
+
+## resources\_gpu\_usb
+Add a new USBAddress (usb\_address) field to ResourcesGPUCard (GPU entries) in the resources API.

--- a/lxd/resources/gpu.go
+++ b/lxd/resources/gpu.go
@@ -188,7 +188,7 @@ func gpuAddDeviceInfo(devicePath string, nvidiaCards map[string]*api.ResourcesGP
 		deviceDevicePath := filepath.Join(devicePath, "device")
 		usbAddr, err := usbAddress(deviceDevicePath)
 		if err != nil {
-			return errors.Wrapf(err, "Failed to track down USB address for %q", devicePath)
+			return errors.Wrapf(err, "Failed to find USB address for %q", devicePath)
 		}
 		if usbAddr != "" {
 			card.USBAddress = usbAddr
@@ -236,7 +236,7 @@ func gpuAddDeviceInfo(devicePath string, nvidiaCards map[string]*api.ResourcesGP
 	if sysfsExists(driverPath) {
 		linkTarget, err := filepath.EvalSymlinks(driverPath)
 		if err != nil {
-			return errors.Wrapf(err, "Failed to track down %q", driverPath)
+			return errors.Wrapf(err, "Failed to find %q", driverPath)
 		}
 
 		// Set the driver name
@@ -464,7 +464,7 @@ func GetGPU() (*api.ResourcesGPU, error) {
 			// PCI address.
 			pciAddr, err := pciAddress(devicePath)
 			if err != nil {
-				return nil, errors.Wrapf(err, "Failed to track down PCI address for %q", devicePath)
+				return nil, errors.Wrapf(err, "Failed to find PCI address for %q", devicePath)
 			}
 			if pciAddr != "" {
 				card.PCIAddress = pciAddr
@@ -488,7 +488,7 @@ func GetGPU() (*api.ResourcesGPU, error) {
 				// Virtual functions need to be added to the parent
 				linkTarget, err := filepath.EvalSymlinks(filepath.Join(devicePath, "physfn"))
 				if err != nil {
-					return nil, errors.Wrapf(err, "Failed to track down %q", filepath.Join(devicePath, "physfn"))
+					return nil, errors.Wrapf(err, "Failed to find %q", filepath.Join(devicePath, "physfn"))
 				}
 				parentAddress := filepath.Base(linkTarget)
 
@@ -550,7 +550,7 @@ func GetGPU() (*api.ResourcesGPU, error) {
 				// Virtual functions need to be added to the parent
 				linkTarget, err := filepath.EvalSymlinks(filepath.Join(devicePath, "physfn"))
 				if err != nil {
-					return nil, errors.Wrapf(err, "Failed to track down %q", filepath.Join(devicePath, "physfn"))
+					return nil, errors.Wrapf(err, "Failed to find %q", filepath.Join(devicePath, "physfn"))
 				}
 				parentAddress := filepath.Base(linkTarget)
 

--- a/lxd/resources/network.go
+++ b/lxd/resources/network.go
@@ -62,7 +62,7 @@ func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsn
 	// USB address
 	usbAddr, err := usbAddress(devicePath)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to track down USB address for %q", devicePath)
+		return errors.Wrapf(err, "Failed to find USB address for %q", devicePath)
 	}
 	if usbAddr != "" {
 		card.USBAddress = usbAddr
@@ -109,7 +109,7 @@ func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsn
 	if sysfsExists(driverPath) {
 		linkTarget, err := filepath.EvalSymlinks(driverPath)
 		if err != nil {
-			return errors.Wrapf(err, "Failed to track down %q", driverPath)
+			return errors.Wrapf(err, "Failed to find %q", driverPath)
 		}
 
 		// Set the driver name
@@ -314,7 +314,7 @@ func GetNetwork() (*api.ResourcesNetwork, error) {
 			// PCI address.
 			pciAddr, err := pciAddress(devicePath)
 			if err != nil {
-				return nil, errors.Wrapf(err, "Failed to track down PCI address for %q", devicePath)
+				return nil, errors.Wrapf(err, "Failed to find PCI address for %q", devicePath)
 			}
 			if pciAddr != "" {
 				card.PCIAddress = pciAddr
@@ -338,7 +338,7 @@ func GetNetwork() (*api.ResourcesNetwork, error) {
 				// Virtual functions need to be added to the parent
 				linkTarget, err := filepath.EvalSymlinks(filepath.Join(devicePath, "physfn"))
 				if err != nil {
-					return nil, errors.Wrapf(err, "Failed to track down %q", filepath.Join(devicePath, "physfn"))
+					return nil, errors.Wrapf(err, "Failed to find %q", filepath.Join(devicePath, "physfn"))
 				}
 				parentAddress := filepath.Base(linkTarget)
 
@@ -400,7 +400,7 @@ func GetNetwork() (*api.ResourcesNetwork, error) {
 				// Virtual functions need to be added to the parent
 				linkTarget, err := filepath.EvalSymlinks(filepath.Join(devicePath, "physfn"))
 				if err != nil {
-					return nil, errors.Wrapf(err, "Failed to track down %q", filepath.Join(devicePath, "physfn"))
+					return nil, errors.Wrapf(err, "Failed to find %q", filepath.Join(devicePath, "physfn"))
 				}
 				parentAddress := filepath.Base(linkTarget)
 

--- a/lxd/resources/storage.go
+++ b/lxd/resources/storage.go
@@ -167,7 +167,7 @@ func GetStorage() (*api.ResourcesStorage, error) {
 			// PCI address
 			pciAddr, err := pciAddress(devicePath)
 			if err != nil {
-				return nil, errors.Wrapf(err, "Failed to track down PCI address for %q", devicePath)
+				return nil, errors.Wrapf(err, "Failed to find PCI address for %q", devicePath)
 			}
 			if pciAddr != "" {
 				disk.PCIAddress = pciAddr
@@ -176,7 +176,7 @@ func GetStorage() (*api.ResourcesStorage, error) {
 			// USB address
 			usbAddr, err := usbAddress(devicePath)
 			if err != nil {
-				return nil, errors.Wrapf(err, "Failed to track down USB address for %q", devicePath)
+				return nil, errors.Wrapf(err, "Failed to find USB address for %q", devicePath)
 			}
 			if usbAddr != "" {
 				disk.USBAddress = usbAddr
@@ -208,7 +208,7 @@ func GetStorage() (*api.ResourcesStorage, error) {
 			if sysfsExists(filepath.Join(devicePath, "subsystem")) {
 				diskSubsystem, err := filepath.EvalSymlinks(filepath.Join(devicePath, "subsystem"))
 				if err != nil {
-					return nil, errors.Wrapf(err, "Failed to track down %q", filepath.Join(devicePath, "subsystem"))
+					return nil, errors.Wrapf(err, "Failed to find %q", filepath.Join(devicePath, "subsystem"))
 				}
 
 				disk.Type = filepath.Base(diskSubsystem)
@@ -322,7 +322,7 @@ func GetStorage() (*api.ResourcesStorage, error) {
 
 					linkTarget, err := filepath.EvalSymlinks(linkPath)
 					if err != nil {
-						return nil, errors.Wrapf(err, "Failed to track down %q", linkPath)
+						return nil, errors.Wrapf(err, "Failed to find %q", linkPath)
 					}
 
 					if linkTarget == filepath.Join("/dev", entryName) {
@@ -344,7 +344,7 @@ func GetStorage() (*api.ResourcesStorage, error) {
 
 					linkTarget, err := filepath.EvalSymlinks(linkPath)
 					if err != nil {
-						return nil, errors.Wrapf(err, "Failed to track down %q", linkPath)
+						return nil, errors.Wrapf(err, "Failed to find %q", linkPath)
 					}
 
 					if linkTarget == filepath.Join("/dev", entryName) {

--- a/lxd/resources/utils.go
+++ b/lxd/resources/utils.go
@@ -137,13 +137,13 @@ func pciAddress(devicePath string) (string, error) {
 	// Track down the device.
 	linkTarget, err := filepath.EvalSymlinks(devicePath)
 	if err != nil {
-		return "", errors.Wrapf(err, "Failed to track down %q", devicePath)
+		return "", errors.Wrapf(err, "Failed to find %q", devicePath)
 	}
 
 	// Extract the subsystem.
 	subsystemTarget, err := filepath.EvalSymlinks(filepath.Join(linkTarget, "subsystem"))
 	if err != nil {
-		return "", errors.Wrapf(err, "Failed to track down %q", filepath.Join(devicePath, "subsystem"))
+		return "", errors.Wrapf(err, "Failed to find %q", filepath.Join(devicePath, "subsystem"))
 	}
 	subsystem := filepath.Base(subsystemTarget)
 
@@ -152,7 +152,7 @@ func pciAddress(devicePath string) (string, error) {
 		linkTarget = filepath.Dir(linkTarget)
 		subsystemTarget, err := filepath.EvalSymlinks(filepath.Join(linkTarget, "subsystem"))
 		if err != nil {
-			return "", errors.Wrapf(err, "Failed to track down %q", filepath.Join(devicePath, "subsystem"))
+			return "", errors.Wrapf(err, "Failed to find %q", filepath.Join(devicePath, "subsystem"))
 		}
 
 		subsystem = filepath.Base(subsystemTarget)

--- a/shared/api/resource.go
+++ b/shared/api/resource.go
@@ -238,6 +238,12 @@ type ResourcesGPUCard struct {
 	// PCI ID of the product
 	// Example: 5916
 	ProductID string `json:"product_id,omitempty" yaml:"product_id,omitempty"`
+
+	// USB address (for USB cards)
+	// Example: 2:7
+	//
+	// API extension: resources_gpu_usb
+	USBAddress string `json:"usb_address,omitempty" yaml:"usb_address,omitempty"`
 }
 
 // ResourcesGPUCardDRM represents the Linux DRM configuration of the GPU

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -277,6 +277,7 @@ var APIExtensions = []string{
 	"server_instance_driver_operational",
 	"server_supported_storage_drivers",
 	"event_lifecycle_requestor_address",
+	"resources_gpu_usb",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Machines with DisplayLink adapters would fail to get GPU information using the resources API.
This fixes the source of the issue (nested devices) and attempts to fill in a USBAddress field too.