### PR TITLE
lxd/init: Allow preseeding cluster_token (stable-4.0)

### DIFF
--- a/doc/clustering.md
+++ b/doc/clustering.md
@@ -145,6 +145,15 @@ opyQ1VRpAg2sV2C4W8irbNqeUsTeZZxhLqp4vNOXXBBrSqUCdPu1JXADV0kavg1l
     value: ""
 ```
 
+When joining a cluster using a cluster join token, the following fields can be omitted:
+
+ - server\_name
+ - cluster\_address
+ - cluster\_certificate
+ - cluster\_password
+
+And instead the full token be passed through the `cluster_token` field.
+
 ## Managing a cluster
 
 Once your cluster is formed you can see a list of its nodes and their

--- a/lxd/init.go
+++ b/lxd/init.go
@@ -24,6 +24,10 @@ type initDataCluster struct {
 	// The path to the cluster certificate
 	// Example: /tmp/cluster.crt
 	ClusterCertificatePath string `json:"cluster_certificate_path" yaml:"cluster_certificate_path"`
+
+	// A cluster join token
+	// Example: BASE64-TOKEN
+	ClusterToken string `json:"cluster_token" yaml:"cluster_token"`
 }
 
 // Helper to initialize node-specific entities on a LXD instance using the

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -177,7 +177,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 			// Cluster certificate
 			cert, err := shared.GetRemoteCertificate(fmt.Sprintf("https://%s", config.Cluster.ClusterAddress), version.UserAgent)
 			if err != nil {
-				fmt.Printf("Error connecting to existing cluster node %q: %v\n", clusterAddress, err)
+				fmt.Printf("Error connecting to existing cluster member %q: %v\n", clusterAddress, err)
 				continue
 			}
 

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
+	"net"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -12,6 +14,7 @@ import (
 	"github.com/lxc/lxd/lxd/storage/filesystem"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/version"
 )
 
 type poolType string
@@ -149,6 +152,51 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		config.Cluster.ClusterCertificate = string(content)
+	}
+
+	// Check if we got a cluster join token, if so, fill in the config with it.
+	if config.Cluster != nil && config.Cluster.ClusterToken != "" {
+		joinToken, err := clusterMemberJoinTokenDecode(config.Cluster.ClusterToken)
+		if err != nil {
+			return errors.Wrapf(err, "Invalid cluster join token")
+		}
+
+		// Set server name from join token
+		config.Cluster.ServerName = joinToken.ServerName
+
+		// Attempt to find a working cluster member to use for joining by retrieving the
+		// cluster certificate from each address in the join token until we succeed.
+		for _, clusterAddress := range joinToken.Addresses {
+			// Cluster URL
+			_, _, err := net.SplitHostPort(clusterAddress)
+			if err != nil {
+				clusterAddress = fmt.Sprintf("%s:%d", clusterAddress, shared.DefaultPort)
+			}
+			config.Cluster.ClusterAddress = clusterAddress
+
+			// Cluster certificate
+			cert, err := shared.GetRemoteCertificate(fmt.Sprintf("https://%s", config.Cluster.ClusterAddress), version.UserAgent)
+			if err != nil {
+				fmt.Printf("Error connecting to existing cluster node %q: %v\n", clusterAddress, err)
+				continue
+			}
+
+			certDigest := shared.CertFingerprint(cert)
+			if joinToken.Fingerprint != certDigest {
+				return fmt.Errorf("Certificate fingerprint mismatch between join token and cluster member %q", clusterAddress)
+			}
+
+			config.Cluster.ClusterCertificate = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
+
+			break // We've found a working cluster member.
+		}
+
+		if config.Cluster.ClusterCertificate == "" {
+			return fmt.Errorf("Unable to connect to any of the cluster members specified in join token")
+		}
+
+		// Raw join token used as cluster password so it can be validated.
+		config.Cluster.ClusterPassword = config.Cluster.ClusterToken
 	}
 
 	// If clustering is enabled, and no cluster.https_address network address

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -218,7 +218,7 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer, serve
 					// Cluster certificate
 					cert, err := shared.GetRemoteCertificate(fmt.Sprintf("https://%s", config.Cluster.ClusterAddress), version.UserAgent)
 					if err != nil {
-						fmt.Printf("Error connecting to existing cluster node %q: %v\n", clusterAddress, err)
+						fmt.Printf("Error connecting to existing cluster member %q: %v\n", clusterAddress, err)
 						continue
 					}
 
@@ -247,7 +247,7 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer, serve
 
 				for {
 					// Cluster URL
-					clusterAddress, err := cli.AskString("IP address or FQDN of an existing cluster node: ", "", nil)
+					clusterAddress, err := cli.AskString("IP address or FQDN of an existing cluster member: ", "", nil)
 					if err != nil {
 						return err
 					}
@@ -262,7 +262,7 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer, serve
 					// Cluster certificate
 					cert, err := shared.GetRemoteCertificate(fmt.Sprintf("https://%s", config.Cluster.ClusterAddress), version.UserAgent)
 					if err != nil {
-						fmt.Printf("Error connecting to existing cluster node: %v\n", err)
+						fmt.Printf("Error connecting to existing cluster member: %v\n", err)
 						continue
 					}
 
@@ -312,7 +312,7 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer, serve
 			// again and if using a one-time join token, will fail.
 			config.Cluster.ClusterPassword = ""
 
-			// Client parameters to connect to the target cluster node.
+			// Client parameters to connect to the target cluster member.
 			args := &lxd.ConnectionArgs{
 				TLSClientCert: string(serverCert.PublicKey()),
 				TLSClientKey:  string(serverCert.PrivateKey()),


### PR DESCRIPTION
Fixes #9187

Looks like https://github.com/lxc/lxd/pull/9113 didn't get backported to stable-4.0. 