### PR TITLE
Generator: Cleanup

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -501,7 +501,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		}
 
 		// Get a list of projects for networks.
-		var projects []api.Project
+		var projects []db.Project
 
 		err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
 			projects, err = tx.GetProjects(db.ProjectFilter{})

--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -71,7 +71,7 @@ type internalRecoverImportPost struct {
 // internalRecoverScan provides the discovery and import functionality for both recovery validate and import steps.
 func internalRecoverScan(d *Daemon, userPools []api.StoragePoolsPost, validateOnly bool) response.Response {
 	var err error
-	var projects map[string]*api.Project
+	var projects map[string]*db.Project
 	var projectProfiles map[string][]*api.Profile
 	var projectNetworks map[string]map[int64]api.Network
 
@@ -85,7 +85,7 @@ func internalRecoverScan(d *Daemon, userPools []api.StoragePoolsPost, validateOn
 		}
 
 		// Convert to map for lookups by name later.
-		projects = make(map[string]*api.Project, len(ps))
+		projects = make(map[string]*db.Project, len(ps))
 		for i := range ps {
 			projects[ps[i].Name] = &ps[i]
 		}

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -159,7 +159,7 @@ func projectsGet(d *Daemon, r *http.Request) response.Response {
 					continue
 				}
 
-				filtered = append(filtered, project)
+				filtered = append(filtered, project.ToAPI())
 			}
 
 			result = filtered
@@ -221,7 +221,7 @@ func projectsGet(d *Daemon, r *http.Request) response.Response {
 //     $ref: "#/responses/InternalServerError"
 func projectsPost(d *Daemon, r *http.Request) response.Response {
 	// Parse the request.
-	project := api.ProjectsPost{}
+	project := db.Project{}
 
 	// Set default features.
 	if project.Config == nil {
@@ -359,7 +359,7 @@ func projectGet(d *Daemon, r *http.Request) response.Response {
 		project.Config,
 	}
 
-	return response.SyncResponseETag(true, project, etag)
+	return response.SyncResponseETag(true, project.ToAPI(), etag)
 }
 
 // swagger:operation PUT /1.0/projects/{name} projects project_put
@@ -525,7 +525,7 @@ func projectPatch(d *Daemon, r *http.Request) response.Response {
 }
 
 // Common logic between PUT and PATCH.
-func projectChange(d *Daemon, project *api.Project, req api.ProjectPut) response.Response {
+func projectChange(d *Daemon, project *db.Project, req api.ProjectPut) response.Response {
 	// Make a list of config keys that have changed.
 	configChanged := []string{}
 	for key := range project.Config {
@@ -829,7 +829,7 @@ func projectStateGet(d *Daemon, r *http.Request) response.Response {
 }
 
 // Check if a project is empty.
-func projectIsEmpty(project *api.Project) bool {
+func projectIsEmpty(project *db.Project) bool {
 	if len(project.UsedBy) > 0 {
 		// Check if the only entity is the default profile.
 		if len(project.UsedBy) == 1 && strings.Contains(project.UsedBy[0], "/profiles/default") {

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -31,7 +31,7 @@ import (
 )
 
 type certificateCache struct {
-	Certificates map[int]map[string]x509.Certificate
+	Certificates map[db.CertificateType]map[string]x509.Certificate
 	Projects     map[string][]string
 	Lock         sync.Mutex
 }
@@ -170,7 +170,7 @@ func certificatesGet(d *Daemon, r *http.Request) response.Response {
 func updateCertificateCache(d *Daemon) {
 	logger.Debug("Refreshing trusted certificate cache")
 
-	newCerts := map[int]map[string]x509.Certificate{}
+	newCerts := map[db.CertificateType]map[string]x509.Certificate{}
 	newProjects := map[string][]string{}
 
 	var dbCerts []db.Certificate
@@ -234,7 +234,7 @@ func updateCertificateCache(d *Daemon) {
 func updateCertificateCacheFromLocal(d *Daemon) error {
 	logger.Debug("Refreshing local trusted certificate cache")
 
-	newCerts := map[int]map[string]x509.Certificate{}
+	newCerts := map[db.CertificateType]map[string]x509.Certificate{}
 
 	var dbCerts []db.Certificate
 	var err error

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -149,7 +149,7 @@ func setDqliteVersionHeader(request *http.Request) {
 // These handlers might return 404, either because this LXD node is a
 // non-clustered node not available over the network or because it is not a
 // database node part of the dqlite cluster.
-func (g *Gateway) HandlerFuncs(nodeRefreshTask func(*APIHeartbeat), trustedCerts func() map[int]map[string]x509.Certificate) map[string]http.HandlerFunc {
+func (g *Gateway) HandlerFuncs(nodeRefreshTask func(*APIHeartbeat), trustedCerts func() map[db.CertificateType]map[string]x509.Certificate) map[string]http.HandlerFunc {
 	database := func(w http.ResponseWriter, r *http.Request) {
 		g.lock.RLock()
 		defer g.lock.RUnlock()

--- a/lxd/cluster/heartbeat_test.go
+++ b/lxd/cluster/heartbeat_test.go
@@ -205,7 +205,7 @@ func (f *heartbeatFixture) node() (*state.State, *cluster.Gateway, string) {
 	mux := http.NewServeMux()
 	server := newServer(serverCert, mux)
 
-	trustedCerts := func() map[int]map[string]x509.Certificate {
+	trustedCerts := func() map[db.CertificateType]map[string]x509.Certificate {
 		return nil
 	}
 

--- a/lxd/cluster/membership_test.go
+++ b/lxd/cluster/membership_test.go
@@ -126,7 +126,7 @@ func TestBootstrap(t *testing.T) {
 	// The cluster certificate is in place.
 	assert.True(t, shared.PathExists(filepath.Join(state.OS.VarDir, "cluster.crt")))
 
-	trustedCerts := func() map[int]map[string]x509.Certificate {
+	trustedCerts := func() map[db.CertificateType]map[string]x509.Certificate {
 		return nil
 	}
 
@@ -259,8 +259,8 @@ func TestJoin(t *testing.T) {
 	altServerCert := shared.TestingAltKeyPair()
 	trustedAltServerCert, _ := x509.ParseCertificate(altServerCert.KeyPair().Certificate[0])
 
-	trustedCerts := func() map[int]map[string]x509.Certificate {
-		return map[int]map[string]x509.Certificate{
+	trustedCerts := func() map[db.CertificateType]map[string]x509.Certificate {
+		return map[db.CertificateType]map[string]x509.Certificate{
 			db.CertificateTypeServer: {
 				altServerCert.Fingerprint(): *trustedAltServerCert,
 			},

--- a/lxd/cluster/tls.go
+++ b/lxd/cluster/tls.go
@@ -52,7 +52,7 @@ func tlsClientConfig(networkCert *shared.CertInfo, serverCert *shared.CertInfo) 
 }
 
 // tlsCheckCert checks certificate access, returns true if certificate is trusted.
-func tlsCheckCert(r *http.Request, networkCert *shared.CertInfo, serverCert *shared.CertInfo, trustedCerts map[int]map[string]x509.Certificate) bool {
+func tlsCheckCert(r *http.Request, networkCert *shared.CertInfo, serverCert *shared.CertInfo, trustedCerts map[db.CertificateType]map[string]x509.Certificate) bool {
 	_, err := x509.ParseCertificate(networkCert.KeyPair().Certificate[0])
 	if err != nil {
 		// Since we have already loaded this certificate, typically

--- a/lxd/cluster/upgrade_test.go
+++ b/lxd/cluster/upgrade_test.go
@@ -139,7 +139,7 @@ func TestUpgradeMembersWithoutRole(t *testing.T) {
 	gateway := newGateway(t, state.Node, serverCert, serverCert)
 	defer gateway.Shutdown()
 
-	trustedCerts := func() map[int]map[string]x509.Certificate {
+	trustedCerts := func() map[db.CertificateType]map[string]x509.Certificate {
 		return nil
 	}
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -267,7 +267,7 @@ func (d *Daemon) checkTrustedClient(r *http.Request) error {
 }
 
 // getTrustedCertificates returns trusted certificates key on DB type and fingerprint.
-func (d *Daemon) getTrustedCertificates() map[int]map[string]x509.Certificate {
+func (d *Daemon) getTrustedCertificates() map[db.CertificateType]map[string]x509.Certificate {
 	d.clientCerts.Lock.Lock()
 	defer d.clientCerts.Lock.Unlock()
 

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -36,14 +36,17 @@ import (
 //go:generate mapper method -p db -e certificate DeleteMany
 //go:generate mapper method -p db -e certificate Update struct=Certificate
 
+// CertificateType indicates the type of the certificate.
+type CertificateType int
+
 // CertificateTypeClient indicates a client certificate type.
-const CertificateTypeClient = 1
+const CertificateTypeClient = CertificateType(1)
 
 // CertificateTypeServer indicates a server certificate type.
-const CertificateTypeServer = 2
+const CertificateTypeServer = CertificateType(2)
 
 // CertificateAPITypeToDBType converts an API type to the equivalent DB type.
-func CertificateAPITypeToDBType(apiType string) (int, error) {
+func CertificateAPITypeToDBType(apiType string) (CertificateType, error) {
 	switch apiType {
 	case api.CertificateTypeClient:
 		return CertificateTypeClient, nil
@@ -58,7 +61,7 @@ func CertificateAPITypeToDBType(apiType string) (int, error) {
 type Certificate struct {
 	ID          int
 	Fingerprint string `db:"primary=yes&comparison=like"`
-	Type        int
+	Type        CertificateType
 	Name        string
 	Certificate string
 	Restricted  bool
@@ -120,7 +123,7 @@ func (c *ClusterTx) UpdateCertificateProjects(id int, projects []string) error {
 type CertificateFilter struct {
 	Fingerprint string // Matched with LIKE
 	Name        string
-	Type        int
+	Type        CertificateType
 }
 
 // GetCertificate gets an CertBaseInfo object from the database.
@@ -187,14 +190,14 @@ func (c *Cluster) UpdateCertificateProjects(id int, projects []string) error {
 func (n *NodeTx) GetCertificates() ([]Certificate, error) {
 	dbCerts := []struct {
 		fingerprint string
-		certType    int
+		certType    CertificateType
 		name        string
 		certificate string
 	}{}
 	dest := func(i int) []interface{} {
 		dbCerts = append(dbCerts, struct {
 			fingerprint string
-			certType    int
+			certType    CertificateType
 			name        string
 			certificate string
 		}{})

--- a/lxd/db/certificates.mapper.go
+++ b/lxd/db/certificates.mapper.go
@@ -61,6 +61,7 @@ UPDATE certificates
 `)
 
 // GetCertificates returns all available certificates.
+// generator: certificate List
 func (c *ClusterTx) GetCertificates(filter CertificateFilter) ([]Certificate, error) {
 	// Result slice.
 	objects := make([]Certificate, 0)
@@ -128,6 +129,7 @@ func (c *ClusterTx) GetCertificates(filter CertificateFilter) ([]Certificate, er
 }
 
 // GetCertificate returns the certificate with the given key.
+// generator: certificate Get
 func (c *ClusterTx) GetCertificate(fingerprint string) (*Certificate, error) {
 	filter := CertificateFilter{}
 	filter.Fingerprint = fingerprint
@@ -148,6 +150,7 @@ func (c *ClusterTx) GetCertificate(fingerprint string) (*Certificate, error) {
 }
 
 // GetCertificateID return the ID of the certificate with the given key.
+// generator: certificate ID
 func (c *ClusterTx) GetCertificateID(fingerprint string) (int64, error) {
 	stmt := c.stmt(certificateID)
 	rows, err := stmt.Query(fingerprint)
@@ -177,6 +180,7 @@ func (c *ClusterTx) GetCertificateID(fingerprint string) (int64, error) {
 }
 
 // CertificateExists checks if a certificate with the given key exists.
+// generator: certificate Exists
 func (c *ClusterTx) CertificateExists(fingerprint string) (bool, error) {
 	_, err := c.GetCertificateID(fingerprint)
 	if err != nil {
@@ -190,6 +194,7 @@ func (c *ClusterTx) CertificateExists(fingerprint string) (bool, error) {
 }
 
 // CreateCertificate adds a new certificate to the database.
+// generator: certificate Create
 func (c *ClusterTx) CreateCertificate(object Certificate) (int64, error) {
 	// Check if a certificate with the same key exists.
 	exists, err := c.CertificateExists(object.Fingerprint)
@@ -227,6 +232,7 @@ func (c *ClusterTx) CreateCertificate(object Certificate) (int64, error) {
 }
 
 // CertificateProjectsRef returns entities used by certificates.
+// generator: certificate ProjectsRef
 func (c *ClusterTx) CertificateProjectsRef(filter CertificateFilter) (map[string][]string, error) {
 	// Result slice.
 	objects := make([]struct {
@@ -291,6 +297,7 @@ func (c *ClusterTx) CertificateProjectsRef(filter CertificateFilter) (map[string
 }
 
 // DeleteCertificate deletes the certificate matching the given key parameters.
+// generator: certificate DeleteOne
 func (c *ClusterTx) DeleteCertificate(filter CertificateFilter) error {
 	// Check which filter criteria are active.
 	criteria := map[string]interface{}{}
@@ -339,6 +346,7 @@ func (c *ClusterTx) DeleteCertificate(filter CertificateFilter) error {
 }
 
 // DeleteCertificates deletes the certificate matching the given key parameters.
+// generator: certificate DeleteMany
 func (c *ClusterTx) DeleteCertificates(filter CertificateFilter) error {
 	// Check which filter criteria are active.
 	criteria := map[string]interface{}{}
@@ -384,6 +392,7 @@ func (c *ClusterTx) DeleteCertificates(filter CertificateFilter) error {
 }
 
 // UpdateCertificate updates the certificate matching the given key parameters.
+// generator: certificate Update
 func (c *ClusterTx) UpdateCertificate(fingerprint string, object Certificate) error {
 	id, err := c.GetCertificateID(fingerprint)
 	if err != nil {

--- a/lxd/db/generate/db/mapping.go
+++ b/lxd/db/generate/db/mapping.go
@@ -14,6 +14,7 @@ type Mapping struct {
 	Package string   // Package of the Go struct
 	Name    string   // Name of the Go struct.
 	Fields  []*Field // Metadata about the Go struct.
+	Filters []*Field // Metadata about the Go struct used for filter fields.
 }
 
 // NaturalKey returns the struct fields that can be used as natural key for
@@ -75,16 +76,16 @@ func (m *Mapping) FieldColumnName(name string) string {
 // FilterFieldByName returns the field with the given name if that field can be
 // used as query filter, an error otherwise.
 func (m *Mapping) FilterFieldByName(name string) (*Field, error) {
-	field := m.FieldByName(name)
-	if field == nil {
-		return nil, fmt.Errorf("Unknown filter %q", name)
+	for _, filter := range m.Filters {
+		if name == filter.Name {
+			if filter.Type.Code != TypeColumn {
+				return nil, fmt.Errorf("Unknown filter %q not a column", name)
+			}
+			return filter, nil
+		}
 	}
 
-	if field.Type.Code != TypeColumn {
-		return nil, fmt.Errorf("Unknown filter %q not a column", name)
-	}
-
-	return field, nil
+	return nil, fmt.Errorf("Unknown filter %q", name)
 }
 
 // ColumnFields returns the fields that map directly to a database column,

--- a/lxd/db/generate/db/mapping.go
+++ b/lxd/db/generate/db/mapping.go
@@ -198,7 +198,7 @@ func (f *Field) ZeroValue() string {
 	switch f.Type.Name {
 	case "string":
 		return `""`
-	case "int", "instancetype.Type", "int64", "OperationType":
+	case "int", "instancetype.Type", "int64", "OperationType", "CertificateType":
 		// FIXME: we use -1 since at the moment integer criteria are
 		// required to be positive.
 		return "-1"
@@ -280,6 +280,7 @@ var columnarTypeNames = []string{
 	"int",
 	"int64",
 	"OperationType",
+	"CertificateType",
 	"string",
 	"time.Time",
 }

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -1067,6 +1067,7 @@ func (m *Method) begin(buf *file.Buffer, comment string, args string, rets strin
 	receiver := fmt.Sprintf("c %s", dbTxType(m.db))
 
 	buf.L("// %s %s", name, comment)
+	buf.L("// generator: %s %s", m.entity, m.kind)
 	buf.L("func (%s) %s(%s) %s {", receiver, name, args, rets)
 }
 

--- a/lxd/db/generate/db/parse_test.go
+++ b/lxd/db/generate/db/parse_test.go
@@ -41,6 +41,9 @@ type Teacher struct {
 	Classes      []Class
 }
 
+type TeacherFilter struct {
+}
+
 func TestParse(t *testing.T) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "parse_test.go", nil, parser.ParseComments)

--- a/lxd/db/images.mapper.go
+++ b/lxd/db/images.mapper.go
@@ -71,6 +71,7 @@ SELECT images.id, projects.name AS project, images.fingerprint, images.type, ima
 `)
 
 // GetImages returns all available images.
+// generator: image List
 func (c *ClusterTx) GetImages(filter ImageFilter) ([]Image, error) {
 	// Result slice.
 	objects := make([]Image, 0)
@@ -178,6 +179,7 @@ func (c *ClusterTx) GetImages(filter ImageFilter) ([]Image, error) {
 }
 
 // GetImage returns the image with the given key.
+// generator: image Get
 func (c *ClusterTx) GetImage(project string, fingerprint string) (*Image, error) {
 	filter := ImageFilter{}
 	filter.Project = project

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -332,9 +332,9 @@ var ErrInstanceListStop = fmt.Errorf("search stopped")
 
 // InstanceList loads all instances across all projects and for each instance runs the instanceFunc passing in the
 // instance and it's project and profiles. Accepts optional filter argument to specify a subset of instances.
-func (c *Cluster) InstanceList(filter *InstanceFilter, instanceFunc func(inst Instance, project api.Project, profiles []api.Profile) error) error {
+func (c *Cluster) InstanceList(filter *InstanceFilter, instanceFunc func(inst Instance, project Project, profiles []api.Profile) error) error {
 	var instances []Instance
-	projectMap := map[string]api.Project{}
+	projectMap := map[string]Project{}
 	projectHasProfiles := map[string]bool{}
 	profilesByProjectAndName := map[string]map[string]Profile{}
 

--- a/lxd/db/instances.mapper.go
+++ b/lxd/db/instances.mapper.go
@@ -223,6 +223,7 @@ UPDATE instances
 `)
 
 // GetInstances returns all available instances.
+// generator: instance List
 func (c *ClusterTx) GetInstances(filter InstanceFilter) ([]Instance, error) {
 	// Result slice.
 	objects := make([]Instance, 0)
@@ -432,6 +433,7 @@ func (c *ClusterTx) GetInstances(filter InstanceFilter) ([]Instance, error) {
 }
 
 // GetInstance returns the instance with the given key.
+// generator: instance Get
 func (c *ClusterTx) GetInstance(project string, name string) (*Instance, error) {
 	filter := InstanceFilter{}
 	filter.Project = project
@@ -454,6 +456,7 @@ func (c *ClusterTx) GetInstance(project string, name string) (*Instance, error) 
 }
 
 // GetInstanceID return the ID of the instance with the given key.
+// generator: instance ID
 func (c *ClusterTx) GetInstanceID(project string, name string) (int64, error) {
 	stmt := c.stmt(instanceID)
 	rows, err := stmt.Query(project, name)
@@ -483,6 +486,7 @@ func (c *ClusterTx) GetInstanceID(project string, name string) (int64, error) {
 }
 
 // InstanceExists checks if a instance with the given key exists.
+// generator: instance Exists
 func (c *ClusterTx) InstanceExists(project string, name string) (bool, error) {
 	_, err := c.GetInstanceID(project, name)
 	if err != nil {
@@ -496,6 +500,7 @@ func (c *ClusterTx) InstanceExists(project string, name string) (bool, error) {
 }
 
 // CreateInstance adds a new instance to the database.
+// generator: instance Create
 func (c *ClusterTx) CreateInstance(object Instance) (int64, error) {
 	// Check if a instance with the same key exists.
 	exists, err := c.InstanceExists(object.Project, object.Name)
@@ -581,6 +586,7 @@ func (c *ClusterTx) CreateInstance(object Instance) (int64, error) {
 }
 
 // InstanceProfilesRef returns entities used by instances.
+// generator: instance ProfilesRef
 func (c *ClusterTx) InstanceProfilesRef(filter InstanceFilter) (map[string]map[string][]string, error) {
 	// Result slice.
 	objects := make([]struct {
@@ -671,6 +677,7 @@ func (c *ClusterTx) InstanceProfilesRef(filter InstanceFilter) (map[string]map[s
 }
 
 // InstanceConfigRef returns entities used by instances.
+// generator: instance ConfigRef
 func (c *ClusterTx) InstanceConfigRef(filter InstanceFilter) (map[string]map[string]map[string]string, error) {
 	// Result slice.
 	objects := make([]struct {
@@ -765,6 +772,7 @@ func (c *ClusterTx) InstanceConfigRef(filter InstanceFilter) (map[string]map[str
 }
 
 // InstanceDevicesRef returns entities used by instances.
+// generator: instance DevicesRef
 func (c *ClusterTx) InstanceDevicesRef(filter InstanceFilter) (map[string]map[string]map[string]map[string]string, error) {
 	// Result slice.
 	objects := make([]struct {
@@ -880,6 +888,7 @@ func (c *ClusterTx) InstanceDevicesRef(filter InstanceFilter) (map[string]map[st
 }
 
 // RenameInstance renames the instance matching the given key parameters.
+// generator: instance Rename
 func (c *ClusterTx) RenameInstance(project string, name string, to string) error {
 	stmt := c.stmt(instanceRename)
 	result, err := stmt.Exec(to, project, name)
@@ -898,6 +907,7 @@ func (c *ClusterTx) RenameInstance(project string, name string, to string) error
 }
 
 // DeleteInstance deletes the instance matching the given key parameters.
+// generator: instance DeleteOne
 func (c *ClusterTx) DeleteInstance(filter InstanceFilter) error {
 	// Check which filter criteria are active.
 	criteria := map[string]interface{}{}
@@ -944,6 +954,7 @@ func (c *ClusterTx) DeleteInstance(filter InstanceFilter) error {
 }
 
 // UpdateInstance updates the instance matching the given key parameters.
+// generator: instance Update
 func (c *ClusterTx) UpdateInstance(project string, name string, object Instance) error {
 	id, err := c.GetInstanceID(project, name)
 	if err != nil {

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -98,13 +98,13 @@ func TestInstanceList_ContainerWithSameNameInDifferentProjects(t *testing.T) {
 	defer cleanup()
 
 	// Create a project with no features
-	project1 := api.ProjectsPost{}
+	project1 := db.Project{}
 	project1.Name = "blah"
 	_, err := tx.CreateProject(project1)
 	require.NoError(t, err)
 
 	// Create a project with the profiles feature and a custom profile.
-	project2 := api.ProjectsPost{}
+	project2 := db.Project{}
 	project2.Name = "test"
 	project2.Config = map[string]string{"features.profiles": "true"}
 	_, err = tx.CreateProject(project2)
@@ -199,7 +199,7 @@ func TestInstanceList(t *testing.T) {
 	require.NoError(t, err)
 
 	var instances []db.Instance
-	err = cluster.InstanceList(nil, func(dbInst db.Instance, p api.Project, profiles []api.Profile) error {
+	err = cluster.InstanceList(nil, func(dbInst db.Instance, p db.Project, profiles []api.Profile) error {
 		dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, profiles)
 		dbInst.Devices = db.ExpandInstanceDevices(deviceConfig.NewDevices(dbInst.Devices), profiles).CloneNative()
 		instances = append(instances, dbInst)

--- a/lxd/db/migration_test.go
+++ b/lxd/db/migration_test.go
@@ -70,7 +70,7 @@ func TestImportPreClusteringData(t *testing.T) {
 		cert := certs[0]
 		assert.Equal(t, 1, cert.ID)
 		assert.Equal(t, "abcd:efgh", cert.Fingerprint)
-		assert.Equal(t, 1, cert.Type)
+		assert.Equal(t, db.CertificateTypeClient, cert.Type)
 		assert.Equal(t, "foo", cert.Name)
 		assert.Equal(t, "FOO", cert.Certificate)
 		return nil

--- a/lxd/db/operations.mapper.go
+++ b/lxd/db/operations.mapper.go
@@ -54,6 +54,7 @@ DELETE FROM operations WHERE node_id = ?
 `)
 
 // GetOperations returns all available operations.
+// generator: operation List
 func (c *ClusterTx) GetOperations(filter OperationFilter) ([]Operation, error) {
 	// Result slice.
 	objects := make([]Operation, 0)
@@ -117,6 +118,7 @@ func (c *ClusterTx) GetOperations(filter OperationFilter) ([]Operation, error) {
 }
 
 // CreateOrReplaceOperation adds a new operation to the database.
+// generator: operation CreateOrReplace
 func (c *ClusterTx) CreateOrReplaceOperation(object Operation) (int64, error) {
 	args := make([]interface{}, 4)
 
@@ -144,6 +146,7 @@ func (c *ClusterTx) CreateOrReplaceOperation(object Operation) (int64, error) {
 }
 
 // DeleteOperation deletes the operation matching the given key parameters.
+// generator: operation DeleteOne
 func (c *ClusterTx) DeleteOperation(filter OperationFilter) error {
 	// Check which filter criteria are active.
 	criteria := map[string]interface{}{}
@@ -191,6 +194,7 @@ func (c *ClusterTx) DeleteOperation(filter OperationFilter) error {
 }
 
 // DeleteOperations deletes the operation matching the given key parameters.
+// generator: operation DeleteMany
 func (c *ClusterTx) DeleteOperations(filter OperationFilter) error {
 	// Check which filter criteria are active.
 	criteria := map[string]interface{}{}

--- a/lxd/db/profiles.mapper.go
+++ b/lxd/db/profiles.mapper.go
@@ -135,6 +135,7 @@ UPDATE profiles
 `)
 
 // GetProfileURIs returns all available profile URIs.
+// generator: profile URIs
 func (c *ClusterTx) GetProfileURIs(filter ProfileFilter) ([]string, error) {
 	// Check which filter criteria are active.
 	criteria := map[string]interface{}{}
@@ -172,6 +173,7 @@ func (c *ClusterTx) GetProfileURIs(filter ProfileFilter) ([]string, error) {
 }
 
 // GetProfiles returns all available profiles.
+// generator: profile List
 func (c *ClusterTx) GetProfiles(filter ProfileFilter) ([]Profile, error) {
 	// Result slice.
 	objects := make([]Profile, 0)
@@ -294,6 +296,7 @@ func (c *ClusterTx) GetProfiles(filter ProfileFilter) ([]Profile, error) {
 }
 
 // GetProfile returns the profile with the given key.
+// generator: profile Get
 func (c *ClusterTx) GetProfile(project string, name string) (*Profile, error) {
 	filter := ProfileFilter{}
 	filter.Project = project
@@ -315,6 +318,7 @@ func (c *ClusterTx) GetProfile(project string, name string) (*Profile, error) {
 }
 
 // ProfileExists checks if a profile with the given key exists.
+// generator: profile Exists
 func (c *ClusterTx) ProfileExists(project string, name string) (bool, error) {
 	_, err := c.GetProfileID(project, name)
 	if err != nil {
@@ -328,6 +332,7 @@ func (c *ClusterTx) ProfileExists(project string, name string) (bool, error) {
 }
 
 // GetProfileID return the ID of the profile with the given key.
+// generator: profile ID
 func (c *ClusterTx) GetProfileID(project string, name string) (int64, error) {
 	stmt := c.stmt(profileID)
 	rows, err := stmt.Query(project, name)
@@ -357,6 +362,7 @@ func (c *ClusterTx) GetProfileID(project string, name string) (int64, error) {
 }
 
 // ProfileConfigRef returns entities used by profiles.
+// generator: profile ConfigRef
 func (c *ClusterTx) ProfileConfigRef(filter ProfileFilter) (map[string]map[string]map[string]string, error) {
 	// Result slice.
 	objects := make([]struct {
@@ -440,6 +446,7 @@ func (c *ClusterTx) ProfileConfigRef(filter ProfileFilter) (map[string]map[strin
 }
 
 // ProfileDevicesRef returns entities used by profiles.
+// generator: profile DevicesRef
 func (c *ClusterTx) ProfileDevicesRef(filter ProfileFilter) (map[string]map[string]map[string]map[string]string, error) {
 	// Result slice.
 	objects := make([]struct {
@@ -544,6 +551,7 @@ func (c *ClusterTx) ProfileDevicesRef(filter ProfileFilter) (map[string]map[stri
 }
 
 // ProfileUsedByRef returns entities used by profiles.
+// generator: profile UsedByRef
 func (c *ClusterTx) ProfileUsedByRef(filter ProfileFilter) (map[string]map[string][]string, error) {
 	// Result slice.
 	objects := make([]struct {
@@ -623,6 +631,7 @@ func (c *ClusterTx) ProfileUsedByRef(filter ProfileFilter) (map[string]map[strin
 }
 
 // CreateProfile adds a new profile to the database.
+// generator: profile Create
 func (c *ClusterTx) CreateProfile(object Profile) (int64, error) {
 	// Check if a profile with the same key exists.
 	exists, err := c.ProfileExists(object.Project, object.Name)
@@ -695,6 +704,7 @@ func (c *ClusterTx) CreateProfile(object Profile) (int64, error) {
 }
 
 // RenameProfile renames the profile matching the given key parameters.
+// generator: profile Rename
 func (c *ClusterTx) RenameProfile(project string, name string, to string) error {
 	stmt := c.stmt(profileRename)
 	result, err := stmt.Exec(to, project, name)
@@ -713,6 +723,7 @@ func (c *ClusterTx) RenameProfile(project string, name string, to string) error 
 }
 
 // DeleteProfile deletes the profile matching the given key parameters.
+// generator: profile DeleteOne
 func (c *ClusterTx) DeleteProfile(filter ProfileFilter) error {
 	// Check which filter criteria are active.
 	criteria := map[string]interface{}{}
@@ -753,6 +764,7 @@ func (c *ClusterTx) DeleteProfile(filter ProfileFilter) error {
 }
 
 // UpdateProfile updates the profile matching the given key parameters.
+// generator: profile Update
 func (c *ClusterTx) UpdateProfile(project string, name string, object Profile) error {
 	id, err := c.GetProfileID(project, name)
 	if err != nil {

--- a/lxd/db/projects.go
+++ b/lxd/db/projects.go
@@ -212,9 +212,9 @@ func (c *ClusterTx) InitProjectWithoutImages(project string) error {
 }
 
 // GetProject returns the project with the given key.
-func (c *Cluster) GetProject(projectName string) (*api.Project, error) {
+func (c *Cluster) GetProject(projectName string) (*Project, error) {
 	var err error
-	var p *api.Project
+	var p *Project
 	err = c.Transaction(func(tx *ClusterTx) error {
 		p, err = tx.GetProject(projectName)
 		if err != nil {

--- a/lxd/db/projects.go
+++ b/lxd/db/projects.go
@@ -19,35 +19,55 @@ import (
 //go:generate -command mapper lxd-generate db mapper -t projects.mapper.go
 //go:generate mapper reset
 //
-//go:generate mapper stmt -e project names
-//go:generate mapper stmt -e project names-by-Name
-//go:generate mapper stmt -e project objects
-//go:generate mapper stmt -e project objects-by-Name
-//go:generate mapper stmt -e project used-by-ref
-//go:generate mapper stmt -e project used-by-ref-by-Name
-//go:generate mapper stmt -e project config-ref
-//go:generate mapper stmt -e project config-ref-by-Name
-//go:generate mapper stmt -e project create
-//go:generate mapper stmt -e project create-config-ref
-//go:generate mapper stmt -e project id
-//go:generate mapper stmt -e project rename
-//go:generate mapper stmt -e project update
-//go:generate mapper stmt -e project delete-by-Name
+//go:generate mapper stmt -p db -e project names
+//go:generate mapper stmt -p db -e project names-by-Name
+//go:generate mapper stmt -p db -e project objects
+//go:generate mapper stmt -p db -e project objects-by-Name
+//go:generate mapper stmt -p db -e project used-by-ref
+//go:generate mapper stmt -p db -e project used-by-ref-by-Name
+//go:generate mapper stmt -p db -e project config-ref
+//go:generate mapper stmt -p db -e project config-ref-by-Name
+//go:generate mapper stmt -p db -e project create struct=Project
+//go:generate mapper stmt -p db -e project create-config-ref
+//go:generate mapper stmt -p db -e project id
+//go:generate mapper stmt -p db -e project rename
+//go:generate mapper stmt -p db -e project update struct=Project
+//go:generate mapper stmt -p db -e project delete-by-Name
 //
-//go:generate mapper method -e project URIs
-//go:generate mapper method -e project List
-//go:generate mapper method -e project Get
-//go:generate mapper method -e project ConfigRef
-//go:generate mapper method -e project Exists
-//go:generate mapper method -e project Create
-//go:generate mapper method -e project UsedByRef
-//go:generate mapper method -e project ID
-//go:generate mapper method -e project Rename
-//go:generate mapper method -e project DeleteOne
+//go:generate mapper method -p db -e project URIs
+//go:generate mapper method -p db -e project List
+//go:generate mapper method -p db -e project Get struct=Project
+//go:generate mapper method -p db -e project ConfigRef
+//go:generate mapper method -p db -e project Exists struct=Project
+//go:generate mapper method -p db -e project Create struct=Project
+//go:generate mapper method -p db -e project UsedByRef
+//go:generate mapper method -p db -e project ID struct=Project
+//go:generate mapper method -p db -e project Rename
+//go:generate mapper method -p db -e project DeleteOne
+
+// Project represents a LXD project
+type Project struct {
+	Description string
+	Name        string   `db:"omit=update"`
+	UsedBy      []string `db:"omit=create"`
+	Config      map[string]string
+}
 
 // ProjectFilter specifies potential query parameter fields.
 type ProjectFilter struct {
-	Name string // If non-empty, return only the project with this name.
+	Name string `db:"omit=update"` // If non-empty, return only the project with this name.
+}
+
+// ToAPI converts the database Project struct to an api.Project entry.
+func (p *Project) ToAPI() api.Project {
+	return api.Project{
+		ProjectPut: api.ProjectPut{
+			Config:      p.Config,
+			Description: p.Description,
+		},
+		Name:   p.Name,
+		UsedBy: p.UsedBy,
+	}
 }
 
 // ProjectHasProfiles is a helper to check if a project has the profiles

--- a/lxd/db/projects.mapper.go
+++ b/lxd/db/projects.mapper.go
@@ -86,6 +86,7 @@ DELETE FROM projects WHERE name = ?
 `)
 
 // GetProjectURIs returns all available project URIs.
+// generator: project URIs
 func (c *ClusterTx) GetProjectURIs(filter ProjectFilter) ([]string, error) {
 	// Check which filter criteria are active.
 	criteria := map[string]interface{}{}
@@ -114,9 +115,10 @@ func (c *ClusterTx) GetProjectURIs(filter ProjectFilter) ([]string, error) {
 }
 
 // GetProjects returns all available projects.
-func (c *ClusterTx) GetProjects(filter ProjectFilter) ([]api.Project, error) {
+// generator: project List
+func (c *ClusterTx) GetProjects(filter ProjectFilter) ([]Project, error) {
 	// Result slice.
-	objects := make([]api.Project, 0)
+	objects := make([]Project, 0)
 
 	// Check which filter criteria are active.
 	criteria := map[string]interface{}{}
@@ -140,7 +142,7 @@ func (c *ClusterTx) GetProjects(filter ProjectFilter) ([]api.Project, error) {
 
 	// Dest function for scanning a row.
 	dest := func(i int) []interface{} {
-		objects = append(objects, api.Project{})
+		objects = append(objects, Project{})
 		return []interface{}{
 			&objects[i].Description,
 			&objects[i].Name,
@@ -151,20 +153,6 @@ func (c *ClusterTx) GetProjects(filter ProjectFilter) ([]api.Project, error) {
 	err := query.SelectObjects(stmt, dest, args...)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to fetch projects")
-	}
-
-	// Fill field Config.
-	configObjects, err := c.ProjectConfigRef(filter)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to fetch field Config")
-	}
-
-	for i := range objects {
-		value := configObjects[objects[i].Name]
-		if value == nil {
-			value = map[string]string{}
-		}
-		objects[i].Config = value
 	}
 
 	// Fill field UsedBy.
@@ -189,11 +177,26 @@ func (c *ClusterTx) GetProjects(filter ProjectFilter) ([]api.Project, error) {
 		objects[i].UsedBy = value
 	}
 
+	// Fill field Config.
+	configObjects, err := c.ProjectConfigRef(filter)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to fetch field Config")
+	}
+
+	for i := range objects {
+		value := configObjects[objects[i].Name]
+		if value == nil {
+			value = map[string]string{}
+		}
+		objects[i].Config = value
+	}
+
 	return objects, nil
 }
 
 // GetProject returns the project with the given key.
-func (c *ClusterTx) GetProject(name string) (*api.Project, error) {
+// generator: project Get
+func (c *ClusterTx) GetProject(name string) (*Project, error) {
 	filter := ProjectFilter{}
 	filter.Name = name
 
@@ -213,6 +216,7 @@ func (c *ClusterTx) GetProject(name string) (*api.Project, error) {
 }
 
 // ProjectConfigRef returns entities used by projects.
+// generator: project ConfigRef
 func (c *ClusterTx) ProjectConfigRef(filter ProjectFilter) (map[string]map[string]string, error) {
 	// Result slice.
 	objects := make([]struct {
@@ -278,6 +282,7 @@ func (c *ClusterTx) ProjectConfigRef(filter ProjectFilter) (map[string]map[strin
 }
 
 // ProjectExists checks if a project with the given key exists.
+// generator: project Exists
 func (c *ClusterTx) ProjectExists(name string) (bool, error) {
 	_, err := c.GetProjectID(name)
 	if err != nil {
@@ -291,7 +296,8 @@ func (c *ClusterTx) ProjectExists(name string) (bool, error) {
 }
 
 // CreateProject adds a new project to the database.
-func (c *ClusterTx) CreateProject(object api.ProjectsPost) (int64, error) {
+// generator: project Create
+func (c *ClusterTx) CreateProject(object Project) (int64, error) {
 	// Check if a project with the same key exists.
 	exists, err := c.ProjectExists(object.Name)
 	if err != nil {
@@ -334,6 +340,7 @@ func (c *ClusterTx) CreateProject(object api.ProjectsPost) (int64, error) {
 }
 
 // ProjectUsedByRef returns entities used by projects.
+// generator: project UsedByRef
 func (c *ClusterTx) ProjectUsedByRef(filter ProjectFilter) (map[string][]string, error) {
 	// Result slice.
 	objects := make([]struct {
@@ -395,6 +402,7 @@ func (c *ClusterTx) ProjectUsedByRef(filter ProjectFilter) (map[string][]string,
 }
 
 // GetProjectID return the ID of the project with the given key.
+// generator: project ID
 func (c *ClusterTx) GetProjectID(name string) (int64, error) {
 	stmt := c.stmt(projectID)
 	rows, err := stmt.Query(name)
@@ -424,6 +432,7 @@ func (c *ClusterTx) GetProjectID(name string) (int64, error) {
 }
 
 // RenameProject renames the project matching the given key parameters.
+// generator: project Rename
 func (c *ClusterTx) RenameProject(name string, to string) error {
 	stmt := c.stmt(projectRename)
 	result, err := stmt.Exec(to, name)
@@ -442,6 +451,7 @@ func (c *ClusterTx) RenameProject(name string, to string) error {
 }
 
 // DeleteProject deletes the project matching the given key parameters.
+// generator: project DeleteOne
 func (c *ClusterTx) DeleteProject(filter ProjectFilter) error {
 	// Check which filter criteria are active.
 	criteria := map[string]interface{}{}

--- a/lxd/db/snapshots.mapper.go
+++ b/lxd/db/snapshots.mapper.go
@@ -91,6 +91,7 @@ DELETE FROM instances_snapshots WHERE instance_id = (SELECT instances.id FROM in
 `)
 
 // GetInstanceSnapshots returns all available instance_snapshots.
+// generator: instance_snapshot List
 func (c *ClusterTx) GetInstanceSnapshots(filter InstanceSnapshotFilter) ([]InstanceSnapshot, error) {
 	// Result slice.
 	objects := make([]InstanceSnapshot, 0)
@@ -206,6 +207,7 @@ func (c *ClusterTx) GetInstanceSnapshots(filter InstanceSnapshotFilter) ([]Insta
 }
 
 // GetInstanceSnapshot returns the instance_snapshot with the given key.
+// generator: instance_snapshot Get
 func (c *ClusterTx) GetInstanceSnapshot(project string, instance string, name string) (*InstanceSnapshot, error) {
 	filter := InstanceSnapshotFilter{}
 	filter.Project = project
@@ -228,6 +230,7 @@ func (c *ClusterTx) GetInstanceSnapshot(project string, instance string, name st
 }
 
 // GetInstanceSnapshotID return the ID of the instance_snapshot with the given key.
+// generator: instance_snapshot ID
 func (c *ClusterTx) GetInstanceSnapshotID(project string, instance string, name string) (int64, error) {
 	stmt := c.stmt(instanceSnapshotID)
 	rows, err := stmt.Query(project, instance, name)
@@ -257,6 +260,7 @@ func (c *ClusterTx) GetInstanceSnapshotID(project string, instance string, name 
 }
 
 // InstanceSnapshotExists checks if a instance_snapshot with the given key exists.
+// generator: instance_snapshot Exists
 func (c *ClusterTx) InstanceSnapshotExists(project string, instance string, name string) (bool, error) {
 	_, err := c.GetInstanceSnapshotID(project, instance, name)
 	if err != nil {
@@ -270,6 +274,7 @@ func (c *ClusterTx) InstanceSnapshotExists(project string, instance string, name
 }
 
 // CreateInstanceSnapshot adds a new instance_snapshot to the database.
+// generator: instance_snapshot Create
 func (c *ClusterTx) CreateInstanceSnapshot(object InstanceSnapshot) (int64, error) {
 	// Check if a instance_snapshot with the same key exists.
 	exists, err := c.InstanceSnapshotExists(object.Project, object.Instance, object.Name)
@@ -346,6 +351,7 @@ func (c *ClusterTx) CreateInstanceSnapshot(object InstanceSnapshot) (int64, erro
 }
 
 // InstanceSnapshotConfigRef returns entities used by instance_snapshots.
+// generator: instance_snapshot ConfigRef
 func (c *ClusterTx) InstanceSnapshotConfigRef(filter InstanceSnapshotFilter) (map[string]map[string]map[string]map[string]string, error) {
 	// Result slice.
 	objects := make([]struct {
@@ -443,6 +449,7 @@ func (c *ClusterTx) InstanceSnapshotConfigRef(filter InstanceSnapshotFilter) (ma
 }
 
 // InstanceSnapshotDevicesRef returns entities used by instance_snapshots.
+// generator: instance_snapshot DevicesRef
 func (c *ClusterTx) InstanceSnapshotDevicesRef(filter InstanceSnapshotFilter) (map[string]map[string]map[string]map[string]map[string]string, error) {
 	// Result slice.
 	objects := make([]struct {
@@ -561,6 +568,7 @@ func (c *ClusterTx) InstanceSnapshotDevicesRef(filter InstanceSnapshotFilter) (m
 }
 
 // RenameInstanceSnapshot renames the instance_snapshot matching the given key parameters.
+// generator: instance_snapshot Rename
 func (c *ClusterTx) RenameInstanceSnapshot(project string, instance string, name string, to string) error {
 	stmt := c.stmt(instanceSnapshotRename)
 	result, err := stmt.Exec(to, project, instance, name)
@@ -579,6 +587,7 @@ func (c *ClusterTx) RenameInstanceSnapshot(project string, instance string, name
 }
 
 // DeleteInstanceSnapshot deletes the instance_snapshot matching the given key parameters.
+// generator: instance_snapshot DeleteOne
 func (c *ClusterTx) DeleteInstanceSnapshot(filter InstanceSnapshotFilter) error {
 	// Check which filter criteria are active.
 	criteria := map[string]interface{}{}

--- a/lxd/db/snapshots_test.go
+++ b/lxd/db/snapshots_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
-	"github.com/lxc/lxd/shared/api"
 )
 
 func TestGetInstanceSnapshots(t *testing.T) {
@@ -90,7 +89,7 @@ func TestGetInstanceSnapshots_SameNameInDifferentProjects(t *testing.T) {
 	defer cleanup()
 
 	// Create an additional project
-	project1 := api.ProjectsPost{}
+	project1 := db.Project{}
 	project1.Name = "p1"
 	_, err := tx.CreateProject(project1)
 	require.NoError(t, err)

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1247,7 +1247,7 @@ func (d *disk) storagePoolVolumeAttachShift(projectName, poolName, volumeName st
 
 		if !shared.IsTrue(poolVolumePut.Config["security.shifted"]) {
 			volumeUsedBy := []instance.Instance{}
-			err = storagePools.VolumeUsedByInstanceDevices(d.state, poolName, projectName, volume, true, func(dbInst db.Instance, project api.Project, profiles []api.Profile, usedByDevices []string) error {
+			err = storagePools.VolumeUsedByInstanceDevices(d.state, poolName, projectName, volume, true, func(dbInst db.Instance, project db.Project, profiles []api.Profile, usedByDevices []string) error {
 				inst, err := instance.Load(d.state, db.InstanceToArgs(&dbInst), profiles)
 				if err != nil {
 					return err

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -238,7 +238,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 			ourNICMAC, _ = net.ParseMAC(v["hwaddr"])
 		}
 
-		err := d.state.Cluster.InstanceList(&filter, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+		err := d.state.Cluster.InstanceList(&filter, func(inst db.Instance, p db.Project, profiles []api.Profile) error {
 			// Get the instance's effective network project name.
 			instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2031,7 +2031,7 @@ func pruneLeftoverImages(d *Daemon) {
 }
 
 func pruneExpiredImages(ctx context.Context, d *Daemon, op *operations.Operation) error {
-	var projects []api.Project
+	var projects []db.Project
 	err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
 		var err error
 		projects, err = tx.GetProjects(db.ProjectFilter{})
@@ -2055,7 +2055,7 @@ func pruneExpiredImages(ctx context.Context, d *Daemon, op *operations.Operation
 	return nil
 }
 
-func pruneExpiredImagesInProject(ctx context.Context, d *Daemon, project api.Project, op *operations.Operation) error {
+func pruneExpiredImagesInProject(ctx context.Context, d *Daemon, project db.Project, op *operations.Operation) error {
 	var expiry int64
 	var err error
 	if project.Config["images.remote_cache_expiry"] != "" {

--- a/lxd/network/acl/acl_load.go
+++ b/lxd/network/acl/acl_load.go
@@ -198,7 +198,7 @@ func UsedBy(s *state.State, aclProjectName string, usageFunc func(matchedACLName
 	}
 
 	// Find instances using the ACLs. Most expensive to do.
-	err = s.Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+	err = s.Cluster.InstanceList(nil, func(inst db.Instance, p db.Project, profiles []api.Profile) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -118,7 +118,7 @@ func (n *ovn) uplinkRoutes(uplink *api.Network) ([]*net.IPNet, error) {
 
 // projectRestrictedSubnets parses the restrict.networks.subnets project setting and returns slice of *net.IPNet.
 // Returns nil slice if no project restrictions, or empty slice if no allowed subnets.
-func (n *ovn) projectRestrictedSubnets(p *api.Project, uplinkNetworkName string) ([]*net.IPNet, error) {
+func (n *ovn) projectRestrictedSubnets(p *db.Project, uplinkNetworkName string) ([]*net.IPNet, error) {
 	// Parse project's restricted subnets.
 	var projectRestrictedSubnets []*net.IPNet // Nil value indicates not restricted.
 	if shared.IsTrue(p.Config["restricted"]) && p.Config["restricted.networks.subnets"] != "" {
@@ -1401,7 +1401,7 @@ func (n *ovn) Create(clientType request.ClientType) error {
 }
 
 // allowedUplinkNetworks returns a list of allowed networks to use as uplinks based on project restrictions.
-func (n *ovn) allowedUplinkNetworks(p *api.Project) ([]string, error) {
+func (n *ovn) allowedUplinkNetworks(p *db.Project) ([]string, error) {
 	// Uplink networks are always from the default project.
 	networks, err := n.state.Cluster.GetNetworks(project.Default)
 	if err != nil {
@@ -1448,7 +1448,7 @@ func (n *ovn) allowedUplinkNetworks(p *api.Project) ([]string, error) {
 // validateUplinkNetwork checks if uplink network is allowed, and if empty string is supplied then tries to select
 // an uplink network from the allowedUplinkNetworks() list if there is only one allowed network.
 // Returns chosen uplink network name to use.
-func (n *ovn) validateUplinkNetwork(p *api.Project, uplinkNetworkName string) (string, error) {
+func (n *ovn) validateUplinkNetwork(p *db.Project, uplinkNetworkName string) (string, error) {
 	allowedUplinkNetworks, err := n.allowedUplinkNetworks(p)
 	if err != nil {
 		return "", err
@@ -2508,7 +2508,7 @@ func (n *ovn) instanceDevicePortRoutesParse(deviceConfig map[string]string) ([]*
 // InstanceDevicePortValidateExternalRoutes validates the external routes for an OVN instance port.
 func (n *ovn) InstanceDevicePortValidateExternalRoutes(deviceInstance instance.Instance, deviceName string, portExternalRoutes []*net.IPNet) error {
 	var err error
-	var p *api.Project
+	var p *db.Project
 	var projectNetworks map[string]map[int64]api.Network
 
 	// Get uplink routes.
@@ -3185,7 +3185,7 @@ func (n *ovn) ovnNICExternalRoutes(ourDeviceInstance instance.Instance, ourDevic
 		return false
 	}
 
-	err := n.state.Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+	err := n.state.Cluster.InstanceList(nil, func(inst db.Instance, p db.Project, profiles []api.Profile) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 		devices := db.ExpandInstanceDevices(deviceConfig.NewDevices(inst.Devices), profiles)
@@ -3298,7 +3298,7 @@ func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]
 
 			// Find all instance NICs that use this network, and re-add the logical OVN instance port.
 			// This will restore the l2proxy DNAT_AND_SNAT rules.
-			err = n.state.Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+			err = n.state.Cluster.InstanceList(nil, func(inst db.Instance, p db.Project, profiles []api.Profile) error {
 				// Get the instance's effective network project name.
 				instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -68,7 +68,7 @@ func RandomDevName(prefix string) string {
 
 // usedByInstanceDevices looks for instance NIC devices using the network and runs the supplied usageFunc for each.
 func usedByInstanceDevices(s *state.State, networkProjectName string, networkName string, usageFunc func(inst db.Instance, nicName string, nicConfig map[string]string) error) error {
-	return s.Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+	return s.Cluster.InstanceList(nil, func(inst db.Instance, p db.Project, profiles []api.Profile) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 
@@ -175,7 +175,7 @@ func UsedBy(s *state.State, networkProjectName string, networkName string, first
 	}
 
 	// Look at instances. Most expensive to do.
-	err = s.Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+	err = s.Cluster.InstanceList(nil, func(inst db.Instance, p db.Project, profiles []api.Profile) error {
 		// Get the instance's effective network project name.
 		instNetworkProject := project.NetworkProjectFromRecord(&p)
 

--- a/lxd/network/network_utils_sriov.go
+++ b/lxd/network/network_utils_sriov.go
@@ -65,7 +65,7 @@ func SRIOVGetHostDevicesInUse(s *state.State) (map[string]struct{}, error) {
 	reservedDevices := map[string]struct{}{}
 
 	// Check if any instances are using the VF device.
-	err = s.Cluster.InstanceList(&filter, func(dbInst db.Instance, p api.Project, profiles []api.Profile) error {
+	err = s.Cluster.InstanceList(&filter, func(dbInst db.Instance, p db.Project, profiles []api.Profile) error {
 		// Expand configs so we take into account profile devices.
 		dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, profiles)
 		dbInst.Devices = db.ExpandInstanceDevices(deviceConfig.NewDevices(dbInst.Devices), profiles).CloneNative()

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -441,7 +441,7 @@ func patchVMRenameUUIDKey(name string, d *Daemon) error {
 	oldUUIDKey := "volatile.vm.uuid"
 	newUUIDKey := "volatile.uuid"
 
-	return d.State().Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+	return d.State().Cluster.InstanceList(nil, func(inst db.Instance, p db.Project, profiles []api.Profile) error {
 		if inst.Type != instancetype.VM {
 			return nil
 		}

--- a/lxd/project/permissions_test.go
+++ b/lxd/project/permissions_test.go
@@ -29,12 +29,10 @@ func TestAllowInstanceCreation_Below(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	_, err := tx.CreateProject(api.ProjectsPost{
+	_, err := tx.CreateProject(db.Project{
 		Name: "p1",
-		ProjectPut: api.ProjectPut{
-			Config: map[string]string{
-				"limits.containers": "5",
-			},
+		Config: map[string]string{
+			"limits.containers": "5",
 		},
 	})
 	require.NoError(t, err)
@@ -63,12 +61,10 @@ func TestAllowInstanceCreation_Above(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	_, err := tx.CreateProject(api.ProjectsPost{
+	_, err := tx.CreateProject(db.Project{
 		Name: "p1",
-		ProjectPut: api.ProjectPut{
-			Config: map[string]string{
-				"limits.containers": "1",
-			},
+		Config: map[string]string{
+			"limits.containers": "1",
 		},
 	})
 	require.NoError(t, err)
@@ -97,12 +93,10 @@ func TestAllowInstanceCreation_DifferentType(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	_, err := tx.CreateProject(api.ProjectsPost{
+	_, err := tx.CreateProject(db.Project{
 		Name: "p1",
-		ProjectPut: api.ProjectPut{
-			Config: map[string]string{
-				"limits.containers": "1",
-			},
+		Config: map[string]string{
+			"limits.containers": "1",
 		},
 	})
 	require.NoError(t, err)
@@ -131,13 +125,11 @@ func TestAllowInstanceCreation_AboveInstances(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	_, err := tx.CreateProject(api.ProjectsPost{
+	_, err := tx.CreateProject(db.Project{
 		Name: "p1",
-		ProjectPut: api.ProjectPut{
-			Config: map[string]string{
-				"limits.containers": "5",
-				"limits.instances":  "1",
-			},
+		Config: map[string]string{
+			"limits.containers": "5",
+			"limits.instances":  "1",
 		},
 	})
 	require.NoError(t, err)

--- a/lxd/project/project.go
+++ b/lxd/project/project.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
-	"github.com/lxc/lxd/shared/api"
 )
 
 // Default is the string used for a default project.
@@ -86,7 +85,7 @@ func StorageVolumeProject(c *db.Cluster, projectName string, volumeType int) (st
 // For custom volume type, if the project supplied has the "features.storage.volumes" flag enabled then the
 // project name is returned, otherwise the default project name is returned. For all other volume types the
 // supplied project's name is returned.
-func StorageVolumeProjectFromRecord(p *api.Project, volumeType int) string {
+func StorageVolumeProjectFromRecord(p *db.Project, volumeType int) string {
 	// Non-custom volumes always use the project specified.
 	if volumeType != db.StoragePoolVolumeTypeCustom {
 		return p.Name
@@ -123,7 +122,7 @@ func NetworkProject(c *db.Cluster, projectName string) (string, map[string]strin
 // NetworkProjectFromRecord returns the project name to use for the network based on the supplied project.
 // If the project supplied has the "features.networks" flag enabled then the project name is returned,
 // otherwise the default project name is returned.
-func NetworkProjectFromRecord(p *api.Project) string {
+func NetworkProjectFromRecord(p *db.Project) string {
 	// Networks only use the project specified if the project has the features.networks feature enabled,
 	// otherwise the legacy behaviour of using the default project for networks is used.
 	if shared.IsTrue(p.Config["features.networks"]) {
@@ -155,7 +154,7 @@ func ProfileProject(c *db.Cluster, projectName string) (string, map[string]strin
 // ProfileProjectFromRecord returns the project name to use for the profile based on the supplied project.
 // If the project supplied has the "features.profiles" flag enabled then the project name is returned,
 // otherwise the default project name is returned.
-func ProfileProjectFromRecord(p *api.Project) string {
+func ProfileProjectFromRecord(p *db.Project) string {
 	// Profiles only use the project specified if the project has the features.profiles feature enabled,
 	// otherwise the default project for profiles is used.
 	if shared.IsTrue(p.Config["features.profiles"]) {

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3112,7 +3112,7 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 
 		// Check for config changing that is not allowed when running instances are using it.
 		if changedConfig["security.shifted"] != "" {
-			err = VolumeUsedByInstanceDevices(b.state, b.name, projectName, curVol, true, func(dbInst db.Instance, project api.Project, profiles []api.Profile, usedByDevices []string) error {
+			err = VolumeUsedByInstanceDevices(b.state, b.name, projectName, curVol, true, func(dbInst db.Instance, project db.Project, profiles []api.Profile, usedByDevices []string) error {
 				inst, err := instance.Load(b.state, db.InstanceToArgs(&dbInst), profiles)
 				if err != nil {
 					return err
@@ -3553,7 +3553,7 @@ func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotNa
 	}
 
 	// Check that the volume isn't in use by running instances.
-	err = VolumeUsedByInstanceDevices(b.state, b.Name(), projectName, curVol, true, func(dbInst db.Instance, project api.Project, profiles []api.Profile, usedByDevices []string) error {
+	err = VolumeUsedByInstanceDevices(b.state, b.Name(), projectName, curVol, true, func(dbInst db.Instance, project db.Project, profiles []api.Profile, usedByDevices []string) error {
 		inst, err := instance.Load(b.state, db.InstanceToArgs(&dbInst), profiles)
 		if err != nil {
 			return err

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -599,14 +599,14 @@ func InstanceContentType(inst instance.Instance) drivers.ContentType {
 // VolumeUsedByProfileDevices finds profiles using a volume and passes them to profileFunc for evaluation.
 // The profileFunc is provided with a profile config, project config and a list of device names that are using
 // the volume.
-func VolumeUsedByProfileDevices(s *state.State, poolName string, projectName string, vol *api.StorageVolume, profileFunc func(profile db.Profile, project api.Project, usedByDevices []string) error) error {
+func VolumeUsedByProfileDevices(s *state.State, poolName string, projectName string, vol *api.StorageVolume, profileFunc func(profile db.Profile, project db.Project, usedByDevices []string) error) error {
 	// Convert the volume type name to our internal integer representation.
 	volumeType, err := VolumeTypeNameToDBType(vol.Type)
 	if err != nil {
 		return err
 	}
 
-	projectMap := map[string]api.Project{}
+	projectMap := map[string]db.Project{}
 	var profiles []db.Profile
 
 	// Retrieve required info from the database in single transaction for performance.
@@ -684,14 +684,14 @@ func VolumeUsedByProfileDevices(s *state.State, poolName string, projectName str
 // is returned immediately. The instanceFunc is executed during a DB transaction, so DB queries are not permitted.
 // The instanceFunc is provided with a instance config, project config, instance's profiles and a list of device
 // names that are using the volume.
-func VolumeUsedByInstanceDevices(s *state.State, poolName string, projectName string, vol *api.StorageVolume, expandDevices bool, instanceFunc func(inst db.Instance, project api.Project, profiles []api.Profile, usedByDevices []string) error) error {
+func VolumeUsedByInstanceDevices(s *state.State, poolName string, projectName string, vol *api.StorageVolume, expandDevices bool, instanceFunc func(inst db.Instance, project db.Project, profiles []api.Profile, usedByDevices []string) error) error {
 	// Convert the volume type name to our internal integer representation.
 	volumeType, err := VolumeTypeNameToDBType(vol.Type)
 	if err != nil {
 		return err
 	}
 
-	return s.Cluster.InstanceList(nil, func(inst db.Instance, p api.Project, profiles []api.Profile) error {
+	return s.Cluster.InstanceList(nil, func(inst db.Instance, p db.Project, profiles []api.Profile) error {
 		// If the volume has a specific cluster member which is different than the instance then skip as
 		// instance cannot be using this volume.
 		if vol.Location != "" && inst.Node != vol.Location {
@@ -778,7 +778,7 @@ func VolumeUsedByExclusiveRemoteInstancesWithProfiles(s *state.State, poolName s
 
 	// Find if volume is attached to a remote instance.
 	var remoteInstance *db.Instance
-	err = VolumeUsedByInstanceDevices(s, poolName, projectName, vol, true, func(dbInst db.Instance, project api.Project, profiles []api.Profile, usedByDevices []string) error {
+	err = VolumeUsedByInstanceDevices(s, poolName, projectName, vol, true, func(dbInst db.Instance, project db.Project, profiles []api.Profile, usedByDevices []string) error {
 		if dbInst.Node != localNode {
 			remoteInstance = &dbInst
 			return db.ErrInstanceListStop // Stop the search, this volume is attached to a remote instance.

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -940,7 +940,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Check if a running instance is using it.
-	err = storagePools.VolumeUsedByInstanceDevices(d.State(), srcPoolName, projectName, vol, true, func(dbInst db.Instance, project api.Project, profiles []api.Profile, usedByDevices []string) error {
+	err = storagePools.VolumeUsedByInstanceDevices(d.State(), srcPoolName, projectName, vol, true, func(dbInst db.Instance, project db.Project, profiles []api.Profile, usedByDevices []string) error {
 		inst, err := instance.Load(d.State(), db.InstanceToArgs(&dbInst), profiles)
 		if err != nil {
 			return err

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -22,7 +22,7 @@ func storagePoolVolumeUpdateUsers(d *Daemon, projectName string, oldPoolName str
 	s := d.State()
 
 	// Update all instances that are using the volume with a local (non-expanded) device.
-	err := storagePools.VolumeUsedByInstanceDevices(s, oldPoolName, projectName, oldVol, false, func(dbInst db.Instance, project api.Project, profiles []api.Profile, usedByDevices []string) error {
+	err := storagePools.VolumeUsedByInstanceDevices(s, oldPoolName, projectName, oldVol, false, func(dbInst db.Instance, project db.Project, profiles []api.Profile, usedByDevices []string) error {
 		inst, err := instance.Load(s, db.InstanceToArgs(&dbInst), profiles)
 		if err != nil {
 			return err
@@ -60,7 +60,7 @@ func storagePoolVolumeUpdateUsers(d *Daemon, projectName string, oldPoolName str
 	}
 
 	// Update all profiles that are using the volume with a device.
-	err = storagePools.VolumeUsedByProfileDevices(s, oldPoolName, projectName, oldVol, func(profile db.Profile, p api.Project, usedByDevices []string) error {
+	err = storagePools.VolumeUsedByProfileDevices(s, oldPoolName, projectName, oldVol, func(profile db.Profile, p db.Project, usedByDevices []string) error {
 		for _, devName := range usedByDevices {
 			if _, exists := profile.Devices[devName]; exists {
 				profile.Devices[devName]["pool"] = newPoolName
@@ -131,7 +131,7 @@ func storagePoolVolumeUsedByGet(s *state.State, projectName string, poolName str
 
 	// Pass false to expandDevices, as we only want to see instances directly using a volume, rather than their
 	// profiles using a volume.
-	err = storagePools.VolumeUsedByInstanceDevices(s, poolName, projectName, vol, false, func(inst db.Instance, p api.Project, profiles []api.Profile, usedByDevices []string) error {
+	err = storagePools.VolumeUsedByInstanceDevices(s, poolName, projectName, vol, false, func(inst db.Instance, p db.Project, profiles []api.Profile, usedByDevices []string) error {
 		if inst.Project == project.Default {
 			volumeUsedBy = append(volumeUsedBy, fmt.Sprintf("/%s/instances/%s", version.APIVersion, inst.Name))
 		} else {
@@ -144,7 +144,7 @@ func storagePoolVolumeUsedByGet(s *state.State, projectName string, poolName str
 		return []string{}, err
 	}
 
-	err = storagePools.VolumeUsedByProfileDevices(s, poolName, projectName, vol, func(profile db.Profile, p api.Project, usedByDevices []string) error {
+	err = storagePools.VolumeUsedByProfileDevices(s, poolName, projectName, vol, func(profile db.Profile, p db.Project, usedByDevices []string) error {
 		if profile.Project == project.Default {
 			volumeUsedBy = append(volumeUsedBy, fmt.Sprintf("/%s/profiles/%s", version.APIVersion, profile.Name))
 		} else {


### PR DESCRIPTION
This PR separates out some of the already-done cleanup from the other Generator PRs. 

Changes: 
* adds `Filter` field to `Mapping`, which holds information about fields in an `[Object]Filter` struct.  
* The Filter struct is now required to be present for the generator to work. All fields in in the Filter struct must also be present in the main struct, and any indirect fields referencing other fields must have both fields in the Filter strut.

* Added a `db.Project` struct to use instead of `api.Project`
* Switched to using `db.CertificateType` instead of integers for certificate types

* Added a one-liner for including the generated command as a comment for the generated method.