### PR TITLE
lxd/device/gpu_mdev: Fix mdevUUID logic

### DIFF
--- a/lxd/device/gpu_mdev.go
+++ b/lxd/device/gpu_mdev.go
@@ -117,7 +117,7 @@ func (d *gpuMdev) startVM() (*deviceConfig.RunConfig, error) {
 
 		// Create the vGPU.
 		if mdevUUID == "" || !shared.PathExists(fmt.Sprintf("/sys/bus/pci/devices/%s/%s", pciAddress, mdevUUID)) {
-			mdevUUID := uuid.New()
+			mdevUUID = uuid.New()
 
 			err = ioutil.WriteFile(filepath.Join(fmt.Sprintf("/sys/bus/pci/devices/%s/mdev_supported_types/%s/create", pciAddress, d.config["mdev"])), []byte(mdevUUID), 200)
 			if err != nil {


### PR DESCRIPTION
A recent uuid package cleanup incorrectly turned an allocation into a
definition, causing the resulting device to miss its UUID field.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>