### PR TITLE
Storage: Prevent custom block volume export

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -1029,6 +1029,10 @@ func (d *btrfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWr
 
 	// Optimized backup.
 
+	if vol.ContentType() == ContentTypeBlock && vol.Type() == VolumeTypeCustom {
+		return ErrNotImplemented
+	}
+
 	if len(snapshots) > 0 {
 		// Check requested snapshot match those in storage.
 		err := vol.SnapshotsMatch(snapshots, op)

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1508,6 +1508,10 @@ func (d *zfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWrit
 
 	// Optimized backup.
 
+	if vol.ContentType() == ContentTypeBlock && vol.Type() == VolumeTypeCustom {
+		return ErrNotImplemented
+	}
+
 	if len(snapshots) > 0 {
 		// Check requested snapshot match those in storage.
 		err := vol.SnapshotsMatch(snapshots, op)

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -449,6 +449,10 @@ func genericVFSGetVolumeDiskPath(vol Volume) (string, error) {
 
 // genericVFSBackupVolume is a generic BackupVolume implementation for VFS-only drivers.
 func genericVFSBackupVolume(d Driver, vol Volume, tarWriter *instancewriter.InstanceTarWriter, snapshots []string, op *operations.Operation) error {
+	if vol.ContentType() == ContentTypeBlock && vol.Type() == VolumeTypeCustom {
+		return ErrNotImplemented
+	}
+
 	if len(snapshots) > 0 {
 		// Check requested snapshot match those in storage.
 		err := vol.SnapshotsMatch(snapshots, op)


### PR DESCRIPTION
This currently silently exports an empty tarball for some storage driver types and has not been audited to work fully for any storage driver, so disable for now until we can implement properly.

Related to #9064

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>