### PR TITLE
lxd/cluster: Fix some early issues with cluster evacuation/restore

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1403,7 +1403,9 @@ func (d *Daemon) Ready() error {
 	s := d.State()
 
 	// Restore containers
-	instancesRestart(s)
+	if !d.cluster.LocalNodeIsEvacuated() {
+		instancesRestart(s)
+	}
 
 	// Re-balance in case things changed while LXD was down
 	deviceTaskBalance(s)

--- a/lxd/device/device_common.go
+++ b/lxd/device/device_common.go
@@ -72,6 +72,11 @@ func (d *deviceCommon) CanHotPlug() bool {
 	return false
 }
 
+// CanMigrate returns whether the device can be migrated to any other cluster member.
+func (d *deviceCommon) CanMigrate() bool {
+	return false
+}
+
 // UpdatableFields returns an empty list of updatable fields as most devices do not support updates.
 func (d *deviceCommon) UpdatableFields(oldDevice Type) []string {
 	return []string{}

--- a/lxd/device/device_interface.go
+++ b/lxd/device/device_interface.go
@@ -18,8 +18,11 @@ type VolatileGetter func() map[string]string
 
 // Type represents a LXD device type.
 type Type interface {
-	// CanHotPlug returns true if device can be managed whilst instance is running.
+	// CanHotPlug returns true if the device can be managed whilst instance is running.
 	CanHotPlug() bool
+
+	// CanMigrate returns true if the device should work properly on any cluster member.
+	CanMigrate() bool
 
 	// UpdatableFields returns a slice of config fields that can be updated. If only fields in this list have
 	// changed then Update() is called rather triggering a device remove & add.

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -54,6 +54,28 @@ type disk struct {
 	deviceCommon
 }
 
+// CanMigrate returns whether the device can be migrated to any other cluster member.
+func (d *disk) CanMigrate() bool {
+	// Root disk is always migratable.
+	if d.config["path"] == "/" {
+		return true
+	}
+
+	// Load the storage pool.
+	pool, err := storagePools.GetPoolByName(d.state, d.config["pool"])
+	if err != nil {
+		return false
+	}
+
+	// Remote disks are migratable.
+	if pool.Driver().Info().Remote {
+		return true
+	}
+
+	return false
+}
+
+// validateConfig checks the supplied config for correctness.
 // isRequired indicates whether the supplied device config requires this device to start OK.
 func (d *disk) isRequired(devConfig deviceConfig.Device) bool {
 	// Defaults to required.

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -47,6 +47,11 @@ func (d *nicBridged) CanHotPlug() bool {
 	return true
 }
 
+// CanMigrate returns whether the device can be migrated to any other cluster member.
+func (d *nicBridged) CanMigrate() bool {
+	return d.config["network"] != ""
+}
+
 // validateConfig checks the supplied config for correctness.
 func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 	if !instanceSupported(instConf.Type(), instancetype.Container, instancetype.VM) {

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -25,6 +25,11 @@ func (d *nicMACVLAN) CanHotPlug() bool {
 	return true
 }
 
+// CanMigrate returns whether the device can be migrated to any other cluster member.
+func (d *nicMACVLAN) CanMigrate() bool {
+	return d.config["network"] != ""
+}
+
 // validateConfig checks the supplied config for correctness.
 func (d *nicMACVLAN) validateConfig(instConf instance.ConfigReader) error {
 	if !instanceSupported(instConf.Type(), instancetype.Container, instancetype.VM) {

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -42,6 +42,11 @@ type nicOVN struct {
 	network ovnNet // Populated in validateConfig().
 }
 
+// CanMigrate returns whether the device can be migrated to any other cluster member.
+func (d *nicOVN) CanMigrate() bool {
+	return true
+}
+
 // UpdatableFields returns a list of fields that can be updated without triggering a device remove & add.
 func (d *nicOVN) UpdatableFields(oldDevice Type) []string {
 	// Check old and new device types match.

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -28,6 +28,11 @@ func (d *nicSRIOV) CanHotPlug() bool {
 	return true
 }
 
+// CanMigrate returns whether the device can be migrated to any other cluster member.
+func (d *nicSRIOV) CanMigrate() bool {
+	return d.config["network"] != ""
+}
+
 // validateConfig checks the supplied config for correctness.
 func (d *nicSRIOV) validateConfig(instConf instance.ConfigReader) error {
 	if !instanceSupported(instConf.Type(), instancetype.Container, instancetype.VM) {

--- a/lxd/device/none.go
+++ b/lxd/device/none.go
@@ -9,6 +9,12 @@ type none struct {
 	deviceCommon
 }
 
+// CanMigrate returns whether the device can be migrated to any other cluster member.
+func (d *none) CanMigrate() bool {
+	return true
+}
+
+// validateConfig checks the supplied config for correctness.
 // validateConfig checks the supplied config for correctness.
 func (d *none) validateConfig(instConf instance.ConfigReader) error {
 	rules := map[string]func(string) error{} // No fields allowed.

--- a/lxd/device/tpm.go
+++ b/lxd/device/tpm.go
@@ -25,6 +25,11 @@ type tpm struct {
 	deviceCommon
 }
 
+// CanMigrate returns whether the device can be migrated to any other cluster member.
+func (d *tpm) CanMigrate() bool {
+	return true
+}
+
 // validateConfig checks the supplied config for correctness.
 func (d *tpm) validateConfig(instConf instance.ConfigReader) error {
 	if !instanceSupported(instConf.Type(), instancetype.Container, instancetype.VM) {

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -277,7 +277,7 @@ func (d *common) VolatileSet(changes map[string]string) error {
 		})
 	}
 	if err != nil {
-		return errors.Wrap(err, "Failed to volatile config")
+		return errors.Wrap(err, "Failed to set volatile config")
 	}
 
 	// Apply the change locally.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6587,6 +6587,11 @@ func (d *lxc) IsRunning() bool {
 	return d.isRunningStatusCode(d.statusCode())
 }
 
+// IsMigratable returns whether the instance can be migrated.
+func (d *lxc) IsMigratable() bool {
+	return d.isMigratable(d)
+}
+
 // InitPID returns PID of init process.
 func (d *lxc) InitPID() int {
 	// Load the go-lxc struct

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5353,6 +5353,11 @@ func (d *qemu) IsFrozen() bool {
 	return d.statusCode() == api.Frozen
 }
 
+// IsMigratable returns whether the instance can be migrated.
+func (d *qemu) IsMigratable() bool {
+	return d.isMigratable(d)
+}
+
 // DeviceEventHandler handles events occurring on the instance's devices.
 func (d *qemu) DeviceEventHandler(runConf *deviceConfig.RunConfig) error {
 	return fmt.Errorf("DeviceEventHandler Not implemented")

--- a/lxd/instance_state.go
+++ b/lxd/instance_state.go
@@ -141,6 +141,11 @@ func instanceStatePut(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
+	// Check if the cluster member is evacuated.
+	if d.cluster.LocalNodeIsEvacuated() {
+		return response.Forbidden(fmt.Errorf("Node is evacuated"))
+	}
+
 	req := api.InstanceStatePut{}
 
 	// We default to -1 (i.e. no timeout) here instead of 0 (instant timeout).

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2614,33 +2614,18 @@ test_clustering_evacuation() {
   LXD_DIR="${LXD_TWO_DIR}" lxc list
 
   # Check instance status
-  if [ "${driver}" = "ceph" ]; then
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c1 | grep -q "Status: RUNNING"
-    ! LXD_DIR="${LXD_TWO_DIR}" lxc info c1 | grep -q "Location: node1" || false
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c2 | grep -q "Status: STOPPED"
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c2 | grep -q "Location: node1"
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c3 | grep -q "Status: STOPPED"
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c3 | grep -q "Location: node1"
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c4 | grep -q "Status: RUNNING"
-    ! LXD_DIR="${LXD_TWO_DIR}" lxc info c4 | grep -q "Location: node1" || false
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c5 | grep -q "Status: STOPPED"
-    ! LXD_DIR="${LXD_TWO_DIR}" lxc info c5 | grep -q "Location: node1" || false
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c6 | grep -q "Status: RUNNING"
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c6 | grep -q "Location: node2"
-  else
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c1 | grep -q "Status: STOPPED"
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c1 | grep -q "Location: node1"
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c2 | grep -q "Status: STOPPED"
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c2 | grep -q "Location: node1"
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c3 | grep -q "Status: STOPPED"
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c3 | grep -q "Location: node1"
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c4 | grep -q "Status: RUNNING"
-    ! LXD_DIR="${LXD_TWO_DIR}" lxc info c4 | grep -q "Location: node1" || false
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c5 | grep -q "Status: STOPPED"
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c5 | grep -q "Location: node1"
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c6 | grep -q "Status: RUNNING"
-    LXD_DIR="${LXD_TWO_DIR}" lxc info c6 | grep -q "Location: node2"
-  fi
+  LXD_DIR="${LXD_TWO_DIR}" lxc info c1 | grep -q "Status: RUNNING"
+  ! LXD_DIR="${LXD_TWO_DIR}" lxc info c1 | grep -q "Location: node1" || false
+  LXD_DIR="${LXD_TWO_DIR}" lxc info c2 | grep -q "Status: RUNNING"
+  ! LXD_DIR="${LXD_TWO_DIR}" lxc info c2 | grep -q "Location: node1" || false
+  LXD_DIR="${LXD_TWO_DIR}" lxc info c3 | grep -q "Status: STOPPED"
+  LXD_DIR="${LXD_TWO_DIR}" lxc info c3 | grep -q "Location: node1"
+  LXD_DIR="${LXD_TWO_DIR}" lxc info c4 | grep -q "Status: RUNNING"
+  ! LXD_DIR="${LXD_TWO_DIR}" lxc info c4 | grep -q "Location: node1" || false
+  LXD_DIR="${LXD_TWO_DIR}" lxc info c5 | grep -q "Status: STOPPED"
+  ! LXD_DIR="${LXD_TWO_DIR}" lxc info c5 | grep -q "Location: node1" || false
+  LXD_DIR="${LXD_TWO_DIR}" lxc info c6 | grep -q "Status: RUNNING"
+  LXD_DIR="${LXD_TWO_DIR}" lxc info c6 | grep -q "Location: node2"
 
   # Ensure instances cannot be created on the evacuated node
   ! LXD_DIR="${LXD_TWO_DIR}" lxc launch testimage c7 --target=node1 || false


### PR DESCRIPTION
This fixes some issues in the logic determining whether something is migratable or not, also moves it over to the device package.
On top of that, it fixes a race/conflict around volatile key usage when mixing API level migration with server level Start by fetching a new copy of the entire instance from the database.