### PR TITLE
Cluster: Fix slow heartbeat response due to multiple remote queries when populating raft node names

### DIFF
--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -229,25 +229,13 @@ func (g *Gateway) HandlerFuncs(nodeRefreshTask func(*APIHeartbeat), trustedCerts
 			raftNodes := make([]db.RaftNode, 0)
 			for _, node := range heartbeatData.Members {
 				if node.RaftID > 0 {
-					nodeInfo := db.NodeInfo{}
-					if g.Cluster != nil {
-						err = g.Cluster.Transaction(func(tx *db.ClusterTx) error {
-							var err error
-							nodeInfo, err = tx.GetNodeByAddress(node.Address)
-							return err
-						})
-						if err != nil {
-							logger.Warn("Failed to retrieve cluster member", log.Ctx{"err": err})
-						}
-					}
-
 					raftNodes = append(raftNodes, db.RaftNode{
 						NodeInfo: client.NodeInfo{
 							ID:      node.RaftID,
 							Address: node.Address,
 							Role:    db.RaftRole(node.RaftRole),
 						},
-						Name: nodeInfo.Name,
+						Name: node.Name,
 					})
 				}
 			}

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -943,7 +943,7 @@ func (g *Gateway) currentRaftNodes() ([]db.RaftNode, error) {
 		return nil, err
 	}
 
-	raftNodes := []db.RaftNode{}
+	raftNodes := make([]db.RaftNode, 0, len(servers))
 	for i, server := range servers {
 		address, err := g.nodeAddress(server.Address)
 		if err != nil {

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -958,19 +958,29 @@ func (g *Gateway) currentRaftNodes() ([]db.RaftNode, error) {
 	// Get the names of the raft nodes from the global database.
 	if g.Cluster != nil {
 		err = g.Cluster.Transaction(func(tx *db.ClusterTx) error {
+			nodes, err := tx.GetNodes()
+			if err != nil {
+				return fmt.Errorf("Failed loading cluster members: %w", err)
+			}
+
+			nodesByAddress := make(map[string]db.NodeInfo, len(nodes))
+			for _, node := range nodes {
+				nodesByAddress[node.Address] = node
+			}
+
 			for i, server := range servers {
-				node, err := tx.GetNodeByAddress(server.Address)
-				if err != nil {
-					return err
+				node, found := nodesByAddress[server.Address]
+				if !found {
+					return fmt.Errorf("Cluster member info not found for %q", server.Address)
 				}
 
 				raftNodes[i].Name = node.Name
-
 			}
+
 			return nil
 		})
 		if err != nil {
-			logger.Warn("Failed to retrieve cluster member", log.Ctx{"err": err})
+			logger.Warn("Failed getting raft nodes", log.Ctx{"err": err})
 		}
 	}
 

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -34,6 +34,7 @@ const (
 type APIHeartbeatMember struct {
 	ID            int64     // ID field value in nodes table.
 	Address       string    // Host and Port of node.
+	Name          string    // Name of cluster member.
 	RaftID        uint64    // ID field value in raft_nodes table, zero if non-raft node.
 	RaftRole      int       // Node role in the raft cluster, from the raft_nodes table
 	Raft          bool      // Deprecated, use non-zero RaftID instead to indicate raft node.

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -75,9 +75,8 @@ func (hbState *APIHeartbeat) Update(fullStateList bool, raftNodes []db.RaftNode,
 	// If we've been supplied a fresh set of node states, this is a full state list.
 	hbState.FullStateList = fullStateList
 
-	raftNodeMap := make(map[string]db.RaftNode)
-
 	// Convert raftNodes to a map keyed on address for lookups later.
+	raftNodeMap := make(map[string]db.RaftNode, len(raftNodes))
 	for _, raftNode := range raftNodes {
 		raftNodeMap[raftNode.Address] = raftNode
 	}

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -86,6 +86,7 @@ func (hbState *APIHeartbeat) Update(fullStateList bool, raftNodes []db.RaftNode,
 		member := APIHeartbeatMember{
 			ID:            node.ID,
 			Address:       node.Address,
+			Name:          node.Name,
 			LastHeartbeat: node.Heartbeat,
 			Online:        !node.Heartbeat.Before(time.Now().Add(-offlineThreshold)),
 		}

--- a/lxd/cluster/recover.go
+++ b/lxd/cluster/recover.go
@@ -139,8 +139,8 @@ func Reconfigure(database *db.Node, raftNodes []db.RaftNode) error {
 	}
 
 	localAddress := info.Address
-	nodes := []client.NodeInfo{}
 
+	nodes := make([]client.NodeInfo, 0, len(raftNodes))
 	for _, raftNode := range raftNodes {
 		nodes = append(nodes, raftNode.NodeInfo)
 


### PR DESCRIPTION
Fixes issue introduced by https://github.com/lxc/lxd/pull/9209/commits/1db065b06b2e1b16ea997927d158a4cae5162714 that was reported from https://discuss.linuxcontainers.org/t/heartbeat-timeouts-after-upgrade-to-4-18/12164

The action of performing 1 transaction and query per raft node in heartbeat payload (in order to enrich the member name) was causing the heartbeat handler to take >1s in scenarios where the recipient cluster member was in a remote DC (so the queries back to the leader were slower) and in cases where there was a larger cluster with more raft members.

When the heartbeat handler exceeds 1s, the leader considers the member offline.

This PR instead adds the member name to the heartbeat payload and performs the enrichment in a single transaction and query on the leader. The name is then available to the recipient cluster members to populate their local raft nodes table as needed.