### PR TITLE
Generator: Parameterized delete

### DIFF
--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -585,8 +585,7 @@ func projectChange(d *Daemon, project *db.Project, req api.ProjectPut) response.
 				}
 			} else {
 				// Delete the project-specific default profile.
-				filter := db.ProfileFilter{Project: project.Name, Name: projecthelpers.Default}
-				err = tx.DeleteProfile(filter)
+				err = tx.DeleteProfile(project.Name, projecthelpers.Default)
 				if err != nil {
 					return errors.Wrap(err, "Delete project default profile")
 				}
@@ -746,7 +745,7 @@ func projectDelete(d *Daemon, r *http.Request) response.Response {
 			return errors.Wrapf(err, "Fetch project id %q", name)
 		}
 
-		return tx.DeleteProject(db.ProjectFilter{Name: name})
+		return tx.DeleteProject(name)
 	})
 
 	if err != nil {

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -958,8 +958,7 @@ func Purge(cluster *db.Cluster, name string) error {
 			return errors.Wrapf(err, "Failed to remove member %q", name)
 		}
 
-		filter := db.CertificateFilter{Name: name, Type: db.CertificateTypeServer}
-		err = tx.DeleteCertificates(filter)
+		err = tx.DeleteCertificates(name, db.CertificateTypeServer)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to remove member %q certificate from trust store", name)
 		}

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -32,8 +32,8 @@ import (
 //go:generate mapper method -p db -e certificate Exists struct=Certificate
 //go:generate mapper method -p db -e certificate Create struct=Certificate
 //go:generate mapper method -p db -e certificate ProjectsRef
-//go:generate mapper method -p db -e certificate DeleteOne
-//go:generate mapper method -p db -e certificate DeleteMany
+//go:generate mapper method -p db -e certificate DeleteOne-by-Fingerprint
+//go:generate mapper method -p db -e certificate DeleteMany-by-Name-and-Type
 //go:generate mapper method -p db -e certificate Update struct=Certificate
 
 // CertificateType indicates the type of the certificate.

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -165,7 +165,7 @@ func (c *Cluster) CreateCertificate(cert Certificate) (int64, error) {
 // DeleteCertificate deletes a certificate from the db.
 func (c *Cluster) DeleteCertificate(fingerprint string) error {
 	err := c.Transaction(func(tx *ClusterTx) error {
-		return tx.DeleteCertificate(CertificateFilter{Fingerprint: fingerprint})
+		return tx.DeleteCertificate(fingerprint)
 	})
 	return err
 }

--- a/lxd/db/certificates.interface.mapper.go
+++ b/lxd/db/certificates.interface.mapper.go
@@ -30,12 +30,12 @@ type CertificateGenerated interface {
 	CertificateProjectsRef(filter CertificateFilter) (map[string][]string, error)
 
 	// DeleteCertificate deletes the certificate matching the given key parameters.
-	// generator: certificate DeleteOne
-	DeleteCertificate(filter CertificateFilter) error
+	// generator: certificate DeleteOne-by-Fingerprint
+	DeleteCertificate(fingerprint string) error
 
 	// DeleteCertificates deletes the certificate matching the given key parameters.
-	// generator: certificate DeleteMany
-	DeleteCertificates(filter CertificateFilter) error
+	// generator: certificate DeleteMany-by-Name-and-Type
+	DeleteCertificates(name string, certificateType CertificateType) error
 
 	// UpdateCertificate updates the certificate matching the given key parameters.
 	// generator: certificate Update

--- a/lxd/db/certificates.mapper.go
+++ b/lxd/db/certificates.mapper.go
@@ -297,39 +297,10 @@ func (c *ClusterTx) CertificateProjectsRef(filter CertificateFilter) (map[string
 }
 
 // DeleteCertificate deletes the certificate matching the given key parameters.
-// generator: certificate DeleteOne
-func (c *ClusterTx) DeleteCertificate(filter CertificateFilter) error {
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Fingerprint != "" {
-		criteria["Fingerprint"] = filter.Fingerprint
-	}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-	if filter.Type != -1 {
-		criteria["Type"] = filter.Type
-	}
-
-	// Pick the prepared statement and arguments to use based on active criteria.
-	var stmt *sql.Stmt
-	var args []interface{}
-
-	if criteria["Name"] != nil && criteria["Type"] != nil {
-		stmt = c.stmt(certificateDeleteByNameAndType)
-		args = []interface{}{
-			filter.Name,
-			filter.Type,
-		}
-	} else if criteria["Fingerprint"] != nil {
-		stmt = c.stmt(certificateDeleteByFingerprint)
-		args = []interface{}{
-			filter.Fingerprint,
-		}
-	} else {
-		return fmt.Errorf("No valid filter for certificate delete")
-	}
-	result, err := stmt.Exec(args...)
+// generator: certificate DeleteOne-by-Fingerprint
+func (c *ClusterTx) DeleteCertificate(fingerprint string) error {
+	stmt := c.stmt(certificateDeleteByFingerprint)
+	result, err := stmt.Exec(fingerprint)
 	if err != nil {
 		return errors.Wrap(err, "Delete certificate")
 	}
@@ -346,39 +317,10 @@ func (c *ClusterTx) DeleteCertificate(filter CertificateFilter) error {
 }
 
 // DeleteCertificates deletes the certificate matching the given key parameters.
-// generator: certificate DeleteMany
-func (c *ClusterTx) DeleteCertificates(filter CertificateFilter) error {
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Fingerprint != "" {
-		criteria["Fingerprint"] = filter.Fingerprint
-	}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-	if filter.Type != -1 {
-		criteria["Type"] = filter.Type
-	}
-
-	// Pick the prepared statement and arguments to use based on active criteria.
-	var stmt *sql.Stmt
-	var args []interface{}
-
-	if criteria["Name"] != nil && criteria["Type"] != nil {
-		stmt = c.stmt(certificateDeleteByNameAndType)
-		args = []interface{}{
-			filter.Name,
-			filter.Type,
-		}
-	} else if criteria["Fingerprint"] != nil {
-		stmt = c.stmt(certificateDeleteByFingerprint)
-		args = []interface{}{
-			filter.Fingerprint,
-		}
-	} else {
-		return fmt.Errorf("No valid filter for certificate delete")
-	}
-	result, err := stmt.Exec(args...)
+// generator: certificate DeleteMany-by-Name-and-Type
+func (c *ClusterTx) DeleteCertificates(name string, certificateType CertificateType) error {
+	stmt := c.stmt(certificateDeleteByNameAndType)
+	result, err := stmt.Exec(name, certificateType)
 	if err != nil {
 		return errors.Wrap(err, "Delete certificate")
 	}

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -286,8 +286,7 @@ func OpenCluster(name string, store driver.NodeStore, address, dir string, timeo
 		cluster.NodeID(nodeID)
 
 		// Delete any operation tied to this node
-		filter := OperationFilter{NodeID: nodeID}
-		err = tx.DeleteOperations(filter)
+		err = tx.DeleteOperations(nodeID)
 		if err != nil {
 			return err
 		}

--- a/lxd/db/generate/db/lex.go
+++ b/lxd/db/generate/db/lex.go
@@ -56,6 +56,17 @@ func stmtCodeVar(entity string, kind string, filters ...string) string {
 	return name
 }
 
+// operation returns the kind of operation being performed, without filter fields.
+func operation(kind string) string {
+	return strings.Split(kind, "-by-")[0]
+}
+
+// activeFilters returns the filters mentioned in the command name.
+func activeFilters(kind string) []string {
+	startIndex := strings.Index(kind, "-by-") + len("-by-")
+	return strings.Split(kind[startIndex:], "-and-")
+}
+
 // Return an expression evaluating if a filter should be used (based on active
 // criteria).
 func activeCriteria(filter []string) string {

--- a/lxd/db/generate/db/mapping.go
+++ b/lxd/db/generate/db/mapping.go
@@ -66,6 +66,18 @@ func (m *Mapping) FieldByName(name string) *Field {
 	return nil
 }
 
+// ActiveFilters returns the active filter fields for the kind of method.
+func (m *Mapping) ActiveFilters(kind string) []*Field {
+	names := activeFilters(kind)
+	fields := []*Field{}
+	for _, name := range names {
+		if field := m.FieldByName(name); field != nil {
+			fields = append(fields, field)
+		}
+	}
+	return fields
+}
+
 // FieldColumnName returns the column name of the field with the given name,
 // prefixed with the entity's table name.
 func (m *Mapping) FieldColumnName(name string) string {

--- a/lxd/db/generate/db/mapping.go
+++ b/lxd/db/generate/db/mapping.go
@@ -145,6 +145,42 @@ func (m *Mapping) RefFields() []*Field {
 	return fields
 }
 
+// FieldArgs converts the given fields to function arguments, rendering their
+// name and type.
+func (m *Mapping) FieldArgs(fields []*Field, extra ...string) string {
+	args := []string{}
+
+	for _, field := range fields {
+		name := lex.Minuscule(field.Name)
+		if name == "type" {
+			name = lex.Minuscule(m.Name) + field.Name
+		}
+		arg := fmt.Sprintf("%s %s", name, field.Type.Name)
+		args = append(args, arg)
+	}
+
+	for _, arg := range extra {
+		args = append(args, arg)
+	}
+
+	return strings.Join(args, ", ")
+}
+
+// FieldParams converts the given fields to function parameters, rendering their
+// name.
+func (m *Mapping) FieldParams(fields []*Field) string {
+	args := make([]string, len(fields))
+	for i, field := range fields {
+		name := lex.Minuscule(field.Name)
+		if name == "type" {
+			name = lex.Minuscule(m.Name) + field.Name
+		}
+		args[i] = name
+	}
+
+	return strings.Join(args, ", ")
+}
+
 // Field holds all information about a field in a Go struct that is relevant
 // for database code generation.
 type Field struct {
@@ -233,28 +269,6 @@ func FieldColumns(fields []*Field) string {
 	return strings.Join(columns, ", ")
 }
 
-// FieldArgs converts the given fields to function arguments, rendering their
-// name and type.
-func FieldArgs(fields []*Field) string {
-	args := make([]string, len(fields))
-	for i, field := range fields {
-		args[i] = fmt.Sprintf("%s %s", lex.Minuscule(field.Name), field.Type.Name)
-	}
-
-	return strings.Join(args, ", ")
-}
-
-// FieldParams converts the given fields to function parameters, rendering their
-// name.
-func FieldParams(fields []*Field) string {
-	args := make([]string, len(fields))
-	for i, field := range fields {
-		args[i] = lex.Minuscule(field.Name)
-	}
-
-	return strings.Join(args, ", ")
-}
-
 // FieldCriteria converts the given fields to AND-separated WHERE criteria.
 func FieldCriteria(fields []*Field) string {
 	criteria := make([]string, len(fields))
@@ -264,6 +278,15 @@ func FieldCriteria(fields []*Field) string {
 	}
 
 	return strings.Join(criteria, " AND ")
+}
+
+// FieldNames returns the names of the given fields.
+func FieldNames(fields []*Field) []string {
+	names := []string{}
+	for _, f := range fields {
+		names = append(names, f.Name)
+	}
+	return names
 }
 
 // Type holds all information about a field in a field type that is relevant

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -571,7 +571,7 @@ func (m *Method) id(buf *file.Buffer) error {
 	defer m.end(buf)
 
 	buf.L("stmt := c.stmt(%s)", stmtCodeVar(m.entity, "ID"))
-	buf.L("rows, err := stmt.Query(%s)", FieldParams(nk))
+	buf.L("rows, err := stmt.Query(%s)", mapping.FieldParams(nk))
 	buf.L("if err != nil {")
 	buf.L("        return -1, errors.Wrap(err, \"Failed to get %s ID\")", m.entity)
 	buf.L("}")
@@ -619,7 +619,7 @@ func (m *Method) exists(buf *file.Buffer) error {
 
 	defer m.end(buf)
 
-	buf.L("_, err := c.Get%sID(%s)", lex.Camel(m.entity), FieldParams(nk))
+	buf.L("_, err := c.Get%sID(%s)", lex.Camel(m.entity), mapping.FieldParams(nk))
 	buf.L("if err != nil {")
 	buf.L("        if err == ErrNoSuchObject {")
 	buf.L("                return false, nil")
@@ -770,7 +770,7 @@ func (m *Method) rename(buf *file.Buffer) error {
 	defer m.end(buf)
 
 	buf.L("stmt := c.stmt(%s)", stmtCodeVar(m.entity, "rename"))
-	buf.L("result, err := stmt.Exec(%s)", "to, "+FieldParams(nk))
+	buf.L("result, err := stmt.Exec(%s)", "to, "+mapping.FieldParams(nk))
 	buf.L("if err != nil {")
 	buf.L("        return errors.Wrap(err, \"Rename %s\")", m.entity)
 	buf.L("}")
@@ -821,7 +821,7 @@ func (m *Method) update(buf *file.Buffer) error {
 	}
 
 	//buf.L("id, err := c.Get%s(%s)", lex.Camel(m.entity), FieldArgs(nk))
-	buf.L("id, err := c.Get%sID(%s)", lex.Camel(m.entity), FieldParams(nk))
+	buf.L("id, err := c.Get%sID(%s)", lex.Camel(m.entity), mapping.FieldParams(nk))
 	buf.L("if err != nil {")
 	buf.L("        return errors.Wrap(err, \"Get %s\")", m.entity)
 	buf.L("}")
@@ -1062,15 +1062,15 @@ func (m *Method) signature(buf *file.Buffer, isInterface bool) error {
 		rets = fmt.Sprintf("(%s, error)", lex.Slice(entityType(m.pkg, m.entity)))
 	case "Get":
 		comment = fmt.Sprintf("returns the %s with the given key.", m.entity)
-		args = FieldArgs(mapping.NaturalKey())
+		args = mapping.FieldArgs(mapping.NaturalKey())
 		rets = fmt.Sprintf("(%s, error)", lex.Star(entityType(m.pkg, m.entity)))
 	case "ID":
 		comment = fmt.Sprintf("return the ID of the %s with the given key.", m.entity)
-		args = FieldArgs(mapping.NaturalKey())
+		args = mapping.FieldArgs(mapping.NaturalKey())
 		rets = "(int64, error)"
 	case "Exists":
 		comment = fmt.Sprintf("checks if a %s with the given key exists.", m.entity)
-		args = FieldArgs(mapping.NaturalKey())
+		args = mapping.FieldArgs(mapping.NaturalKey())
 		rets = "(bool, error)"
 	case "Create":
 		entityCreate, ok := m.config["struct"]
@@ -1090,7 +1090,7 @@ func (m *Method) signature(buf *file.Buffer, isInterface bool) error {
 		rets = "(int64, error)"
 	case "Rename":
 		comment = fmt.Sprintf("renames the %s matching the given key parameters.", m.entity)
-		args = FieldArgs(mapping.NaturalKey()) + ", to string"
+		args = mapping.FieldArgs(mapping.NaturalKey(), "to string")
 		rets = "error"
 	case "Update":
 		entityUpdate, ok := m.config["struct"]
@@ -1098,7 +1098,7 @@ func (m *Method) signature(buf *file.Buffer, isInterface bool) error {
 			entityUpdate = entityPut(m.entity)
 		}
 		comment = fmt.Sprintf("updates the %s matching the given key parameters.", m.entity)
-		args = FieldArgs(mapping.NaturalKey()) + fmt.Sprintf(", object %s", entityType(m.pkg, entityUpdate))
+		args = mapping.FieldArgs(mapping.NaturalKey(), fmt.Sprintf("object %s", entityType(m.pkg, entityUpdate)))
 		rets = "error"
 	case "DeleteOne":
 		comment = fmt.Sprintf("deletes the %s matching the given key parameters.", m.entity)

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -44,7 +44,7 @@ func (m *Method) Generate(buf *file.Buffer) error {
 	if strings.HasSuffix(m.kind, "Ref") {
 		return m.ref(buf)
 	}
-	switch m.kind {
+	switch operation(m.kind) {
 	case "URIs":
 		return m.uris(buf)
 	case "List":
@@ -1051,7 +1051,7 @@ func (m *Method) signature(buf *file.Buffer, isInterface bool) error {
 		return nil
 	}
 
-	switch m.kind {
+	switch operation(m.kind) {
 	case "URIs":
 		comment = fmt.Sprintf("returns all available %s URIs.", m.entity)
 		args = fmt.Sprintf("filter %s", entityFilter(m.entity))
@@ -1119,7 +1119,7 @@ func (m *Method) signature(buf *file.Buffer, isInterface bool) error {
 func (m *Method) begin(buf *file.Buffer, comment string, args string, rets string, isInterface bool) {
 	name := ""
 	entity := lex.Camel(m.entity)
-	switch m.kind {
+	switch operation(m.kind) {
 	case "URIs":
 		name = fmt.Sprintf("Get%sURIs", entity)
 	case "List":

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -75,7 +75,7 @@ import (
 //go:generate mapper method -p db -e instance ConfigRef
 //go:generate mapper method -p db -e instance DevicesRef
 //go:generate mapper method -p db -e instance Rename
-//go:generate mapper method -p db -e instance DeleteOne
+//go:generate mapper method -p db -e instance DeleteOne-by-Project-and-Name
 //go:generate mapper method -p db -e instance Update struct=Instance
 
 // Instance is a value object holding db-related details about an instance.

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -726,22 +726,12 @@ SELECT storage_pools.name FROM storage_pools
 func (c *Cluster) DeleteInstance(project, name string) error {
 	if strings.Contains(name, shared.SnapshotDelimiter) {
 		parts := strings.SplitN(name, shared.SnapshotDelimiter, 2)
-		filter := InstanceSnapshotFilter{
-			Project:  project,
-			Instance: parts[0],
-			Name:     parts[1],
-		}
 		return c.Transaction(func(tx *ClusterTx) error {
-			return tx.DeleteInstanceSnapshot(filter)
+			return tx.DeleteInstanceSnapshot(project, parts[0], parts[1])
 		})
 	}
-
-	filter := InstanceFilter{
-		Project: project,
-		Name:    name,
-	}
 	return c.Transaction(func(tx *ClusterTx) error {
-		return tx.DeleteInstance(filter)
+		return tx.DeleteInstance(project, name)
 	})
 }
 

--- a/lxd/db/instances.interface.mapper.go
+++ b/lxd/db/instances.interface.mapper.go
@@ -42,8 +42,8 @@ type InstanceGenerated interface {
 	RenameInstance(project string, name string, to string) error
 
 	// DeleteInstance deletes the instance matching the given key parameters.
-	// generator: instance DeleteOne
-	DeleteInstance(filter InstanceFilter) error
+	// generator: instance DeleteOne-by-Project-and-Name
+	DeleteInstance(project string, name string) error
 
 	// UpdateInstance updates the instance matching the given key parameters.
 	// generator: instance Update

--- a/lxd/db/instances.mapper.go
+++ b/lxd/db/instances.mapper.go
@@ -907,37 +907,10 @@ func (c *ClusterTx) RenameInstance(project string, name string, to string) error
 }
 
 // DeleteInstance deletes the instance matching the given key parameters.
-// generator: instance DeleteOne
-func (c *ClusterTx) DeleteInstance(filter InstanceFilter) error {
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Project != "" {
-		criteria["Project"] = filter.Project
-	}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-	if filter.Node != "" {
-		criteria["Node"] = filter.Node
-	}
-	if filter.Type != -1 {
-		criteria["Type"] = filter.Type
-	}
-
-	// Pick the prepared statement and arguments to use based on active criteria.
-	var stmt *sql.Stmt
-	var args []interface{}
-
-	if criteria["Project"] != nil && criteria["Name"] != nil {
-		stmt = c.stmt(instanceDeleteByProjectAndName)
-		args = []interface{}{
-			filter.Project,
-			filter.Name,
-		}
-	} else {
-		return fmt.Errorf("No valid filter for instance delete")
-	}
-	result, err := stmt.Exec(args...)
+// generator: instance DeleteOne-by-Project-and-Name
+func (c *ClusterTx) DeleteInstance(project string, name string) error {
+	stmt := c.stmt(instanceDeleteByProjectAndName)
+	result, err := stmt.Exec(project, name)
 	if err != nil {
 		return errors.Wrap(err, "Delete instance")
 	}

--- a/lxd/db/operations.go
+++ b/lxd/db/operations.go
@@ -19,8 +19,8 @@ import (
 
 //go:generate mapper method -p db -e operation List
 //go:generate mapper method -p db -e operation CreateOrReplace struct=Operation
-//go:generate mapper method -p db -e operation DeleteOne
-//go:generate mapper method -p db -e operation DeleteMany
+//go:generate mapper method -p db -e operation DeleteOne-by-UUID
+//go:generate mapper method -p db -e operation DeleteMany-by-NodeID
 
 // Operation holds information about a single LXD operation running on a node
 // in the cluster.

--- a/lxd/db/operations.interface.mapper.go
+++ b/lxd/db/operations.interface.mapper.go
@@ -14,10 +14,10 @@ type OperationGenerated interface {
 	CreateOrReplaceOperation(object Operation) (int64, error)
 
 	// DeleteOperation deletes the operation matching the given key parameters.
-	// generator: operation DeleteOne
-	DeleteOperation(filter OperationFilter) error
+	// generator: operation DeleteOne-by-UUID
+	DeleteOperation(uUID string) error
 
 	// DeleteOperations deletes the operation matching the given key parameters.
-	// generator: operation DeleteMany
-	DeleteOperations(filter OperationFilter) error
+	// generator: operation DeleteMany-by-NodeID
+	DeleteOperations(nodeID int64) error
 }

--- a/lxd/db/operations.mapper.go
+++ b/lxd/db/operations.mapper.go
@@ -146,38 +146,10 @@ func (c *ClusterTx) CreateOrReplaceOperation(object Operation) (int64, error) {
 }
 
 // DeleteOperation deletes the operation matching the given key parameters.
-// generator: operation DeleteOne
-func (c *ClusterTx) DeleteOperation(filter OperationFilter) error {
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.ID != -1 {
-		criteria["ID"] = filter.ID
-	}
-	if filter.NodeID != -1 {
-		criteria["NodeID"] = filter.NodeID
-	}
-	if filter.UUID != "" {
-		criteria["UUID"] = filter.UUID
-	}
-
-	// Pick the prepared statement and arguments to use based on active criteria.
-	var stmt *sql.Stmt
-	var args []interface{}
-
-	if criteria["UUID"] != nil {
-		stmt = c.stmt(operationDeleteByUUID)
-		args = []interface{}{
-			filter.UUID,
-		}
-	} else if criteria["NodeID"] != nil {
-		stmt = c.stmt(operationDeleteByNodeID)
-		args = []interface{}{
-			filter.NodeID,
-		}
-	} else {
-		return fmt.Errorf("No valid filter for operation delete")
-	}
-	result, err := stmt.Exec(args...)
+// generator: operation DeleteOne-by-UUID
+func (c *ClusterTx) DeleteOperation(uUID string) error {
+	stmt := c.stmt(operationDeleteByUUID)
+	result, err := stmt.Exec(uUID)
 	if err != nil {
 		return errors.Wrap(err, "Delete operation")
 	}
@@ -194,38 +166,10 @@ func (c *ClusterTx) DeleteOperation(filter OperationFilter) error {
 }
 
 // DeleteOperations deletes the operation matching the given key parameters.
-// generator: operation DeleteMany
-func (c *ClusterTx) DeleteOperations(filter OperationFilter) error {
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.ID != -1 {
-		criteria["ID"] = filter.ID
-	}
-	if filter.NodeID != -1 {
-		criteria["NodeID"] = filter.NodeID
-	}
-	if filter.UUID != "" {
-		criteria["UUID"] = filter.UUID
-	}
-
-	// Pick the prepared statement and arguments to use based on active criteria.
-	var stmt *sql.Stmt
-	var args []interface{}
-
-	if criteria["UUID"] != nil {
-		stmt = c.stmt(operationDeleteByUUID)
-		args = []interface{}{
-			filter.UUID,
-		}
-	} else if criteria["NodeID"] != nil {
-		stmt = c.stmt(operationDeleteByNodeID)
-		args = []interface{}{
-			filter.NodeID,
-		}
-	} else {
-		return fmt.Errorf("No valid filter for operation delete")
-	}
-	result, err := stmt.Exec(args...)
+// generator: operation DeleteMany-by-NodeID
+func (c *ClusterTx) DeleteOperations(nodeID int64) error {
+	stmt := c.stmt(operationDeleteByNodeID)
+	result, err := stmt.Exec(nodeID)
 	if err != nil {
 		return errors.Wrap(err, "Delete operation")
 	}

--- a/lxd/db/operations_test.go
+++ b/lxd/db/operations_test.go
@@ -48,8 +48,7 @@ func TestOperation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "abcd", ops[0].UUID)
 
-	filter = db.OperationFilter{UUID: "abcd"}
-	err = tx.DeleteOperation(filter)
+	err = tx.DeleteOperation("abcd")
 	require.NoError(t, err)
 
 	filter = db.OperationFilter{UUID: "abcd"}
@@ -93,8 +92,7 @@ func TestOperationNoProject(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "abcd", ops[0].UUID)
 
-	filter = db.OperationFilter{UUID: "abcd"}
-	err = tx.DeleteOperation(filter)
+	err = tx.DeleteOperation("abcd")
 	require.NoError(t, err)
 
 	filter = db.OperationFilter{UUID: "abcd"}

--- a/lxd/db/profiles.go
+++ b/lxd/db/profiles.go
@@ -51,7 +51,7 @@ import (
 //go:generate mapper method -p db -e profile UsedByRef
 //go:generate mapper method -p db -e profile Create struct=Profile
 //go:generate mapper method -p db -e profile Rename
-//go:generate mapper method -p db -e profile DeleteOne
+//go:generate mapper method -p db -e profile DeleteOne-by-Project-and-Name
 //go:generate mapper method -p db -e profile Update struct=Profile
 
 // Profile is a value object holding db-related details about a profile.

--- a/lxd/db/profiles.interface.mapper.go
+++ b/lxd/db/profiles.interface.mapper.go
@@ -46,8 +46,8 @@ type ProfileGenerated interface {
 	RenameProfile(project string, name string, to string) error
 
 	// DeleteProfile deletes the profile matching the given key parameters.
-	// generator: profile DeleteOne
-	DeleteProfile(filter ProfileFilter) error
+	// generator: profile DeleteOne-by-Project-and-Name
+	DeleteProfile(project string, name string) error
 
 	// UpdateProfile updates the profile matching the given key parameters.
 	// generator: profile Update

--- a/lxd/db/profiles.mapper.go
+++ b/lxd/db/profiles.mapper.go
@@ -723,31 +723,10 @@ func (c *ClusterTx) RenameProfile(project string, name string, to string) error 
 }
 
 // DeleteProfile deletes the profile matching the given key parameters.
-// generator: profile DeleteOne
-func (c *ClusterTx) DeleteProfile(filter ProfileFilter) error {
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Project != "" {
-		criteria["Project"] = filter.Project
-	}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-
-	// Pick the prepared statement and arguments to use based on active criteria.
-	var stmt *sql.Stmt
-	var args []interface{}
-
-	if criteria["Project"] != nil && criteria["Name"] != nil {
-		stmt = c.stmt(profileDeleteByProjectAndName)
-		args = []interface{}{
-			filter.Project,
-			filter.Name,
-		}
-	} else {
-		return fmt.Errorf("No valid filter for profile delete")
-	}
-	result, err := stmt.Exec(args...)
+// generator: profile DeleteOne-by-Project-and-Name
+func (c *ClusterTx) DeleteProfile(project string, name string) error {
+	stmt := c.stmt(profileDeleteByProjectAndName)
+	result, err := stmt.Exec(project, name)
 	if err != nil {
 		return errors.Wrap(err, "Delete profile")
 	}

--- a/lxd/db/projects.go
+++ b/lxd/db/projects.go
@@ -43,7 +43,7 @@ import (
 //go:generate mapper method -p db -e project UsedByRef
 //go:generate mapper method -p db -e project ID struct=Project
 //go:generate mapper method -p db -e project Rename
-//go:generate mapper method -p db -e project DeleteOne
+//go:generate mapper method -p db -e project DeleteOne-by-Name
 
 // Project represents a LXD project
 type Project struct {

--- a/lxd/db/projects.interface.mapper.go
+++ b/lxd/db/projects.interface.mapper.go
@@ -42,6 +42,6 @@ type ProjectGenerated interface {
 	RenameProject(name string, to string) error
 
 	// DeleteProject deletes the project matching the given key parameters.
-	// generator: project DeleteOne
-	DeleteProject(filter ProjectFilter) error
+	// generator: project DeleteOne-by-Name
+	DeleteProject(name string) error
 }

--- a/lxd/db/projects.mapper.go
+++ b/lxd/db/projects.mapper.go
@@ -451,27 +451,10 @@ func (c *ClusterTx) RenameProject(name string, to string) error {
 }
 
 // DeleteProject deletes the project matching the given key parameters.
-// generator: project DeleteOne
-func (c *ClusterTx) DeleteProject(filter ProjectFilter) error {
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-
-	// Pick the prepared statement and arguments to use based on active criteria.
-	var stmt *sql.Stmt
-	var args []interface{}
-
-	if criteria["Name"] != nil {
-		stmt = c.stmt(projectDeleteByName)
-		args = []interface{}{
-			filter.Name,
-		}
-	} else {
-		return fmt.Errorf("No valid filter for project delete")
-	}
-	result, err := stmt.Exec(args...)
+// generator: project DeleteOne-by-Name
+func (c *ClusterTx) DeleteProject(name string) error {
+	stmt := c.stmt(projectDeleteByName)
+	result, err := stmt.Exec(name)
 	if err != nil {
 		return errors.Wrap(err, "Delete project")
 	}

--- a/lxd/db/snapshots.go
+++ b/lxd/db/snapshots.go
@@ -39,7 +39,7 @@ import (
 //go:generate mapper method -p db -e instance_snapshot ConfigRef
 //go:generate mapper method -p db -e instance_snapshot DevicesRef
 //go:generate mapper method -p db -e instance_snapshot Rename
-//go:generate mapper method -p db -e instance_snapshot DeleteOne
+//go:generate mapper method -p db -e instance_snapshot DeleteOne-by-Project-and-Instance-and-Name
 
 // InstanceSnapshot is a value object holding db-related details about a snapshot.
 type InstanceSnapshot struct {

--- a/lxd/db/snapshots.interface.mapper.go
+++ b/lxd/db/snapshots.interface.mapper.go
@@ -38,6 +38,6 @@ type InstanceSnapshotGenerated interface {
 	RenameInstanceSnapshot(project string, instance string, name string, to string) error
 
 	// DeleteInstanceSnapshot deletes the instance_snapshot matching the given key parameters.
-	// generator: instance_snapshot DeleteOne
-	DeleteInstanceSnapshot(filter InstanceSnapshotFilter) error
+	// generator: instance_snapshot DeleteOne-by-Project-and-Instance-and-Name
+	DeleteInstanceSnapshot(project string, instance string, name string) error
 }

--- a/lxd/db/snapshots.mapper.go
+++ b/lxd/db/snapshots.mapper.go
@@ -587,35 +587,10 @@ func (c *ClusterTx) RenameInstanceSnapshot(project string, instance string, name
 }
 
 // DeleteInstanceSnapshot deletes the instance_snapshot matching the given key parameters.
-// generator: instance_snapshot DeleteOne
-func (c *ClusterTx) DeleteInstanceSnapshot(filter InstanceSnapshotFilter) error {
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Project != "" {
-		criteria["Project"] = filter.Project
-	}
-	if filter.Instance != "" {
-		criteria["Instance"] = filter.Instance
-	}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-
-	// Pick the prepared statement and arguments to use based on active criteria.
-	var stmt *sql.Stmt
-	var args []interface{}
-
-	if criteria["Project"] != nil && criteria["Instance"] != nil && criteria["Name"] != nil {
-		stmt = c.stmt(instanceSnapshotDeleteByProjectAndInstanceAndName)
-		args = []interface{}{
-			filter.Project,
-			filter.Instance,
-			filter.Name,
-		}
-	} else {
-		return fmt.Errorf("No valid filter for instance_snapshot delete")
-	}
-	result, err := stmt.Exec(args...)
+// generator: instance_snapshot DeleteOne-by-Project-and-Instance-and-Name
+func (c *ClusterTx) DeleteInstanceSnapshot(project string, instance string, name string) error {
+	stmt := c.stmt(instanceSnapshotDeleteByProjectAndInstanceAndName)
+	result, err := stmt.Exec(project, instance, name)
 	if err != nil {
 		return errors.Wrap(err, "Delete instance_snapshot")
 	}

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -62,8 +62,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 	suite.Req.Nil(err, "Failed to create the unprivileged profile.")
 	defer func() {
 		suite.d.cluster.Transaction(func(tx *db.ClusterTx) error {
-			filter := db.ProfileFilter{Project: "default", Name: "unprivileged"}
-			return tx.DeleteProfile(filter)
+			return tx.DeleteProfile("default", "unprivileged")
 		})
 	}()
 

--- a/lxd/operations/linux.go
+++ b/lxd/operations/linux.go
@@ -45,8 +45,7 @@ func removeDBOperation(op *Operation) error {
 	}
 
 	err := op.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
-		filter := db.OperationFilter{UUID: op.id}
-		return tx.DeleteOperation(filter)
+		return tx.DeleteOperation(op.id)
 	})
 
 	return err

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -859,8 +859,7 @@ func patchInvalidProfileNames(name string, d *Daemon) error {
 		if strings.Contains(profile, "/") || shared.StringInSlice(profile, []string{".", ".."}) {
 			logger.Info("Removing unreachable profile (invalid name)", log.Ctx{"name": profile})
 			err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
-				filter := db.ProfileFilter{Project: project.Default, Name: profile}
-				return tx.DeleteProfile(filter)
+				return tx.DeleteProfile(project.Default, profile)
 			})
 			if err != nil {
 				return err

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -690,8 +690,7 @@ func profileDelete(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Profile is currently in use")
 		}
 
-		filter := db.ProfileFilter{Project: projectName, Name: name}
-		return tx.DeleteProfile(filter)
+		return tx.DeleteProfile(projectName, name)
 	})
 	if err != nil {
 		return response.SmartError(err)


### PR DESCRIPTION
The goal here is adding explicit arguments to delete, and introducing a few helpers that will come in handy later on as we refactor/change more of the generator.

Main changes: 
* Generated Delete methods now take arguments instead of filters.
* Generating Delete methods now requires arguments to be passed to the generator via -by- statements, as in: `DeleteMany-by-Name-and-Type`.
* Added `ActiveFilters` and `activeFilters` helpers for parsing the `-by-` field into slices of `Field` and `string`, respectively. 
* Added proper handling of fields named `Type` to `FieldArgs` and `FieldParams` by making the functions into methods on `Mapper`. As well, added support for adding additional arguments directly into the methods, so all arguments are handled in one place.