### PR TITLE
Network: Code cleanups

### DIFF
--- a/lxd/db/network_acls.go
+++ b/lxd/db/network_acls.go
@@ -99,7 +99,7 @@ func (c *Cluster) GetNetworkACL(projectName string, name string) (int64, *api.Ne
 			return err
 		}
 
-		err = c.networkACLConfig(tx, id, &acl)
+		err = networkACLConfig(tx, id, &acl)
 		if err != nil {
 			return errors.Wrapf(err, "Failed loading config")
 		}
@@ -155,7 +155,7 @@ func (c *Cluster) GetNetworkACLNameAndProjectWithID(networkACLID int) (string, s
 }
 
 // networkACLConfig populates the config map of the Network ACL with the given ID.
-func (c *Cluster) networkACLConfig(tx *ClusterTx, id int64, acl *api.NetworkACL) error {
+func networkACLConfig(tx *ClusterTx, id int64, acl *api.NetworkACL) error {
 	q := `
 		SELECT key, value
 		FROM networks_acls_config

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -95,7 +95,7 @@ func (n *common) validate(config map[string]string, driverRules map[string]func(
 		}
 
 		// User keys are not validated.
-		if strings.HasPrefix(k, "user.") {
+		if shared.IsUserConfig(k) {
 			continue
 		}
 


### PR DESCRIPTION
- Remove `networkACLConfigUpdate` as not needed  (shifts config deletion into `UpdateNetworkACL` directly).
- Switch to `shared.IsUserConfig()`.
