### PR TITLE
Clarify why a profile device cannot be modified on an instance

### DIFF
--- a/lxc/config_device.go
+++ b/lxc/config_device.go
@@ -244,7 +244,13 @@ func (c *cmdConfigDeviceGet) Run(cmd *cobra.Command, args []string) error {
 
 		dev, ok := inst.Devices[devname]
 		if !ok {
-			return fmt.Errorf(i18n.G("The device doesn't exist"))
+			_, ok = inst.ExpandedDevices[devname]
+			if !ok {
+				return fmt.Errorf(i18n.G("The device doesn't exist"))
+			}
+
+			return fmt.Errorf(i18n.G("Device from profile(s) cannot be retrieved for individual instance"))
+
 		}
 
 		fmt.Println(dev[key])
@@ -484,7 +490,13 @@ func (c *cmdConfigDeviceRemove) Run(cmd *cobra.Command, args []string) error {
 		for _, devname := range args[1:] {
 			_, ok := inst.Devices[devname]
 			if !ok {
-				return fmt.Errorf(i18n.G("The device doesn't exist"))
+				_, ok := inst.ExpandedDevices[devname]
+				if !ok {
+					return fmt.Errorf(i18n.G("The device doesn't exist"))
+				}
+
+				return fmt.Errorf(i18n.G("Device from profile(s) cannot be removed from individual instance. Override device or modify profile instead"))
+
 			}
 			delete(inst.Devices, devname)
 		}
@@ -593,7 +605,12 @@ func (c *cmdConfigDeviceSet) Run(cmd *cobra.Command, args []string) error {
 		}
 		dev, ok := inst.Devices[devname]
 		if !ok {
-			return fmt.Errorf(i18n.G("The device doesn't exist"))
+			_, ok = inst.ExpandedDevices[devname]
+			if !ok {
+				return fmt.Errorf(i18n.G("The device doesn't exist"))
+			}
+
+			return fmt.Errorf(i18n.G("Device from profile(s) cannot be modified for individual instance. Override device or modify profile instead"))
 		}
 
 		for k, v := range keys {

--- a/lxc/config_device.go
+++ b/lxc/config_device.go
@@ -232,7 +232,7 @@ func (c *cmdConfigDeviceGet) Run(cmd *cobra.Command, args []string) error {
 
 		dev, ok := profile.Devices[devname]
 		if !ok {
-			return fmt.Errorf(i18n.G("The device doesn't exist"))
+			return fmt.Errorf(i18n.G("Device doesn't exist"))
 		}
 
 		fmt.Println(dev[key])
@@ -246,7 +246,7 @@ func (c *cmdConfigDeviceGet) Run(cmd *cobra.Command, args []string) error {
 		if !ok {
 			_, ok = inst.ExpandedDevices[devname]
 			if !ok {
-				return fmt.Errorf(i18n.G("The device doesn't exist"))
+				return fmt.Errorf(i18n.G("Device doesn't exist"))
 			}
 
 			return fmt.Errorf(i18n.G("Device from profile(s) cannot be retrieved for individual instance"))
@@ -472,7 +472,7 @@ func (c *cmdConfigDeviceRemove) Run(cmd *cobra.Command, args []string) error {
 		for _, devname := range args[1:] {
 			_, ok := profile.Devices[devname]
 			if !ok {
-				return fmt.Errorf(i18n.G("The device doesn't exist"))
+				return fmt.Errorf(i18n.G("Device doesn't exist"))
 			}
 			delete(profile.Devices, devname)
 		}
@@ -492,7 +492,7 @@ func (c *cmdConfigDeviceRemove) Run(cmd *cobra.Command, args []string) error {
 			if !ok {
 				_, ok := inst.ExpandedDevices[devname]
 				if !ok {
-					return fmt.Errorf(i18n.G("The device doesn't exist"))
+					return fmt.Errorf(i18n.G("Device doesn't exist"))
 				}
 
 				return fmt.Errorf(i18n.G("Device from profile(s) cannot be removed from individual instance. Override device or modify profile instead"))
@@ -586,7 +586,7 @@ func (c *cmdConfigDeviceSet) Run(cmd *cobra.Command, args []string) error {
 
 		dev, ok := profile.Devices[devname]
 		if !ok {
-			return fmt.Errorf(i18n.G("The device doesn't exist"))
+			return fmt.Errorf(i18n.G("Device doesn't exist"))
 		}
 
 		for k, v := range keys {
@@ -607,7 +607,7 @@ func (c *cmdConfigDeviceSet) Run(cmd *cobra.Command, args []string) error {
 		if !ok {
 			_, ok = inst.ExpandedDevices[devname]
 			if !ok {
-				return fmt.Errorf(i18n.G("The device doesn't exist"))
+				return fmt.Errorf(i18n.G("Device doesn't exist"))
 			}
 
 			return fmt.Errorf(i18n.G("Device from profile(s) cannot be modified for individual instance. Override device or modify profile instead"))

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1280,9 +1280,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1359,12 +1359,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr "Gerät %s wurde zu %s hinzugefügt\n"
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, fuzzy, c-format
 msgid "Device %s overridden for %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, fuzzy, c-format
 msgid "Device %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
@@ -1373,6 +1373,28 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #, fuzzy, c-format
 msgid "Device already exists: %s"
 msgstr "entfernte Instanz %s existiert bereits"
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+#, fuzzy
+msgid "Device doesn't exist"
+msgstr "entfernte Instanz %s existiert nicht"
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
+msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
 #, fuzzy, c-format
@@ -2230,7 +2252,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 #, fuzzy
 msgid "List instance devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2666,9 +2688,9 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Missing instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 #, fuzzy
 msgid "Missing name"
 msgstr "Fehlende Zusammenfassung."
@@ -2930,7 +2952,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, fuzzy, c-format
 msgid "No value found in %q"
 msgstr "kein Wert in %q gefunden\n"
@@ -3322,7 +3344,7 @@ msgstr "Entferntes Administrator Passwort"
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3532,12 +3554,12 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 #, fuzzy
 msgid "Set device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3546,7 +3568,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3696,7 +3718,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 #, fuzzy
 msgid "Show full device configuration"
 msgstr "Geräte zu Containern oder Profilen hinzufügen"
@@ -3994,16 +4016,10 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 #, fuzzy
 msgid "The device already exists"
 msgstr "entfernte Instanz %s existiert bereits"
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-#, fuzzy
-msgid "The device doesn't exist"
-msgstr "entfernte Instanz %s existiert nicht"
 
 #: lxc/delete.go:105
 msgid "The instance is currently running, stop it first or pass --force"
@@ -4029,7 +4045,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 #, fuzzy
 msgid "The profile device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -4204,7 +4220,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unset all profiles on the target instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 #, fuzzy
 msgid "Unset device configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -4612,7 +4628,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>"
@@ -4622,7 +4638,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
@@ -4630,7 +4646,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
@@ -4646,7 +4662,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
@@ -4654,7 +4670,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
@@ -5041,7 +5057,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 #, fuzzy
 msgid "[<remote>:]<profile>"
@@ -5050,7 +5066,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
@@ -5058,7 +5074,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
@@ -5090,7 +5106,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1058,9 +1058,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1135,12 +1135,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1148,6 +1148,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1960,7 +1981,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2356,9 +2377,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2607,7 +2628,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2988,7 +3009,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3183,11 +3204,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3196,7 +3217,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3340,7 +3361,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3618,13 +3639,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3651,7 +3667,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3820,7 +3836,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4083,16 +4099,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4100,11 +4116,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4292,16 +4308,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4317,7 +4333,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -960,7 +960,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1220,9 +1220,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1297,12 +1297,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1311,6 +1311,28 @@ msgstr ""
 #, c-format
 msgid "Device already exists: %s"
 msgstr "El dispostivo ya existe: %s"
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+#, fuzzy
+msgid "Device doesn't exist"
+msgstr "El dispostivo ya existe: %s"
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
+msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
 #, fuzzy, c-format
@@ -2129,7 +2151,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2529,9 +2551,9 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Missing instance name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2781,7 +2803,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -3165,7 +3187,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3364,11 +3386,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3377,7 +3399,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3521,7 +3543,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3799,13 +3821,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3832,7 +3849,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -4001,7 +4018,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4294,18 +4311,18 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4315,12 +4332,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4552,18 +4569,18 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4583,7 +4600,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -999,7 +999,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1294,9 +1294,9 @@ msgstr "Récupération de l'image : %s"
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1372,12 +1372,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr "Périphérique %s ajouté à %s"
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, fuzzy, c-format
 msgid "Device %s overridden for %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "Périphérique %s retiré de %s"
@@ -1386,6 +1386,28 @@ msgstr "Périphérique %s retiré de %s"
 #, fuzzy, c-format
 msgid "Device already exists: %s"
 msgstr "le serveur distant %s existe déjà"
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+#, fuzzy
+msgid "Device doesn't exist"
+msgstr "Le périphérique n'existe pas"
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
+msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
 #, fuzzy, c-format
@@ -2252,7 +2274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 #, fuzzy
 msgid "List instance devices"
 msgstr "Création du conteneur"
@@ -2730,9 +2752,9 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Missing instance name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 #, fuzzy
 msgid "Missing name"
 msgstr "Résumé manquant."
@@ -2997,7 +3019,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -3404,7 +3426,7 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -3632,12 +3654,12 @@ msgstr "Protocole du serveur (lxd ou simplestreams)"
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 #, fuzzy
 msgid "Set device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3646,7 +3668,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3798,7 +3820,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 #, fuzzy
 msgid "Show full device configuration"
 msgstr "Afficher la configuration étendue"
@@ -4101,14 +4123,9 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 #, fuzzy
 msgid "The device already exists"
-msgstr "Le périphérique n'existe pas"
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr "Le périphérique n'existe pas"
 
 #: lxc/delete.go:105
@@ -4142,7 +4159,7 @@ msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 #, fuzzy
 msgid "The profile device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
@@ -4317,7 +4334,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 #, fuzzy
 msgid "Unset device configuration keys"
 msgstr "Clé de configuration invalide"
@@ -4752,7 +4769,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>"
@@ -4765,7 +4782,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
@@ -4773,7 +4790,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
@@ -4789,7 +4806,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
@@ -4797,7 +4814,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
@@ -5238,7 +5255,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 #, fuzzy
 msgid "[<remote>:]<profile>"
@@ -5247,7 +5264,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
@@ -5255,7 +5272,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
@@ -5287,7 +5304,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -947,7 +947,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1209,9 +1209,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1286,12 +1286,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1300,6 +1300,28 @@ msgstr ""
 #, c-format
 msgid "Device already exists: %s"
 msgstr "La periferica esiste già: %s"
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+#, fuzzy
+msgid "Device doesn't exist"
+msgstr "il remote %s non esiste"
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
+msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
 #, c-format
@@ -2120,7 +2142,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 #, fuzzy
 msgid "List instance devices"
 msgstr "Creazione del container in corso"
@@ -2523,9 +2545,9 @@ msgstr "Il nome del container è: %s"
 msgid "Missing instance name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2774,7 +2796,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -3158,7 +3180,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "Creazione del container in corso"
@@ -3358,11 +3380,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3371,7 +3393,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3515,7 +3537,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3795,14 +3817,9 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
 msgstr "La periferica esiste già"
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
-msgstr ""
 
 #: lxc/delete.go:105
 msgid "The instance is currently running, stop it first or pass --force"
@@ -3828,7 +3845,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 #, fuzzy
 msgid "The profile device doesn't exist"
 msgstr "il remote %s non esiste"
@@ -3999,7 +4016,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4294,18 +4311,18 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -4315,12 +4332,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr "Creazione del container in corso"
@@ -4552,18 +4569,18 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -4583,7 +4600,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr "Creazione del container in corso"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: 2021-07-25 13:36+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr "LXD サーバ内で、またはサーバ間でインスタンスをコピーします"
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr "プロファイルに継承されたデバイスをコピーし、設定キーを上書きします"
 
@@ -1227,9 +1227,9 @@ msgstr "警告を削除します"
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1304,12 +1304,12 @@ msgstr "プロファイルからストレージボリュームを取り外しま
 msgid "Device %s added to %s"
 msgstr "デバイス %s が %s に追加されました"
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr "デバイス %s が %s で上書きされました"
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "デバイス %s が %s から削除されました"
@@ -1318,6 +1318,28 @@ msgstr "デバイス %s が %s から削除されました"
 #, c-format
 msgid "Device already exists: %s"
 msgstr "デバイスは既に存在します: %s"
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+#, fuzzy
+msgid "Device doesn't exist"
+msgstr "デバイスが存在しません"
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
+msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
 #, c-format
@@ -2214,7 +2236,7 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr "インスタンスのデバイスを一覧表示します"
 
@@ -2735,9 +2757,9 @@ msgstr "クラスターメンバー名がありません"
 msgid "Missing instance name"
 msgstr "インスタンス名を指定する必要があります"
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr "名前を指定する必要があります"
 
@@ -2990,7 +3012,7 @@ msgstr "コピー元のボリュームに対するストレージプールが指
 msgid "No storage pool for target volume specified"
 msgstr "コピー先のボリュームに対するストレージプールが指定されていません"
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr "%q に設定する値が指定されていません"
@@ -3373,7 +3395,7 @@ msgstr "エイリアスを削除します"
 msgid "Remove all rules that match"
 msgstr "マッチするルールをすべて削除します"
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr "インスタンスのデバイスを削除します"
 
@@ -3575,11 +3597,11 @@ msgstr "サーバのプロトコル (lxd or simplestreams)"
 msgid "Server version: %s\n"
 msgstr "サーバのバージョン: %s\n"
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr "デバイスの設定項目を設定します"
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3592,7 +3614,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3768,7 +3790,7 @@ msgstr "バックグラウンド操作の詳細を表示します"
 msgid "Show events from all projects"
 msgstr "すべてのプロジェクトのイベントを表示します"
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr "デバイスの設定をすべて表示します"
 
@@ -4046,14 +4068,9 @@ msgstr "--storage と --target は同時に指定できません"
 msgid "The destination LXD server is not clustered"
 msgstr "移動先の LXD サーバはクラスタに属していません"
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
 msgstr "デバイスはすでに存在します"
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
-msgstr "デバイスが存在しません"
 
 #: lxc/delete.go:105
 msgid "The instance is currently running, stop it first or pass --force"
@@ -4084,7 +4101,7 @@ msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 "ローカルイメージ '%s' が見つかりません。代わりに '%s:' を試してみてください。"
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr "プロファイルのデバイスが存在しません"
 
@@ -4273,7 +4290,7 @@ msgstr "未知のファイルタイプ '%s'"
 msgid "Unset all profiles on the target instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr "デバイスの設定を削除します"
 
@@ -4544,16 +4561,16 @@ msgstr "[<remote>:]<image> [<target>]"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr "[<remote>:]<instance>"
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr "[<remote>:]<instance> <device> <key>"
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr "[<remote>:]<instance> <device> <key>=<value>..."
 
@@ -4561,11 +4578,11 @@ msgstr "[<remote>:]<instance> <device> <key>=<value>..."
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr "[<remote>:]<instance> <device> <type> [key=value...]"
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "[<remote>:]<instance> <device> [key=value...]"
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr "[<remote>:]<instance> <name>..."
 
@@ -4758,16 +4775,16 @@ msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr "[<remote>:]<profile>"
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr "[<remote>:]<profile> <device> <key>"
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr "[<remote>:]<profile> <device> <key>=<value>..."
 
@@ -4783,7 +4800,7 @@ msgstr "[<remote>:]<profile> <key>"
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "[<remote>:]<profile> <key><value>..."
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr "[<remote>:]<profile> <name>..."
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2021-07-28 18:02-0400\n"
+        "POT-Creation-Date: 2021-07-29 15:21+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -762,7 +762,7 @@ msgstr  ""
 msgid   "Copy instances within or in between LXD servers"
 msgstr  ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid   "Copy profile inherited devices and override configuration keys"
 msgstr  ""
 
@@ -1004,7 +1004,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:93 lxc/cluster.go:174 lxc/cluster.go:224 lxc/cluster.go:274 lxc/cluster.go:357 lxc/cluster.go:442 lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268 lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523 lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:33 lxc/config_trust.go:77 lxc/config_trust.go:153 lxc/config_trust.go:265 lxc/config_trust.go:345 lxc/config_trust.go:388 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:108 lxc/file.go:157 lxc/file.go:220 lxc/file.go:410 lxc/image.go:38 lxc/image.go:144 lxc/image.go:290 lxc/image.go:341 lxc/image.go:466 lxc/image.go:625 lxc/image.go:845 lxc/image.go:980 lxc/image.go:1278 lxc/image.go:1357 lxc/image.go:1416 lxc/image.go:1468 lxc/image.go:1524 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50 lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33 lxc/network.go:116 lxc/network.go:201 lxc/network.go:274 lxc/network.go:348 lxc/network.go:398 lxc/network.go:483 lxc/network.go:568 lxc/network.go:691 lxc/network.go:749 lxc/network.go:829 lxc/network.go:924 lxc/network.go:993 lxc/network.go:1043 lxc/network.go:1113 lxc/network.go:1175 lxc/network_acl.go:30 lxc/network_acl.go:91 lxc/network_acl.go:161 lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346 lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564 lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677 lxc/network_acl.go:798 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:238 lxc/storage_volume.go:326 lxc/storage_volume.go:493 lxc/storage_volume.go:572 lxc/storage_volume.go:648 lxc/storage_volume.go:730 lxc/storage_volume.go:811 lxc/storage_volume.go:1011 lxc/storage_volume.go:1099 lxc/storage_volume.go:1186 lxc/storage_volume.go:1370 lxc/storage_volume.go:1402 lxc/storage_volume.go:1515 lxc/storage_volume.go:1591 lxc/storage_volume.go:1690 lxc/storage_volume.go:1724 lxc/storage_volume.go:1822 lxc/storage_volume.go:1889 lxc/storage_volume.go:2030 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:93 lxc/cluster.go:174 lxc/cluster.go:224 lxc/cluster.go:274 lxc/cluster.go:357 lxc/cluster.go:442 lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:33 lxc/config_trust.go:77 lxc/config_trust.go:153 lxc/config_trust.go:265 lxc/config_trust.go:345 lxc/config_trust.go:388 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:108 lxc/file.go:157 lxc/file.go:220 lxc/file.go:410 lxc/image.go:38 lxc/image.go:144 lxc/image.go:290 lxc/image.go:341 lxc/image.go:466 lxc/image.go:625 lxc/image.go:845 lxc/image.go:980 lxc/image.go:1278 lxc/image.go:1357 lxc/image.go:1416 lxc/image.go:1468 lxc/image.go:1524 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:34 lxc/init.go:40 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50 lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33 lxc/network.go:116 lxc/network.go:201 lxc/network.go:274 lxc/network.go:348 lxc/network.go:398 lxc/network.go:483 lxc/network.go:568 lxc/network.go:691 lxc/network.go:749 lxc/network.go:829 lxc/network.go:924 lxc/network.go:993 lxc/network.go:1043 lxc/network.go:1113 lxc/network.go:1175 lxc/network_acl.go:30 lxc/network_acl.go:91 lxc/network_acl.go:161 lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346 lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564 lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677 lxc/network_acl.go:798 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:238 lxc/storage_volume.go:326 lxc/storage_volume.go:493 lxc/storage_volume.go:572 lxc/storage_volume.go:648 lxc/storage_volume.go:730 lxc/storage_volume.go:811 lxc/storage_volume.go:1011 lxc/storage_volume.go:1099 lxc/storage_volume.go:1186 lxc/storage_volume.go:1370 lxc/storage_volume.go:1402 lxc/storage_volume.go:1515 lxc/storage_volume.go:1591 lxc/storage_volume.go:1690 lxc/storage_volume.go:1724 lxc/storage_volume.go:1822 lxc/storage_volume.go:1889 lxc/storage_volume.go:2030 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid   "Description"
 msgstr  ""
 
@@ -1029,12 +1029,12 @@ msgstr  ""
 msgid   "Device %s added to %s"
 msgstr  ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid   "Device %s overridden for %s"
 msgstr  ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid   "Device %s removed from %s"
 msgstr  ""
@@ -1042,6 +1042,22 @@ msgstr  ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid   "Device already exists: %s"
+msgstr  ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475 lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid   "Device doesn't exist"
+msgstr  ""
+
+#: lxc/config_device.go:613
+msgid   "Device from profile(s) cannot be modified for individual instance. Override device or modify profile instead"
+msgstr  ""
+
+#: lxc/config_device.go:498
+msgid   "Device from profile(s) cannot be removed from individual instance. Override device or modify profile instead"
+msgstr  ""
+
+#: lxc/config_device.go:252
+msgid   "Device from profile(s) cannot be retrieved for individual instance"
 msgstr  ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1823,7 +1839,7 @@ msgid   "List images\n"
         "    t - Type"
 msgstr  ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid   "List instance devices"
 msgstr  ""
 
@@ -2200,7 +2216,7 @@ msgstr  ""
 msgid   "Missing instance name"
 msgstr  ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297 lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558 lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303 lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570 lxc/config_device.go:675
 msgid   "Missing name"
 msgstr  ""
 
@@ -2425,7 +2441,7 @@ msgstr  ""
 msgid   "No storage pool for target volume specified"
 msgstr  ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid   "No value found in %q"
 msgstr  ""
@@ -2801,7 +2817,7 @@ msgstr  ""
 msgid   "Remove all rules that match"
 msgstr  ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid   "Remove instance devices"
 msgstr  ""
 
@@ -2993,18 +3009,18 @@ msgstr  ""
 msgid   "Server version: %s\n"
 msgstr  ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid   "Set device configuration keys"
 msgstr  ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid   "Set device configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr  ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid   "Set device configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -3132,7 +3148,7 @@ msgstr  ""
 msgid   "Show events from all projects"
 msgstr  ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid   "Show full device configuration"
 msgstr  ""
 
@@ -3408,12 +3424,8 @@ msgstr  ""
 msgid   "The destination LXD server is not clustered"
 msgstr  ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid   "The device already exists"
-msgstr  ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469 lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid   "The device doesn't exist"
 msgstr  ""
 
 #: lxc/delete.go:105
@@ -3438,7 +3450,7 @@ msgstr  ""
 msgid   "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr  ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid   "The profile device doesn't exist"
 msgstr  ""
 
@@ -3597,7 +3609,7 @@ msgstr  ""
 msgid   "Unset all profiles on the target instance"
 msgstr  ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid   "Unset device configuration keys"
 msgstr  ""
 
@@ -3849,15 +3861,15 @@ msgstr  ""
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53 lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53 lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid   "[<remote>:]<instance>"
 msgstr  ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid   "[<remote>:]<instance> <device> <key>"
 msgstr  ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid   "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr  ""
 
@@ -3865,11 +3877,11 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr  ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid   "[<remote>:]<instance> <device> [key=value...]"
 msgstr  ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid   "[<remote>:]<instance> <name>..."
 msgstr  ""
 
@@ -4049,15 +4061,15 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr  ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301 lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301 lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid   "[<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid   "[<remote>:]<profile> <device> <key>"
 msgstr  ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid   "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr  ""
 
@@ -4073,7 +4085,7 @@ msgstr  ""
 msgid   "[<remote>:]<profile> <key><value>..."
 msgstr  ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid   "[<remote>:]<profile> <name>..."
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -939,7 +939,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1192,9 +1192,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1269,12 +1269,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1282,6 +1282,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -2091,7 +2112,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2485,9 +2506,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2734,7 +2755,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -3115,7 +3136,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3310,11 +3331,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3323,7 +3344,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3467,7 +3488,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3745,13 +3766,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3778,7 +3794,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3947,7 +3963,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4210,16 +4226,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4227,11 +4243,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4419,16 +4435,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4444,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -957,7 +957,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1210,9 +1210,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1287,12 +1287,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1300,6 +1300,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -2109,7 +2130,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2503,9 +2524,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2752,7 +2773,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -3133,7 +3154,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3328,11 +3349,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3341,7 +3362,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3485,7 +3506,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3763,13 +3784,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3796,7 +3812,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3965,7 +3981,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4228,16 +4244,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4245,11 +4261,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4437,16 +4453,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4462,7 +4478,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr "Copiar imagens entre servidores"
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1251,9 +1251,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1330,12 +1330,12 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Device %s added to %s"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr "Dispositivo %s sobreposto em %s"
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "Dispositivo %s removido de %s"
@@ -1344,6 +1344,28 @@ msgstr "Dispositivo %s removido de %s"
 #, c-format
 msgid "Device already exists: %s"
 msgstr "O dispositivo já existe: %s"
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+#, fuzzy
+msgid "Device doesn't exist"
+msgstr "Alias %s não existe"
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
+msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
 #, fuzzy, c-format
@@ -2170,7 +2192,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2575,9 +2597,9 @@ msgstr "Nome de membro do cluster"
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2825,7 +2847,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -3211,7 +3233,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3416,12 +3438,12 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 #, fuzzy
 msgid "Set device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3430,7 +3452,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3579,7 +3601,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 #, fuzzy
 msgid "Show full device configuration"
 msgstr "Adicionar dispositivos aos containers ou perfis"
@@ -3868,13 +3890,8 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3901,7 +3918,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -4071,7 +4088,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 #, fuzzy
 msgid "Unset device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -4351,16 +4368,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4368,11 +4385,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4565,17 +4582,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Criar perfis"
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4591,7 +4608,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: 2020-10-08 08:16+0000\n"
 "Last-Translator: Artem <KovalevArtem.ru@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -975,7 +975,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1243,9 +1243,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1321,12 +1321,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1334,6 +1334,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -2161,7 +2182,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 #, fuzzy
 msgid "List instance devices"
 msgstr "Копирование образа: %s"
@@ -2571,9 +2592,9 @@ msgstr "Копирование образа: %s"
 msgid "Missing instance name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2827,7 +2848,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -3209,7 +3230,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3412,11 +3433,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3425,7 +3446,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3570,7 +3591,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3855,13 +3876,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3888,7 +3904,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -4057,7 +4073,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4437,7 +4453,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>"
@@ -4446,7 +4462,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
@@ -4454,7 +4470,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
@@ -4470,7 +4486,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
@@ -4478,7 +4494,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
@@ -4846,7 +4862,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 #, fuzzy
 msgid "[<remote>:]<profile>"
@@ -4855,7 +4871,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
@@ -4863,7 +4879,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
@@ -4895,7 +4911,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: 2020-11-05 02:45+0000\n"
 "Last-Translator: wdggg <wdggg7@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -855,7 +855,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1108,9 +1108,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1185,12 +1185,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1198,6 +1198,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -2007,7 +2028,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2401,9 +2422,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2650,7 +2671,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -3031,7 +3052,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3226,11 +3247,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3239,7 +3260,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3383,7 +3404,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3661,13 +3682,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3694,7 +3710,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3863,7 +3879,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4126,16 +4142,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4143,11 +4159,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4335,16 +4351,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4360,7 +4376,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-07-28 18:02-0400\n"
+"POT-Creation-Date: 2021-07-29 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Copy instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/config_device.go:338 lxc/config_device.go:339
+#: lxc/config_device.go:344 lxc/config_device.go:345
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1054,9 +1054,9 @@ msgstr ""
 #: lxc/cluster.go:593 lxc/cluster.go:655 lxc/cluster.go:753 lxc/cluster.go:832
 #: lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455
 #: lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:268
-#: lxc/config_device.go:339 lxc/config_device.go:432 lxc/config_device.go:523
-#: lxc/config_device.go:530 lxc/config_device.go:634 lxc/config_device.go:706
+#: lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274
+#: lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535
+#: lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723
 #: lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:177 lxc/config_template.go:28
 #: lxc/config_template.go:68 lxc/config_template.go:111
@@ -1131,12 +1131,12 @@ msgstr ""
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:409
+#: lxc/config_device.go:415
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:516
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1144,6 +1144,27 @@ msgstr ""
 #: lxc/utils.go:136 lxc/utils.go:160
 #, c-format
 msgid "Device already exists: %s"
+msgstr ""
+
+#: lxc/config_device.go:235 lxc/config_device.go:249 lxc/config_device.go:475
+#: lxc/config_device.go:495 lxc/config_device.go:589 lxc/config_device.go:610
+msgid "Device doesn't exist"
+msgstr ""
+
+#: lxc/config_device.go:613
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:498
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
+msgstr ""
+
+#: lxc/config_device.go:252
+msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
 #: lxc/info.go:261 lxc/info.go:285
@@ -1953,7 +1974,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:267 lxc/config_device.go:268
+#: lxc/config_device.go:273 lxc/config_device.go:274
 msgid "List instance devices"
 msgstr ""
 
@@ -2347,9 +2368,9 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:297
-#: lxc/config_device.go:363 lxc/config_device.go:456 lxc/config_device.go:558
-#: lxc/config_device.go:658
+#: lxc/config_device.go:113 lxc/config_device.go:220 lxc/config_device.go:303
+#: lxc/config_device.go:369 lxc/config_device.go:462 lxc/config_device.go:570
+#: lxc/config_device.go:675
 msgid "Missing name"
 msgstr ""
 
@@ -2596,7 +2617,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:124 lxc/config_device.go:387
+#: lxc/config_device.go:124 lxc/config_device.go:393
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -2977,7 +2998,7 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: lxc/config_device.go:431 lxc/config_device.go:432
+#: lxc/config_device.go:437 lxc/config_device.go:438
 msgid "Remove instance devices"
 msgstr ""
 
@@ -3172,11 +3193,11 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config_device.go:520
+#: lxc/config_device.go:532
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:523
+#: lxc/config_device.go:535
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3185,7 +3206,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:530
+#: lxc/config_device.go:542
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -3329,7 +3350,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:633 lxc/config_device.go:634
+#: lxc/config_device.go:650 lxc/config_device.go:651
 msgid "Show full device configuration"
 msgstr ""
 
@@ -3607,13 +3628,8 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:375
+#: lxc/config_device.go:140 lxc/config_device.go:157 lxc/config_device.go:381
 msgid "The device already exists"
-msgstr ""
-
-#: lxc/config_device.go:235 lxc/config_device.go:247 lxc/config_device.go:469
-#: lxc/config_device.go:487 lxc/config_device.go:577 lxc/config_device.go:596
-msgid "The device doesn't exist"
 msgstr ""
 
 #: lxc/delete.go:105
@@ -3640,7 +3656,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/config_device.go:380
+#: lxc/config_device.go:386
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -3809,7 +3825,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:705 lxc/config_device.go:706
+#: lxc/config_device.go:722 lxc/config_device.go:723
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -4072,16 +4088,16 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:271 lxc/config_device.go:629 lxc/config_metadata.go:53
+#: lxc/config_device.go:277 lxc/config_device.go:646 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:175 lxc/config_template.go:237 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:191 lxc/config_device.go:701
+#: lxc/config_device.go:191 lxc/config_device.go:718
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:522
+#: lxc/config_device.go:534
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -4089,11 +4105,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:337
+#: lxc/config_device.go:343
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:426
+#: lxc/config_device.go:432
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -4281,16 +4297,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/config_device.go:273 lxc/config_device.go:631 lxc/profile.go:301
+#: lxc/config_device.go:279 lxc/config_device.go:648 lxc/profile.go:301
 #: lxc/profile.go:354 lxc/profile.go:405 lxc/profile.go:823
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:193 lxc/config_device.go:703
+#: lxc/config_device.go:193 lxc/config_device.go:720
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:529
+#: lxc/config_device.go:541
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -4306,7 +4322,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/config_device.go:428
+#: lxc/config_device.go:434
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 


### PR DESCRIPTION
This closes #9054.
