### PR TITLE
Storage: Allow quota removal from VM config filesystem volumes

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1770,7 +1770,11 @@ func (b *lxdBackend) SetInstanceQuota(inst instance.Instance, size string, vmSta
 
 	// Apply the filesystem volume quota (only when main volume is block).
 	if vol.IsVMBlock() {
-		if vmStateSize == "" {
+		// Apply default VM config filesystem size if main volume size is specified and no custom
+		// vmStateSize is specified. This way if the main volume size is empty (i.e removing quota) then
+		// this will also pass empty quota for the config filesystem volume as well, allowing a former
+		// quota to be removed from both volumes.
+		if vmStateSize == "" && size != "" {
 			vmStateSize = drivers.DefaultVMBlockFilesystemSize
 		}
 

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -765,14 +765,25 @@ func (d *btrfs) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, 
 			d.logger.Debug("Accounting for VM image file size", "sizeBytes", sizeBytes)
 		}
 
-		// Apply the limit.
-		_, err := shared.RunCommand("btrfs", "qgroup", "limit", fmt.Sprintf("%d", sizeBytes), volPath)
+		// Apply the limit to referenced data in qgroup.
+		_, err = shared.RunCommand("btrfs", "qgroup", "limit", fmt.Sprintf("%d", sizeBytes), qgroup, volPath)
+		if err != nil {
+			return err
+		}
+
+		// Remove any former exclusive data limit.
+		_, err = shared.RunCommand("btrfs", "qgroup", "limit", "-e", "none", qgroup, volPath)
 		if err != nil {
 			return err
 		}
 	} else if qgroup != "" {
-		// Remove the limit.
-		_, err := shared.RunCommand("btrfs", "qgroup", "limit", "none", qgroup, volPath)
+		// Remove all limits.
+		_, err = shared.RunCommand("btrfs", "qgroup", "limit", "none", qgroup, volPath)
+		if err != nil {
+			return err
+		}
+
+		_, err = shared.RunCommand("btrfs", "qgroup", "limit", "none", "-e", qgroup, volPath)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -762,6 +762,7 @@ func (d *btrfs) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, 
 
 			// Add that to the requested filesystem size (to ignore it from the quota).
 			sizeBytes += blockSize
+			d.logger.Debug("Accounting for VM image file size", "sizeBytes", sizeBytes)
 		}
 
 		// Apply the limit.

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -310,6 +310,7 @@ func (d *dir) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 
 		// Add that to the requested filesystem size (to ignore it from the quota).
 		sizeBytes += blockSize
+		d.logger.Debug("Accounting for VM image file size", "sizeBytes", sizeBytes)
 	}
 
 	return d.setQuota(vol.MountPath(), volID, sizeBytes)


### PR DESCRIPTION
If supported by the storage driver.

Also ensure that BTRFS quota types are consistently set/unset as needed.

This is something I noticed whilst looking at https://discuss.linuxcontainers.org/t/btrfs-issues-storage-pools-btrfs-empty-and-btrfs-quota-100-while-inside-the-vm-only-48-utilized/11897 - that a BTRFS quota set on a VM filesystem volume was not removed if the `size` property was removed.