### PR TITLE
lxd/apparmor: Allow remount using strictatime

### DIFF
--- a/lxd/apparmor/instance_lxc.go
+++ b/lxd/apparmor/instance_lxc.go
@@ -560,6 +560,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   mount options=(ro,remount,bind,nosuid,noexec),
   mount options=(ro,remount,bind,nosuid,noexec,nodev),
   mount options=(ro,remount,bind,nosuid,noexec,strictatime),
+  mount options=(ro,remount,nosuid,noexec,strictatime),
 
   # Allow remounting things read-only
   mount options=(ro,remount) /,


### PR DESCRIPTION
This should make systemd a bit happier in unprivileged containers.

Closes #9083

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>