### PR TITLE
Response: Rework SmartError function to support stdlib errors package unwrapping

### DIFF
--- a/lxd/response/smart_linux.go
+++ b/lxd/response/smart_linux.go
@@ -4,43 +4,14 @@
 package response
 
 import (
-	"database/sql"
-	"os"
+	"net/http"
 
 	"github.com/canonical/go-dqlite/driver"
-	"github.com/lxc/lxd/lxd/db"
 	"github.com/mattn/go-sqlite3"
-	"github.com/pkg/errors"
 )
 
-// SmartError returns the right error message based on err.
-func SmartError(err error) Response {
-	if err == nil {
-		return EmptySyncResponse
-	}
-
-	switch errors.Cause(err) {
-	case os.ErrNotExist, sql.ErrNoRows, db.ErrNoSuchObject:
-		if errors.Cause(err) != err {
-			return NotFound(err)
-		}
-
-		return NotFound(nil)
-	case os.ErrPermission:
-		if errors.Cause(err) != err {
-			return Forbidden(err)
-		}
-
-		return Forbidden(nil)
-	case db.ErrAlreadyDefined, sqlite3.ErrConstraintUnique:
-		if errors.Cause(err) != err {
-			return Conflict(err)
-		}
-
-		return Conflict(nil)
-	case driver.ErrNoAvailableLeader:
-		return Unavailable(err)
-	default:
-		return InternalError(err)
-	}
+// Populates error slices with Linux specific error types for use with SmartError().
+func init() {
+	httpResponseErrors[http.StatusConflict] = append(httpResponseErrors[http.StatusConflict], sqlite3.ErrConstraintUnique)
+	httpResponseErrors[http.StatusServiceUnavailable] = append(httpResponseErrors[http.StatusServiceUnavailable], driver.ErrNoAvailableLeader)
 }

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -334,7 +334,7 @@ func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 	// Create new single node storage pool.
 	err = storagePoolCreateGlobal(d.State(), req, clientType)
 	if err != nil {
-		return response.InternalError(err)
+		return response.SmartError(err)
 	}
 
 	d.State().Events.SendLifecycle(projectName, lifecycle.StoragePoolCreated.Event(req.Name, projectName, requestor, ctx))

--- a/lxd/storage_pools_utils.go
+++ b/lxd/storage_pools_utils.go
@@ -21,7 +21,7 @@ func storagePoolDBCreate(s *state.State, poolName, poolDescription string, drive
 	// Check that the storage pool does not already exist.
 	_, err := s.Cluster.GetStoragePoolID(poolName)
 	if err == nil {
-		return -1, fmt.Errorf("The storage pool already exists")
+		return -1, fmt.Errorf("The storage pool already exists: %w", db.ErrAlreadyDefined)
 	}
 
 	// Make sure that we don't pass a nil to the next function.
@@ -42,7 +42,7 @@ func storagePoolDBCreate(s *state.State, poolName, poolDescription string, drive
 	// Create the database entry for the storage pool.
 	id, err := dbStoragePoolCreateAndUpdateCache(s, poolName, poolDescription, driver, config)
 	if err != nil {
-		return -1, fmt.Errorf("Error inserting %s into database: %s", poolName, err)
+		return -1, fmt.Errorf("Error inserting %s into database: %w", poolName, err)
 	}
 
 	return id, nil

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -459,7 +459,7 @@ test_backup_rename() {
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
 
-  if ! lxc query -X POST /1.0/containers/c1/backups/backupmissing -d '{\"name\": \"backupnewname\"}' --wait 2>&1 | grep -q "Error: not found" ; then
+  if ! lxc query -X POST /1.0/containers/c1/backups/backupmissing -d '{\"name\": \"backupnewname\"}' --wait 2>&1 | grep -q "Error: Not Found" ; then
     echo "invalid rename response for missing container"
     false
   fi
@@ -678,7 +678,7 @@ test_backup_volume_rename_delete() {
   # Create test volume.
   lxc storage volume create "${pool}" vol1
 
-  if ! lxc query -X POST /1.0/storage-pools/"${pool}"/volumes/custom/vol1/backups/backupmissing -d '{\"name\": \"backupnewname\"}' --wait 2>&1 | grep -q "not found" ; then
+  if ! lxc query -X POST /1.0/storage-pools/"${pool}"/volumes/custom/vol1/backups/backupmissing -d '{\"name\": \"backupnewname\"}' --wait 2>&1 | grep -q "Not Found" ; then
     echo "invalid rename response for missing storage volume"
     false
   fi


### PR DESCRIPTION
As we begin the transition to using the stdlib `errors` package for error wrapping rather than `github.com/pkg/errors` this PR updates the `response.SmartError()` function to utilise both packages in order to find the root cause of an error and simplifies the process it uses to match against known errors to convert them to HTTP status codes.

Also switches to using the generic HTTP status text when the errors exactly match rather than a hardcoded internal string.
In some cases this is identical or similar (except the casing), but there are a few differences I felt I should highlight:

* Forbidden used to return "not authorized" now would return "Forbidden" - this seems more appropriate as "not authorized" is a different HTTP error code - perhaps we should be using that instead?
* Conflict used to return "already exists" now would return "Conflict".
* Unavailable used to return "unavailable" now would return "Service Unavailable".