### PR TITLE
Network: Exports bridge forward addresses via BGP

### DIFF
--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -2803,5 +2803,10 @@ func (n *bridge) forwardsSetup() error {
 		return fmt.Errorf("Failed applying firewall address forwards: %w", err)
 	}
 
+	err = n.forwardBGPSetupPrefixes()
+	if err != nil {
+		return fmt.Errorf("Failed applying BGP prefixes for address forwards: %w", err)
+	}
+
 	return nil
 }

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -579,6 +579,24 @@ func (n *common) bgpSetupPeers(oldConfig map[string]string) error {
 	return nil
 }
 
+// bgpNextHopAddress parses nexthop configuration and returns next hop address to use for BGP routes.
+// Uses first of bgp.ipv{ipVersion}.nexthop or volatile.network.ipv{ipVersion}.address or wildcard address.
+func (n *common) bgpNextHopAddress(ipVersion uint) net.IP {
+	nextHopAddr := net.ParseIP(n.config[fmt.Sprintf("bgp.ipv%d.nexthop", ipVersion)])
+	if nextHopAddr == nil {
+		nextHopAddr = net.ParseIP(n.config[fmt.Sprintf("volatile.network.ipv%d.address", ipVersion)])
+		if nextHopAddr == nil {
+			if ipVersion == 4 {
+				nextHopAddr = net.ParseIP("0.0.0.0")
+			} else {
+				nextHopAddr = net.ParseIP("::")
+			}
+		}
+	}
+
+	return nextHopAddr
+}
+
 // bgpSetupPrefixes refreshes the prefix list for the network.
 func (n *common) bgpSetupPrefixes(oldConfig map[string]string) error {
 	// Parse nexthop configuration.

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -509,6 +509,12 @@ func (n *common) bgpClear(config map[string]string) error {
 		return err
 	}
 
+	// Clear existing address forward prefixes for network.
+	err = n.state.BGP.RemovePrefixByOwner(fmt.Sprintf("network_%d_forward", n.id))
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -504,7 +504,7 @@ func (n *common) bgpClear(config map[string]string) error {
 	}
 
 	// Clear all prefixes.
-	err = n.bgpClearPrefixes()
+	err = n.state.BGP.RemovePrefixByOwner(fmt.Sprintf("network_%d", n.id))
 	if err != nil {
 		return err
 	}
@@ -522,16 +522,6 @@ func (n *common) bgpClearPeers(config map[string]string) error {
 		if err != nil {
 			return err
 		}
-	}
-
-	return nil
-}
-
-// bgpClearPrefixes removes all BGP prefixes for the network.
-func (n *common) bgpClearPrefixes() error {
-	err := n.state.BGP.RemovePrefixByOwner(fmt.Sprintf("network_%d", n.id))
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -484,12 +484,12 @@ func (n *common) bgpValidationRules(config map[string]string) (map[string]func(v
 func (n *common) bgpSetup(oldConfig map[string]string) error {
 	err := n.bgpSetupPeers(oldConfig)
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed setting up BGP peers: %w", err)
 	}
 
 	err = n.bgpSetupPrefixes(oldConfig)
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed setting up BGP prefixes: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
This PR adds support for exporting `bridge` network address forwards through BGP.

E.g.

```
lxc query /internal/testing/bgp
{
	"peers": [],
	"prefixes": [
		{
			"nexthop": "::",
			"owner": "network_1",
			"prefix": "fd42:b545:2e58:ec06::/64"
		},
		{
			"nexthop": "0.0.0.0",
			"owner": "network_1_forward",
			"prefix": "10.0.0.1/32"
		},
		{
			"nexthop": "0.0.0.0",
			"owner": "network_1",
			"prefix": "10.128.213.0/24"
		},
		{
			"nexthop": "0.0.0.0",
			"owner": "network_1_forward",
			"prefix": "10.128.213.2/32"
		}
	],
	"server": {
		"address": "",
		"asn": 0,
		"router_id": "<nil>",
		"running": false
	}
}
```