### PR TITLE
Allow local options when storage creation

### DIFF
--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -964,12 +964,20 @@ func (c *Cluster) FillMissingStoragePoolDriver() error {
 
 // StoragePoolNodeConfigKeys lists all storage pool config keys which are node-specific.
 var StoragePoolNodeConfigKeys = []string{
-	"size",
-	"source",
-	"volatile.initial_source",
-	"zfs.pool_name",
-	"lvm.thinpool_name",
-	"lvm.vg_name",
+    "btrfs.mount_options",
+    "lvm.thinpool_name",
+    "lvm.use_thinpool",
+    "lvm.vg.force_reuse",
+    "lvm.vg_name",
+    "size",
+    "source",
+    "volatile.initial_source",
+    "volume.block.filesystem",
+    "volume.block.mount_options",
+    "volume.lvm.stripes",
+    "volume.lvm.stripes.size",
+    "volume.size",
+    "zfs.pool_name",
 }
 
 // IsRemoteStorage return whether a given pool is backed by remote storage.


### PR DESCRIPTION
Hi there, these changes will fix issues like #4823.

So, we are trying to use LXC clustering instead of bunch of single nodes. And we are stucked after first attempt to migrate it about storage creation issue. Now we creates storage pool like this:

```(bash)
lxc \
    storage create --target=lxd-1 \
    lxd.btrfs \
    lvm \
    lvm.use_thinpool=false \
    lvm.vg.force_reuse=true \
    lvm.vg_name=lxd-nr \
    source=lxd-nr \
    volume.block.filesystem=btrfs \
    volume.block.mount_options=compress=zstd,discard,autodefrag,commit=60,datacow,datasum,flushoncommit,inode_cache,ssd,thread_pool=4,user_subvol_rm_allowed volume.size=8GB 
```

So, this still failing and after a fast investigation, I found the #4823, so this PR adding some config options as allowed in this case.