### PR TITLE
API: Adds StatusError error type and updates SmartError to handle it

### DIFF
--- a/client/lxd.go
+++ b/client/lxd.go
@@ -3,7 +3,6 @@ package lxd
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -167,7 +166,7 @@ func lxdParseResponse(resp *http.Response) (*api.Response, string, error) {
 
 	// Handle errors
 	if response.Type == api.ErrorResponse {
-		return nil, "", errors.New(response.Error)
+		return nil, "", api.StatusErrorf(resp.StatusCode, response.Error)
 	}
 
 	return &response, etag, nil

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"math/big"
 	"net"
+	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -178,7 +179,7 @@ func (n *ovn) validateExternalSubnet(uplinkRoutes []*net.IPNet, projectRestricte
 	}
 
 	if !foundMatch {
-		return fmt.Errorf("Uplink network doesn't contain %q in its routes", ipNet.String())
+		return api.StatusErrorf(http.StatusBadRequest, "Uplink network doesn't contain %q in its routes", ipNet.String())
 	}
 
 	return nil

--- a/lxd/response/smart.go
+++ b/lxd/response/smart.go
@@ -9,6 +9,7 @@ import (
 	pkgErrors "github.com/pkg/errors"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/shared/api"
 )
 
 var httpResponseErrors = map[int][]error{
@@ -22,6 +23,12 @@ var httpResponseErrors = map[int][]error{
 func SmartError(err error) Response {
 	if err == nil {
 		return EmptySyncResponse
+	}
+
+	var statusErr *api.StatusError
+
+	if errors.As(err, &statusErr) {
+		return &errorResponse{statusErr.Status(), err.Error()}
 	}
 
 	for httpStatusCode, checkErrs := range httpResponseErrors {

--- a/shared/api/error.go
+++ b/shared/api/error.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// StatusErrorf returns a new StatusError containing the specified status and message.
+func StatusErrorf(status int, format string, a ...interface{}) *StatusError {
+	return &StatusError{
+		status: status,
+		msg:    fmt.Sprintf(format, a...),
+	}
+}
+
+// StatusError error type that contains an HTTP status code and message.
+type StatusError struct {
+	status int
+	msg    string
+}
+
+// Error returns the error message or the http.StatusText() of the status code if message is empty.
+func (e *StatusError) Error() string {
+	if e.msg != "" {
+		return e.msg
+	}
+
+	return http.StatusText(e.status)
+}
+
+// Status returns the HTTP status code.
+func (e *StatusError) Status() int {
+	return e.status
+}


### PR DESCRIPTION
Based on a recent discussion with @morphis to allow LXD client users to access the response status code, and an additional desire to be able to return accurate HTTP status codes back to the client from deeper within LXD's callstack.

- This allows functions that return an error due to a known specific error scenario (such as a conflict or not found error) to explicitly pass than information as an HTTP status code by returning a `api.StatusError` type.
- Adds the `api.StatusErrorf()` helper function for creating `api.StatusError` errors, e.g. `api.StatusErrorf(400, "Field %q is invalid", "myfield")`
- Updates `response.SmartError()` to detect `api.StatusError` type error and alter the API HTTP status response accordingly.
- Updates `client.lxdParseResponse()` to convert the HTTP status code and error text returned from the server response into a `api.StatusError` and then "interface smuggle" this back to the caller, so that, if they choose, they can type assert to `api.StatusError` and access the `Status()` function so they can programmatically ascertain the type of error that has occurred without having to inspect the raw error text itself (which is liable to change over time and has no fixed format).
- Provides an example usage scenario in `validateExternalSubnet`.


This may eventually lead to us being able to get rid of the numerous helper functions in `lxd/response`, such as `NotImplemented()` and `NotFound()`.