### PR TITLE
lxc: Fix aliases containing @ARGS@

### DIFF
--- a/lxc/main_aliases.go
+++ b/lxc/main_aliases.go
@@ -71,9 +71,9 @@ func expandAlias(conf *config.Config, args []string) ([]string, bool) {
 	}
 	hasReplacedArgsVar := false
 
-	for i, aliasArg := range aliasValue {
-		if aliasArg == "@ARGS@" && len(origArgs) > i {
-			newArgs = append(newArgs, origArgs[i+1:]...)
+	for _, aliasArg := range aliasValue {
+		if aliasArg == "@ARGS@" && len(origArgs) > 2 {
+			newArgs = append(newArgs, origArgs[2:]...)
 			hasReplacedArgsVar = true
 		} else {
 			newArgs = append(newArgs, aliasArg)

--- a/lxc/main_test.go
+++ b/lxc/main_test.go
@@ -38,6 +38,7 @@ func TestExpandAliases(t *testing.T) {
 		"tester 12": "list",
 		"foo":       "list @ARGS@ -c n",
 		"ssh":       "/usr/bin/ssh @ARGS@",
+		"bar":       "exec c1 -- @ARGS@",
 	}
 
 	testcases := []aliasTestcase{
@@ -56,6 +57,10 @@ func TestExpandAliases(t *testing.T) {
 		{
 			input:    []string{"lxc", "ssh", "c1"},
 			expected: []string{"/usr/bin/ssh", "c1"},
+		},
+		{
+			input:    []string{"lxc", "bar", "ls", "/"},
+			expected: []string{"lxc", "exec", "c1", "--", "ls", "/"},
 		},
 	}
 


### PR DESCRIPTION
Consider the following alias: `lxc alias add foo "exec c1 -- echo @ARGS@"`.
Previously, this would expand to `lxc exec c1 -- echo @ARGS@ 1` if
called as `lxc foo 1`, which is incorrect.

This fixes the expansion of `@ARGS@` which makes the above call
correctly expand to `lxc exec c1 -- echo 1`.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
