### PR TITLE
Generator: Use Pointers for Filter fields.

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2348,7 +2348,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request) response.Response {
 
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
 		// If evacuating, consider only the instances on the node which needs to be evacuated.
-		dbInstances, err = tx.GetInstances(db.InstanceFilter{Node: nodeName})
+		dbInstances, err = tx.GetInstances(db.InstanceFilter{Node: &nodeName})
 		if err != nil {
 			return errors.Wrap(err, "Failed to get instances")
 		}
@@ -2502,7 +2502,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 	var dbInstances []db.Instance
 
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
-		dbInstances, err = tx.GetInstances(*db.InstanceFilterAllInstances())
+		dbInstances, err = tx.GetInstances(db.InstanceFilter{})
 		if err != nil {
 			return errors.Wrap(err, "Failed to get instances")
 		}

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -101,7 +101,7 @@ func ConnectIfInstanceIsRemote(cluster *db.Cluster, projectName string, name str
 	var address string // Node address
 	err := cluster.Transaction(func(tx *db.ClusterTx) error {
 		var err error
-		address, err = tx.GetNodeAddressOfInstance(projectName, name, instanceType)
+		address, err = tx.GetNodeAddressOfInstance(projectName, name, db.InstanceTypeFilter(instanceType))
 		return err
 	})
 	if err != nil {

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -349,7 +349,8 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 		if err != nil {
 			return err
 		}
-		filter := db.OperationFilter{NodeID: tx.GetNodeID()}
+		nodeID := tx.GetNodeID()
+		filter := db.OperationFilter{NodeID: &nodeID}
 		operations, err = tx.GetOperations(filter)
 		if err != nil {
 			return err

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -140,7 +140,7 @@ func (d *Daemon) ImageDownload(r *http.Request, op *operations.Operation, args *
 	}
 
 	// Check if the image already exists in this project (partial hash match).
-	_, imgInfo, err := d.cluster.GetImage(args.ProjectName, fp, false)
+	_, imgInfo, err := d.cluster.GetImage(fp, db.ImageFilter{Project: &args.ProjectName})
 	if err == nil {
 		// Check if the image is available locally or it's on another node.
 		nodeAddress, err := d.State().Cluster.LocateImage(imgInfo.Fingerprint)
@@ -179,7 +179,7 @@ func (d *Daemon) ImageDownload(r *http.Request, op *operations.Operation, args *
 			}
 
 			var id int
-			id, imgInfo, err = d.cluster.GetImage(args.ProjectName, fp, false)
+			id, imgInfo, err = d.cluster.GetImage(fp, db.ImageFilter{Project: &args.ProjectName})
 			if err != nil {
 				return nil, err
 			}
@@ -488,7 +488,7 @@ func (d *Daemon) ImageDownload(r *http.Request, op *operations.Operation, args *
 
 	// Record the image source
 	if alias != fp {
-		id, _, err := d.cluster.GetImage(args.ProjectName, fp, false)
+		id, _, err := d.cluster.GetImage(fp, db.ImageFilter{Project: &args.ProjectName})
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -122,9 +122,9 @@ func (c *ClusterTx) UpdateCertificateProjects(id int, projects []string) error {
 
 // CertificateFilter specifies potential query parameter fields.
 type CertificateFilter struct {
-	Fingerprint string
-	Name        string
-	Type        CertificateType
+	Fingerprint *string
+	Name        *string
+	Type        *CertificateType
 }
 
 // GetCertificate gets an CertBaseInfo object from the database.

--- a/lxd/db/certificates.mapper.go
+++ b/lxd/db/certificates.mapper.go
@@ -67,30 +67,20 @@ func (c *ClusterTx) GetCertificates(filter CertificateFilter) ([]Certificate, er
 	// Result slice.
 	objects := make([]Certificate, 0)
 
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Fingerprint != "" {
-		criteria["Fingerprint"] = filter.Fingerprint
-	}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-	if filter.Type != -1 {
-		criteria["Type"] = filter.Type
-	}
-
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Fingerprint"] != nil {
+	if filter.Fingerprint != nil && filter.Name == nil && filter.Type == nil {
 		stmt = c.stmt(certificateObjectsByFingerprint)
 		args = []interface{}{
 			filter.Fingerprint,
 		}
-	} else {
+	} else if filter.Fingerprint == nil && filter.Name == nil && filter.Type == nil {
 		stmt = c.stmt(certificateObjects)
 		args = []interface{}{}
+	} else {
+		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
@@ -133,7 +123,7 @@ func (c *ClusterTx) GetCertificates(filter CertificateFilter) ([]Certificate, er
 // generator: certificate GetOne
 func (c *ClusterTx) GetCertificate(fingerprint string) (*Certificate, error) {
 	filter := CertificateFilter{}
-	filter.Fingerprint = fingerprint
+	filter.Fingerprint = &fingerprint
 
 	objects, err := c.GetCertificates(filter)
 	if err != nil {
@@ -241,27 +231,20 @@ func (c *ClusterTx) CertificateProjectsRef(filter CertificateFilter) (map[string
 		Value       string
 	}, 0)
 
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Fingerprint != "" {
-		criteria["Fingerprint"] = filter.Fingerprint
-	}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Fingerprint"] != nil {
+	if filter.Fingerprint != nil && filter.Name == nil && filter.Type == nil {
 		stmt = c.stmt(certificateProjectsRefByFingerprint)
 		args = []interface{}{
 			filter.Fingerprint,
 		}
-	} else {
+	} else if filter.Fingerprint == nil && filter.Name == nil && filter.Type == nil {
 		stmt = c.stmt(certificateProjectsRef)
 		args = []interface{}{}
+	} else {
+		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.

--- a/lxd/db/db_internal_test.go
+++ b/lxd/db/db_internal_test.go
@@ -186,8 +186,9 @@ func (s *dbTestSuite) Test_deleting_an_image_cascades_on_related_tables() {
 func (s *dbTestSuite) Test_ImageGet_finds_image_for_fingerprint() {
 	var err error
 	var result *api.Image
+	project := "default"
 
-	_, result, err = s.db.GetImage("default", "fingerprint", false)
+	_, result, err = s.db.GetImage("fingerprint", ImageFilter{Project: &project})
 	s.Nil(err)
 	s.NotNil(result)
 	s.Equal(result.Filename, "filename")
@@ -197,9 +198,10 @@ func (s *dbTestSuite) Test_ImageGet_finds_image_for_fingerprint() {
 }
 
 func (s *dbTestSuite) Test_ImageGet_for_missing_fingerprint() {
+	project := "default"
 	var err error
 
-	_, _, err = s.db.GetImage("default", "unknown", false)
+	_, _, err = s.db.GetImage("unknown", ImageFilter{Project: &project})
 	s.Equal(err, ErrNoSuchObject)
 }
 
@@ -246,7 +248,8 @@ func (s *dbTestSuite) Test_CreateImageAlias() {
 }
 
 func (s *dbTestSuite) Test_GetCachedImageSourceFingerprint() {
-	imageID, _, err := s.db.GetImage("default", "fingerprint", false)
+	project := "default"
+	imageID, _, err := s.db.GetImage("fingerprint", ImageFilter{Project: &project})
 	s.Nil(err)
 
 	err = s.db.CreateImageSource(imageID, "server.remote", "simplestreams", "", "test")
@@ -258,7 +261,8 @@ func (s *dbTestSuite) Test_GetCachedImageSourceFingerprint() {
 }
 
 func (s *dbTestSuite) Test_GetCachedImageSourceFingerprint_no_match() {
-	imageID, _, err := s.db.GetImage("default", "fingerprint", false)
+	project := "default"
+	imageID, _, err := s.db.GetImage("fingerprint", ImageFilter{Project: &project})
 	s.Nil(err)
 
 	err = s.db.CreateImageSource(imageID, "server.remote", "simplestreams", "", "test")

--- a/lxd/db/entity.go
+++ b/lxd/db/entity.go
@@ -254,7 +254,8 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 		var op Operation
 
 		err = c.transaction(func(tx *ClusterTx) error {
-			filter := OperationFilter{ID: int64(entityID)}
+			id := int64(entityID)
+			filter := OperationFilter{ID: &id}
 			ops, err := tx.GetOperations(filter)
 			if err != nil {
 				return err

--- a/lxd/db/entity.go
+++ b/lxd/db/entity.go
@@ -138,7 +138,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 		var instances []Instance
 
 		err = c.transaction(func(tx *ClusterTx) error {
-			instances, err = tx.GetInstances(*InstanceFilterAllInstances())
+			instances, err = tx.GetInstances(InstanceFilter{})
 			if err != nil {
 				return err
 			}
@@ -170,7 +170,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 		var instances []Instance
 
 		err = c.transaction(func(tx *ClusterTx) error {
-			instances, err = tx.GetInstances(*InstanceFilterAllInstances())
+			instances, err = tx.GetInstances(InstanceFilter{})
 			if err != nil {
 				return err
 			}

--- a/lxd/db/generate/db/lex.go
+++ b/lxd/db/generate/db/lex.go
@@ -69,13 +69,20 @@ func activeFilters(kind string) []string {
 
 // Return an expression evaluating if a filter should be used (based on active
 // criteria).
-func activeCriteria(filter []string) string {
+func activeCriteria(filter []string, ignoredFilter []string) string {
 	expr := ""
 	for i, name := range filter {
 		if i > 0 {
 			expr += " && "
 		}
 		expr += fmt.Sprintf("filter.%s != nil", name)
+	}
+
+	for _, name := range ignoredFilter {
+		if len(expr) > 0 {
+			expr += " && "
+		}
+		expr += fmt.Sprintf("filter.%s == nil", name)
 	}
 
 	return expr

--- a/lxd/db/generate/db/lex.go
+++ b/lxd/db/generate/db/lex.go
@@ -75,7 +75,7 @@ func activeCriteria(filter []string) string {
 		if i > 0 {
 			expr += " && "
 		}
-		expr += fmt.Sprintf("criteria[%q] != nil", name)
+		expr += fmt.Sprintf("filter.%s != nil", name)
 	}
 
 	return expr

--- a/lxd/db/generate/db/mapping.go
+++ b/lxd/db/generate/db/mapping.go
@@ -236,50 +236,6 @@ func (f *Field) Column() string {
 	return column
 }
 
-// ZeroValue returns the literal representing the zero value for this field. The type
-// code of the field must be TypeColumn.
-func (f *Field) ZeroValue() string {
-	if f.Type.Code != TypeColumn {
-		panic("attempt to get zero value of non-column field")
-	}
-
-	switch f.Type.Name {
-	case "string":
-		return `""`
-	case "int", "instancetype.Type", "int64", "OperationType", "CertificateType":
-		// FIXME: we use -1 since at the moment integer criteria are
-		// required to be positive.
-		return "-1"
-	case "bool":
-		return "false"
-	default:
-		panic("unsupported zero value")
-	}
-}
-
-// FieldColumns converts thegiven fields to list of column names separated
-// by a comma.
-func FieldColumns(fields []*Field) string {
-	columns := make([]string, len(fields))
-
-	for i, field := range fields {
-		columns[i] = field.Column()
-	}
-
-	return strings.Join(columns, ", ")
-}
-
-// FieldCriteria converts the given fields to AND-separated WHERE criteria.
-func FieldCriteria(fields []*Field) string {
-	criteria := make([]string, len(fields))
-
-	for i, field := range fields {
-		criteria[i] = fmt.Sprintf("%s = ?", field.Column())
-	}
-
-	return strings.Join(criteria, " AND ")
-}
-
 // FieldNames returns the names of the given fields.
 func FieldNames(fields []*Field) []string {
 	names := []string{}

--- a/lxd/db/generate/db/parse.go
+++ b/lxd/db/generate/db/parse.go
@@ -100,32 +100,6 @@ func sortFilter(filter []string) []string {
 	return f
 }
 
-// Criteria returns a list of criteria
-func Criteria(pkg *ast.Package, entity string) ([]string, error) {
-	name := fmt.Sprintf("%sFilter", lex.Camel(entity))
-	str := findStruct(pkg.Scope, name)
-
-	if str == nil {
-		return nil, fmt.Errorf("No filter declared for %q", entity)
-	}
-
-	criteria := []string{}
-
-	for _, f := range str.Fields.List {
-		if len(f.Names) != 1 {
-			return nil, fmt.Errorf("Unexpected fields number")
-		}
-
-		if !f.Names[0].IsExported() {
-			return nil, fmt.Errorf("Unexported field name")
-		}
-
-		criteria = append(criteria, f.Names[0].Name)
-	}
-
-	return criteria, nil
-}
-
 // Parse the structure declaration with the given name found in the given Go package.
 // Any 'Entity' struct should also have an 'EntityFilter' struct defined in the same file.
 func Parse(pkg *ast.Package, name string, kind string) (*Mapping, error) {

--- a/lxd/db/generate/db/parse.go
+++ b/lxd/db/generate/db/parse.go
@@ -37,10 +37,11 @@ var defaultPackages = []string{
 }
 
 // FiltersFromStmt parses all filtering statement defined for the given entity. It
-// returns all supported combinations of filters, sorted by number of criteria.
-func FiltersFromStmt(pkg *ast.Package, kind string, entity string) [][]string {
+// returns all supported combinations of filters, sorted by number of criteria, and
+// the corresponding set of unused filters from the Filter struct.
+func FiltersFromStmt(pkg *ast.Package, kind string, entity string, filters []*Field) ([][]string, [][]string) {
 	objects := pkg.Scope.Objects
-	filters := [][]string{}
+	stmtFilters := [][]string{}
 
 	prefix := fmt.Sprintf("%s%sBy", lex.Minuscule(lex.Camel(entity)), lex.Camel(kind))
 
@@ -49,16 +50,29 @@ func FiltersFromStmt(pkg *ast.Package, kind string, entity string) [][]string {
 			continue
 		}
 		rest := name[len(prefix):]
-		filters = append(filters, strings.Split(rest, "And"))
+		stmtFilters = append(stmtFilters, strings.Split(rest, "And"))
 	}
 
-	return sortFilters(filters)
+	stmtFilters = sortFilters(stmtFilters)
+	ignoredFilters := [][]string{}
+
+	for _, filterGroup := range stmtFilters {
+		ignoredFilterGroup := []string{}
+		for _, filter := range filters {
+			if !shared.StringInSlice(filter.Name, filterGroup) {
+				ignoredFilterGroup = append(ignoredFilterGroup, filter.Name)
+			}
+		}
+		ignoredFilters = append(ignoredFilters, ignoredFilterGroup)
+	}
+
+	return stmtFilters, ignoredFilters
 }
 
 // RefFiltersFromStmt parses all filtering statement defined for the given entity reference.
-func RefFiltersFromStmt(pkg *ast.Package, entity string, ref string) [][]string {
+func RefFiltersFromStmt(pkg *ast.Package, entity string, ref string, filters []*Field) ([][]string, [][]string) {
 	objects := pkg.Scope.Objects
-	filters := [][]string{}
+	stmtFilters := [][]string{}
 
 	prefix := fmt.Sprintf("%s%sRefBy", lex.Minuscule(lex.Camel(entity)), lex.Capital(ref))
 
@@ -67,10 +81,23 @@ func RefFiltersFromStmt(pkg *ast.Package, entity string, ref string) [][]string 
 			continue
 		}
 		rest := name[len(prefix):]
-		filters = append(filters, strings.Split(rest, "And"))
+		stmtFilters = append(stmtFilters, strings.Split(rest, "And"))
 	}
 
-	return sortFilters(filters)
+	stmtFilters = sortFilters(stmtFilters)
+	ignoredFilters := [][]string{}
+
+	for _, filterGroup := range stmtFilters {
+		ignoredFilterGroup := []string{}
+		for _, filter := range filters {
+			if !shared.StringInSlice(filter.Name, filterGroup) {
+				ignoredFilterGroup = append(ignoredFilterGroup, filter.Name)
+			}
+		}
+		ignoredFilters = append(ignoredFilters, ignoredFilterGroup)
+	}
+
+	return stmtFilters, ignoredFilters
 }
 
 func sortFilters(filters [][]string) [][]string {

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -53,11 +53,11 @@ type Image struct {
 
 // ImageFilter can be used to filter results yielded by GetImages.
 type ImageFilter struct {
-	Project     string
-	Fingerprint string
-	Public      bool
-	Cached      bool
-	AutoUpdate  bool
+	Project     *string
+	Fingerprint *string
+	Public      *bool
+	Cached      *bool
+	AutoUpdate  *bool
 }
 
 // ImageSourceProtocol maps image source protocol codes to human-readable names.

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -270,7 +270,8 @@ func (c *Cluster) GetExpiredImagesInProject(expiry int64, project string) ([]str
 	var images []Image
 	err := c.Transaction(func(tx *ClusterTx) error {
 		var err error
-		images, err = tx.GetImages(ImageFilter{Cached: true, Project: project})
+		cached := true
+		images, err = tx.GetImages(ImageFilter{Cached: &cached, Project: &project})
 		return err
 	})
 	if err != nil {

--- a/lxd/db/images_test.go
+++ b/lxd/db/images_test.go
@@ -63,30 +63,32 @@ func TestImageExists(t *testing.T) {
 func TestGetImage(t *testing.T) {
 	cluster, cleanup := db.NewTestCluster(t)
 	defer cleanup()
+	project := "default"
 
 	// public image with 'default' project
-	err := cluster.CreateImage("default", "abcd1", "x.gz", 16, true, false, "amd64", time.Now(), time.Now(), map[string]string{}, "container")
+	err := cluster.CreateImage(project, "abcd1", "x.gz", 16, true, false, "amd64", time.Now(), time.Now(), map[string]string{}, "container")
 	require.NoError(t, err)
 
 	// 'public' is ignored if 'false'
-	id, img, err := cluster.GetImage("default", "a", false)
+	id, img, err := cluster.GetImage("a", db.ImageFilter{Project: &project})
 	require.NoError(t, err)
 	assert.Equal(t, img.Public, true)
 	assert.NotEqual(t, id, -1)
 
 	// non-public image with 'default' project
-	err = cluster.CreateImage("default", "abcd2", "x.gz", 16, false, false, "amd64", time.Now(), time.Now(), map[string]string{}, "container")
+	err = cluster.CreateImage(project, "abcd2", "x.gz", 16, false, false, "amd64", time.Now(), time.Now(), map[string]string{}, "container")
 	require.NoError(t, err)
 
 	// empty project fails
-	_, _, err = cluster.GetImage("", "a", false)
+	_, _, err = cluster.GetImage("a", db.ImageFilter{})
 	require.Error(t, err)
 
 	// 'public' is ignored if 'false', returning both entries
-	_, _, err = cluster.GetImage("default", "a", false)
+	_, _, err = cluster.GetImage("a", db.ImageFilter{Project: &project})
 	require.Error(t, err)
 
-	id, img, err = cluster.GetImage("default", "a", true)
+	public := true
+	id, img, err = cluster.GetImage("a", db.ImageFilter{Project: &project, Public: &public})
 	require.NoError(t, err)
 	assert.Equal(t, img.Public, true)
 	assert.NotEqual(t, id, -1)

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -103,7 +103,7 @@ type InstanceFilter struct {
 	Project *string
 	Name    *string
 	Node    *string
-	Type    *instancetype.Type
+	Type    *instancetype.Type `db:"omit=profiles-ref,config-ref,devices-ref"`
 }
 
 // InstanceFilterAllInstances returns a predefined filter for returning all instances.

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -100,10 +100,10 @@ type Instance struct {
 
 // InstanceFilter specifies potential query parameter fields.
 type InstanceFilter struct {
-	Project string
-	Name    string
-	Node    string
-	Type    instancetype.Type
+	Project *string
+	Name    *string
+	Node    *string
+	Type    *instancetype.Type
 }
 
 // InstanceFilterAllInstances returns a predefined filter for returning all instances.

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -106,11 +106,6 @@ type InstanceFilter struct {
 	Type    *instancetype.Type `db:"omit=profiles-ref,config-ref,devices-ref"`
 }
 
-// InstanceFilterAllInstances returns a predefined filter for returning all instances.
-func InstanceFilterAllInstances() *InstanceFilter {
-	return &InstanceFilter{Type: instancetype.Any}
-}
-
 // InstanceToArgs is a convenience to convert an Instance db struct into the legacy InstanceArgs.
 func InstanceToArgs(inst *Instance) InstanceArgs {
 	args := InstanceArgs{

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -662,8 +662,8 @@ func (c *ClusterTx) GetInstanceSnapshotsWithName(project string, name string) ([
 		return nil, err
 	}
 	filter := InstanceSnapshotFilter{
-		Project:  project,
-		Instance: name,
+		Project:  &project,
+		Instance: &name,
 	}
 
 	snapshots, err := c.GetInstanceSnapshots(filter)

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -159,6 +159,15 @@ type InstanceArgs struct {
 	ExpiryDate   time.Time
 }
 
+// InstanceTypeFilter returns an InstanceFilter populated with a valid instance type,
+// or an empty filter if instance type is 'Any'.
+func InstanceTypeFilter(instanceType instancetype.Type) InstanceFilter {
+	if instanceType != instancetype.Any {
+		return InstanceFilter{Type: &instanceType}
+	}
+	return InstanceFilter{}
+}
+
 // GetInstanceNames returns the names of all containers the given project.
 func (c *ClusterTx) GetInstanceNames(project string) ([]string, error) {
 	stmt := `

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -545,7 +545,9 @@ func (c *ClusterTx) GetLocalInstancesInProject(filter InstanceFilter) ([]Instanc
 		return nil, errors.Wrap(err, "Local node name")
 	}
 
-	filter.Node = &node
+	if node != "" {
+		filter.Node = &node
+	}
 
 	return c.GetInstances(filter)
 }

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -338,9 +338,8 @@ func (c *Cluster) InstanceList(filter *InstanceFilter, instanceFunc func(inst In
 	projectHasProfiles := map[string]bool{}
 	profilesByProjectAndName := map[string]map[string]Profile{}
 
-	// Default to listing all instances if no filter provided.
 	if filter == nil {
-		filter = InstanceFilterAllInstances()
+		filter = &InstanceFilter{}
 	}
 
 	// Retrieve required info from the database in single transaction for performance.
@@ -543,9 +542,9 @@ func (c *ClusterTx) GetLocalInstancesInProject(projectName string, instanceType 
 	}
 
 	filter := InstanceFilter{
-		Project: projectName,
-		Node:    node,
-		Type:    instanceType,
+		Project: &projectName,
+		Node:    &node,
+		Type:    &instanceType,
 	}
 
 	return c.GetInstances(filter)

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -36,7 +36,7 @@ func TestContainerList(t *testing.T) {
 	addContainerDevice(t, tx, "c2", "eth0", "nic", nil)
 	addContainerDevice(t, tx, "c3", "root", "disk", map[string]string{"x": "y"})
 
-	filter := db.InstanceFilter{Type: instancetype.Container}
+	filter := db.InstanceTypeFilter(instancetype.Container)
 	containers, err := tx.GetInstances(filter)
 	require.NoError(t, err)
 	assert.Len(t, containers, 3)
@@ -75,11 +75,11 @@ func TestContainerList_FilterByNode(t *testing.T) {
 	addContainer(t, tx, nodeID1, "c2")
 	addContainer(t, tx, nodeID2, "c3")
 
-	filter := db.InstanceFilter{
-		Project: "default",
-		Node:    "node2",
-		Type:    instancetype.Container,
-	}
+	filter := db.InstanceTypeFilter(instancetype.Container)
+	project := "default"
+	node := "node2"
+	filter.Project = &project
+	filter.Node = &node
 
 	containers, err := tx.GetInstances(filter)
 	require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestInstanceList_ContainerWithSameNameInDifferentProjects(t *testing.T) {
 	_, err = tx.CreateInstance(c1p2)
 	require.NoError(t, err)
 
-	containers, err := tx.GetInstances(*db.InstanceFilterAllInstances())
+	containers, err := tx.GetInstances(db.InstanceFilter{})
 	require.NoError(t, err)
 
 	assert.Len(t, containers, 2)
@@ -332,7 +332,7 @@ func TestGetInstanceNamesByNodeAddress(t *testing.T) {
 	addContainer(t, tx, nodeID3, "c3")
 	addContainer(t, tx, nodeID2, "c4")
 
-	result, err := tx.GetInstanceNamesByNodeAddress("default", instancetype.Container)
+	result, err := tx.GetInstanceNamesByNodeAddress("default", db.InstanceTypeFilter(instancetype.Container))
 	require.NoError(t, err)
 	assert.Equal(
 		t,
@@ -356,7 +356,7 @@ func TestGetInstanceToNodeMap(t *testing.T) {
 	addContainer(t, tx, nodeID2, "c1")
 	addContainer(t, tx, nodeID1, "c2")
 
-	result, err := tx.GetInstanceToNodeMap("default", instancetype.Container)
+	result, err := tx.GetInstanceToNodeMap("default", db.InstanceTypeFilter(instancetype.Container))
 	require.NoError(t, err)
 	assert.Equal(
 		t,
@@ -420,7 +420,7 @@ func TestGetLocalInstancesInProject(t *testing.T) {
 	addContainerDevice(t, tx, "c2", "eth0", "nic", nil)
 	addContainerDevice(t, tx, "c4", "root", "disk", map[string]string{"x": "y"})
 
-	containers, err := tx.GetLocalInstancesInProject("", instancetype.Container)
+	containers, err := tx.GetLocalInstancesInProject(db.InstanceTypeFilter(instancetype.Container))
 	require.NoError(t, err)
 	assert.Len(t, containers, 3)
 

--- a/lxd/db/operations.go
+++ b/lxd/db/operations.go
@@ -35,9 +35,9 @@ type Operation struct {
 
 // OperationFilter specifies potential query parameter fields.
 type OperationFilter struct {
-	ID     int64
-	NodeID int64
-	UUID   string
+	ID     *int64
+	NodeID *int64
+	UUID   *string
 }
 
 // GetNodesWithRunningOperations returns a list of nodes that have running operations

--- a/lxd/db/operations.mapper.go
+++ b/lxd/db/operations.mapper.go
@@ -60,40 +60,30 @@ func (c *ClusterTx) GetOperations(filter OperationFilter) ([]Operation, error) {
 	// Result slice.
 	objects := make([]Operation, 0)
 
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.ID != -1 {
-		criteria["ID"] = filter.ID
-	}
-	if filter.NodeID != -1 {
-		criteria["NodeID"] = filter.NodeID
-	}
-	if filter.UUID != "" {
-		criteria["UUID"] = filter.UUID
-	}
-
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["UUID"] != nil {
+	if filter.UUID != nil && filter.ID == nil && filter.NodeID == nil {
 		stmt = c.stmt(operationObjectsByUUID)
 		args = []interface{}{
 			filter.UUID,
 		}
-	} else if criteria["NodeID"] != nil {
+	} else if filter.NodeID != nil && filter.ID == nil && filter.UUID == nil {
 		stmt = c.stmt(operationObjectsByNodeID)
 		args = []interface{}{
 			filter.NodeID,
 		}
-	} else if criteria["ID"] != nil {
+	} else if filter.ID != nil && filter.NodeID == nil && filter.UUID == nil {
 		stmt = c.stmt(operationObjectsByID)
 		args = []interface{}{
 			filter.ID,
 		}
-	} else {
+	} else if filter.ID == nil && filter.NodeID == nil && filter.UUID == nil {
 		stmt = c.stmt(operationObjects)
 		args = []interface{}{}
+	} else {
+		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.

--- a/lxd/db/operations_test.go
+++ b/lxd/db/operations_test.go
@@ -18,24 +18,26 @@ func TestOperation(t *testing.T) {
 
 	projectID, err := tx.GetProjectID("default")
 	require.NoError(t, err)
+	nodeID := tx.GetNodeID()
+	uuid := "abcd"
 
 	opInfo := db.Operation{
-		NodeID:    tx.GetNodeID(),
+		NodeID:    nodeID,
 		Type:      db.OperationInstanceCreate,
-		UUID:      "abcd",
+		UUID:      uuid,
 		ProjectID: &projectID,
 	}
 	id, err := tx.CreateOrReplaceOperation(opInfo)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), id)
 
-	filter := db.OperationFilter{NodeID: tx.GetNodeID()}
+	filter := db.OperationFilter{NodeID: &nodeID}
 	operations, err := tx.GetOperations(filter)
 	require.NoError(t, err)
 	assert.Len(t, operations, 1)
 	assert.Equal(t, operations[0].UUID, "abcd")
 
-	filter = db.OperationFilter{UUID: "abcd"}
+	filter = db.OperationFilter{UUID: &uuid}
 	ops, err := tx.GetOperations(filter)
 	require.NoError(t, err)
 	assert.Equal(t, len(ops), 1)
@@ -43,7 +45,7 @@ func TestOperation(t *testing.T) {
 	assert.Equal(t, id, operation.ID)
 	assert.Equal(t, db.OperationInstanceCreate, operation.Type)
 
-	filter = db.OperationFilter{NodeID: tx.GetNodeID()}
+	filter = db.OperationFilter{NodeID: &nodeID}
 	ops, err = tx.GetOperations(filter)
 	require.NoError(t, err)
 	assert.Equal(t, "abcd", ops[0].UUID)
@@ -51,7 +53,7 @@ func TestOperation(t *testing.T) {
 	err = tx.DeleteOperation("abcd")
 	require.NoError(t, err)
 
-	filter = db.OperationFilter{UUID: "abcd"}
+	filter = db.OperationFilter{UUID: &uuid}
 	ops, err = tx.GetOperations(filter)
 	require.NoError(t, err)
 	assert.Equal(t, len(ops), 0)
@@ -62,23 +64,26 @@ func TestOperationNoProject(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
+	nodeID := tx.GetNodeID()
+	uuid := "abcd"
+
 	opInfo := db.Operation{
-		NodeID: tx.GetNodeID(),
+		NodeID: nodeID,
 		Type:   db.OperationInstanceCreate,
-		UUID:   "abcd",
+		UUID:   uuid,
 	}
 
 	id, err := tx.CreateOrReplaceOperation(opInfo)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), id)
 
-	filter := db.OperationFilter{NodeID: tx.GetNodeID()}
+	filter := db.OperationFilter{NodeID: &nodeID}
 	operations, err := tx.GetOperations(filter)
 	require.NoError(t, err)
 	assert.Len(t, operations, 1)
 	assert.Equal(t, operations[0].UUID, "abcd")
 
-	filter = db.OperationFilter{UUID: "abcd"}
+	filter = db.OperationFilter{UUID: &uuid}
 	ops, err := tx.GetOperations(filter)
 	require.NoError(t, err)
 	assert.Equal(t, len(ops), 1)
@@ -87,7 +92,7 @@ func TestOperationNoProject(t *testing.T) {
 	assert.Equal(t, id, operation.ID)
 	assert.Equal(t, db.OperationInstanceCreate, operation.Type)
 
-	filter = db.OperationFilter{NodeID: tx.GetNodeID()}
+	filter = db.OperationFilter{NodeID: &nodeID}
 	ops, err = tx.GetOperations(filter)
 	require.NoError(t, err)
 	assert.Equal(t, "abcd", ops[0].UUID)
@@ -95,7 +100,7 @@ func TestOperationNoProject(t *testing.T) {
 	err = tx.DeleteOperation("abcd")
 	require.NoError(t, err)
 
-	filter = db.OperationFilter{UUID: "abcd"}
+	filter = db.OperationFilter{UUID: &uuid}
 	ops, err = tx.GetOperations(filter)
 	require.NoError(t, err)
 	assert.Equal(t, len(ops), 0)

--- a/lxd/db/profiles.go
+++ b/lxd/db/profiles.go
@@ -81,8 +81,8 @@ func ProfileToAPI(profile *Profile) *api.Profile {
 
 // ProfileFilter specifies potential query parameter fields.
 type ProfileFilter struct {
-	Project string
-	Name    string
+	Project *string
+	Name    *string
 }
 
 // GetProjectProfileNames returns slice of profile names keyed on the project they belong to.

--- a/lxd/db/profiles.mapper.go
+++ b/lxd/db/profiles.mapper.go
@@ -138,33 +138,24 @@ UPDATE profiles
 // GetProfileURIs returns all available profile URIs.
 // generator: profile URIs
 func (c *ClusterTx) GetProfileURIs(filter ProfileFilter) ([]string, error) {
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Project != "" {
-		criteria["Project"] = filter.Project
-	}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-
-	// Pick the prepared statement and arguments to use based on active criteria.
-	var stmt *sql.Stmt
 	var args []interface{}
-
-	if criteria["Project"] != nil && criteria["Name"] != nil {
+	var stmt *sql.Stmt
+	if filter.Project != nil && filter.Name != nil {
 		stmt = c.stmt(profileNamesByProjectAndName)
 		args = []interface{}{
 			filter.Project,
 			filter.Name,
 		}
-	} else if criteria["Project"] != nil {
+	} else if filter.Project != nil && filter.Name == nil {
 		stmt = c.stmt(profileNamesByProject)
 		args = []interface{}{
 			filter.Project,
 		}
-	} else {
+	} else if filter.Project == nil && filter.Name == nil {
 		stmt = c.stmt(profileNames)
 		args = []interface{}{}
+	} else {
+		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	code := cluster.EntityTypes["profile"]
@@ -179,33 +170,26 @@ func (c *ClusterTx) GetProfiles(filter ProfileFilter) ([]Profile, error) {
 	// Result slice.
 	objects := make([]Profile, 0)
 
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Project != "" {
-		criteria["Project"] = filter.Project
-	}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Project"] != nil && criteria["Name"] != nil {
+	if filter.Project != nil && filter.Name != nil {
 		stmt = c.stmt(profileObjectsByProjectAndName)
 		args = []interface{}{
 			filter.Project,
 			filter.Name,
 		}
-	} else if criteria["Project"] != nil {
+	} else if filter.Project != nil && filter.Name == nil {
 		stmt = c.stmt(profileObjectsByProject)
 		args = []interface{}{
 			filter.Project,
 		}
-	} else {
+	} else if filter.Project == nil && filter.Name == nil {
 		stmt = c.stmt(profileObjects)
 		args = []interface{}{}
+	} else {
+		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
@@ -300,8 +284,8 @@ func (c *ClusterTx) GetProfiles(filter ProfileFilter) ([]Profile, error) {
 // generator: profile GetOne
 func (c *ClusterTx) GetProfile(project string, name string) (*Profile, error) {
 	filter := ProfileFilter{}
-	filter.Project = project
-	filter.Name = name
+	filter.Project = &project
+	filter.Name = &name
 
 	objects, err := c.GetProfiles(filter)
 	if err != nil {
@@ -373,33 +357,26 @@ func (c *ClusterTx) ProfileConfigRef(filter ProfileFilter) (map[string]map[strin
 		Value   string
 	}, 0)
 
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Project != "" {
-		criteria["Project"] = filter.Project
-	}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Project"] != nil && criteria["Name"] != nil {
+	if filter.Project != nil && filter.Name != nil {
 		stmt = c.stmt(profileConfigRefByProjectAndName)
 		args = []interface{}{
 			filter.Project,
 			filter.Name,
 		}
-	} else if criteria["Project"] != nil {
+	} else if filter.Project != nil && filter.Name == nil {
 		stmt = c.stmt(profileConfigRefByProject)
 		args = []interface{}{
 			filter.Project,
 		}
-	} else {
+	} else if filter.Project == nil && filter.Name == nil {
 		stmt = c.stmt(profileConfigRef)
 		args = []interface{}{}
+	} else {
+		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
@@ -459,33 +436,26 @@ func (c *ClusterTx) ProfileDevicesRef(filter ProfileFilter) (map[string]map[stri
 		Value   string
 	}, 0)
 
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Project != "" {
-		criteria["Project"] = filter.Project
-	}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Project"] != nil && criteria["Name"] != nil {
+	if filter.Project != nil && filter.Name != nil {
 		stmt = c.stmt(profileDevicesRefByProjectAndName)
 		args = []interface{}{
 			filter.Project,
 			filter.Name,
 		}
-	} else if criteria["Project"] != nil {
+	} else if filter.Project != nil && filter.Name == nil {
 		stmt = c.stmt(profileDevicesRefByProject)
 		args = []interface{}{
 			filter.Project,
 		}
-	} else {
+	} else if filter.Project == nil && filter.Name == nil {
 		stmt = c.stmt(profileDevicesRef)
 		args = []interface{}{}
+	} else {
+		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
@@ -561,33 +531,26 @@ func (c *ClusterTx) ProfileUsedByRef(filter ProfileFilter) (map[string]map[strin
 		Value   string
 	}, 0)
 
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Project != "" {
-		criteria["Project"] = filter.Project
-	}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Project"] != nil && criteria["Name"] != nil {
+	if filter.Project != nil && filter.Name != nil {
 		stmt = c.stmt(profileUsedByRefByProjectAndName)
 		args = []interface{}{
 			filter.Project,
 			filter.Name,
 		}
-	} else if criteria["Project"] != nil {
+	} else if filter.Project != nil && filter.Name == nil {
 		stmt = c.stmt(profileUsedByRefByProject)
 		args = []interface{}{
 			filter.Project,
 		}
-	} else {
+	} else if filter.Project == nil && filter.Name == nil {
 		stmt = c.stmt(profileUsedByRef)
 		args = []interface{}{}
+	} else {
+		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.

--- a/lxd/db/projects.go
+++ b/lxd/db/projects.go
@@ -55,7 +55,7 @@ type Project struct {
 
 // ProjectFilter specifies potential query parameter fields.
 type ProjectFilter struct {
-	Name string `db:"omit=update"` // If non-empty, return only the project with this name.
+	Name *string `db:"omit=update"` // If non-empty, return only the project with this name.
 }
 
 // ToAPI converts the database Project struct to an api.Project entry.

--- a/lxd/db/projects.mapper.go
+++ b/lxd/db/projects.mapper.go
@@ -89,24 +89,18 @@ DELETE FROM projects WHERE name = ?
 // GetProjectURIs returns all available project URIs.
 // generator: project URIs
 func (c *ClusterTx) GetProjectURIs(filter ProjectFilter) ([]string, error) {
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-
-	// Pick the prepared statement and arguments to use based on active criteria.
-	var stmt *sql.Stmt
 	var args []interface{}
-
-	if criteria["Name"] != nil {
+	var stmt *sql.Stmt
+	if filter.Name != nil {
 		stmt = c.stmt(projectNamesByName)
 		args = []interface{}{
 			filter.Name,
 		}
-	} else {
+	} else if filter.Name == nil {
 		stmt = c.stmt(projectNames)
 		args = []interface{}{}
+	} else {
+		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	code := cluster.EntityTypes["project"]
@@ -121,24 +115,20 @@ func (c *ClusterTx) GetProjects(filter ProjectFilter) ([]Project, error) {
 	// Result slice.
 	objects := make([]Project, 0)
 
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Name"] != nil {
+	if filter.Name != nil {
 		stmt = c.stmt(projectObjectsByName)
 		args = []interface{}{
 			filter.Name,
 		}
-	} else {
+	} else if filter.Name == nil {
 		stmt = c.stmt(projectObjects)
 		args = []interface{}{}
+	} else {
+		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
@@ -199,7 +189,7 @@ func (c *ClusterTx) GetProjects(filter ProjectFilter) ([]Project, error) {
 // generator: project GetOne
 func (c *ClusterTx) GetProject(name string) (*Project, error) {
 	filter := ProjectFilter{}
-	filter.Name = name
+	filter.Name = &name
 
 	objects, err := c.GetProjects(filter)
 	if err != nil {
@@ -226,24 +216,20 @@ func (c *ClusterTx) ProjectConfigRef(filter ProjectFilter) (map[string]map[strin
 		Value string
 	}, 0)
 
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Name"] != nil {
+	if filter.Name != nil {
 		stmt = c.stmt(projectConfigRefByName)
 		args = []interface{}{
 			filter.Name,
 		}
-	} else {
+	} else if filter.Name == nil {
 		stmt = c.stmt(projectConfigRef)
 		args = []interface{}{}
+	} else {
+		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
@@ -349,24 +335,20 @@ func (c *ClusterTx) ProjectUsedByRef(filter ProjectFilter) (map[string][]string,
 		Value string
 	}, 0)
 
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Name"] != nil {
+	if filter.Name != nil {
 		stmt = c.stmt(projectUsedByRefByName)
 		args = []interface{}{
 			filter.Name,
 		}
-	} else {
+	} else if filter.Name == nil {
 		stmt = c.stmt(projectUsedByRef)
 		args = []interface{}{}
+	} else {
+		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.

--- a/lxd/db/snapshots.go
+++ b/lxd/db/snapshots.go
@@ -57,9 +57,9 @@ type InstanceSnapshot struct {
 
 // InstanceSnapshotFilter specifies potential query parameter fields.
 type InstanceSnapshotFilter struct {
-	Project  string
-	Instance string
-	Name     string
+	Project  *string
+	Instance *string
+	Name     *string
 }
 
 // InstanceSnapshotToInstance is a temporary convenience function to merge

--- a/lxd/db/snapshots.mapper.go
+++ b/lxd/db/snapshots.mapper.go
@@ -97,38 +97,28 @@ func (c *ClusterTx) GetInstanceSnapshots(filter InstanceSnapshotFilter) ([]Insta
 	// Result slice.
 	objects := make([]InstanceSnapshot, 0)
 
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Project != "" {
-		criteria["Project"] = filter.Project
-	}
-	if filter.Instance != "" {
-		criteria["Instance"] = filter.Instance
-	}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Project"] != nil && criteria["Instance"] != nil && criteria["Name"] != nil {
+	if filter.Project != nil && filter.Instance != nil && filter.Name != nil {
 		stmt = c.stmt(instanceSnapshotObjectsByProjectAndInstanceAndName)
 		args = []interface{}{
 			filter.Project,
 			filter.Instance,
 			filter.Name,
 		}
-	} else if criteria["Project"] != nil && criteria["Instance"] != nil {
+	} else if filter.Project != nil && filter.Instance != nil && filter.Name == nil {
 		stmt = c.stmt(instanceSnapshotObjectsByProjectAndInstance)
 		args = []interface{}{
 			filter.Project,
 			filter.Instance,
 		}
-	} else {
+	} else if filter.Project == nil && filter.Instance == nil && filter.Name == nil {
 		stmt = c.stmt(instanceSnapshotObjects)
 		args = []interface{}{}
+	} else {
+		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
@@ -211,9 +201,9 @@ func (c *ClusterTx) GetInstanceSnapshots(filter InstanceSnapshotFilter) ([]Insta
 // generator: instance_snapshot GetOne
 func (c *ClusterTx) GetInstanceSnapshot(project string, instance string, name string) (*InstanceSnapshot, error) {
 	filter := InstanceSnapshotFilter{}
-	filter.Project = project
-	filter.Instance = instance
-	filter.Name = name
+	filter.Project = &project
+	filter.Instance = &instance
+	filter.Name = &name
 
 	objects, err := c.GetInstanceSnapshots(filter)
 	if err != nil {
@@ -363,38 +353,28 @@ func (c *ClusterTx) InstanceSnapshotConfigRef(filter InstanceSnapshotFilter) (ma
 		Value    string
 	}, 0)
 
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Project != "" {
-		criteria["Project"] = filter.Project
-	}
-	if filter.Instance != "" {
-		criteria["Instance"] = filter.Instance
-	}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Project"] != nil && criteria["Instance"] != nil && criteria["Name"] != nil {
+	if filter.Project != nil && filter.Instance != nil && filter.Name != nil {
 		stmt = c.stmt(instanceSnapshotConfigRefByProjectAndInstanceAndName)
 		args = []interface{}{
 			filter.Project,
 			filter.Instance,
 			filter.Name,
 		}
-	} else if criteria["Project"] != nil && criteria["Instance"] != nil {
+	} else if filter.Project != nil && filter.Instance != nil && filter.Name == nil {
 		stmt = c.stmt(instanceSnapshotConfigRefByProjectAndInstance)
 		args = []interface{}{
 			filter.Project,
 			filter.Instance,
 		}
-	} else {
+	} else if filter.Project == nil && filter.Instance == nil && filter.Name == nil {
 		stmt = c.stmt(instanceSnapshotConfigRef)
 		args = []interface{}{}
+	} else {
+		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.
@@ -463,38 +443,28 @@ func (c *ClusterTx) InstanceSnapshotDevicesRef(filter InstanceSnapshotFilter) (m
 		Value    string
 	}, 0)
 
-	// Check which filter criteria are active.
-	criteria := map[string]interface{}{}
-	if filter.Project != "" {
-		criteria["Project"] = filter.Project
-	}
-	if filter.Instance != "" {
-		criteria["Instance"] = filter.Instance
-	}
-	if filter.Name != "" {
-		criteria["Name"] = filter.Name
-	}
-
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
 	var args []interface{}
 
-	if criteria["Project"] != nil && criteria["Instance"] != nil && criteria["Name"] != nil {
+	if filter.Project != nil && filter.Instance != nil && filter.Name != nil {
 		stmt = c.stmt(instanceSnapshotDevicesRefByProjectAndInstanceAndName)
 		args = []interface{}{
 			filter.Project,
 			filter.Instance,
 			filter.Name,
 		}
-	} else if criteria["Project"] != nil && criteria["Instance"] != nil {
+	} else if filter.Project != nil && filter.Instance != nil && filter.Name == nil {
 		stmt = c.stmt(instanceSnapshotDevicesRefByProjectAndInstance)
 		args = []interface{}{
 			filter.Project,
 			filter.Instance,
 		}
-	} else {
+	} else if filter.Project == nil && filter.Instance == nil && filter.Name == nil {
 		stmt = c.stmt(instanceSnapshotDevicesRef)
 		args = []interface{}{}
+	} else {
+		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
 	// Dest function for scanning a row.

--- a/lxd/db/snapshots_test.go
+++ b/lxd/db/snapshots_test.go
@@ -70,7 +70,9 @@ func TestGetInstanceSnapshots_FilterByInstance(t *testing.T) {
 	addInstanceSnapshot(t, tx, 2, "snap1")
 	addInstanceSnapshot(t, tx, 2, "snap2")
 
-	filter := db.InstanceSnapshotFilter{Project: "default", Instance: "c2"}
+	project := "default"
+	instance := "c2"
+	filter := db.InstanceSnapshotFilter{Project: &project, Instance: &instance}
 	snapshots, err := tx.GetInstanceSnapshots(filter)
 	require.NoError(t, err)
 	assert.Len(t, snapshots, 2)
@@ -137,7 +139,9 @@ func TestGetInstanceSnapshots_SameNameInDifferentProjects(t *testing.T) {
 	_, err = tx.CreateInstanceSnapshot(s1p1)
 	require.NoError(t, err)
 
-	filter := db.InstanceSnapshotFilter{Project: "p1", Instance: "i1"}
+	instance := "i1"
+	project := "p1"
+	filter := db.InstanceSnapshotFilter{Project: &project, Instance: &instance}
 	snapshots, err := tx.GetInstanceSnapshots(filter)
 	require.NoError(t, err)
 

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -222,10 +222,9 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 	// Check there isn't another NIC with any of the same addresses specified on the same cluster member.
 	// Can only validate this when the instance is supplied (and not doing profile validation).
 	if d.inst != nil {
+		node := d.inst.Location()
 		filter := db.InstanceFilter{
-			Project: "",                // All projects.
-			Node:    d.inst.Location(), // Managed bridge networks have a per-server DHCP daemon.
-			Type:    instancetype.Any,
+			Node: &node, // Managed bridge networks have a per-server DHCP daemon.
 		}
 
 		ourNICIPs := make(map[string]net.IP, 2)

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -342,7 +342,7 @@ func imgPostInstanceInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *ope
 	info.Fingerprint = fmt.Sprintf("%x", sha256.Sum(nil))
 	info.CreatedAt = time.Now().UTC()
 
-	_, _, err = d.cluster.GetImage(projectName, info.Fingerprint, false)
+	_, _, err = d.cluster.GetImage(info.Fingerprint, db.ImageFilter{Project: &projectName})
 	if err != db.ErrNoSuchObject {
 		if err != nil {
 			return nil, err
@@ -397,7 +397,7 @@ func imgPostRemoteInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *opera
 		return nil, err
 	}
 
-	id, info, err := d.cluster.GetImage(project, info.Fingerprint, false)
+	id, info, err := d.cluster.GetImage(info.Fingerprint, db.ImageFilter{Project: &project})
 	if err != nil {
 		return nil, err
 	}
@@ -477,7 +477,7 @@ func imgPostURLInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operatio
 		return nil, err
 	}
 
-	id, info, err := d.cluster.GetImage(project, info.Fingerprint, false)
+	id, info, err := d.cluster.GetImage(info.Fingerprint, db.ImageFilter{Project: &project})
 	if err != nil {
 		return nil, err
 	}
@@ -1002,7 +1002,7 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 				return fmt.Errorf("Alias already exists: %s", alias.Name)
 			}
 
-			id, _, err := d.cluster.GetImage(projectName, info.Fingerprint, false)
+			id, _, err := d.cluster.GetImage(info.Fingerprint, db.ImageFilter{Project: &projectName})
 			if err != nil {
 				return errors.Wrapf(err, "Fetch image %q", info.Fingerprint)
 			}
@@ -1517,7 +1517,12 @@ func autoUpdateImages(ctx context.Context, d *Daemon) error {
 		var newImage *api.Image
 
 		for _, image := range images {
-			_, imageInfo, err := d.cluster.GetImage(image.Project, image.Fingerprint, image.Public)
+			filter := db.ImageFilter{Project: &image.Project}
+			if image.Public {
+				filter.Public = &image.Public
+			}
+
+			_, imageInfo, err := d.cluster.GetImage(image.Fingerprint, filter)
 			if err != nil {
 				logger.Error("Failed to get image", log.Ctx{"err": err, "project": image.Project, "fingerprint": image.Fingerprint})
 				continue
@@ -1875,7 +1880,7 @@ func autoUpdateImage(ctx context.Context, d *Daemon, op *operations.Operation, i
 			continue
 		}
 
-		newID, _, err := d.cluster.GetImage(projectName, hash, false)
+		newID, _, err := d.cluster.GetImage(hash, db.ImageFilter{Project: &projectName})
 		if err != nil {
 			logger.Error("Error loading image", log.Ctx{"err": err, "fingerprint": hash})
 			continue
@@ -2131,7 +2136,7 @@ func pruneExpiredImagesInProject(ctx context.Context, d *Daemon, project db.Proj
 			}
 		}
 
-		imgID, _, err := d.cluster.GetImage(project.Name, img, false)
+		imgID, _, err := d.cluster.GetImage(img, db.ImageFilter{Project: &project.Name})
 		if err != nil {
 			return errors.Wrapf(err, "Error retrieving image info for fingerprint %q and project %q", img, project.Name)
 		}
@@ -2187,7 +2192,7 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 	do := func(op *operations.Operation) error {
 		// Use the fingerprint we received in a LIKE query and use the full
 		// fingerprint we receive from the database in all further queries.
-		imgID, imgInfo, err := d.cluster.GetImage(projectName, fingerprint, false)
+		imgID, imgInfo, err := d.cluster.GetImage(fingerprint, db.ImageFilter{Project: &projectName})
 		if err != nil {
 			return err
 		}
@@ -2310,8 +2315,13 @@ func imageDeleteFromDisk(fingerprint string) {
 	}
 }
 
-func doImageGet(db *db.Cluster, project, fingerprint string, public bool) (*api.Image, response.Response) {
-	_, imgInfo, err := db.GetImage(project, fingerprint, public)
+func doImageGet(cluster *db.Cluster, project, fingerprint string, public bool) (*api.Image, response.Response) {
+	filter := db.ImageFilter{Project: &project}
+	if public {
+		filter.Public = &public
+	}
+
+	_, imgInfo, err := cluster.GetImage(fingerprint, filter)
 	if err != nil {
 		return nil, response.SmartError(err)
 	}
@@ -2509,7 +2519,7 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 	// Get current value
 	projectName := projectParam(r)
 	fingerprint := mux.Vars(r)["fingerprint"]
-	id, info, err := d.cluster.GetImage(projectName, fingerprint, false)
+	id, info, err := d.cluster.GetImage(fingerprint, db.ImageFilter{Project: &projectName})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -2595,7 +2605,7 @@ func imagePatch(d *Daemon, r *http.Request) response.Response {
 	// Get current value
 	projectName := projectParam(r)
 	fingerprint := mux.Vars(r)["fingerprint"]
-	id, info, err := d.cluster.GetImage(projectName, fingerprint, false)
+	id, info, err := d.cluster.GetImage(fingerprint, db.ImageFilter{Project: &projectName})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -2714,7 +2724,7 @@ func imageAliasesPost(d *Daemon, r *http.Request) response.Response {
 		return response.Conflict(fmt.Errorf("Alias '%s' already exists", req.Name))
 	}
 
-	id, _, err := d.cluster.GetImage(projectName, req.Target, false)
+	id, _, err := d.cluster.GetImage(req.Target, db.ImageFilter{Project: &projectName})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -3049,7 +3059,7 @@ func imageAliasPut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("The target field is required"))
 	}
 
-	imageId, _, err := d.cluster.GetImage(projectName, req.Target, false)
+	imageId, _, err := d.cluster.GetImage(req.Target, db.ImageFilter{Project: &projectName})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -3139,7 +3149,7 @@ func imageAliasPatch(d *Daemon, r *http.Request) response.Response {
 		alias.Description = description
 	}
 
-	imageId, _, err := d.cluster.GetImage(projectName, alias.Target, false)
+	imageId, _, err := d.cluster.GetImage(alias.Target, db.ImageFilter{Project: &projectName})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -3283,7 +3293,7 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 	var err error
 	if r.RemoteAddr == "@devlxd" {
 		// /dev/lxd API requires exact match
-		_, imgInfo, err = d.cluster.GetImage(projectName, fingerprint, false)
+		_, imgInfo, err = d.cluster.GetImage(fingerprint, db.ImageFilter{Project: &projectName})
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -3292,7 +3302,7 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 			return response.NotFound(fmt.Errorf("Image '%s' not found", fingerprint))
 		}
 	} else {
-		_, imgInfo, err = d.cluster.GetImage(projectName, fingerprint, false)
+		_, imgInfo, err = d.cluster.GetImage(fingerprint, db.ImageFilter{Project: &projectName})
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -3401,7 +3411,7 @@ func imageExportPost(d *Daemon, r *http.Request) response.Response {
 	fingerprint := mux.Vars(r)["fingerprint"]
 
 	// Check if the image exists
-	_, _, err := d.cluster.GetImage(projectName, fingerprint, false)
+	_, _, err := d.cluster.GetImage(fingerprint, db.ImageFilter{Project: &projectName})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -3528,7 +3538,7 @@ func imageSecret(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 	fingerprint := mux.Vars(r)["fingerprint"]
 
-	_, imgInfo, err := d.cluster.GetImage(projectName, fingerprint, false)
+	_, imgInfo, err := d.cluster.GetImage(fingerprint, db.ImageFilter{Project: &projectName})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -3631,7 +3641,7 @@ func imageImportFromNode(imagesDir string, client lxd.InstanceServer, fingerprin
 func imageRefresh(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 	fingerprint := mux.Vars(r)["fingerprint"]
-	imageId, imageInfo, err := d.cluster.GetImage(projectName, fingerprint, false)
+	imageId, imageInfo, err := d.cluster.GetImage(fingerprint, db.ImageFilter{Project: &projectName})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -3783,7 +3793,7 @@ func imageSyncBetweenNodes(d *Daemon, r *http.Request, project string, fingerpri
 	source = source.UseProject(project)
 
 	// Get the image.
-	_, image, err := d.cluster.GetImage(project, fingerprint, false)
+	_, image, err := d.cluster.GetImage(fingerprint, db.ImageFilter{Project: &project})
 	if err != nil {
 		return errors.Wrap(err, "Failed to get image")
 	}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
-	"github.com/lxc/lxd/client"
+	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/filter"
@@ -1444,7 +1444,8 @@ func autoUpdateImages(ctx context.Context, d *Daemon) error {
 	err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
 		var err error
 
-		images, err := tx.GetImages(db.ImageFilter{AutoUpdate: true})
+		autoUpdate := true
+		images, err := tx.GetImages(db.ImageFilter{AutoUpdate: &autoUpdate})
 		if err != nil {
 			return err
 		}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -87,7 +87,7 @@ func instanceCreateFromImage(d *Daemon, r *http.Request, args db.InstanceArgs, h
 	s := d.State()
 
 	// Get the image properties.
-	_, img, err := s.Cluster.GetImage(args.Project, hash, false)
+	_, img, err := s.Cluster.GetImage(hash, db.ImageFilter{Project: &args.Project})
 	if err != nil {
 		return nil, errors.Wrapf(err, "Fetch image %s from database", hash)
 	}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -390,7 +390,9 @@ func instanceLoadNodeProjectAll(s *state.State, project string, instanceType ins
 	var cts []db.Instance
 	err := s.Cluster.Transaction(func(tx *db.ClusterTx) error {
 		var err error
-		cts, err = tx.GetLocalInstancesInProject(project, instanceType)
+		filter := db.InstanceTypeFilter(instanceType)
+		filter.Project = &project
+		cts, err = tx.GetLocalInstancesInProject(filter)
 		if err != nil {
 			return err
 		}

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -716,7 +716,7 @@ func ResolveImage(s *state.State, project string, source api.InstanceSource) (st
 
 		var image *api.Image
 		for _, imageHash := range hashes {
-			_, img, err := s.Cluster.GetImage(project, imageHash, false)
+			_, img, err := s.Cluster.GetImage(imageHash, db.ImageFilter{Project: &project})
 			if err != nil {
 				continue
 			}
@@ -800,7 +800,7 @@ func SuitableArchitectures(s *state.State, project string, req api.InstancesPost
 
 		// Handle local images.
 		if req.Source.Server == "" {
-			_, img, err := s.Cluster.GetImage(project, hash, false)
+			_, img, err := s.Cluster.GetImage(hash, db.ImageFilter{Project: &project})
 			if err != nil {
 				return nil, err
 			}

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -611,7 +611,8 @@ func LoadNodeAll(s *state.State, instanceType instancetype.Type) ([]Instance, er
 	var insts []db.Instance
 	err := s.Cluster.Transaction(func(tx *db.ClusterTx) error {
 		var err error
-		insts, err = tx.GetLocalInstancesInProject("", instanceType)
+		filter := db.InstanceTypeFilter(instanceType)
+		insts, err = tx.GetLocalInstancesInProject(filter)
 		if err != nil {
 			return err
 		}

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 
-	"github.com/lxc/lxd/client"
+	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/backup"
 	"github.com/lxc/lxd/lxd/db"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
@@ -563,8 +563,7 @@ func LoadByProject(s *state.State, project string) ([]Instance, error) {
 	var cts []db.Instance
 	err := s.Cluster.Transaction(func(tx *db.ClusterTx) error {
 		filter := db.InstanceFilter{
-			Project: project,
-			Type:    instancetype.Any,
+			Project: &project,
 		}
 		var err error
 		cts, err = tx.GetInstances(filter)

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -123,7 +123,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 			targetNodeOffline = node.IsOffline(config.OfflineThreshold())
 
 			// Load source node.
-			address, err := tx.GetNodeAddressOfInstance(projectName, name, instanceType)
+			address, err := tx.GetNodeAddressOfInstance(projectName, name, db.InstanceTypeFilter(instanceType))
 			if err != nil {
 				return errors.Wrap(err, "Failed to get address of instance's node")
 			}

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -257,12 +257,12 @@ func doInstancesGet(d *Daemon, r *http.Request) (interface{}, error) {
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
 		var err error
 
-		result, err = tx.GetInstanceNamesByNodeAddress(projectName, instanceType)
+		result, err = tx.GetInstanceNamesByNodeAddress(projectName, db.InstanceTypeFilter(instanceType))
 		if err != nil {
 			return err
 		}
 
-		nodes, err = tx.GetInstanceToNodeMap(projectName, instanceType)
+		nodes, err = tx.GetInstanceToNodeMap(projectName, db.InstanceTypeFilter(instanceType))
 		if err != nil {
 			return err
 		}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1080,7 +1080,7 @@ func clusterCopyContainerInternal(d *Daemon, r *http.Request, source instance.In
 		var err error
 
 		// Load source node.
-		nodeAddress, err = tx.GetNodeAddressOfInstance(projectName, name, source.Type())
+		nodeAddress, err = tx.GetNodeAddressOfInstance(projectName, name, db.InstanceTypeFilter(source.Type()))
 		if err != nil {
 			return errors.Wrap(err, "Failed to get address of instance's node")
 		}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -116,7 +116,7 @@ func createFromImage(d *Daemon, r *http.Request, projectName string, req *api.In
 				return err
 			}
 		} else {
-			_, info, err = d.cluster.GetImage(projectName, hash, false)
+			_, info, err = d.cluster.GetImage(hash, db.ImageFilter{Project: &projectName})
 			if err != nil {
 				return err
 			}

--- a/lxd/network/network_utils_sriov.go
+++ b/lxd/network/network_utils_sriov.go
@@ -14,7 +14,6 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/device/pci"
-	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/ip"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
@@ -57,9 +56,7 @@ func SRIOVGetHostDevicesInUse(s *state.State) (map[string]struct{}, error) {
 	}
 
 	filter := db.InstanceFilter{
-		Project: "", // All projects.
-		Node:    localNode,
-		Type:    instancetype.Any,
+		Node: &localNode,
 	}
 
 	reservedDevices := map[string]struct{}{}

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -191,7 +191,7 @@ func operationGet(d *Daemon, r *http.Request) response.Response {
 	// Then check if the query is from an operation on another node, and, if so, forward it
 	var address string
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
-		filter := db.OperationFilter{UUID: id}
+		filter := db.OperationFilter{UUID: &id}
 		ops, err := tx.GetOperations(filter)
 		if err != nil {
 			return err
@@ -268,7 +268,7 @@ func operationDelete(d *Daemon, r *http.Request) response.Response {
 	// Then check if the query is from an operation on another node, and, if so, forward it
 	var address string
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
-		filter := db.OperationFilter{UUID: id}
+		filter := db.OperationFilter{UUID: &id}
 		ops, err := tx.GetOperations(filter)
 		if err != nil {
 			return err
@@ -318,7 +318,7 @@ func operationCancel(d *Daemon, r *http.Request, projectName string, op *api.Ope
 	var memberAddress string
 	var err error
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
-		filter := db.OperationFilter{UUID: op.ID}
+		filter := db.OperationFilter{UUID: &op.ID}
 		ops, err := tx.GetOperations(filter)
 		if err != nil {
 			return errors.Wrapf(err, "Failed loading operation %q", op.ID)
@@ -855,7 +855,7 @@ func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 	// Then check if the query is from an operation on another node, and, if so, forward it
 	var address string
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
-		filter := db.OperationFilter{UUID: id}
+		filter := db.OperationFilter{UUID: &id}
 		ops, err := tx.GetOperations(filter)
 		if err != nil {
 			return err
@@ -979,7 +979,7 @@ func operationWebsocketGet(d *Daemon, r *http.Request) response.Response {
 
 	var address string
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
-		filter := db.OperationFilter{UUID: id}
+		filter := db.OperationFilter{UUID: &id}
 		ops, err := tx.GetOperations(filter)
 		if err != nil {
 			return err

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -3328,13 +3328,14 @@ func patchStorageApiDirBindMount(name string, d *Daemon) error {
 }
 
 func patchFixUploadedAt(name string, d *Daemon) error {
-	images, err := d.cluster.GetImagesFingerprints("default", false)
+	projectName := project.Default
+	images, err := d.cluster.GetImagesFingerprints(projectName, false)
 	if err != nil {
 		return err
 	}
 
 	for _, fingerprint := range images {
-		id, image, err := d.cluster.GetImage("default", fingerprint, false)
+		id, image, err := d.cluster.GetImage(fingerprint, db.ImageFilter{Project: &projectName})
 		if err != nil {
 			return err
 		}

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -148,7 +148,7 @@ func profilesGet(d *Daemon, r *http.Request) response.Response {
 	var result interface{}
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
 		filter := db.ProfileFilter{
-			Project: projectName,
+			Project: &projectName,
 		}
 		if recursion {
 			profiles, err := tx.GetProfiles(filter)

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -1010,8 +1010,7 @@ func fetchProject(tx *db.ClusterTx, projectName string, skipIfNoLimits bool) (*p
 	}
 
 	instances, err := tx.GetInstances(db.InstanceFilter{
-		Type:    instancetype.Any,
-		Project: projectName,
+		Project: &projectName,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "Fetch project instances from database")

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -997,10 +997,11 @@ func fetchProject(tx *db.ClusterTx, projectName string, skipIfNoLimits bool) (*p
 	// If the project has the profiles feature enabled, we use its own
 	// profiles to expand the instances configs, otherwise we use the
 	// profiles from the default project.
+	defaultProject := Default
 	if projectName == Default || shared.IsTrue(project.Config["features.profiles"]) {
-		profilesFilter.Project = projectName
+		profilesFilter.Project = &projectName
 	} else {
-		profilesFilter.Project = Default
+		profilesFilter.Project = &defaultProject
 	}
 
 	profiles, err := tx.GetProfiles(profilesFilter)

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1236,6 +1236,8 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 	args.Config = rootDiskConf
 	args.Name = inst.Name()
 
+	projectName := inst.Project()
+
 	// If migration header supplies a volume size, then use that as block volume size instead of pool default.
 	// This way if the volume being received is larger than the pool default size, the block volume created
 	// will still be able to accommodate it.
@@ -1247,7 +1249,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 	}
 
 	// Get the volume name on storage.
-	volStorageName := project.Instance(inst.Project(), args.Name)
+	volStorageName := project.Instance(projectName, args.Name)
 
 	vol := b.newVolume(volType, contentType, volStorageName, args.Config)
 
@@ -1278,7 +1280,8 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 			fingerprint := inst.ExpandedConfig()["volatile.base_image"]
 
 			// Confirm that the image is present in the project.
-			_, _, err = b.state.Cluster.GetImage(inst.Project(), fingerprint, false)
+
+			_, _, err = b.state.Cluster.GetImage(fingerprint, db.ImageFilter{Project: &projectName})
 			if err != db.ErrNoSuchObject && err != nil {
 				return err
 			}

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -901,7 +901,7 @@ func storagePoolDelete(d *Daemon, r *http.Request) response.Response {
 		}
 
 		for _, volume := range volumeNames {
-			_, imgInfo, err := d.cluster.GetImage(projectName, volume, false)
+			_, imgInfo, err := d.cluster.GetImage(volume, db.ImageFilter{Project: &projectName})
 			if err != nil {
 				return response.InternalError(errors.Wrapf(err, "Failed getting image info for %q", volume))
 			}


### PR DESCRIPTION
This PR jumps off #9072  and  changes all `-Filter` struct fields to be pointers, simplifying the zero-value handling of generated methods to just check if a field is `nil`. 

For the most part, it was straightforward, until I dealt with `Instances`. Had to rework that a few times, thanks to `instancetype.Any`. What I ended up doing is create a helper function called `InstanceTypeFilter` that takes in an `instancetype.Type` and generates the appropriate filter. This doesn't necessarily prevent anyone from dangerously adding `instancetype.Any` into `InstanceFilter` manually, but it does make doing so look really ugly  and easy to spot by comparison. Without using this helper, forcing an `instancetype` into the `InstanceFilter` would look like:
```
instanceType := instancetype.Any
filter := InstanceFilter{Type: &instanceType}
```
which should be a giveaway that something wrong is happening :)

Other than that, the other big change is with `GetImage`. As part of #9072, I changed its arguments to be pointers as a bandaid, but here I've replaced those with `ImageFilter`, simply omitting the `Public` field when it's not used.

There's still one quirky spot in `lxd/db/instances.go`, in the method `GetLocalInstancesInProject`. This method has an empty string check on the value of `GetLocalNodeName`, because it is returning an empty string in the event that it can't find a node. I was debating making this method return a pointer to a string instead, and return `nil` if it can't find anything. I'd appreciate some thoughts on that!
