### PR TITLE
Storage: Detect and remove orphaned BTRFS image sub volumes when removing the pool

### DIFF
--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -815,7 +815,7 @@ func (c *Cluster) getStoragePoolConfig(poolID int64) (map[string]string, error) 
 	return config, nil
 }
 
-// CreateStoragePool creates new storage pool.
+// CreateStoragePool creates new storage pool. Also creates a local node entry with state storagePoolPending.
 func (c *Cluster) CreateStoragePool(poolName string, poolDescription string, poolDriver string, poolConfig map[string]string) (int64, error) {
 	var id int64
 	err := c.Transaction(func(tx *ClusterTx) error {

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2337,7 +2337,9 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 				return nil
 			}
 		} else {
-			// We somehow have an unrecorded on-disk volume, assume it's a partial unpack and delete it.
+			// We have an unrecorded on-disk volume, assume it's a partial unpack and delete it.
+			// This can occur if LXD process exits unexpectedly during an image unpack or if the
+			// storage pool has been recovered (which would not recreate the image volume DB records).
 			logger.Warn("Deleting leftover/partially unpacked image volume")
 			err = b.driver.DeleteVolume(imgVol, op)
 			if err != nil {

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -368,6 +368,10 @@ func (d *zfs) Update(changedConfig map[string]string) error {
 
 // Mount mounts the storage pool.
 func (d *zfs) Mount() (bool, error) {
+	if d.config["zfs.pool_name"] == "" {
+		return false, fmt.Errorf("Cannot mount pool as %q is not specified", "zfs.pool")
+	}
+
 	// Check if already setup.
 	if d.checkDataset(d.config["zfs.pool_name"]) {
 		return false, nil

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -31,7 +31,7 @@ func wipeDirectory(path string) error {
 			return nil
 		}
 
-		return errors.Wrapf(err, "Failed to list directory '%s'", path)
+		return errors.Wrapf(err, "Failed listing directory %q", path)
 	}
 
 	// Individually wipe all entries.
@@ -39,7 +39,7 @@ func wipeDirectory(path string) error {
 		entryPath := filepath.Join(path, entry.Name())
 		err := os.RemoveAll(entryPath)
 		if err != nil && !os.IsNotExist(err) {
-			return errors.Wrapf(err, "Failed to remove '%s'", entryPath)
+			return errors.Wrapf(err, "Failed removing %q", entryPath)
 		}
 	}
 


### PR DESCRIPTION
- Detect and remove orphaned BTRFS image sub volumes when removing the pool. Otherwise the pool cannot be removed. This can occur if a partial image unpack has occurred or during pool DB recovery the existing image volumes won't get their DB records restored.
- Improve error quoting and message consistency.
- Add validations to ZFS Mount for quick and clear failure if config settings are missing.