### PR TITLE
NIC: Works around routed NIC regression in liblxc by setting zero broadcast address

### DIFF
--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -263,7 +263,10 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 	if d.config["ipv4.address"] != "" {
 		for _, addr := range strings.Split(d.config["ipv4.address"], ",") {
 			addr = strings.TrimSpace(addr)
-			nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv4.address", Value: fmt.Sprintf("%s/32", addr)})
+			// Specify the broadcast address as 0.0.0.0 as there is no broadcast address on this link.
+			// This stops liblxc from trying to calculate a broadcast address (and getting it wrong)
+			// which can prevent instances communicating with each other using adjacent IP addresses.
+			nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv4.address", Value: fmt.Sprintf("%s/32 0.0.0.0", addr)})
 		}
 
 		if nicHasAutoGateway(d.config["ipv4.gateway"]) {

--- a/test/suites/container_devices_nic_routed.sh
+++ b/test/suites/container_devices_nic_routed.sh
@@ -63,6 +63,9 @@ test_container_devices_nic_routed() {
     mtu=1600
   lxc start "${ctName}"
 
+  # Check IP is assigned and doesn't have a broadcast address set.
+  lxc exec "${ctName}" -- ip a | grep "inet 192.0.2.1${ipRand}/32 scope global eth0"
+
   # Check custom MTU is applied.
   if ! lxc exec "${ctName}" -- ip link show eth0 | grep "mtu 1600" ; then
     echo "mtu invalid"


### PR DESCRIPTION
See https://discuss.linuxcontainers.org/t/container-cant-ping-its-neighbour-ip-address-since-its-also-its-own-broadcast-address/11829

Change was introduced in liblxc by https://github.com/lxc/lxc/commit/365136359f8bf991ed172b498909000ec18b32de which change how the broadcast address was automatically calculated. Previously when using a `routed` NIC with a /32 IPv4 address it was being set to `255.255.255.255` which allowed adjacent IP communication.

However that commit changed it so that the broadcast address was either set to the same IP as the specified address or the address after it, which could lead adjacent IPs not being reachable if assigned on different instance NICs.

This PR uses the undocumented feature in libxc to specify an all-zero broadcast address, which then works around the change in the automatic calculation. The reason I didn't specify the 255.255.255.255 address which was previous behaviour is that AFAIK there shouldn't be an explicit broadcast address set on the `routed` NIC point-to-point links anyway, and using an all-zero broadcast address replicates the behaviour I see when manually running:

```
ip a add n.n.n.n/32 dev eth0
```

The equivalent IPv6 address setting code in liblxc doesn't appear to have any broadcast address detection or support for setting it, so I have not had to work around that part.

CC @brauner 