### PR TITLE
lxd/cgroup: Fix handling of non-systemd cgroup2

### DIFF
--- a/lxd/cgroup/file.go
+++ b/lxd/cgroup/file.go
@@ -42,7 +42,7 @@ func NewFileReadWriter(pid int, unifiedCapable bool) (*CGroup, error) {
 				path = filepath.Join("/sys/fs/cgroup", fields[2])
 			}
 
-			if fields[2] != "/init.scope" {
+			if fields[2] == "/init.scope" {
 				path = filepath.Dir(path)
 			}
 		}


### PR DESCRIPTION
The logic present in the filesystem-based cgroup reader was backwards
and should only extract the parent directory when the cgroup IS
/init.slice and not on other systems. This was leading the cgroup path
to be /sys/fs/ instead of /sys/fs/cgroup/ on non-systemd cgroup2
installs.

Closes #8896

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>