### PR TITLE
syscall_wrappers: don't conflict with glibc provided close_range()

### DIFF
--- a/lxd/include/syscall_wrappers.h
+++ b/lxd/include/syscall_wrappers.h
@@ -16,7 +16,7 @@
 #define CLOSE_RANGE_UNSHARE (1U << 1)
 #endif
 
-static inline int close_range(unsigned int fd, unsigned int max_fd, unsigned int flags)
+static inline int lxd_close_range(unsigned int fd, unsigned int max_fd, unsigned int flags)
 {
 	return syscall(__NR_close_range, fd, max_fd, flags);
 }

--- a/lxd/main_checkfeature.go
+++ b/lxd/main_checkfeature.go
@@ -496,7 +496,7 @@ static void is_close_range_aware(void)
 	if (fd < 0)
 		return;
 
-	if (close_range(fd, fd, CLOSE_RANGE_UNSHARE))
+	if (lxd_close_range(fd, fd, CLOSE_RANGE_UNSHARE))
 		return;
 
 	close_range_aware = true;

--- a/lxd/main_forkexec.go
+++ b/lxd/main_forkexec.go
@@ -290,7 +290,7 @@ __attribute__ ((noinline)) static int __forkexec(void)
 	if (!argvp || !*argvp)
 		return log_error(EXIT_FAILURE, "No command specified");
 
-	ret = close_range(EXEC_PIPE_FD + 1, UINT_MAX, CLOSE_RANGE_UNSHARE);
+	ret = lxd_close_range(EXEC_PIPE_FD + 1, UINT_MAX, CLOSE_RANGE_UNSHARE);
 	if (ret) {
 		// Fallback to close_inherited() when the syscall is not
 		// available or when CLOSE_RANGE_UNSHARE isn't supported.


### PR DESCRIPTION
Newer glibc version's provide a wrapper for close_range().

Fixes: #9084
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>