### PR TITLE
Generator: Remove wildcard support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ update-schema:
 	mv lxd/db/generate/lxd-generate $(GOPATH)/bin
 	go generate ./...
 	gofmt -s -w ./lxd/db/
+	goimports -w ./lxd/db/
 	@echo "Code generation completed"
 
 .PHONY: update-api

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -60,7 +60,7 @@ func CertificateAPITypeToDBType(apiType string) (CertificateType, error) {
 // Certificate is here to pass the certificates content from the database around.
 type Certificate struct {
 	ID          int
-	Fingerprint string `db:"primary=yes&comparison=like"`
+	Fingerprint string `db:"primary=yes"`
 	Type        CertificateType
 	Name        string
 	Certificate string
@@ -121,7 +121,7 @@ func (c *ClusterTx) UpdateCertificateProjects(id int, projects []string) error {
 
 // CertificateFilter specifies potential query parameter fields.
 type CertificateFilter struct {
-	Fingerprint string // Matched with LIKE
+	Fingerprint string
 	Name        string
 	Type        CertificateType
 }

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/pkg/errors"
 )
 
 // Code generation directives.
@@ -131,16 +132,47 @@ type CertificateFilter struct {
 // pass a shortform and will get the full fingerprint.
 // There can never be more than one certificate with a given fingerprint, as it is
 // enforced by a UNIQUE constraint in the schema.
-func (c *Cluster) GetCertificate(fingerprint string) (*Certificate, error) {
+func (c *Cluster) GetCertificate(fingerprintPrefix string) (*Certificate, error) {
 	var err error
 	var cert *Certificate
+	objects := []Certificate{}
 	err = c.Transaction(func(tx *ClusterTx) error {
-		cert, err = tx.GetCertificate(fingerprint + "%")
+		sql := `
+SELECT certificates.id, certificates.fingerprint, certificates.type, certificates.name, certificates.certificate, certificates.restricted
+FROM certificates
+WHERE certificates.fingerprint LIKE ?
+ORDER BY certificates.fingerprint
+		`
+		stmt, err := tx.prepare(sql)
 		if err != nil {
 			return err
 		}
+		dest := func(i int) []interface{} {
+			objects = append(objects, Certificate{})
+			return []interface{}{
+				&objects[i].ID,
+				&objects[i].Fingerprint,
+				&objects[i].Type,
+				&objects[i].Name,
+				&objects[i].Certificate,
+				&objects[i].Restricted,
+			}
+		}
 
-		cert, err = tx.GetCertificate(cert.Fingerprint)
+		err = query.SelectObjects(stmt, dest, fingerprintPrefix+"%")
+		if err != nil {
+			return errors.Wrap(err, "Failed to fetch certificates")
+		}
+
+		if len(objects) > 1 {
+			return fmt.Errorf("More than one certificate matches")
+		}
+
+		if len(objects) == 0 {
+			return ErrNoSuchObject
+		}
+
+		cert, err = tx.GetCertificate(objects[0].Fingerprint)
 		return err
 	})
 	if err != nil {

--- a/lxd/db/certificates.mapper.go
+++ b/lxd/db/certificates.mapper.go
@@ -8,6 +8,7 @@ package db
 import (
 	"database/sql"
 	"fmt"
+
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared/api"
@@ -25,7 +26,7 @@ SELECT certificates.id, certificates.fingerprint, certificates.type, certificate
 var certificateObjectsByFingerprint = cluster.RegisterStmt(`
 SELECT certificates.id, certificates.fingerprint, certificates.type, certificates.name, certificates.certificate, certificates.restricted
   FROM certificates
-  WHERE certificates.fingerprint LIKE ? ORDER BY certificates.fingerprint
+  WHERE certificates.fingerprint = ? ORDER BY certificates.fingerprint
 `)
 
 var certificateProjectsRef = cluster.RegisterStmt(`

--- a/lxd/db/certificates_test.go
+++ b/lxd/db/certificates_test.go
@@ -19,7 +19,7 @@ func TestGetCertificate(t *testing.T) {
 	_, err := tx.CreateCertificate(db.Certificate{Fingerprint: "foobar"})
 	require.NoError(t, err)
 
-	cert, err := tx.GetCertificate("foo%")
+	cert, err := tx.GetCertificate("foobar")
 	require.NoError(t, err)
 	assert.Equal(t, cert.Fingerprint, "foobar")
 }

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -159,13 +159,6 @@ func (m *Method) getMany(buf *file.Buffer) error {
 		return errors.Wrap(err, "Parse entity struct")
 	}
 
-	criteria, err := Criteria(m.packages["db"], m.entity)
-	if err != nil {
-		return errors.Wrap(err, "Parse filter struct")
-	}
-
-	filters := FiltersFromStmt(m.packages["db"], "objects", m.entity)
-
 	// Go type name the objects to return (e.g. api.Foo).
 	typ := entityType(m.pkg, m.entity)
 
@@ -178,61 +171,72 @@ func (m *Method) getMany(buf *file.Buffer) error {
 	buf.L("// Result slice.")
 	buf.L("objects := make(%s, 0)", lex.Slice(typ))
 	buf.N()
-	buf.L("// Check which filter criteria are active.")
-	buf.L("criteria := map[string]interface{}{}")
 
-	for _, name := range criteria {
-		var zero string
-		if name == "Parent" {
-			zero = `""`
-		} else {
-			field := mapping.FieldByName(name)
-			if field == nil {
-				return fmt.Errorf("No field named %q in filter struct", name)
-			}
-			zero = field.ZeroValue()
+	filters := FiltersFromStmt(m.packages["db"], "objects", m.entity)
+	if len(filters) == 0 {
+		buf.L("stmt := c.stmt(%s)", stmtCodeVar(m.entity, "objects"))
+		buf.L("args := []interface{}{}")
+	} else {
+		buf.L("// Check which filter criteria are active.")
+		buf.L("criteria := map[string]interface{}{}")
+		criteria, err := Criteria(m.packages["db"], m.entity)
+		if err != nil {
+			return errors.Wrap(err, "Parse filter struct")
 		}
-		buf.L("if filter.%s != %s {", name, zero)
-		buf.L("        criteria[%q] = filter.%s", name, name)
-		buf.L("}")
-	}
 
-	buf.N()
-	buf.L("// Pick the prepared statement and arguments to use based on active criteria.")
-	buf.L("var stmt *sql.Stmt")
-	buf.L("var args []interface{}")
-	buf.N()
-
-	for i, filter := range filters {
-		branch := "if"
-		if i > 0 {
-			branch = "} else if"
-		}
-		buf.L("%s %s {", branch, activeCriteria(filter))
-
-		buf.L("stmt = c.stmt(%s)", stmtCodeVar(m.entity, "objects", filter...))
-		buf.L("args = []interface{}{")
-
-		for _, name := range filter {
+		for _, name := range criteria {
+			var zero string
 			if name == "Parent" {
-				buf.L("len(filter.Parent)+1,")
-				buf.L("filter.%s+\"/\",", name)
+				zero = `""`
 			} else {
-				buf.L("filter.%s,", name)
+				field := mapping.FieldByName(name)
+				if field == nil {
+					return fmt.Errorf("No field named %q in filter struct", name)
+				}
+				zero = field.ZeroValue()
+			}
+			buf.L("if filter.%s != %s {", name, zero)
+			buf.L("        criteria[%q] = filter.%s", name, name)
+			buf.L("}")
+		}
+
+		buf.N()
+		buf.L("// Pick the prepared statement and arguments to use based on active criteria.")
+		buf.L("var stmt *sql.Stmt")
+		buf.L("var args []interface{}")
+		buf.N()
+
+		for i, filter := range filters {
+			branch := "if"
+			if i > 0 {
+				branch = "} else if"
+			}
+			buf.L("%s %s {", branch, activeCriteria(filter))
+
+			buf.L("stmt = c.stmt(%s)", stmtCodeVar(m.entity, "objects", filter...))
+			buf.L("args = []interface{}{")
+
+			for _, name := range filter {
+				if name == "Parent" {
+					buf.L("len(filter.Parent)+1,")
+					buf.L("filter.%s+\"/\",", name)
+				} else {
+					buf.L("filter.%s,", name)
+				}
+			}
+
+			buf.L("}")
+
+			// Last branch, no filter to use.
+			if i == len(filters)-1 {
+				buf.L("} else {")
 			}
 		}
-
+		// Else branch.
+		buf.L("stmt = c.stmt(%s)", stmtCodeVar(m.entity, "objects"))
+		buf.L("args = []interface{}{}")
 		buf.L("}")
-
-		// Last branch, no filter to use.
-		if i == len(filters)-1 {
-			buf.L("} else {")
-		}
 	}
-	// Else branch.
-	buf.L("stmt = c.stmt(%s)", stmtCodeVar(m.entity, "objects"))
-	buf.L("args = []interface{}{}")
-	buf.L("}")
 
 	buf.N()
 	buf.L("// Dest function for scanning a row.")
@@ -374,67 +378,71 @@ func (m *Method) ref(buf *file.Buffer) error {
 
 	defer m.end(buf)
 
-	criteria, err := Criteria(m.packages["db"], m.entity)
-	if err != nil {
-		return errors.Wrap(err, "Parse filter struct")
-	}
-
-	filters := RefFiltersFromStmt(m.packages["db"], m.entity, name)
-
 	buf.L("// Result slice.")
 	buf.L("objects := make(%s, 0)", lex.Slice(destType))
 	buf.N()
-	buf.L("// Check which filter criteria are active.")
-	buf.L("criteria := map[string]interface{}{}")
+	filters := RefFiltersFromStmt(m.packages["db"], m.entity, name)
+	if len(filters) == 0 {
+		buf.L("stmt := c.stmt(%s)", stmtCodeVar(m.entity, m.kind))
+		buf.L("args := []interface{}{}")
+	} else {
+		criteria, err := Criteria(m.packages["db"], m.entity)
+		if err != nil {
+			return errors.Wrap(err, "Parse filter struct")
+		}
 
-	for _, name := range criteria {
-		var zero string
-		if name == "Parent" {
-			zero = `""`
-		} else {
-			field := mapping.FieldByName(name)
-			if !field.IsPrimary() {
-				continue
+		buf.L("// Check which filter criteria are active.")
+		buf.L("criteria := map[string]interface{}{}")
+
+		for _, name := range criteria {
+			var zero string
+			if name == "Parent" {
+				zero = `""`
+			} else {
+				field := mapping.FieldByName(name)
+				if !field.IsPrimary() {
+					continue
+				}
+				zero = field.ZeroValue()
 			}
-			zero = field.ZeroValue()
+			buf.L("if filter.%s != %s {", name, zero)
+			buf.L("        criteria[%q] = filter.%s", name, name)
+			buf.L("}")
 		}
-		buf.L("if filter.%s != %s {", name, zero)
-		buf.L("        criteria[%q] = filter.%s", name, name)
+
+		buf.N()
+		buf.L("// Pick the prepared statement and arguments to use based on active criteria.")
+		buf.L("var stmt *sql.Stmt")
+		buf.L("var args []interface{}")
+		buf.N()
+
+		for i, filter := range filters {
+			branch := "if"
+			if i > 0 {
+				branch = "} else if"
+			}
+			buf.L("%s %s {", branch, activeCriteria(filter))
+
+			buf.L("stmt = c.stmt(%s)", stmtCodeVar(m.entity, m.kind, filter...))
+			buf.L("args = []interface{}{")
+
+			for _, name := range filter {
+				buf.L("filter.%s,", name)
+			}
+
+			buf.L("}")
+
+			// Last branch, no filter to use.
+			if i == len(filters)-1 {
+				buf.L("} else {")
+			}
+		}
+
+		// Else branch.
+		buf.L("stmt = c.stmt(%s)", stmtCodeVar(m.entity, m.kind))
+		buf.L("args = []interface{}{}")
 		buf.L("}")
 	}
-
-	buf.N()
-	buf.L("// Pick the prepared statement and arguments to use based on active criteria.")
-	buf.L("var stmt *sql.Stmt")
-	buf.L("var args []interface{}")
-	buf.N()
-
-	for i, filter := range filters {
-		branch := "if"
-		if i > 0 {
-			branch = "} else if"
-		}
-		buf.L("%s %s {", branch, activeCriteria(filter))
-
-		buf.L("stmt = c.stmt(%s)", stmtCodeVar(m.entity, m.kind, filter...))
-		buf.L("args = []interface{}{")
-
-		for _, name := range filter {
-			buf.L("filter.%s,", name)
-		}
-
-		buf.L("}")
-
-		// Last branch, no filter to use.
-		if i == len(filters)-1 {
-			buf.L("} else {")
-		}
-	}
-
-	// Else branch.
-	buf.L("stmt = c.stmt(%s)", stmtCodeVar(m.entity, m.kind))
-	buf.L("args = []interface{}{}")
-	buf.L("}")
 	buf.N()
 	buf.L("// Dest function for scanning a row.")
 	buf.L("dest := %s", destFunc("objects", destType, destFields))

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -88,7 +88,7 @@ func (m *Method) uris(buf *file.Buffer) error {
 		return errors.Wrap(err, "Parse filter struct")
 	}
 
-	filters := Filters(m.packages["db"], "objects", m.entity)
+	filters := FiltersFromStmt(m.packages["db"], "objects", m.entity)
 
 	if err := m.signature(buf, false); err != nil {
 		return err
@@ -164,7 +164,7 @@ func (m *Method) getMany(buf *file.Buffer) error {
 		return errors.Wrap(err, "Parse filter struct")
 	}
 
-	filters := Filters(m.packages["db"], "objects", m.entity)
+	filters := FiltersFromStmt(m.packages["db"], "objects", m.entity)
 
 	// Go type name the objects to return (e.g. api.Foo).
 	typ := entityType(m.pkg, m.entity)
@@ -379,7 +379,7 @@ func (m *Method) ref(buf *file.Buffer) error {
 		return errors.Wrap(err, "Parse filter struct")
 	}
 
-	filters := RefFilters(m.packages["db"], m.entity, name)
+	filters := RefFiltersFromStmt(m.packages["db"], m.entity, name)
 
 	buf.L("// Result slice.")
 	buf.L("objects := make(%s, 0)", lex.Slice(destType))

--- a/lxd/db/generate/db/parse.go
+++ b/lxd/db/generate/db/parse.go
@@ -36,9 +36,9 @@ var defaultPackages = []string{
 	"github.com/lxc/lxd/lxd/db",
 }
 
-// Filters parses all filtering statement defined for the given entity. It
+// FiltersFromStmt parses all filtering statement defined for the given entity. It
 // returns all supported combinations of filters, sorted by number of criteria.
-func Filters(pkg *ast.Package, kind string, entity string) [][]string {
+func FiltersFromStmt(pkg *ast.Package, kind string, entity string) [][]string {
 	objects := pkg.Scope.Objects
 	filters := [][]string{}
 
@@ -55,8 +55,8 @@ func Filters(pkg *ast.Package, kind string, entity string) [][]string {
 	return sortFilters(filters)
 }
 
-// RefFilters parses all filtering statement defined for the given entity reference.
-func RefFilters(pkg *ast.Package, entity string, ref string) [][]string {
+// RefFiltersFromStmt parses all filtering statement defined for the given entity reference.
+func RefFiltersFromStmt(pkg *ast.Package, entity string, ref string) [][]string {
 	objects := pkg.Scope.Objects
 	filters := [][]string{}
 

--- a/lxd/db/generate/db/stmt.go
+++ b/lxd/db/generate/db/stmt.go
@@ -121,19 +121,7 @@ func (s *Stmt) objects(buf *file.Buffer) error {
 				column = mapping.FieldColumnName(field.Name)
 			}
 
-			comparison, ok := field.Config["comparison"]
-			if !ok {
-				comparison = []string{"equal"}
-			}
-			switch comparison[0] {
-			case "equal":
-				where += fmt.Sprintf("%s = ? ", column)
-			case "like":
-				where += fmt.Sprintf("%s LIKE ? ", column)
-			default:
-				panic("unknown 'comparison' value")
-			}
-
+			where += fmt.Sprintf("%s = ? ", column)
 		}
 
 	}

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -449,10 +449,12 @@ func (c *Cluster) ImageIsReferencedByOtherProjects(project string, fingerprint s
 // The fingerprint argument will be queried with a LIKE query, means you can
 // pass a shortform and will get the full fingerprint. However in case the
 // shortform matches more than one image, an error will be returned.
-func (c *Cluster) GetImage(project, fingerprint string, public bool) (int, *api.Image, error) {
+// publicOnly, when true, will return the image only if it is public;
+// a false value will return any image matching the fingerprint prefix.
+func (c *Cluster) GetImage(project string, fingerprintPrefix string, publicOnly bool) (int, *api.Image, error) {
 	var image api.Image
 	var object Image
-	if fingerprint == "" {
+	if fingerprintPrefix == "" {
 		return -1, nil, ErrNoSuchObject
 	}
 	err := c.Transaction(func(tx *ClusterTx) error {
@@ -467,12 +469,12 @@ func (c *Cluster) GetImage(project, fingerprint string, public bool) (int, *api.
 
 		// FIXME
 		// Properly check zero values of 'public', and don't include it in GetImage at all if it should be ignored.
-		publicOrNil := &public
-		if !public {
+		publicOrNil := &publicOnly
+		if !publicOnly {
 			publicOrNil = nil
 		}
 
-		images, err := tx.getImagesByFingerprintPrefix(fingerprint, &project, publicOrNil)
+		images, err := tx.getImagesByFingerprintPrefix(fingerprintPrefix, &project, publicOrNil)
 		if err != nil {
 			return errors.Wrap(err, "Failed to fetch images")
 		}

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -464,11 +464,15 @@ func (c *Cluster) GetImage(project, fingerprint string, public bool) (int, *api.
 		if !enabled {
 			project = "default"
 		}
-		images, err := tx.GetImages(ImageFilter{
-			Project:     project,
-			Fingerprint: fingerprint + "%",
-			Public:      public,
-		})
+
+		// FIXME
+		// Properly check zero values of 'public', and don't include it in GetImage at all if it should be ignored.
+		publicOrNil := &public
+		if !public {
+			publicOrNil = nil
+		}
+
+		images, err := tx.getImagesByFingerprintPrefix(fingerprint, &project, publicOrNil)
 		if err != nil {
 			return errors.Wrap(err, "Failed to fetch images")
 		}
@@ -519,9 +523,7 @@ func (c *Cluster) GetImageFromAnyProject(fingerprint string) (int, *api.Image, e
 	var object Image
 
 	err := c.Transaction(func(tx *ClusterTx) error {
-		images, err := tx.GetImages(ImageFilter{
-			Fingerprint: fingerprint + "%",
-		})
+		images, err := tx.getImagesByFingerprintPrefix(fingerprint, nil, nil)
 		if err != nil {
 			return errors.Wrap(err, "Failed to fetch images")
 		}
@@ -554,6 +556,65 @@ func (c *Cluster) GetImageFromAnyProject(fingerprint string) (int, *api.Image, e
 	}
 
 	return object.ID, &image, nil
+}
+
+// getImagesByFingerprintPrefix returns the images with fingerprints matching the prefix.
+// Optional filters 'project' and 'public' will be included if not nil.
+func (c *ClusterTx) getImagesByFingerprintPrefix(fingerprintPrefix string, project *string, public *bool) ([]Image, error) {
+	sql := `
+SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
+FROM images 
+JOIN projects ON images.project_id = projects.id
+WHERE images.fingerprint LIKE ?
+`
+	args := []interface{}{fingerprintPrefix + "%"}
+	if project != nil {
+		sql += `AND project = ?
+	`
+		args = append(args, *project)
+	}
+	if public != nil {
+		sql += `AND images.public = ?
+	`
+		args = append(args, *public)
+	}
+	sql += `ORDER BY projects.id, images.fingerprint
+`
+
+	objects := []Image{}
+	// Dest function for scanning a row.
+	dest := func(i int) []interface{} {
+		objects = append(objects, Image{})
+		return []interface{}{
+			&objects[i].ID,
+			&objects[i].Project,
+			&objects[i].Fingerprint,
+			&objects[i].Type,
+			&objects[i].Filename,
+			&objects[i].Size,
+			&objects[i].Public,
+			&objects[i].Architecture,
+			&objects[i].CreationDate,
+			&objects[i].ExpiryDate,
+			&objects[i].UploadDate,
+			&objects[i].Cached,
+			&objects[i].LastUseDate,
+			&objects[i].AutoUpdate,
+		}
+	}
+
+	stmt, err := c.prepare(sql)
+	if err != nil {
+		return nil, err
+	}
+
+	// Select.
+	err = query.SelectObjects(stmt, dest, args...)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to fetch images")
+	}
+
+	return objects, nil
 }
 
 // LocateImage returns the address of an online node that has a local copy of

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -26,8 +26,6 @@ import (
 //go:generate mapper stmt -p db -e image objects-by-Project
 //go:generate mapper stmt -p db -e image objects-by-Project-and-Cached
 //go:generate mapper stmt -p db -e image objects-by-Project-and-Public
-//go:generate mapper stmt -p db -e image objects-by-Project-and-Fingerprint
-//go:generate mapper stmt -p db -e image objects-by-Project-and-Fingerprint-and-Public
 //go:generate mapper stmt -p db -e image objects-by-Fingerprint
 //go:generate mapper stmt -p db -e image objects-by-Cached
 //go:generate mapper stmt -p db -e image objects-by-AutoUpdate
@@ -39,7 +37,7 @@ import (
 type Image struct {
 	ID           int
 	Project      string `db:"primary=yes&join=projects.name"`
-	Fingerprint  string `db:"primary=yes&comparison=like"`
+	Fingerprint  string `db:"primary=yes"`
 	Type         int
 	Filename     string
 	Size         int64
@@ -56,7 +54,7 @@ type Image struct {
 // ImageFilter can be used to filter results yielded by GetImages.
 type ImageFilter struct {
 	Project     string
-	Fingerprint string // Matched with LIKE
+	Fingerprint string
 	Public      bool
 	Cached      bool
 	AutoUpdate  bool

--- a/lxd/db/instances.mapper.go
+++ b/lxd/db/instances.mapper.go
@@ -8,6 +8,7 @@ package db
 import (
 	"database/sql"
 	"fmt"
+
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared/api"

--- a/lxd/db/operations.mapper.go
+++ b/lxd/db/operations.mapper.go
@@ -8,6 +8,7 @@ package db
 import (
 	"database/sql"
 	"fmt"
+
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared/api"

--- a/lxd/db/profiles.mapper.go
+++ b/lxd/db/profiles.mapper.go
@@ -8,6 +8,7 @@ package db
 import (
 	"database/sql"
 	"fmt"
+
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared/api"

--- a/lxd/db/projects.mapper.go
+++ b/lxd/db/projects.mapper.go
@@ -8,6 +8,7 @@ package db
 import (
 	"database/sql"
 	"fmt"
+
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared/api"

--- a/lxd/db/snapshots.mapper.go
+++ b/lxd/db/snapshots.mapper.go
@@ -8,6 +8,7 @@ package db
 import (
 	"database/sql"
 	"fmt"
+
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared/api"

--- a/lxd/db/transaction.go
+++ b/lxd/db/transaction.go
@@ -53,3 +53,13 @@ func (c *ClusterTx) stmt(code int) *sql.Stmt {
 	}
 	return c.tx.Stmt(stmt)
 }
+
+// prepare prepares a new statement from a SQL string.
+func (c *ClusterTx) prepare(sql string) (*sql.Stmt, error) {
+	stmt, err := c.tx.Prepare(sql)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to prepare statement with error: %v", err)
+	}
+
+	return stmt, nil
+}


### PR DESCRIPTION
This PR drops support for the tag `db:comparison` in the generator. If a `LIKE` query is required, as is the case for `Image`, it is written by hand. 

This caused a bit of an awkward situation with our current strategy of using `false` for boolean zero-values. There's currently a `FIXME` with a conditional that uses `nil` if `Public` is `false`. I'm planning on removing that in an upcoming PR, where I replace Filter fields with pointers.

I also removed some unused statements, and thus needed to add support for queries with no filters, with a simple if-block. The function name `Filters` was quite confusing, and it wasn't very clear to me that it was parsing the statement variable names, so I renamed it to `FiltersFromStmt` to make that clear.

I also added `goimports` to the makefile to prune any unused imports as a result of the above changes.