### PR TITLE
shared/api/network/forward: Fix api extension references

### DIFF
--- a/shared/api/network_forward.go
+++ b/shared/api/network_forward.go
@@ -9,7 +9,7 @@ import (
 //
 // swagger:model
 //
-// API extension: network_forwards
+// API extension: network_forward
 type NetworkForwardPort struct {
 	// Description of the forward port
 	// Example: My web server forward
@@ -62,7 +62,7 @@ func (p *NetworkForwardPort) Normalise() {
 //
 // swagger:model
 //
-// API extension: network_forwards
+// API extension: network_forward
 type NetworkForwardsPost struct {
 	NetworkForwardPut `yaml:",inline"`
 
@@ -85,7 +85,7 @@ func (f *NetworkForwardsPost) Normalise() {
 //
 // swagger:model
 //
-// API extension: network_forwards
+// API extension: network_forward
 type NetworkForwardPut struct {
 	// Description of the forward listen IP
 	// Example: My public IP forward
@@ -117,7 +117,7 @@ func (f *NetworkForwardPut) Normalise() {
 //
 // swagger:model
 //
-// API extension: network_forwards
+// API extension: network_forward
 type NetworkForward struct {
 	NetworkForwardPut `yaml:",inline"`
 


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>