### PR TITLE
Instance: Change IsSameLogicalInstance to consider volatile.uuid globally unique 

### DIFF
--- a/doc/instances.md
+++ b/doc/instances.md
@@ -114,7 +114,7 @@ volatile.idmap.next                         | string    | -             | The id
 volatile.last\_state.idmap                  | string    | -             | Serialized instance uid/gid map
 volatile.last\_state.power                  | string    | -             | Instance state as of last host shutdown
 volatile.vsock\_id                          | string    | -             | Instance vsock ID used as of last start
-volatile.uuid                               | string    | -             | Instance UUID
+volatile.uuid                               | string    | -             | Instance UUID (globally unique across all servers and projects)
 volatile.\<name\>.apply\_quota              | string    | -             | Disk quota to be applied on next instance start
 volatile.\<name\>.ceph\_rbd                 | string    | -             | RBD device path for Ceph disk devices
 volatile.\<name\>.host\_name                | string    | -             | Network device name on the host

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -266,7 +266,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 
 				// Skip our own device. This avoids triggering duplicate device errors during
 				// updates or when making temporary copies of our instance during migrations.
-				if instance.IsSameLocgicalInstance(d.inst, &inst) && d.Name() == devName {
+				if instance.IsSameLogicalInstance(d.inst, &inst) && d.Name() == devName {
 					continue
 				}
 

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -1202,9 +1202,9 @@ func MoveTemporaryName(inst Instance) string {
 	return fmt.Sprintf("lxd-move-of-%s", inst.LocalConfig()["volatile.uuid"])
 }
 
-// IsSameLocgicalInstance returns true if the supplied Instance and db.Instance have the same project and name or
+// IsSameLogicalInstance returns true if the supplied Instance and db.Instance have the same project and name or
 // if they have the same volatile.uuid values.
-func IsSameLocgicalInstance(inst Instance, dbInst *db.Instance) bool {
+func IsSameLogicalInstance(inst Instance, dbInst *db.Instance) bool {
 	// Instance name is unique within a project.
 	if dbInst.Project == inst.Project() && dbInst.Name == inst.Name() {
 		return true

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -1202,10 +1202,18 @@ func MoveTemporaryName(inst Instance) string {
 	return fmt.Sprintf("lxd-move-of-%s", inst.LocalConfig()["volatile.uuid"])
 }
 
-// IsSameLocgicalInstance returns true if the supplied Instance and db.Instance have the same project, and either
-// the same name or volatile.uuid values.
+// IsSameLocgicalInstance returns true if the supplied Instance and db.Instance have the same project and name or
+// if they have the same volatile.uuid values.
 func IsSameLocgicalInstance(inst Instance, dbInst *db.Instance) bool {
-	if dbInst.Project == inst.Project() && (dbInst.Name == inst.Name() || dbInst.Config["volatile.uuid"] == inst.LocalConfig()["volatile.uuid"]) {
+	// Instance name is unique within a project.
+	if dbInst.Project == inst.Project() && dbInst.Name == inst.Name() {
+		return true
+	}
+
+	// Instance UUID is expected to be globally unique (which then allows for the *temporary* existence of
+	// duplicate instances of different names with the same volatile.uuid in order to accommodate moving
+	// instances between projects and storage pools without triggering duplicate resource errors).
+	if dbInst.Config["volatile.uuid"] == inst.LocalConfig()["volatile.uuid"] {
 		return true
 	}
 


### PR DESCRIPTION
Allows for an instance to be moved between projects without triggering duplicate MAC address errors.