### PR TITLE
Added lxc-dev package for fix build in debian

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -41,7 +41,7 @@ later to work. On ubuntu, you can get those with:
 
 ```bash
 sudo apt update
-sudo apt install acl autoconf dnsmasq-base git golang libacl1-dev libcap-dev liblxc1 liblxc-dev libsqlite3-dev libtool libudev-dev liblz4-dev libuv1-dev make pkg-config rsync squashfs-tools tar tcl xz-utils ebtables
+sudo apt install acl autoconf dnsmasq-base git golang libacl1-dev libcap-dev liblxc1 liblxc-dev lxc-dev libsqlite3-dev libtool libudev-dev liblz4-dev libuv1-dev make pkg-config rsync squashfs-tools tar tcl xz-utils ebtables
 ```
 
 Note that when building LXC yourself, ensure to build it with the appropriate


### PR DESCRIPTION
Earlier, when building lxd, I got an error in debian 10/11, now I found a solution in this [issue](https://github.com/lxc/go-lxc/issues/44#issuecomment-121228595). To solve this problem, you just need to install the _lxc-dev_ package

stacktrace:

> $ make

```
go get -t -v -d ./...
CC="cc" CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" go install -v -tags "libsqlite3"  ./...
gopkg.in/lxc/go-lxc.v2
# pkg-config --cflags  -- lxc
Package lxc was not found in the pkg-config search path.
Perhaps you should add the directory containing `lxc.pc'
to the PKG_CONFIG_PATH environment variable
No package 'lxc' found
pkg-config: exit status 1
make: *** [Makefile:28: build] Error 2
```
