### PR TITLE
Cluster: More IPv6 listener bug fixes

### DIFF
--- a/lxd/endpoints/cluster.go
+++ b/lxd/endpoints/cluster.go
@@ -69,7 +69,7 @@ func (e *Endpoints) ClusterUpdateAddress(address string) error {
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("cannot listen on https socket: %v", err)
+			return nil, fmt.Errorf("Cannot listen on cluster HTTPS socket %q: %w", address, err)
 		}
 
 		return &listener, nil

--- a/lxd/endpoints/network.go
+++ b/lxd/endpoints/network.go
@@ -103,7 +103,7 @@ func (e *Endpoints) NetworkUpdateAddress(address string) error {
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("cannot listen on https socket: %v", err)
+			return nil, fmt.Errorf("Cannot listen on network HTTPS socket %q: %w", address, err)
 		}
 
 		return &listener, nil

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -218,6 +218,10 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 	// Detect if the user has chosen to join a cluster using the new
 	// cluster join API format, and use the dedicated API if so.
 	if config.Cluster != nil && config.Cluster.ClusterAddress != "" && config.Cluster.ServerAddress != "" {
+		// Ensure the server and cluster addresses are in canonical form.
+		config.Cluster.ServerAddress = util.CanonicalNetworkAddress(config.Cluster.ServerAddress)
+		config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(config.Cluster.ClusterAddress)
+
 		op, err := d.UpdateCluster(config.Cluster.ClusterPut, "")
 		if err != nil {
 			return errors.Wrap(err, "Failed to join cluster")

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -4,7 +4,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
-	"net"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -12,6 +11,7 @@ import (
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/storage/filesystem"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/version"
@@ -180,11 +180,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 		// cluster certificate from each address in the join token until we succeed.
 		for _, clusterAddress := range joinToken.Addresses {
 			// Cluster URL
-			_, _, err := net.SplitHostPort(clusterAddress)
-			if err != nil {
-				clusterAddress = fmt.Sprintf("%s:%d", clusterAddress, shared.DefaultPort)
-			}
-			config.Cluster.ClusterAddress = clusterAddress
+			config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(clusterAddress)
 
 			// Cluster certificate
 			cert, err := shared.GetRemoteCertificate(fmt.Sprintf("https://%s", config.Cluster.ClusterAddress), version.UserAgent)

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -224,12 +224,7 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer, serve
 				// Attempt to find a working cluster member to use for joining by retrieving the
 				// cluster certificate from each address in the join token until we succeed.
 				for _, clusterAddress := range joinToken.Addresses {
-					// Cluster URL
-					_, _, err := net.SplitHostPort(clusterAddress)
-					if err != nil {
-						clusterAddress = fmt.Sprintf("%s:%d", clusterAddress, shared.DefaultPort)
-					}
-					config.Cluster.ClusterAddress = clusterAddress
+					config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(clusterAddress)
 
 					// Cluster certificate
 					cert, err := shared.GetRemoteCertificate(fmt.Sprintf("https://%s", config.Cluster.ClusterAddress), version.UserAgent)
@@ -268,12 +263,7 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer, serve
 						return err
 					}
 
-					_, _, err = net.SplitHostPort(clusterAddress)
-					if err != nil {
-						clusterAddress = fmt.Sprintf("%s:%d", clusterAddress, shared.DefaultPort)
-					}
-
-					config.Cluster.ClusterAddress = clusterAddress
+					config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(clusterAddress)
 
 					// Cluster certificate
 					cert, err := shared.GetRemoteCertificate(fmt.Sprintf("https://%s", config.Cluster.ClusterAddress), version.UserAgent)

--- a/lxd/util/net.go
+++ b/lxd/util/net.go
@@ -69,7 +69,8 @@ func (a *inMemoryAddr) String() string {
 }
 
 // CanonicalNetworkAddress parses the given network address and returns a string of the form "host:port",
-// possibly filling it with the default port if it's missing.
+// possibly filling it with the default port if it's missing. It will also wrap a bare IPv6 address with square
+// brackets if needed.
 func CanonicalNetworkAddress(address string) string {
 	_, _, err := net.SplitHostPort(address)
 	if err != nil {

--- a/lxd/util/net.go
+++ b/lxd/util/net.go
@@ -181,33 +181,47 @@ func IsAddressCovered(address1, address2 string) bool {
 
 	// If address1 contains a host name, let's try to resolve it, in order
 	// to compare the actual IPs.
-	addresses1 := []string{host1}
+	var addresses1 []net.IP
 	if host1 != "" {
-		ip1 := net.ParseIP(host1)
-		if ip1 == nil {
+		ip := net.ParseIP(host1)
+		if ip != nil {
+			addresses1 = append(addresses1, ip)
+		} else {
 			ips, err := net.LookupHost(host1)
 			if err == nil && len(ips) > 0 {
-				addresses1 = ips
+				for _, ipStr := range ips {
+					ip := net.ParseIP(ipStr)
+					if ip != nil {
+						addresses1 = append(addresses1, ip)
+					}
+				}
 			}
 		}
 	}
 
 	// If address2 contains a host name, let's try to resolve it, in order
 	// to compare the actual IPs.
-	addresses2 := []string{host2}
+	var addresses2 []net.IP
 	if host2 != "" {
-		ip2 := net.ParseIP(host2)
-		if ip2 == nil {
+		ip := net.ParseIP(host2)
+		if ip != nil {
+			addresses2 = append(addresses2, ip)
+		} else {
 			ips, err := net.LookupHost(host2)
 			if err == nil && len(ips) > 0 {
-				addresses2 = ips
+				for _, ipStr := range ips {
+					ip := net.ParseIP(ipStr)
+					if ip != nil {
+						addresses2 = append(addresses2, ip)
+					}
+				}
 			}
 		}
 	}
 
 	for _, a1 := range addresses1 {
 		for _, a2 := range addresses2 {
-			if a1 == a2 {
+			if a1.Equal(a2) {
 				return true
 			}
 		}

--- a/lxd/util/net.go
+++ b/lxd/util/net.go
@@ -73,10 +73,11 @@ func (a *inMemoryAddr) String() string {
 func CanonicalNetworkAddress(address string) string {
 	_, _, err := net.SplitHostPort(address)
 	if err != nil {
-		if net.ParseIP(address) != nil {
+		ip := net.ParseIP(address)
+		if ip != nil {
 			// If the input address is a bare IP address, then convert it to a proper listen address
-			// using the default port and wrap IPv6 addresses in square brackets.
-			address = net.JoinHostPort(address, fmt.Sprintf("%d", shared.DefaultPort))
+			// using the canonical IP with default port and wrap IPv6 addresses in square brackets.
+			address = net.JoinHostPort(ip.String(), fmt.Sprintf("%d", shared.DefaultPort))
 		} else {
 			// Otherwise assume this is either a host name or a partial address (e.g `[::]`) without
 			// a port number, so append the default port.


### PR DESCRIPTION
Fixes #9186, and as I was working on that I also discovered that if you specified an initial first-member server address of `2602:fc62:b:1018:0:1::2` then it would later pass the listener coverage checks because of its canonical form `2602:fc62:b:1018:0:1:0:2` causing a listener bind error.

I also noticed that we were doing a partial canonicalisation in the cluster join token logic, so that now uses `util.CanonicalNetworkAddress` too.

So now we are converting the specified addresses to their canonical form in more places, and also using true `net.IP` for coverage checking rather than literal string comparison.