### PR TITLE
lxc/init: When using network flag support managed networks

### DIFF
--- a/lxc/init.go
+++ b/lxc/init.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
@@ -165,7 +166,7 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.InstanceServer
 	if c.flagNetwork != "" {
 		network, _, err := d.GetNetwork(c.flagNetwork)
 		if err != nil {
-			return nil, "", err
+			return nil, "", errors.Wrapf(err, "Failed loading network %q", c.flagNetwork)
 		}
 
 		// Prepare the instance's NIC device entry.
@@ -215,7 +216,7 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.InstanceServer
 	if c.flagStorage != "" {
 		_, _, err := d.GetStoragePool(c.flagStorage)
 		if err != nil {
-			return nil, "", err
+			return nil, "", errors.Wrapf(err, "Failed loading storage pool %q", c.flagStorage)
 		}
 
 		devicesMap["root"] = map[string]string{

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -175,12 +175,14 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.InstanceServer
 			// If network is managed, use the network property rather than nictype, so that the
 			// network's inherited properties are loaded into the NIC when started.
 			device = map[string]string{
+				"name":    "eth0",
 				"type":    "nic",
 				"network": network.Name,
 			}
 		} else {
 			// If network is unmanaged default to using a macvlan connected to the specified interface.
 			device = map[string]string{
+				"name":    "eth0",
 				"type":    "nic",
 				"nictype": "macvlan",
 				"parent":  c.flagNetwork,
@@ -192,7 +194,7 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.InstanceServer
 			}
 		}
 
-		devicesMap[c.flagNetwork] = device
+		devicesMap["eth0"] = device
 	}
 
 	if len(stdinData.Config) > 0 {

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -938,35 +938,35 @@ test_clustering_network() {
   # Check instance can be connected to created network and assign static DHCP allocations.
   LXD_DIR="${LXD_ONE_DIR}" lxc network show "${net}"
   LXD_DIR="${LXD_ONE_DIR}" lxc init --target node1 -n "${net}" testimage c1
-  LXD_DIR="${LXD_ONE_DIR}" lxc config device set c1 "${net}" ipv4.address=192.0.2.2
+  LXD_DIR="${LXD_ONE_DIR}" lxc config device set c1 eth0 ipv4.address=192.0.2.2
 
   # Check cannot assign static IPv6 without stateful DHCPv6 enabled.
-  ! LXD_DIR="${LXD_ONE_DIR}" lxc config device set c1 "${net}" ipv6.address=2001:db8::2 || false
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc config device set c1 eth0 ipv6.address=2001:db8::2 || false
   LXD_DIR="${LXD_ONE_DIR}" lxc network set "${net}" ipv6.dhcp.stateful=true
-  LXD_DIR="${LXD_ONE_DIR}" lxc config device set c1 "${net}" ipv6.address=2001:db8::2
+  LXD_DIR="${LXD_ONE_DIR}" lxc config device set c1 eth0 ipv6.address=2001:db8::2
 
   # Check duplicate static DHCP allocation detection is working for same server as c1.
   LXD_DIR="${LXD_ONE_DIR}" lxc init --target node1 -n "${net}" testimage c2
-  ! LXD_DIR="${LXD_ONE_DIR}" lxc config device set c2 "${net}" ipv4.address=192.0.2.2 || false
-  ! LXD_DIR="${LXD_ONE_DIR}" lxc config device set c2 "${net}" ipv6.address=2001:db8::2 || false
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc config device set c2 eth0 ipv4.address=192.0.2.2 || false
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc config device set c2 eth0 ipv6.address=2001:db8::2 || false
 
   # Check duplicate static DHCP allocation is allowed for instance on a different server.
   LXD_DIR="${LXD_ONE_DIR}" lxc init --target node2 -n "${net}" testimage c3
-  LXD_DIR="${LXD_ONE_DIR}" lxc config device set c3 "${net}" ipv4.address=192.0.2.2
-  LXD_DIR="${LXD_ONE_DIR}" lxc config device set c3 "${net}" ipv6.address=2001:db8::2
+  LXD_DIR="${LXD_ONE_DIR}" lxc config device set c3 eth0 ipv4.address=192.0.2.2
+  LXD_DIR="${LXD_ONE_DIR}" lxc config device set c3 eth0 ipv6.address=2001:db8::2
 
   # Check duplicate MAC address assignment detection is working using both network and parent keys.
-  c1MAC=$(LXD_DIR="${LXD_ONE_DIR}" lxc config get c1 volatile."${net}".hwaddr)
-  ! LXD_DIR="${LXD_ONE_DIR}" lxc config device set c2 "${net}" hwaddr="${c1MAC}" || false
-  LXD_DIR="${LXD_ONE_DIR}" lxc config device set c3 "${net}" hwaddr="${c1MAC}"
+  c1MAC=$(LXD_DIR="${LXD_ONE_DIR}" lxc config get c1 volatile.eth0.hwaddr)
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc config device set c2 eth0 hwaddr="${c1MAC}" || false
+  LXD_DIR="${LXD_ONE_DIR}" lxc config device set c3 eth0 hwaddr="${c1MAC}"
 
   # Check duplicate static MAC assignment detection is working for same server as c1.
-  LXD_DIR="${LXD_ONE_DIR}" lxc config device remove c2 "${net}"
-  ! LXD_DIR="${LXD_ONE_DIR}" lxc config device add c2 "${net}" nic hwaddr="${c1MAC}" nictype=bridged parent="${net}" || false
+  LXD_DIR="${LXD_ONE_DIR}" lxc config device remove c2 eth0
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc config device add c2 eth0 nic hwaddr="${c1MAC}" nictype=bridged parent="${net}" || false
 
   # Check duplicate static MAC assignment is allowed for instance on a different server.
-  LXD_DIR="${LXD_ONE_DIR}" lxc config device remove c3 "${net}"
-  LXD_DIR="${LXD_ONE_DIR}" lxc config device add c3 "${net}" nic hwaddr="${c1MAC}" nictype=bridged parent="${net}"
+  LXD_DIR="${LXD_ONE_DIR}" lxc config device remove c3 eth0
+  LXD_DIR="${LXD_ONE_DIR}" lxc config device add c3 eth0 nic hwaddr="${c1MAC}" nictype=bridged parent="${net}"
 
   # Cleanup instances and image.
   LXD_DIR="${LXD_ONE_DIR}" lxc delete -f c1 c2 c3


### PR DESCRIPTION
Previously we added support for detecting if a server supported the NIC `network` property and then allowed the use of any managed network when doing `lxc network attach` in https://github.com/lxc/lxd/pull/8334.

This PR does something similar for the `--network` flag in `lxc init` and `lxc launch`.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>