### PR TITLE
Cluster: Add mutex to cluster join token creation

### DIFF
--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -55,7 +55,7 @@ func (c *cmdCluster) Command() *cobra.Command {
 	clusterEditCmd := cmdClusterEdit{global: c.global, cluster: c}
 	cmd.AddCommand(clusterEditCmd.Command())
 
-	// Add
+	// Add token
 	cmdClusterAdd := cmdClusterAdd{global: c.global, cluster: c}
 	cmd.AddCommand(cmdClusterAdd.Command())
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -1064,6 +1065,8 @@ func clusterNodesGet(d *Daemon, r *http.Request) response.Response {
 	return response.SyncResponse(true, urls)
 }
 
+var clusterNodesPostMu sync.Mutex // Used to prevent races when creating cluster join tokens.
+
 // swagger:operation POST /1.0/cluster/members cluster cluster_members_post
 //
 // Request a join token
@@ -1146,6 +1149,11 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 	if len(onlineNodeAddresses) < 1 {
 		return response.InternalError(fmt.Errorf("There are no online cluster members"))
 	}
+
+	// Lock to prevent concurrent requests racing the operationsGetByType function and creating duplicates.
+	// We have to do this because collecting all of the operations from existing cluster members can take time.
+	clusterNodesPostMu.Lock()
+	defer clusterNodesPostMu.Unlock()
 
 	// Remove any existing join tokens for the requested cluster member, this way we only ever have one active
 	// join token for each potential new member, and it has the most recent active members list for joining.


### PR DESCRIPTION
To prevent races creating duplicate entries for the same name.