### PR TITLE
Extend cgroup abstraction and other preparations for metrics

### DIFF
--- a/lxd/cgroup/abstraction.go
+++ b/lxd/cgroup/abstraction.go
@@ -801,3 +801,28 @@ func (cg *CGroup) GetIOStats() (map[string]*IOStats, error) {
 
 	return nil, ErrUnknownVersion
 }
+
+// GetTotalProcesses returns the total number of processes
+func (cg *CGroup) GetTotalProcesses() (int64, error) {
+	version := cgControllers["pids"]
+	switch version {
+	case Unavailable:
+		return -1, ErrControllerMissing
+	case V1:
+		val, err := cg.rw.Get(version, "pids", "pids.current")
+		if err != nil {
+			return -1, err
+		}
+
+		return strconv.ParseInt(val, 10, 64)
+	case V2:
+		val, err := cg.rw.Get(version, "pids", "pids.current")
+		if err != nil {
+			return -1, err
+		}
+
+		return strconv.ParseInt(val, 10, 64)
+	}
+
+	return -1, ErrUnknownVersion
+}

--- a/lxd/cgroup/types.go
+++ b/lxd/cgroup/types.go
@@ -21,3 +21,11 @@ type ReadWriter interface {
 	Get(backend Backend, controller string, key string) (string, error)
 	Set(backend Backend, controller string, key string, value string) error
 }
+
+// IOStats represent IO stats.
+type IOStats struct {
+	ReadBytes       uint64
+	ReadsCompleted  uint64
+	WrittenBytes    uint64
+	WritesCompleted uint64
+}

--- a/lxd/cgroup/types.go
+++ b/lxd/cgroup/types.go
@@ -29,3 +29,9 @@ type IOStats struct {
 	WrittenBytes    uint64
 	WritesCompleted uint64
 }
+
+// CPUStats represent CPU stats.
+type CPUStats struct {
+	User   int64
+	System int64
+}

--- a/lxd/storage/filesystem/fs.go
+++ b/lxd/storage/filesystem/fs.go
@@ -41,7 +41,12 @@ func Detect(path string) (string, error) {
 		return "", err
 	}
 
-	switch fs.Type {
+	return FSTypeToName(fs.Type)
+}
+
+// FSTypeToName returns the name of the given fs type.
+func FSTypeToName(fsType int64) (string, error) {
+	switch fsType {
 	case FilesystemSuperMagicBtrfs:
 		return "btrfs", nil
 	case FilesystemSuperMagicZfs:
@@ -54,10 +59,10 @@ func Detect(path string) (string, error) {
 		return "xfs", nil
 	case FilesystemSuperMagicNfs:
 		return "nfs", nil
-	default:
-		logger.Debugf("Unknown backing filesystem type: 0x%x", fs.Type)
-		return fmt.Sprintf("0x%x", fs.Type), nil
 	}
+
+	logger.Debugf("Unknown backing filesystem type: 0x%x", fsType)
+	return fmt.Sprintf("0x%x", fsType), nil
 }
 
 func parseMountinfo(name string) int {


### PR DESCRIPTION
- lxd/cgroup: Add GetMemoryStats
- lxd/cgroup: Add GetIOStats
- lxd/cgroup: Add GetCPUAcctUsageAll
- lxd/cgroup: Add GetTotalProcesses
- lxd/response: Add SyncResponsePlain
- lxd/storage/filesystem: Add FSTypeToName
