### PR TITLE
Add 'name' to 'raft_nodes' table.

### DIFF
--- a/doc/clustering.md
+++ b/doc/clustering.md
@@ -338,15 +338,19 @@ This will present a YAML representation of this node's last recorded information
 about the rest of the cluster:
 
 ```yaml
-latest_segment: "12345"     # The last transaction id of this node (Read-only)
+# Latest dqlite segment ID: 1234
+
 members:
-  - id: 1	            # Internal ID of the node (Read-only)
+  - id: 1             # Internal ID of the node (Read-only)
+    name: node1       # Name of the cluster member (Read-only)
     address: 10.0.0.10:8443 # Last known address of the node (Writeable)
     role: voter             # Last known role of the node (Writeable)
   - id: 2
+   name: node2
     address: 10.0.0.11:8443
     role: stand-by
   - id: 3
+   name: node3
     address: 10.0.0.12:8443
     role: spare
 ```

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1897,6 +1897,7 @@ type internalRaftNode struct {
 	ID      uint64 `json:"id" yaml:"id"`
 	Address string `json:"address" yaml:"address"`
 	Role    int    `json:"role" yaml:"role"`
+	Name    string `json:"name" yaml:"name"`
 }
 
 // Used to update the cluster after a database node has been removed, and
@@ -2007,6 +2008,7 @@ func changeMemberRole(d *Daemon, r *http.Request, address string, nodes []db.Raf
 			ID:      node.ID,
 			Address: node.Address,
 			Role:    int(node.Role),
+			Name:    node.Name,
 		})
 	}
 
@@ -2099,6 +2101,7 @@ func internalClusterPostAssign(d *Daemon, r *http.Request) response.Response {
 		nodes[i].ID = node.ID
 		nodes[i].Address = node.Address
 		nodes[i].Role = db.RaftRole(node.Role)
+		nodes[i].Name = node.Name
 	}
 	err = cluster.Assign(d.State(), d.gateway, nodes)
 	if err != nil {

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -229,10 +229,25 @@ func (g *Gateway) HandlerFuncs(nodeRefreshTask func(*APIHeartbeat), trustedCerts
 			raftNodes := make([]db.RaftNode, 0)
 			for _, node := range heartbeatData.Members {
 				if node.RaftID > 0 {
+					nodeInfo := db.NodeInfo{}
+					if g.Cluster != nil {
+						err = g.Cluster.Transaction(func(tx *db.ClusterTx) error {
+							var err error
+							nodeInfo, err = tx.GetNodeByAddress(node.Address)
+							return err
+						})
+						if err != nil {
+							logger.Warn("Failed to retrieve cluster member", log.Ctx{"err": err})
+						}
+					}
+
 					raftNodes = append(raftNodes, db.RaftNode{
-						ID:      node.RaftID,
-						Address: node.Address,
-						Role:    db.RaftRole(node.RaftRole),
+						NodeInfo: client.NodeInfo{
+							ID:      node.RaftID,
+							Address: node.Address,
+							Role:    db.RaftRole(node.RaftRole),
+						},
+						Name: nodeInfo.Name,
 					})
 				}
 			}
@@ -801,7 +816,7 @@ func (g *Gateway) init(bootstrap bool) error {
 			}
 			g.memoryDial = dqliteMemoryDial(g.bindAddress)
 			g.store.inMemory = client.NewInmemNodeStore()
-			g.store.Set(context.Background(), []client.NodeInfo{*info})
+			g.store.Set(context.Background(), []client.NodeInfo{info.NodeInfo})
 		} else {
 			go runDqliteProxy(g.stopCh, g.bindAddress, g.acceptCh)
 			g.store.inMemory = nil
@@ -927,14 +942,39 @@ func (g *Gateway) currentRaftNodes() ([]db.RaftNode, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	raftNodes := []db.RaftNode{}
 	for i, server := range servers {
 		address, err := g.nodeAddress(server.Address)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to fetch raft server address")
 		}
 		servers[i].Address = address
+
+		raftNode := db.RaftNode{NodeInfo: servers[i]}
+		raftNodes = append(raftNodes, raftNode)
 	}
-	return servers, nil
+
+	// Get the names of the raft nodes from the global database.
+	if g.Cluster != nil {
+		err = g.Cluster.Transaction(func(tx *db.ClusterTx) error {
+			for i, server := range servers {
+				node, err := tx.GetNodeByAddress(server.Address)
+				if err != nil {
+					return err
+				}
+
+				raftNodes[i].Name = node.Name
+
+			}
+			return nil
+		})
+		if err != nil {
+			logger.Warn("Failed to retrieve cluster member", log.Ctx{"err": err})
+		}
+	}
+
+	return raftNodes, nil
 }
 
 // Translate a raft address to a node address. They are always the same except

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/canonical/go-dqlite/app"
 	"github.com/canonical/go-dqlite/client"
+
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/node"
@@ -57,7 +58,7 @@ func Bootstrap(state *state.State, gateway *Gateway, serverName string) error {
 		}
 
 		// Add ourselves as first raft node
-		err = tx.CreateFirstRaftNode(address)
+		err = tx.CreateFirstRaftNode(address, serverName)
 		if err != nil {
 			return errors.Wrap(err, "failed to insert first raft node")
 		}
@@ -280,7 +281,16 @@ func Accept(state *state.State, gateway *Gateway, name, address string, schema, 
 			standbys++
 		}
 	}
-	node := db.RaftNode{ID: uint64(id), Address: address, Role: db.RaftSpare}
+
+	node := db.RaftNode{
+		NodeInfo: client.NodeInfo{
+			ID:      uint64(id),
+			Address: address,
+			Role:    db.RaftSpare,
+		},
+		Name: name,
+	}
+
 	if count > 1 && voters < int(maxVoters) {
 		node.Role = db.RaftVoter
 	} else if standbys < int(maxStandBy) {
@@ -416,7 +426,7 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 	logger.Info("Adding node to cluster", log15.Ctx{"id": info.ID, "address": info.Address, "role": info.Role})
 	ctx, cancel = context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-	err = client.Add(ctx, *info)
+	err = client.Add(ctx, info.NodeInfo)
 	if err != nil {
 		return errors.Wrap(err, "Failed to join cluster")
 	}
@@ -918,11 +928,11 @@ func newRolesChanges(state *state.State, gateway *Gateway, nodes []db.RaftNode) 
 
 	for _, node := range nodes {
 		if HasConnectivity(gateway.networkCert, gateway.serverCert(), node.Address) {
-			cluster[node] = &client.NodeMetadata{
+			cluster[node.NodeInfo] = &client.NodeMetadata{
 				FailureDomain: domains[node.Address],
 			}
 		} else {
-			cluster[node] = nil
+			cluster[node.NodeInfo] = nil
 		}
 
 	}

--- a/lxd/cluster/membership_test.go
+++ b/lxd/cluster/membership_test.go
@@ -399,7 +399,7 @@ func (h *membershipFixtures) ClusterAddress(address string) {
 // Add the given address to the raft_nodes table.
 func (h *membershipFixtures) RaftNode(address string) {
 	err := h.state.Node.Transaction(func(tx *db.NodeTx) error {
-		_, err := tx.CreateRaftNode(address)
+		_, err := tx.CreateRaftNode(address, "rusp")
 		return err
 	})
 	require.NoError(h.t, err)

--- a/lxd/cluster/raft_test.go
+++ b/lxd/cluster/raft_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 
 	"github.com/canonical/go-dqlite/client"
+	"github.com/stretchr/testify/require"
+
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
-	"github.com/stretchr/testify/require"
 )
 
 // Set the cluster.https_address config key to the given address, and insert the
@@ -22,7 +23,7 @@ func setRaftRole(t *testing.T, database *db.Node, address string) client.NodeSto
 		if err != nil {
 			return err
 		}
-		_, err = tx.CreateRaftNode(address)
+		_, err = tx.CreateRaftNode(address, "test")
 		return err
 	}))
 

--- a/lxd/cluster/recover.go
+++ b/lxd/cluster/recover.go
@@ -3,7 +3,7 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -180,8 +180,14 @@ func Reconfigure(database *db.Node, raftNodes []db.RaftNode) error {
 	}
 
 	if len(content) > 0 {
-		dir := filepath.Join(database.Dir(), "patch.global.sql")
-		err := ioutil.WriteFile(dir, []byte(content), 0644)
+		filePath := filepath.Join(database.Dir(), "patch.global.sql")
+		file, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		_, err = file.Write([]byte(content))
 		if err != nil {
 			return err
 		}

--- a/lxd/cluster/upgrade_test.go
+++ b/lxd/cluster/upgrade_test.go
@@ -11,13 +11,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/canonical/go-dqlite/client"
 	"github.com/canonical/go-dqlite/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // A node can unblock other nodes that were waiting for a cluster upgrade to
@@ -65,8 +67,8 @@ func TestMaybeUpdate_Upgrade(t *testing.T) {
 
 	state.Node.Transaction(func(tx *db.NodeTx) error {
 		nodes := []db.RaftNode{
-			{ID: 1, Address: "0.0.0.0:666"},
-			{ID: 2, Address: "1.2.3.4:666"},
+			{NodeInfo: client.NodeInfo{ID: 1, Address: "0.0.0.0:666"}},
+			{NodeInfo: client.NodeInfo{ID: 2, Address: "1.2.3.4:666"}},
 		}
 		err := tx.ReplaceRaftNodes(nodes)
 		require.NoError(t, err)

--- a/lxd/db/node/schema.go
+++ b/lxd/db/node/schema.go
@@ -30,8 +30,9 @@ CREATE TABLE raft_nodes (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     address TEXT NOT NULL,
     role INTEGER NOT NULL DEFAULT 0,
+    name TEXT NOT NULL default "",
     UNIQUE (address)
 );
 
-INSERT INTO schema (version, updated_at) VALUES (41, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (42, strftime("%s"))
 `

--- a/lxd/db/node/update.go
+++ b/lxd/db/node/update.go
@@ -98,6 +98,7 @@ var updates = map[int]schema.Update{
 	39: updateFromV38,
 	40: updateFromV39,
 	41: updateFromV40,
+	42: updateFromV41,
 }
 
 // UpdateFromPreClustering is the last schema version where clustering support
@@ -105,6 +106,14 @@ var updates = map[int]schema.Update{
 const UpdateFromPreClustering = 36
 
 // Schema updates begin here
+
+func updateFromV41(tx *sql.Tx) error {
+	stmt := `
+	ALTER TABLE raft_nodes ADD COLUMN name TEXT NOT NULL default "";
+	`
+	_, err := tx.Exec(stmt)
+	return err
+}
 
 func updateFromV40(tx *sql.Tx) error {
 	stmt := `

--- a/lxd/db/raft.go
+++ b/lxd/db/raft.go
@@ -15,7 +15,10 @@ import (
 //
 // This is just a convenience alias for the equivalent data structure in the
 // dqlite client package.
-type RaftNode = client.NodeInfo
+type RaftNode struct {
+	client.NodeInfo
+	Name string
+}
 
 // RaftRole captures the role of dqlite/raft node.
 type RaftRole = client.NodeRole
@@ -34,9 +37,9 @@ func (n *NodeTx) GetRaftNodes() ([]RaftNode, error) {
 	nodes := []RaftNode{}
 	dest := func(i int) []interface{} {
 		nodes = append(nodes, RaftNode{})
-		return []interface{}{&nodes[i].ID, &nodes[i].Address, &nodes[i].Role}
+		return []interface{}{&nodes[i].ID, &nodes[i].Address, &nodes[i].Role, &nodes[i].Name}
 	}
-	stmt, err := n.tx.Prepare("SELECT id, address, role FROM raft_nodes ORDER BY id")
+	stmt, err := n.tx.Prepare("SELECT id, address, role, name FROM raft_nodes ORDER BY id")
 	if err != nil {
 		return nil, err
 	}
@@ -80,9 +83,9 @@ func (n *NodeTx) GetRaftNodeAddress(id int64) (string, error) {
 //
 // This method is supposed to be called when there are no rows in raft_nodes,
 // and it will replace whatever existing row has ID 1.
-func (n *NodeTx) CreateFirstRaftNode(address string) error {
-	columns := []string{"id", "address"}
-	values := []interface{}{int64(1), address}
+func (n *NodeTx) CreateFirstRaftNode(address string, name string) error {
+	columns := []string{"id", "address", "name"}
+	values := []interface{}{int64(1), address, name}
 	id, err := query.UpsertObject(n.tx, "raft_nodes", columns, values)
 	if err != nil {
 		return err
@@ -95,9 +98,9 @@ func (n *NodeTx) CreateFirstRaftNode(address string) error {
 
 // CreateRaftNode adds a node to the current list of LXD nodes that are part of the
 // dqlite Raft cluster. It returns the ID of the newly inserted row.
-func (n *NodeTx) CreateRaftNode(address string) (int64, error) {
-	columns := []string{"address"}
-	values := []interface{}{address}
+func (n *NodeTx) CreateRaftNode(address string, name string) (int64, error) {
+	columns := []string{"address", "name"}
+	values := []interface{}{address, name}
 	return query.UpsertObject(n.tx, "raft_nodes", columns, values)
 }
 
@@ -121,9 +124,9 @@ func (n *NodeTx) ReplaceRaftNodes(nodes []RaftNode) error {
 		return err
 	}
 
-	columns := []string{"id", "address", "role"}
+	columns := []string{"id", "address", "role", "name"}
 	for _, node := range nodes {
-		values := []interface{}{node.ID, node.Address, node.Role}
+		values := []interface{}{node.ID, node.Address, node.Role, node.Name}
 		_, err := query.UpsertObject(n.tx, "raft_nodes", columns, values)
 		if err != nil {
 			return err

--- a/lxd/db/raft.go
+++ b/lxd/db/raft.go
@@ -101,9 +101,9 @@ func (n *NodeTx) CreateRaftNode(address string) (int64, error) {
 	return query.UpsertObject(n.tx, "raft_nodes", columns, values)
 }
 
-// RemoteRaftNode removes a node from the current list of LXD nodes that are
+// RemoveRaftNode removes a node from the current list of LXD nodes that are
 // part of the dqlite Raft cluster.
-func (n *NodeTx) RemoteRaftNode(id int64) error {
+func (n *NodeTx) RemoveRaftNode(id int64) error {
 	deleted, err := query.DeleteObject(n.tx, "raft_nodes", id)
 	if err != nil {
 		return err

--- a/lxd/db/raft_test.go
+++ b/lxd/db/raft_test.go
@@ -72,7 +72,7 @@ func TestCreateFirstRaftNode(t *testing.T) {
 	err := tx.CreateFirstRaftNode("1.2.3.4:666")
 	assert.NoError(t, err)
 
-	err = tx.RemoteRaftNode(1)
+	err = tx.RemoveRaftNode(1)
 	assert.NoError(t, err)
 
 	err = tx.CreateFirstRaftNode("5.6.7.8:666")
@@ -94,23 +94,23 @@ func TestCreateRaftNode(t *testing.T) {
 }
 
 // Delete an existing raft node.
-func TestRemoteRaftNode(t *testing.T) {
+func TestRemoveRaftNode(t *testing.T) {
 	tx, cleanup := db.NewTestNodeTx(t)
 	defer cleanup()
 
 	id, err := tx.CreateRaftNode("1.2.3.4:666")
 	require.NoError(t, err)
 
-	err = tx.RemoteRaftNode(id)
+	err = tx.RemoveRaftNode(id)
 	assert.NoError(t, err)
 }
 
 // Delete a non-existing raft node returns an error.
-func TestRemoteRaftNode_NonExisting(t *testing.T) {
+func TestRemoveRaftNode_NonExisting(t *testing.T) {
 	tx, cleanup := db.NewTestNodeTx(t)
 	defer cleanup()
 
-	err := tx.RemoteRaftNode(1)
+	err := tx.RemoveRaftNode(1)
 	assert.Equal(t, db.ErrNoSuchObject, err)
 }
 

--- a/lxd/db/raft_test.go
+++ b/lxd/db/raft_test.go
@@ -6,9 +6,11 @@ package db_test
 import (
 	"testing"
 
-	"github.com/lxc/lxd/lxd/db"
+	"github.com/canonical/go-dqlite/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/lxc/lxd/lxd/db"
 )
 
 // Fetch all raft nodes.
@@ -16,10 +18,10 @@ func TestRaftNodes(t *testing.T) {
 	tx, cleanup := db.NewTestNodeTx(t)
 	defer cleanup()
 
-	id1, err := tx.CreateRaftNode("1.2.3.4:666")
+	id1, err := tx.CreateRaftNode("1.2.3.4:666", "test")
 	require.NoError(t, err)
 
-	id2, err := tx.CreateRaftNode("5.6.7.8:666")
+	id2, err := tx.CreateRaftNode("5.6.7.8:666", "test")
 	require.NoError(t, err)
 
 	nodes, err := tx.GetRaftNodes()
@@ -36,10 +38,10 @@ func TestGetRaftNodeAddresses(t *testing.T) {
 	tx, cleanup := db.NewTestNodeTx(t)
 	defer cleanup()
 
-	_, err := tx.CreateRaftNode("1.2.3.4:666")
+	_, err := tx.CreateRaftNode("1.2.3.4:666", "test")
 	require.NoError(t, err)
 
-	_, err = tx.CreateRaftNode("5.6.7.8:666")
+	_, err = tx.CreateRaftNode("5.6.7.8:666", "test")
 	require.NoError(t, err)
 
 	addresses, err := tx.GetRaftNodeAddresses()
@@ -53,10 +55,10 @@ func TestGetRaftNodeAddress(t *testing.T) {
 	tx, cleanup := db.NewTestNodeTx(t)
 	defer cleanup()
 
-	_, err := tx.CreateRaftNode("1.2.3.4:666")
+	_, err := tx.CreateRaftNode("1.2.3.4:666", "test")
 	require.NoError(t, err)
 
-	id, err := tx.CreateRaftNode("5.6.7.8:666")
+	id, err := tx.CreateRaftNode("5.6.7.8:666", "test")
 	require.NoError(t, err)
 
 	address, err := tx.GetRaftNodeAddress(id)
@@ -69,13 +71,13 @@ func TestCreateFirstRaftNode(t *testing.T) {
 	tx, cleanup := db.NewTestNodeTx(t)
 	defer cleanup()
 
-	err := tx.CreateFirstRaftNode("1.2.3.4:666")
+	err := tx.CreateFirstRaftNode("1.2.3.4:666", "test")
 	assert.NoError(t, err)
 
 	err = tx.RemoveRaftNode(1)
 	assert.NoError(t, err)
 
-	err = tx.CreateFirstRaftNode("5.6.7.8:666")
+	err = tx.CreateFirstRaftNode("5.6.7.8:666", "test")
 	assert.NoError(t, err)
 
 	address, err := tx.GetRaftNodeAddress(1)
@@ -88,7 +90,7 @@ func TestCreateRaftNode(t *testing.T) {
 	tx, cleanup := db.NewTestNodeTx(t)
 	defer cleanup()
 
-	id, err := tx.CreateRaftNode("1.2.3.4:666")
+	id, err := tx.CreateRaftNode("1.2.3.4:666", "test")
 	assert.Equal(t, int64(1), id)
 	assert.NoError(t, err)
 }
@@ -98,7 +100,7 @@ func TestRemoveRaftNode(t *testing.T) {
 	tx, cleanup := db.NewTestNodeTx(t)
 	defer cleanup()
 
-	id, err := tx.CreateRaftNode("1.2.3.4:666")
+	id, err := tx.CreateRaftNode("1.2.3.4:666", "test")
 	require.NoError(t, err)
 
 	err = tx.RemoveRaftNode(id)
@@ -119,12 +121,12 @@ func TestReplaceRaftNodes(t *testing.T) {
 	tx, cleanup := db.NewTestNodeTx(t)
 	defer cleanup()
 
-	_, err := tx.CreateRaftNode("1.2.3.4:666")
+	_, err := tx.CreateRaftNode("1.2.3.4:666", "test")
 	require.NoError(t, err)
 
 	nodes := []db.RaftNode{
-		{ID: 2, Address: "2.2.2.2:666"},
-		{ID: 3, Address: "3.3.3.3:666"},
+		{NodeInfo: client.NodeInfo{ID: 2, Address: "2.2.2.2:666"}},
+		{NodeInfo: client.NodeInfo{ID: 3, Address: "3.3.3.3:666"}},
 	}
 	err = tx.ReplaceRaftNodes(nodes)
 	assert.NoError(t, err)

--- a/lxd/node/raft.go
+++ b/lxd/node/raft.go
@@ -1,6 +1,8 @@
 package node
 
 import (
+	"github.com/canonical/go-dqlite/client"
+
 	"github.com/lxc/lxd/lxd/db"
 )
 
@@ -36,7 +38,8 @@ func DetermineRaftNode(tx *db.NodeTx) (*db.RaftNode, error) {
 	// If cluster.https_address is the empty string, then this LXD instance is
 	// not running in clustering mode.
 	if address == "" {
-		return &db.RaftNode{ID: 1}, nil
+		nodeInfo := client.NodeInfo{ID: 1}
+		return &db.RaftNode{NodeInfo: nodeInfo, Name: ""}, nil
 	}
 
 	nodes, err := tx.GetRaftNodes()
@@ -47,7 +50,8 @@ func DetermineRaftNode(tx *db.NodeTx) (*db.RaftNode, error) {
 	// If cluster.https_address and the raft_nodes table is not populated,
 	// this must be a joining node.
 	if len(nodes) == 0 {
-		return &db.RaftNode{ID: 1}, nil
+		nodeInfo := client.NodeInfo{ID: 1}
+		return &db.RaftNode{NodeInfo: nodeInfo, Name: ""}, nil
 	}
 
 	// Try to find a matching node.

--- a/lxd/node/raft_test.go
+++ b/lxd/node/raft_test.go
@@ -3,11 +3,13 @@ package node_test
 import (
 	"testing"
 
-	"github.com/lxc/lxd/lxd/db"
-	"github.com/lxc/lxd/lxd/node"
+	"github.com/canonical/go-dqlite/client"
 	"github.com/mpvl/subtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/node"
 )
 
 // The raft identity (ID and address) of a node depends on the value of
@@ -23,25 +25,25 @@ func TestDetermineRaftNode(t *testing.T) {
 			`no cluster.https_address set`,
 			"",
 			[]string{},
-			&db.RaftNode{ID: 1},
+			&db.RaftNode{NodeInfo: client.NodeInfo{ID: 1}},
 		},
 		{
 			`cluster.https_address set and no raft_nodes rows`,
 			"1.2.3.4:8443",
 			[]string{},
-			&db.RaftNode{ID: 1},
+			&db.RaftNode{NodeInfo: client.NodeInfo{ID: 1}},
 		},
 		{
 			`cluster.https_address set and matching the one and only raft_nodes row`,
 			"1.2.3.4:8443",
 			[]string{"1.2.3.4:8443"},
-			&db.RaftNode{ID: 1, Address: "1.2.3.4:8443"},
+			&db.RaftNode{NodeInfo: client.NodeInfo{ID: 1, Address: "1.2.3.4:8443"}},
 		},
 		{
 			`cluster.https_address set and matching one of many raft_nodes rows`,
 			"5.6.7.8:999",
 			[]string{"1.2.3.4:666", "5.6.7.8:999"},
-			&db.RaftNode{ID: 2, Address: "5.6.7.8:999"},
+			&db.RaftNode{NodeInfo: client.NodeInfo{ID: 2, Address: "5.6.7.8:999"}},
 		},
 		{
 			`core.cluster set and no matching raft_nodes row`,
@@ -60,7 +62,7 @@ func TestDetermineRaftNode(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, address := range c.addresses {
-				_, err := tx.CreateRaftNode(address)
+				_, err := tx.CreateRaftNode(address, "test")
 				require.NoError(t, err)
 			}
 


### PR DESCRIPTION
This PR adds the cluster member name field as a column to the `raft_nodes` local table. Since the dqlite representation of a raft node is still limited to `ID,` `Address`, and `Role`, the `Name` is extracted from the global `nodes` database, if the global database is accessible. If not, the field will not be populated. 

Also addressed a few small bugs:
* Typo in `RemoteRaftNode`, should be `RemoveRaftNode`
* If `patch.global.sql` exists already, append to it in `lxd cluster edit`
* Make `latest_segment` a comment instead of a yaml field to prevent any confusion with its value being different node-to-node.