### PR TITLE
lxd: Hide built-in completion command

### DIFF
--- a/lxd/main_daemon.go
+++ b/lxd/main_daemon.go
@@ -36,6 +36,7 @@ func (c *cmdDaemon) Command() *cobra.Command {
   the local LXD daemon and which may not be performed through the REST API alone.
 `
 	cmd.RunE = c.Run
+	cmd.CompletionOptions = cobra.CompletionOptions{DisableDefaultCmd: true}
 	cmd.Flags().StringVar(&c.flagGroup, "group", "", "The group of users that will be allowed to talk to LXD"+"``")
 
 	return cmd


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
