### PR TITLE
More listener bugfixes

### DIFF
--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -242,7 +242,7 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 		rHost = host
 		rPort = port
 	} else {
-		rPort = fmt.Sprintf("%d", shared.DefaultPort)
+		rPort = fmt.Sprintf("%d", shared.HTTPSDefaultPort)
 	}
 
 	if rScheme == "unix" {

--- a/lxd-agent/main_agent.go
+++ b/lxd-agent/main_agent.go
@@ -120,7 +120,7 @@ func (c *cmdAgent) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Setup the listener.
-	l, err := vsock.Listen(shared.DefaultPort)
+	l, err := vsock.Listen(shared.HTTPSDefaultPort)
 	if err != nil {
 		return errors.Wrap(err, "Failed to listen on vsock")
 	}

--- a/lxd-p2c/utils.go
+++ b/lxd-p2c/utils.go
@@ -205,7 +205,7 @@ func parseURL(URL string) (string, error) {
 
 	// If no port was provided, use default port
 	if u.Port() == "" {
-		u.Host = fmt.Sprintf("%s:%d", u.Hostname(), shared.DefaultPort)
+		u.Host = fmt.Sprintf("%s:%d", u.Hostname(), shared.HTTPSDefaultPort)
 	}
 
 	return u.String(), nil

--- a/lxd/endpoints/cluster.go
+++ b/lxd/endpoints/cluster.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/lxc/lxd/lxd/util"
+	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -28,7 +29,7 @@ func (e *Endpoints) ClusterUpdateAddress(address string) error {
 	networkAddress := e.NetworkAddress()
 
 	if address != "" {
-		address = util.CanonicalNetworkAddress(address)
+		address = util.CanonicalNetworkAddress(address, shared.HTTPSDefaultPort)
 	}
 
 	oldAddress := e.ClusterAddress()

--- a/lxd/endpoints/endpoints.go
+++ b/lxd/endpoints/endpoints.go
@@ -237,7 +237,11 @@ func (e *Endpoints) up(config *Config) error {
 		}
 	}
 
-	isCovered := util.IsAddressCovered(config.ClusterAddress, config.NetworkAddress)
+	isCovered := false
+	if config.NetworkAddress != "" {
+		isCovered = util.IsAddressCovered(config.ClusterAddress, config.NetworkAddress)
+	}
+
 	if config.ClusterAddress != "" && !isCovered {
 		attempts := 0
 	againCluster:

--- a/lxd/endpoints/network.go
+++ b/lxd/endpoints/network.go
@@ -59,7 +59,7 @@ func (e *Endpoints) NetworkAddress() string {
 // it down and restarting it.
 func (e *Endpoints) NetworkUpdateAddress(address string) error {
 	if address != "" {
-		address = util.CanonicalNetworkAddress(address)
+		address = util.CanonicalNetworkAddress(address, shared.HTTPSDefaultPort)
 	}
 
 	oldAddress := e.NetworkAddress()
@@ -179,7 +179,7 @@ func (e *Endpoints) NetworkUpdateTrustedProxy(trustedProxy string) {
 
 // Create a new net.Listener bound to the tcp socket of the network endpoint.
 func networkCreateListener(address string, cert *shared.CertInfo) (net.Listener, error) {
-	listener, err := net.Listen("tcp", util.CanonicalNetworkAddress(address))
+	listener, err := net.Listen("tcp", util.CanonicalNetworkAddress(address, shared.HTTPSDefaultPort))
 	if err != nil {
 		return nil, errors.Wrap(err, "Bind network address")
 	}

--- a/lxd/endpoints/pprof.go
+++ b/lxd/endpoints/pprof.go
@@ -46,7 +46,7 @@ func (e *Endpoints) PprofAddress() string {
 // PprofUpdateAddress updates the address for the pprof endpoint, shutting it down and restarting it.
 func (e *Endpoints) PprofUpdateAddress(address string) error {
 	if address != "" {
-		address = util.CanonicalNetworkAddress(address, shared.HTTPSDefaultPort)
+		address = util.CanonicalNetworkAddress(address, shared.HTTPDefaultPort)
 	}
 
 	oldAddress := e.NetworkAddress()

--- a/lxd/endpoints/pprof.go
+++ b/lxd/endpoints/pprof.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/lxc/lxd/lxd/util"
+	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 
 	_ "net/http/pprof" // pprof magic
@@ -45,7 +46,7 @@ func (e *Endpoints) PprofAddress() string {
 // PprofUpdateAddress updates the address for the pprof endpoint, shutting it down and restarting it.
 func (e *Endpoints) PprofUpdateAddress(address string) error {
 	if address != "" {
-		address = util.CanonicalNetworkAddress(address)
+		address = util.CanonicalNetworkAddress(address, shared.HTTPSDefaultPort)
 	}
 
 	oldAddress := e.NetworkAddress()

--- a/lxd/main_cluster.go
+++ b/lxd/main_cluster.go
@@ -440,7 +440,7 @@ func (c *cmdClusterRemoveRaftNode) Run(cmd *cobra.Command, args []string) error 
 		return fmt.Errorf("Missing required arguments")
 	}
 
-	address := util.CanonicalNetworkAddress(args[0])
+	address := util.CanonicalNetworkAddress(args[0], shared.HTTPSDefaultPort)
 
 	// Prompt for confirmation unless --quiet was passed.
 	if !c.flagNonInteractive {

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -66,7 +66,7 @@ func (c *cmdInit) Command() *cobra.Command {
 	cmd.Flags().BoolVar(&c.flagDump, "dump", false, "Dump YAML config to stdout")
 
 	cmd.Flags().StringVar(&c.flagNetworkAddress, "network-address", "", "Address to bind LXD to (default: none)"+"``")
-	cmd.Flags().IntVar(&c.flagNetworkPort, "network-port", -1, fmt.Sprintf("Port to bind LXD to (default: %d)"+"``", shared.DefaultPort))
+	cmd.Flags().IntVar(&c.flagNetworkPort, "network-port", -1, fmt.Sprintf("Port to bind LXD to (default: %d)"+"``", shared.HTTPSDefaultPort))
 	cmd.Flags().StringVar(&c.flagStorageBackend, "storage-backend", "", "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"+"``")
 	cmd.Flags().StringVar(&c.flagStorageDevice, "storage-create-device", "", "Setup device based storage using DEVICE"+"``")
 	cmd.Flags().IntVar(&c.flagStorageLoopSize, "storage-create-loop", -1, "Setup loop based storage with SIZE in GB"+"``")

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -180,7 +180,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 		// cluster certificate from each address in the join token until we succeed.
 		for _, clusterAddress := range joinToken.Addresses {
 			// Cluster URL
-			config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(clusterAddress)
+			config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(clusterAddress, shared.HTTPSDefaultPort)
 
 			// Cluster certificate
 			cert, err := shared.GetRemoteCertificate(fmt.Sprintf("https://%s", config.Cluster.ClusterAddress), version.UserAgent)
@@ -219,8 +219,8 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 	// cluster join API format, and use the dedicated API if so.
 	if config.Cluster != nil && config.Cluster.ClusterAddress != "" && config.Cluster.ServerAddress != "" {
 		// Ensure the server and cluster addresses are in canonical form.
-		config.Cluster.ServerAddress = util.CanonicalNetworkAddress(config.Cluster.ServerAddress)
-		config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(config.Cluster.ClusterAddress)
+		config.Cluster.ServerAddress = util.CanonicalNetworkAddress(config.Cluster.ServerAddress, shared.HTTPSDefaultPort)
+		config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(config.Cluster.ClusterAddress, shared.HTTPSDefaultPort)
 
 		op, err := d.UpdateCluster(config.Cluster.ClusterPut, "")
 		if err != nil {

--- a/lxd/main_init_auto.go
+++ b/lxd/main_init_auto.go
@@ -59,7 +59,7 @@ func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServe
 	}
 
 	if c.flagNetworkPort == -1 {
-		c.flagNetworkPort = shared.DefaultPort
+		c.flagNetworkPort = shared.HTTPSDefaultPort
 	}
 
 	// Fill in the node configuration

--- a/lxd/main_init_auto.go
+++ b/lxd/main_init_auto.go
@@ -68,7 +68,7 @@ func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServe
 
 	// Network listening
 	if c.flagNetworkAddress != "" {
-		config.Config["core.https_address"] = util.CanonicalNetworkAddressFromAddressAndPort(c.flagNetworkAddress, c.flagNetworkPort)
+		config.Config["core.https_address"] = util.CanonicalNetworkAddressFromAddressAndPort(c.flagNetworkAddress, c.flagNetworkPort, shared.HTTPSDefaultPort)
 
 		if c.flagTrustPassword != "" {
 			config.Config["core.trust_password"] = c.flagTrustPassword

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -136,7 +136,7 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer, serve
 		// Cluster server address
 		address := util.NetworkInterfaceAddress()
 		validateServerAddress := func(value string) error {
-			address := util.CanonicalNetworkAddress(value)
+			address := util.CanonicalNetworkAddress(value, shared.HTTPSDefaultPort)
 
 			host, _, _ := net.SplitHostPort(address)
 			if shared.StringInSlice(host, []string{"", "[::]", "0.0.0.0"}) {
@@ -164,7 +164,7 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer, serve
 			return err
 		}
 
-		serverAddress = util.CanonicalNetworkAddress(serverAddress)
+		serverAddress = util.CanonicalNetworkAddress(serverAddress, shared.HTTPSDefaultPort)
 		config.Node.Config["core.https_address"] = serverAddress
 
 		clusterJoin, err := cli.AskBool("Are you joining an existing cluster? (yes/no) [default=no]: ", "no")
@@ -224,7 +224,7 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer, serve
 				// Attempt to find a working cluster member to use for joining by retrieving the
 				// cluster certificate from each address in the join token until we succeed.
 				for _, clusterAddress := range joinToken.Addresses {
-					config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(clusterAddress)
+					config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(clusterAddress, shared.HTTPSDefaultPort)
 
 					// Cluster certificate
 					cert, err := shared.GetRemoteCertificate(fmt.Sprintf("https://%s", config.Cluster.ClusterAddress), version.UserAgent)
@@ -263,7 +263,7 @@ func (c *cmdInit) askClustering(config *cmdInitData, d lxd.InstanceServer, serve
 						return err
 					}
 
-					config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(clusterAddress)
+					config.Cluster.ClusterAddress = util.CanonicalNetworkAddress(clusterAddress, shared.HTTPSDefaultPort)
 
 					// Cluster certificate
 					cert, err := shared.GetRemoteCertificate(fmt.Sprintf("https://%s", config.Cluster.ClusterAddress), version.UserAgent)

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -1011,7 +1011,7 @@ they otherwise would.
 			}
 
 			netPort, err := cli.AskInt(fmt.Sprintf("Port to bind LXD to [default=%d]: ", shared.HTTPSDefaultPort), 1, 65535, fmt.Sprintf("%d", shared.HTTPSDefaultPort), func(netPort int64) error {
-				address := util.CanonicalNetworkAddressFromAddressAndPort(netAddr, int(netPort))
+				address := util.CanonicalNetworkAddressFromAddressAndPort(netAddr, int(netPort), shared.HTTPSDefaultPort)
 
 				if err == nil {
 					if server.Config["cluster.https_address"] == address || server.Config["core.https_address"] == address {
@@ -1032,7 +1032,7 @@ they otherwise would.
 				return err
 			}
 
-			config.Node.Config["core.https_address"] = util.CanonicalNetworkAddressFromAddressAndPort(netAddr, int(netPort))
+			config.Node.Config["core.https_address"] = util.CanonicalNetworkAddressFromAddressAndPort(netAddr, int(netPort), shared.HTTPSDefaultPort)
 			config.Node.Config["core.trust_password"] = cli.AskPassword("Trust password for new clients: ")
 			if config.Node.Config["core.trust_password"] == "" {
 				fmt.Printf("No password set, client certificates will have to be manually trusted.")

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -1010,7 +1010,7 @@ they otherwise would.
 				netAddr = fmt.Sprintf("[%s]", netAddr)
 			}
 
-			netPort, err := cli.AskInt(fmt.Sprintf("Port to bind LXD to [default=%d]: ", shared.DefaultPort), 1, 65535, fmt.Sprintf("%d", shared.DefaultPort), func(netPort int64) error {
+			netPort, err := cli.AskInt(fmt.Sprintf("Port to bind LXD to [default=%d]: ", shared.HTTPSDefaultPort), 1, 65535, fmt.Sprintf("%d", shared.HTTPSDefaultPort), func(netPort int64) error {
 				address := util.CanonicalNetworkAddressFromAddressAndPort(netAddr, int(netPort))
 
 				if err == nil {

--- a/lxd/node/config.go
+++ b/lxd/node/config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lxc/lxd/lxd/config"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/util"
+	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/validate"
 )
 
@@ -38,7 +39,7 @@ func ConfigLoad(tx *db.NodeTx) (*Config, error) {
 func (c *Config) HTTPSAddress() string {
 	networkAddress := c.m.GetString("core.https_address")
 	if networkAddress != "" {
-		return util.CanonicalNetworkAddress(networkAddress)
+		return util.CanonicalNetworkAddress(networkAddress, shared.HTTPSDefaultPort)
 	}
 
 	return networkAddress
@@ -59,7 +60,7 @@ func (c *Config) BGPRouterID() string {
 func (c *Config) ClusterAddress() string {
 	clusterAddress := c.m.GetString("cluster.https_address")
 	if clusterAddress != "" {
-		return util.CanonicalNetworkAddress(clusterAddress)
+		return util.CanonicalNetworkAddress(clusterAddress, shared.HTTPSDefaultPort)
 	}
 
 	return clusterAddress

--- a/lxd/node/config.go
+++ b/lxd/node/config.go
@@ -68,7 +68,12 @@ func (c *Config) ClusterAddress() string {
 
 // DebugAddress returns the address and port to setup the pprof listener on
 func (c *Config) DebugAddress() string {
-	return c.m.GetString("core.debug_address")
+	debugAddress := c.m.GetString("core.debug_address")
+	if debugAddress != "" {
+		return util.CanonicalNetworkAddress(debugAddress, shared.HTTPDefaultPort)
+	}
+
+	return debugAddress
 }
 
 // MAASMachine returns the MAAS machine this instance is associated with, if

--- a/lxd/resources/network.go
+++ b/lxd/resources/network.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -434,7 +435,7 @@ func GetNetworkState(name string) (*api.NetworkState, error) {
 	// Get some information
 	netIf, err := net.InterfaceByName(name)
 	if err != nil {
-		return nil, fmt.Errorf("Network interface %q not found", name)
+		return nil, api.StatusErrorf(http.StatusNotFound, "Network interface %q not found", name)
 	}
 
 	netState := "down"

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -198,7 +198,7 @@ func ListenAddresses(value string) ([]string, error) {
 	localHost, localPort, err := net.SplitHostPort(value)
 	if err != nil {
 		localHost = value
-		localPort = fmt.Sprintf("%d", shared.DefaultPort)
+		localPort = fmt.Sprintf("%d", shared.HTTPSDefaultPort)
 	}
 
 	if localHost == "0.0.0.0" || localHost == "::" || localHost == "[::]" {

--- a/lxd/util/net.go
+++ b/lxd/util/net.go
@@ -71,18 +71,18 @@ func (a *inMemoryAddr) String() string {
 // CanonicalNetworkAddress parses the given network address and returns a string of the form "host:port",
 // possibly filling it with the default port if it's missing. It will also wrap a bare IPv6 address with square
 // brackets if needed.
-func CanonicalNetworkAddress(address string) string {
+func CanonicalNetworkAddress(address string, defaultPort int) string {
 	_, _, err := net.SplitHostPort(address)
 	if err != nil {
 		ip := net.ParseIP(address)
 		if ip != nil {
 			// If the input address is a bare IP address, then convert it to a proper listen address
 			// using the canonical IP with default port and wrap IPv6 addresses in square brackets.
-			address = net.JoinHostPort(ip.String(), fmt.Sprintf("%d", shared.HTTPSDefaultPort))
+			address = net.JoinHostPort(ip.String(), fmt.Sprintf("%d", defaultPort))
 		} else {
 			// Otherwise assume this is either a host name or a partial address (e.g `[::]`) without
 			// a port number, so append the default port.
-			address = fmt.Sprintf("%s:%d", address, shared.HTTPSDefaultPort)
+			address = fmt.Sprintf("%s:%d", address, defaultPort)
 		}
 	}
 
@@ -94,7 +94,7 @@ func CanonicalNetworkAddress(address string) string {
 func CanonicalNetworkAddressFromAddressAndPort(address string, port int) string {
 	// Because we accept just the host part of an IPv6 listen address (e.g. `[::]`) don't use net.JoinHostPort.
 	// If a bare IP address is supplied then CanonicalNetworkAddress will use net.JoinHostPort if needed.
-	return CanonicalNetworkAddress(fmt.Sprintf("%s:%d", address, port))
+	return CanonicalNetworkAddress(fmt.Sprintf("%s:%d", address, port), shared.HTTPSDefaultPort)
 }
 
 // ServerTLSConfig returns a new server-side tls.Config generated from the give
@@ -157,8 +157,8 @@ func NetworkInterfaceAddress() string {
 // address2, in the sense that they are either the same address or address2 is
 // specified using a wildcard with the same port of address1.
 func IsAddressCovered(address1, address2 string) bool {
-	address1 = CanonicalNetworkAddress(address1)
-	address2 = CanonicalNetworkAddress(address2)
+	address1 = CanonicalNetworkAddress(address1, shared.HTTPSDefaultPort)
+	address2 = CanonicalNetworkAddress(address2, shared.HTTPSDefaultPort)
 
 	if address1 == address2 {
 		return true
@@ -249,7 +249,7 @@ func IsAddressCovered(address1, address2 string) bool {
 
 // IsWildCardAddress returns whether the given address is a wildcard.
 func IsWildCardAddress(address string) bool {
-	address = CanonicalNetworkAddress(address)
+	address = CanonicalNetworkAddress(address, shared.HTTPSDefaultPort)
 
 	host, _, err := net.SplitHostPort(address)
 	if err != nil {

--- a/lxd/util/net.go
+++ b/lxd/util/net.go
@@ -78,11 +78,11 @@ func CanonicalNetworkAddress(address string) string {
 		if ip != nil {
 			// If the input address is a bare IP address, then convert it to a proper listen address
 			// using the canonical IP with default port and wrap IPv6 addresses in square brackets.
-			address = net.JoinHostPort(ip.String(), fmt.Sprintf("%d", shared.DefaultPort))
+			address = net.JoinHostPort(ip.String(), fmt.Sprintf("%d", shared.HTTPSDefaultPort))
 		} else {
 			// Otherwise assume this is either a host name or a partial address (e.g `[::]`) without
 			// a port number, so append the default port.
-			address = fmt.Sprintf("%s:%d", address, shared.DefaultPort)
+			address = fmt.Sprintf("%s:%d", address, shared.HTTPSDefaultPort)
 		}
 	}
 

--- a/lxd/util/net.go
+++ b/lxd/util/net.go
@@ -91,10 +91,10 @@ func CanonicalNetworkAddress(address string, defaultPort int) string {
 
 // CanonicalNetworkAddressFromAddressAndPort returns a network address from separate address and port values.
 // The address accepts values such as "[::]", "::" and "localhost".
-func CanonicalNetworkAddressFromAddressAndPort(address string, port int) string {
+func CanonicalNetworkAddressFromAddressAndPort(address string, port int, defaultPort int) string {
 	// Because we accept just the host part of an IPv6 listen address (e.g. `[::]`) don't use net.JoinHostPort.
 	// If a bare IP address is supplied then CanonicalNetworkAddress will use net.JoinHostPort if needed.
-	return CanonicalNetworkAddress(fmt.Sprintf("%s:%d", address, port), shared.HTTPSDefaultPort)
+	return CanonicalNetworkAddress(fmt.Sprintf("%s:%d", address, port), defaultPort)
 }
 
 // ServerTLSConfig returns a new server-side tls.Config generated from the give

--- a/lxd/util/net_test.go
+++ b/lxd/util/net_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/lxc/lxd/lxd/util"
+	"github.com/lxc/lxd/shared"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -45,7 +46,7 @@ func TestCanonicalNetworkAddress(t *testing.T) {
 	}
 	for in, out := range cases {
 		t.Run(in, func(t *testing.T) {
-			assert.Equal(t, out, util.CanonicalNetworkAddress(in))
+			assert.Equal(t, out, util.CanonicalNetworkAddress(in, shared.HTTPSDefaultPort))
 		})
 	}
 

--- a/lxd/vsock/vsock.go
+++ b/lxd/vsock/vsock.go
@@ -41,7 +41,7 @@ func HTTPClient(vsockID int, tlsClientCert string, tlsClientKey string, tlsServe
 
 			// Retry for up to 1s at 100ms interval to handle various failures.
 			for i := 0; i < 10; i++ {
-				conn, err = Dial(uint32(vsockID), shared.DefaultPort)
+				conn, err = Dial(uint32(vsockID), shared.HTTPSDefaultPort)
 				if err == nil {
 					break
 				} else {
@@ -49,7 +49,7 @@ func HTTPClient(vsockID int, tlsClientCert string, tlsClientKey string, tlsServe
 					msg := err.Error()
 					if strings.Contains(msg, "connection timed out") {
 						// Retry once.
-						conn, err = Dial(uint32(vsockID), shared.DefaultPort)
+						conn, err = Dial(uint32(vsockID), shared.HTTPSDefaultPort)
 						break
 					} else if strings.Contains(msg, "connection refused") {
 						break

--- a/shared/util.go
+++ b/shared/util.go
@@ -32,7 +32,7 @@ import (
 )
 
 const SnapshotDelimiter = "/"
-const DefaultPort = 8443
+const HTTPSDefaultPort = 8443
 
 // URLEncode encodes a path and query parameters to a URL.
 func URLEncode(path string, query map[string]string) (string, error) {

--- a/shared/util.go
+++ b/shared/util.go
@@ -33,6 +33,7 @@ import (
 
 const SnapshotDelimiter = "/"
 const HTTPSDefaultPort = 8443
+const HTTPDefaultPort = 8080
 
 // URLEncode encodes a path and query parameters to a URL.
 func URLEncode(path string, query map[string]string) (string, error) {

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -157,6 +157,25 @@ test_clustering_enable() {
   )
 
   kill_lxd "${LXD_INIT_DIR}"
+
+  # Test cluster listener after reload
+  LXD_INIT_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  chmod +x "${LXD_INIT_DIR}"
+  spawn_lxd "${LXD_INIT_DIR}" false
+
+  (
+    set -e
+    # shellcheck disable=SC2034,SC2030
+    LXD_DIR=${LXD_INIT_DIR}
+    lxc config set cluster.https_address 127.0.0.1:8443
+    kill -9 "$(cat "${LXD_DIR}/lxd.pid")"
+    respawn_lxd "${LXD_DIR}" true
+    # Enable clustering.
+    lxc cluster enable node1
+    lxc cluster list | grep -q 127.0.0.1:8443
+  )
+
+  kill_lxd "${LXD_INIT_DIR}"
 }
 
 test_clustering_membership() {


### PR DESCRIPTION
Closes #9188
https://github.com/lxc/lxd/pull/9199/commits/c02ab335de1ba726abd6e372d5608ae123358a91
https://github.com/lxc/lxd/pull/9199/commits/2fdc6c952fa539c84073bc44bfdb445fc6ffde27
Changes: 
* Makes sure the network address is not unset to `""` before checking if it covers the cluster address.
* Adds a test for this case.

Closes #9191
https://github.com/lxc/lxd/pull/9199/commits/9ba9447574b9cd91919be49c54886ce88f581521
Changes:
* Uses `api.StatusErrorf` to return a not-found error instead of an internal error.
* Thanks to @tomponline for the fix here :)

Closes #9193
https://github.com/lxc/lxd/pull/9199/commits/a29655125b15448bf7e3ef236783d20241b39ee2 and the rest.
Changes:
* Replaces `shared.DefaultPort` with `shared.HTTPSDefaultPort` and adds `shared.HTTPDefaultPort` to set `8443` and `8080` as ports, respectively.
* Adds these default ports as a parameter option to `CanonicalNetworkAddress`.
* Ensures `core.debug_address` is always consumed in canonical format with an HTTP port. 