### PR TITLE
Instance: Don't trigger duplicate NIC warnings when performing cross-pool move

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -260,8 +260,9 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 					continue
 				}
 
-				// Skip our own device.
-				if inst.Name == d.inst.Name() && inst.Project == d.inst.Project() && d.Name() == devName {
+				// Skip our own device. This avoids triggering duplicate device errors during
+				// updates or when making temporary copies of our instance during migrations.
+				if instance.IsSameLocgicalInstance(d.inst, &inst) && d.Name() == devName {
 					continue
 				}
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2055,11 +2055,19 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 		return "", nil, err
 	}
 
-	// Generate UUID if not present.
+	volatileSet := make(map[string]string)
+
+	// Generate UUID if not present (do this before UpdateBackupFile() call).
 	instUUID := d.localConfig["volatile.uuid"]
 	if instUUID == "" {
 		instUUID = uuid.New()
-		d.VolatileSet(map[string]string{"volatile.uuid": instUUID})
+		volatileSet["volatile.uuid"] = instUUID
+	}
+
+	// Apply any volatile changes that need to be made.
+	err = d.VolatileSet(volatileSet)
+	if err != nil {
+		return "", nil, errors.Wrapf(err, "Failed setting volatile keys")
 	}
 
 	// Create the devices

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -992,14 +992,14 @@ func (d *qemu) Start(stateful bool) error {
 
 	volatileSet := make(map[string]string)
 
-	// Update vsock ID in volatile if needed (for recovery).
+	// Update vsock ID in volatile if needed for recovery (do this before UpdateBackupFile() call).
 	oldVsockID := d.localConfig["volatile.vsock_id"]
 	newVsockID := strconv.Itoa(d.vsockID())
 	if oldVsockID != newVsockID {
 		volatileSet["volatile.vsock_id"] = newVsockID
 	}
 
-	// Generate UUID if not present.
+	// Generate UUID if not present (do this before UpdateBackupFile() call).
 	instUUID := d.localConfig["volatile.uuid"]
 	if instUUID == "" {
 		instUUID = uuid.New()

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/flosch/pongo2"
+	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 
 	"github.com/lxc/lxd/client"
@@ -941,6 +942,10 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, volu
 
 	if args.BaseImage != "" {
 		args.Config["volatile.base_image"] = args.BaseImage
+	}
+
+	if args.Config["volatile.uuid"] == "" {
+		args.Config["volatile.uuid"] = uuid.New()
 	}
 
 	if args.Devices == nil {

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -1181,3 +1181,20 @@ func NextSnapshotName(s *state.State, inst Instance, defaultPattern string) (str
 
 	return pattern, nil
 }
+
+// MoveTemporaryName returns a name derived from the instance's volatile.uuid, to use when moving an instance
+// across pools or cluster members which can be used for the naming the temporary copy before deleting the original
+// instance and renaming the copy to the original name.
+func MoveTemporaryName(inst Instance) string {
+	return fmt.Sprintf("lxd-move-of-%s", inst.LocalConfig()["volatile.uuid"])
+}
+
+// IsSameLocgicalInstance returns true if the supplied Instance and db.Instance have the same project, and either
+// the same name or volatile.uuid values.
+func IsSameLocgicalInstance(inst Instance, dbInst *db.Instance) bool {
+	if dbInst.Project == inst.Project() && (dbInst.Name == inst.Name() || dbInst.Config["volatile.uuid"] == inst.LocalConfig()["volatile.uuid"]) {
+		return true
+	}
+
+	return false
+}

--- a/test/suites/container_local_cross_pool_handling.sh
+++ b/test/suites/container_local_cross_pool_handling.sh
@@ -15,6 +15,9 @@ test_container_local_cross_pool_handling() {
     LXD_DIR="${LXD_STORAGE_DIR}"
     ensure_import_testimage
 
+    brName="lxdt$$"
+    lxc network create "${brName}"
+
     if storage_backend_available "btrfs"; then
       lxc storage create "lxdtest-$(basename "${LXD_DIR}")-btrfs" btrfs size=100GB
     fi
@@ -57,6 +60,9 @@ test_container_local_cross_pool_handling() {
         fi
 
         lxc init testimage c1
+        lxc config device add c1 eth0 nic network="${brName}"
+        lxc config show c1
+
         originalPool=$(lxc profile device get default root pool)
 
         # Check volatile.apply_template is initialised during create.
@@ -111,6 +117,8 @@ test_container_local_cross_pool_handling() {
         lxc delete -f c2
       fi
     done
+
+    lxc network delete "${brName}"
   )
 
   # shellcheck disable=SC2031


### PR DESCRIPTION
Fixes https://discuss.linuxcontainers.org/t/move-migration-operation-failure/11781

- Populates instance `volatile.uuid` config key on creation (so it always exists).
- Uses a consistent temporary instance name (derived from the source instance's `volatile.uuid` config key) when creating a temporary copy of an instance during a migration or storage pool move (before the original is removed and the copy rename to the original name).
- Adds a helper function for use when validating if a resource belongs to the same logical instance (either the original instance or the temporary copy of the original instance).
- Update tests to check for this scenario.

We probably should add a check for `volatile.uuid` being unique in the future, which would then break this fix, however having the `IsSameLocgicalInstance` function means we only need to update the logic in there (however we decide to detect that the copied instance is in fact the same as the source for resource validation purposes). 

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>