### PR TITLE
Storage: Create pool mount path if needed in Mount

### DIFF
--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -77,6 +77,17 @@ EOF
     # Check custom volume appears removed.
     ! lxc storage volume ls "${poolName}" | grep vol1_test || false
 
+    # Shutdown LXD so pools are unmounted.
+    shutdown_lxd "${LXD_DIR}"
+
+    # Remove empty directory structures for pool drivers that don't have a mounted root.
+    # This is so we can test the restoration of the storage pool directory structure.
+    if [ "$poolDriver" != "dir" ] && [ "$poolDriver" != "btrfs" ] && [ "$poolDriver" != "cephfs" ]; then
+      rm -rvf "${LXD_DIR}/storage-pools/${poolName}"
+    fi
+
+    respawn_lxd "${LXD_DIR}" true
+
     cat <<EOF | lxd recover
 no
 yes


### PR DESCRIPTION
Allows storage pool recovery when mount path is missing.

Reported from https://discuss.linuxcontainers.org/t/moving-a-block-device-storage-pool-to-a-new-server/11935/3?u=tomp

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>