### PR TITLE
LXC: Fix panic when empty argument passed to lxc command

### DIFF
--- a/lxc/main_aliases.go
+++ b/lxc/main_aliases.go
@@ -49,7 +49,7 @@ func expandAlias(conf *config.Config, args []string) ([]string, bool) {
 	var origArgs []string
 
 	for _, arg := range args[1:] {
-		if arg[0] != '-' {
+		if !strings.HasPrefix(arg, "-") {
 			break
 		}
 


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>