### PR TITLE
Network: Add source NAT address support

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1407,3 +1407,8 @@ Add a new USBAddress (usb\_address) field to ResourcesGPUCard (GPU entries) in t
 ## clustering\_evacuation
 Adds `POST /1.0/cluster/members/<name>/state` endpoint for evacuating and restoring cluster members.
 It also adds the config keys `cluster.evacuate` and `volatile.evacuate.origin` for setting the evacuation method (`auto`, `stop` or `migrate`) and the origin of any migrated instance respectively.
+
+## network\_ovn\_nat\_address
+This introduces the `ipv4.nat.address` and `ipv6.nat.address` configuration keys for LXD `ovn` networks.
+Those keys control the source address used for outbound traffic from the OVN virtual network.
+These keys can only be specified when the OVN network's uplink network has `ovn.ingress_mode=routed`.

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -364,7 +364,9 @@ dns.search                           | string    | -                     | -    
 ipv4.address                         | string    | standard mode         | auto (on create only)     | IPv4 address for the bridge (CIDR notation). Use "none" to turn off IPv4 or "auto" to generate a new random unused subnet
 ipv4.dhcp                            | boolean   | ipv4 address          | true                      | Whether to allocate addresses using DHCP
 ipv4.nat                             | boolean   | ipv4 address          | false                     | Whether to NAT (will default to true if unset and a random ipv4.address is generated)
+ipv4.nat.address                     | string    | ipv4 address          | -                         | The source address used for outbound traffic from the network (requires uplink `ovn.ingress_mode=routed`)
 ipv6.address                         | string    | standard mode         | auto (on create only)     | IPv6 address for the bridge (CIDR notation). Use "none" to turn off IPv6 or "auto" to generate a new random unused subnet
+ipv6.nat.address                     | string    | ipv6 address          | -                         | The source address used for outbound traffic from the network (requires uplink `ovn.ingress_mode=routed`)
 ipv6.dhcp                            | boolean   | ipv6 address          | true                      | Whether to provide additional network configuration over DHCP
 ipv6.dhcp.stateful                   | boolean   | ipv6 dhcp             | false                     | Whether to allocate addresses using DHCP
 ipv6.nat                             | boolean   | ipv6 address          | false                     | Whether to NAT (will default to true if unset and a random ipv6.address is generated)

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2681,6 +2681,11 @@ func (n *ovn) InstanceDevicePortValidateExternalRoutes(deviceInstance instance.I
 
 		// Check the external port route doesn't fall within any existing OVN network external subnets.
 		for _, externalSubnetUser := range externalSubnetsInUse {
+			// Skip our own network's SNAT address (as it can be used for NICs in the network).
+			if externalSubnetUser.networkSNAT && externalSubnetUser.networkProject == n.project && externalSubnetUser.networkName == n.name {
+				continue
+			}
+
 			if deviceInstance == nil {
 				// Skip checking instance devices during profile validation, only do this when
 				// an instance is supplied.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -184,6 +184,16 @@ func (n *ovn) validateExternalSubnet(uplinkRoutes []*net.IPNet, projectRestricte
 	return nil
 }
 
+type externalSubnetUsage struct {
+	subnet          *net.IPNet
+	networkProject  string
+	networkName     string
+	networkSNAT     bool
+	instanceProject string
+	instanceName    string
+	instanceDevice  string
+}
+
 // Validate network config.
 func (n *ovn) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -277,7 +277,7 @@ func (n *ovn) Validate(config map[string]string) error {
 	}
 
 	// If NAT disabled, parse the external subnets that are being requested.
-	var externalSubnets []*net.IPNet
+	var externalSubnets []*net.IPNet // Subnets to check for conflicts with other networks/NICs.
 	for _, keyPrefix := range []string{"ipv4", "ipv6"} {
 		addressKey := fmt.Sprintf("%s.address", keyPrefix)
 		if !shared.IsTrue(config[fmt.Sprintf("%s.nat", keyPrefix)]) && validate.IsOneOf("", "none", "auto")(config[addressKey]) != nil {
@@ -286,6 +286,7 @@ func (n *ovn) Validate(config map[string]string) error {
 				return errors.Wrapf(err, "Failed parsing %q", addressKey)
 			}
 
+			// Add to list to check for conflicts.
 			externalSubnets = append(externalSubnets, ipNet)
 		}
 	}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -273,7 +273,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		if !shared.IsTrue(config[fmt.Sprintf("%s.nat", keyPrefix)]) && validate.IsOneOf("", "none", "auto")(config[addressKey]) != nil {
 			_, ipNet, err := net.ParseCIDR(config[addressKey])
 			if err != nil {
-				return errors.Wrapf(err, "Failed parsing %s", addressKey)
+				return errors.Wrapf(err, "Failed parsing %q", addressKey)
 			}
 
 			externalSubnets = append(externalSubnets, ipNet)

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -279,6 +279,7 @@ var APIExtensions = []string{
 	"event_lifecycle_requestor_address",
 	"resources_gpu_usb",
 	"clustering_evacuation",
+	"network_ovn_nat_address",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
See https://discuss.linuxcontainers.org/t/lxd-floating-ip-addresses/11801 for tech spec.

Adds support for specifying an outbound external NAT address for `ovn` networks using `ipv4.nat.address` and `ipv6.nat.address`.

The specified address must be within one of the uplink network's `ipv{n}.routes` and not overlap with an external subnet in use by another OVN network on the same uplink (either the network itself or one of the NICs connected to it).

NICs connected to the same OVN network may have externally routed subnet(s) that overlap with the network's `ipv{n}.nat.address`.

Because the NAT addresses will be by definition outside of the uplink's own subnet, it is required that routes are added on the uplink that forward the desired addresses to the OVN network's external router IP (`volatile.network.ipv{n}.address`), either manually or via a route advert mechanism such as BGP.

This PR also restructures how external address overlap detection is done so that all references to an uplink's external routes by connected OVN resources (be that networks or NICs) are retrieved using a single function, and then the per-scenario exclusions are done locally to each specific function rather than trying to pass in exclusions which was how it was done before.

This should also make it easier when expanding overlap detection for external floating IPs described in https://discuss.linuxcontainers.org/t/lxd-floating-ip-addresses/11801.