### PR TITLE
Remove mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,2 +1,0 @@
-site_name: "LXD - system container manager"
-theme: readthedocs


### PR DESCRIPTION
Since we've moved away from readthedocs, this file can be removed.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
