### PR TITLE
Daemon: Shutdown improvements

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -64,7 +64,7 @@ func restServer(d *Daemon) *http.Server {
 		response.SyncResponse(true, []string{"/1.0"}).Render(w)
 	})
 
-	for endpoint, f := range d.gateway.HandlerFuncs(d.NodeRefreshTask, d.getTrustedCertificates) {
+	for endpoint, f := range d.gateway.HandlerFuncs(d.HeartbeatMemberHook, d.getTrustedCertificates) {
 		mux.HandleFunc(endpoint, f)
 	}
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1942,6 +1942,7 @@ func rebalanceMemberRoles(d *Daemon, r *http.Request) error {
 	}
 
 again:
+	logger.Info("Rebalancing member roles")
 	address, nodes, err := cluster.Rebalance(d.State(), d.gateway)
 	if err != nil {
 		return err

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2027,6 +2027,8 @@ func changeMemberRole(d *Daemon, r *http.Request, address string, nodes []db.Raf
 
 // Try to handover the role of this member to another one.
 func handoverMemberRole(d *Daemon) error {
+	logger.Info("Handing over member role")
+
 	// If we aren't clustered, there's nothing to do.
 	clustered, err := cluster.Enabled(d.db)
 	if err != nil {
@@ -2048,14 +2050,17 @@ func handoverMemberRole(d *Daemon) error {
 
 	// Find the cluster leader.
 findLeader:
+	logger.Info("Finding leader address")
 	leader, err := d.gateway.LeaderAddress()
 	if err != nil {
 		return err
 	}
+
 	if leader == "" {
 		// Give up.
 		//
 		// TODO: retry a few times?
+		logger.Error("No leader found")
 		return nil
 	}
 

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -71,6 +71,9 @@ func NewGateway(db *db.Node, networkCert *shared.CertInfo, serverCert func() *sh
 	return gateway, nil
 }
 
+// HeartbeatMemberTask used to execute a function after sending/receiving a heartbeat.
+type HeartbeatMemberTask func(heartbeatData *APIHeartbeat, leader bool)
+
 // Gateway mediates access to the dqlite cluster using a gRPC SQL client, and
 // possibly runs a dqlite replica on this LXD node (if we're configured to do
 // so).
@@ -114,7 +117,7 @@ type Gateway struct {
 
 	// Used for the heartbeat handler
 	Cluster                   *db.Cluster
-	HeartbeatNodeHook         func(*APIHeartbeat)
+	HeartbeatMemberHook       HeartbeatMemberTask
 	HeartbeatOfflineThreshold time.Duration
 	heartbeatCancel           context.CancelFunc
 	heartbeatCancelLock       sync.Mutex

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -152,7 +152,7 @@ func setDqliteVersionHeader(request *http.Request) {
 // These handlers might return 404, either because this LXD node is a
 // non-clustered node not available over the network or because it is not a
 // database node part of the dqlite cluster.
-func (g *Gateway) HandlerFuncs(nodeRefreshTask func(*APIHeartbeat), trustedCerts func() map[db.CertificateType]map[string]x509.Certificate) map[string]http.HandlerFunc {
+func (g *Gateway) HandlerFuncs(heartbeatMemberHook HeartbeatMemberTask, trustedCerts func() map[db.CertificateType]map[string]x509.Certificate) map[string]http.HandlerFunc {
 	database := func(w http.ResponseWriter, r *http.Request) {
 		g.lock.RLock()
 		defer g.lock.RUnlock()
@@ -274,8 +274,8 @@ func (g *Gateway) HandlerFuncs(nodeRefreshTask func(*APIHeartbeat), trustedCerts
 			}
 
 			// If node refresh task is specified, run it async.
-			if nodeRefreshTask != nil {
-				go nodeRefreshTask(&heartbeatData)
+			if heartbeatMemberHook != nil {
+				go heartbeatMemberHook(&heartbeatData, false)
 			}
 
 			return

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -457,8 +457,11 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 		logger.Warn("Heartbeat round duration greater than heartbeat interval", log.Ctx{"duration": duration, "interval": heartbeatInterval})
 	}
 
-	// Update last leader heartbeat time so next time a full node state list can be sent (if not this time).
-	logger.Debug("Completed heartbeat round", log.Ctx{"duration": duration, "address": localAddress})
+	if mode != hearbeatNormal {
+		logger.Info("Completed heartbeat round", log.Ctx{"duration": duration, "address": localAddress, "mode": modeStr})
+	} else {
+		logger.Debug("Completed heartbeat round", log.Ctx{"duration": duration, "address": localAddress, "mode": modeStr})
+	}
 }
 
 // HeartbeatNode performs a single heartbeat request against the node with the given address.

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -448,8 +448,8 @@ func (g *Gateway) heartbeat(ctx context.Context, mode heartbeatMode) {
 	}
 
 	// If full node state was sent and node refresh task is specified, run it async.
-	if g.HeartbeatNodeHook != nil {
-		go g.HeartbeatNodeHook(hbState)
+	if g.HeartbeatMemberHook != nil {
+		go g.HeartbeatMemberHook(hbState, true)
 	}
 
 	duration := time.Now().Sub(startTime)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1108,7 +1108,7 @@ func (d *Daemon) init() error {
 
 		logger.Debug("Restarting all the containers following directory rename")
 		s := d.State()
-		instancesShutdown(s)
+		instancesShutdown(s, true)
 		instancesRestart(s)
 	}
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1450,10 +1450,12 @@ func (d *Daemon) Kill() {
 		d.clusterMembershipMutex.Lock()
 		d.clusterMembershipClosing = true
 		d.clusterMembershipMutex.Unlock()
+
 		err := handoverMemberRole(d)
 		if err != nil {
-			logger.Warnf("Could not handover member's responsibilities: %v", err)
+			logger.Error("Could not handover member's responsibilities", log.Ctx{"err": err})
 		}
+
 		d.gateway.Kill()
 		d.cluster.Kill()
 	}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1424,7 +1424,10 @@ func (d *Daemon) Ready() error {
 }
 
 func (d *Daemon) numRunningInstances() (int, error) {
-	results, err := instance.LoadNodeAll(d.State(), instancetype.Any)
+	ctx, ctxCancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer ctxCancel()
+
+	results, err := instance.LoadNodeAllContext(ctx, d.State(), instancetype.Any)
 	if err != nil {
 		return 0, err
 	}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1447,6 +1447,7 @@ func (d *Daemon) numRunningInstances() (int, error) {
 // retried in case of failure.
 func (d *Daemon) Kill() {
 	if d.gateway != nil {
+		logger.Info("Marking daemon as closing")
 		d.clusterMembershipMutex.Lock()
 		d.clusterMembershipClosing = true
 		d.clusterMembershipMutex.Unlock()

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1483,16 +1483,16 @@ func (d *Daemon) Stop() error {
 		//        timeout for database queries.
 		ch := make(chan bool)
 		go func() {
-			n, err := d.numRunningContainers()
+			n, err := d.numRunningInstances()
 			if err != nil {
-				logger.Warnf("Failed to get number of running containers: %v", err)
+				logger.Warn("Failed to get number of running instances", log.Ctx{"err": err})
 			}
 			ch <- err != nil || n == 0
 		}()
 		select {
 		case shouldUnmount = <-ch:
 		case <-time.After(2 * time.Second):
-			logger.Warnf("Give up waiting to get number of running containers")
+			logger.Warn("Give up waiting to get number of running instances")
 			shouldUnmount = true
 		}
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1423,8 +1423,8 @@ func (d *Daemon) Ready() error {
 	return nil
 }
 
-func (d *Daemon) numRunningContainers() (int, error) {
-	results, err := instance.LoadNodeAll(d.State(), instancetype.Container)
+func (d *Daemon) numRunningInstances() (int, error) {
+	results, err := instance.LoadNodeAll(d.State(), instancetype.Any)
 	if err != nil {
 		return 0, err
 	}

--- a/lxd/db/entity.go
+++ b/lxd/db/entity.go
@@ -4,6 +4,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -33,7 +34,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 	case cluster.TypeImage:
 		var images []Image
 
-		err = c.transaction(func(tx *ClusterTx) error {
+		err = c.transaction(context.TODO(), func(tx *ClusterTx) error {
 			images, err = tx.GetImages(ImageFilter{})
 			if err != nil {
 				return err
@@ -60,7 +61,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 	case cluster.TypeProfile:
 		var profiles []Profile
 
-		err = c.transaction(func(tx *ClusterTx) error {
+		err = c.transaction(context.TODO(), func(tx *ClusterTx) error {
 			profiles, err = tx.GetProfiles(ProfileFilter{})
 			if err != nil {
 				return err
@@ -87,7 +88,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 	case cluster.TypeProject:
 		projects := make(map[int64]string)
 
-		err = c.transaction(func(tx *ClusterTx) error {
+		err = c.transaction(context.TODO(), func(tx *ClusterTx) error {
 			projects, err = tx.GetProjectIDsToNames()
 			if err != nil {
 				return err
@@ -108,7 +109,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 	case cluster.TypeCertificate:
 		var certificates []Certificate
 
-		err = c.transaction(func(tx *ClusterTx) error {
+		err = c.transaction(context.TODO(), func(tx *ClusterTx) error {
 			certificates, err = tx.GetCertificates(CertificateFilter{})
 			if err != nil {
 				return err
@@ -137,7 +138,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 	case cluster.TypeInstance:
 		var instances []Instance
 
-		err = c.transaction(func(tx *ClusterTx) error {
+		err = c.transaction(context.TODO(), func(tx *ClusterTx) error {
 			instances, err = tx.GetInstances(InstanceFilter{})
 			if err != nil {
 				return err
@@ -169,7 +170,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 
 		var instances []Instance
 
-		err = c.transaction(func(tx *ClusterTx) error {
+		err = c.transaction(context.TODO(), func(tx *ClusterTx) error {
 			instances, err = tx.GetInstances(InstanceFilter{})
 			if err != nil {
 				return err
@@ -196,7 +197,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 	case cluster.TypeInstanceSnapshot:
 		var snapshots []InstanceSnapshot
 
-		err = c.transaction(func(tx *ClusterTx) error {
+		err = c.transaction(context.TODO(), func(tx *ClusterTx) error {
 			snapshots, err = tx.GetInstanceSnapshots(InstanceSnapshotFilter{})
 			if err != nil {
 				return err
@@ -237,7 +238,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 	case cluster.TypeNode:
 		var nodeInfo NodeInfo
 
-		err := c.transaction(func(tx *ClusterTx) error {
+		err := c.transaction(context.TODO(), func(tx *ClusterTx) error {
 			nodeInfo, err = tx.GetNodeWithID(entityID)
 			if err != nil {
 				return err
@@ -253,7 +254,7 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 	case cluster.TypeOperation:
 		var op Operation
 
-		err = c.transaction(func(tx *ClusterTx) error {
+		err = c.transaction(context.TODO(), func(tx *ClusterTx) error {
 			id := int64(entityID)
 			filter := OperationFilter{ID: &id}
 			ops, err := tx.GetOperations(filter)

--- a/lxd/db/query/transaction.go
+++ b/lxd/db/query/transaction.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"context"
 	"database/sql"
 	"strings"
 
@@ -9,8 +10,14 @@ import (
 )
 
 // Transaction executes the given function within a database transaction.
+// Deprecated, please use TransactionContext.
 func Transaction(db *sql.DB, f func(*sql.Tx) error) error {
-	tx, err := db.Begin()
+	return TransactionContext(context.TODO(), db, f)
+}
+
+// TransactionContext executes the given function within a database transaction.
+func TransactionContext(ctx context.Context, db *sql.DB, f func(*sql.Tx) error) error {
+	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		// If there is a leftover transaction let's try to rollback,
 		// we'll then retry again.

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -2,6 +2,7 @@ package instance
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"fmt"
 	"math/big"
@@ -607,9 +608,14 @@ func LoadFromAllProjects(s *state.State) ([]Instance, error) {
 
 // LoadNodeAll loads all instances of this nodes.
 func LoadNodeAll(s *state.State, instanceType instancetype.Type) ([]Instance, error) {
+	return LoadNodeAllContext(context.TODO(), s, instanceType)
+}
+
+// LoadNodeAllContext loads all instances of this nodes.
+func LoadNodeAllContext(ctx context.Context, s *state.State, instanceType instancetype.Type) ([]Instance, error) {
 	// Get all the container arguments
 	var insts []db.Instance
-	err := s.Cluster.Transaction(func(tx *db.ClusterTx) error {
+	err := s.Cluster.TransactionContext(ctx, func(tx *db.ClusterTx) error {
 		var err error
 		filter := db.InstanceTypeFilter(instanceType)
 		insts, err = tx.GetLocalInstancesInProject(filter)

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -347,6 +347,8 @@ func instancesOnDisk() (map[string][]string, error) {
 }
 
 func instancesShutdown(s *state.State) error {
+	logger.Info("Shutting down local instances")
+
 	var wg sync.WaitGroup
 
 	dbAvailable := true

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -366,6 +366,7 @@ func instancesShutdown(s *state.State, dbAvailable bool) error {
 		instances = []instance.Instance{}
 
 		// List all containers on disk
+		// tomp TODO add VM support here.
 		cnames, err := instancesOnDisk()
 		if err != nil {
 			return err

--- a/lxd/main_daemon.go
+++ b/lxd/main_daemon.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,6 +11,8 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
 
+	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/sys"
 	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
@@ -80,60 +83,73 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 
 	s := d.State()
 
-	cleanStop := func() {
+	stop := func(sig os.Signal) {
 		// Cancelling the context will make everyone aware that we're shutting down.
 		d.cancel()
 
-		// waitForOperations will block until all operations are done, or it's forced to shut down.
-		// For the latter case, we re-use the shutdown channel which is filled when a shutdown is
-		// initiated using `lxd shutdown`.
-		waitForOperations(s, d.shutdownChan)
+		// Wait for ongoing operations to finish if requested.
+		if sig == unix.SIGPWR || sig == unix.SIGTERM {
+			dbAvailable := true
+			var shutdownTimeout time.Duration
 
-		done := make(chan struct{})
+			dbCtx, dbCtxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer dbCtxCancel()
 
-		// Unmount image and backup volumes if set.
-		go func() {
-			err := daemonStorageUnmount(s)
+			err = s.Cluster.TransactionContext(dbCtx, func(tx *db.ClusterTx) error {
+				config, err := cluster.ConfigLoad(tx)
+				if err != nil {
+					return err
+				}
+
+				shutdownTimeout = config.ShutdownTimeout()
+
+				return nil
+			})
 			if err != nil {
-				logger.Warn("Failed to unmount image and backup volumes", log.Ctx{"err": err})
+				logger.Error("Database is not available, using default shutdown timeout", log.Ctx{"err": err})
+				shutdownTimeout = 5 * time.Minute
+				dbAvailable = false
 			}
 
-			done <- struct{}{}
-		}()
+			// waitForOperations will block until all operations are done, or it's forced to shut down.
+			// For the latter case, we re-use the shutdown channel which is filled when a shutdown is
+			// initiated using `lxd shutdown`.
+			// We wait up to 5 minutes for exec/console operations to finish. If there are still
+			// running operations, we shut down the instances which will terminate the operations.
+			logger.Info("Waiting for all operations to finish", log.Ctx{"timeout": shutdownTimeout})
+			opCtx, opCtxCancel := context.WithTimeout(context.Background(), shutdownTimeout)
+			defer opCtxCancel()
 
-		// Only wait 60 seconds in case the storage backend is unreachable.
-		select {
-		case <-time.After(time.Minute):
-			logger.Warn("Timed out waiting for image and backup volume")
-		case <-done:
+			waitForOperations(opCtx, s, d.shutdownChan)
+
+			// Clean up instance, networks and storage pools if full clean shutdown requested.
+			if sig == unix.SIGPWR {
+				instancesShutdown(s, dbAvailable)
+
+				if dbAvailable {
+					networkShutdown(s)
+					daemonStorageUnmount(s)
+				} else {
+					logger.Error("Skipping network and storage shutdown as database not available")
+				}
+			}
+		} else {
+			logger.Info("Exiting") // Just exit for all other signals.
 		}
-
-		d.Kill()
 	}
 
 	select {
 	case sig := <-ch:
-		if sig == unix.SIGPWR {
-			logger.Infof("Received '%s signal', waiting for all operations to finish", sig)
-			cleanStop()
-
-			instancesShutdown(s)
-			networkShutdown(s)
-		} else if sig == unix.SIGTERM {
-			logger.Infof("Received '%s signal', waiting for all operations to finish", sig)
-			cleanStop()
-		} else {
-			logger.Infof("Received '%s signal', exiting", sig)
-			d.Kill()
-		}
-
+		logger.Info("Received signal", log.Ctx{"signal": sig})
+		stop(sig)
 	case <-d.shutdownChan:
-		logger.Infof("Asked to shutdown by API, waiting for all operations to finish")
-		cleanStop()
-
-		instancesShutdown(s)
-		networkShutdown(s)
+		logger.Info("Asked to shutdown by API")
+		stop(unix.SIGPWR)
 	}
 
-	return d.Stop()
+	d.Kill()
+	err = d.Stop()
+
+	logger.Info("Stopped")
+	return err
 }

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1584,6 +1584,8 @@ func networkStartup(s *state.State) error {
 }
 
 func networkShutdown(s *state.State) error {
+	logger.Info("Stopping networks")
+
 	var err error
 
 	// Get a list of projects.

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/mdlayher/netx/eui64"
@@ -1591,7 +1593,10 @@ func networkShutdown(s *state.State) error {
 	// Get a list of projects.
 	var projectNames []string
 
-	err = s.Cluster.Transaction(func(tx *db.ClusterTx) error {
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer ctxCancel()
+
+	err = s.Cluster.TransactionContext(ctx, func(tx *db.ClusterTx) error {
 		projectNames, err = tx.GetProjectNames()
 		return err
 	})

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2451,7 +2451,7 @@ test_clustering_failure_domains() {
 
   # Shutdown a node in az2, its replacement is picked from az2.
   LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
-  sleep 3
+  sleep 15
 
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node2 | grep -q "database: false"
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node5 | grep -q "database: true"

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -265,7 +265,7 @@ test_clustering_membership() {
   # detected as down.
   LXD_DIR="${LXD_ONE_DIR}" lxc config set cluster.offline_threshold 11
   LXD_DIR="${LXD_THREE_DIR}" lxd shutdown
-  sleep 18
+  sleep 15
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster show node3 | grep -q "status: Offline"
 
@@ -2118,6 +2118,9 @@ test_clustering_handover() {
   # Shutdown the first node.
   LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
 
+  # Wait some time to possibly allow for a leadership change.
+  sleep 15
+
   # The fourth node has been promoted, while the first one demoted.
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list
   LXD_DIR="${LXD_THREE_DIR}" lxc cluster list
@@ -2128,7 +2131,7 @@ test_clustering_handover() {
   LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
 
   # Wait some time to possibly allow for a leadership change.
-  sleep 10
+  sleep 15
 
   LXD_DIR="${LXD_THREE_DIR}" lxc cluster list
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2999,12 +2999,18 @@ test_clustering_remove_leader() {
   ns2="${prefix}2"
   spawn_lxd_and_join_cluster "${ns2}" "${bridge}" "${cert}" 2 1 "${LXD_TWO_DIR}"
 
+  # Wait some time to possibly allow for a leadership change.
+  sleep 15
+
   # Ensure successful communication
   LXD_DIR="${LXD_ONE_DIR}" lxc info --target node2 | grep -q "server_name: node2"
   LXD_DIR="${LXD_TWO_DIR}" lxc info --target node1 | grep -q "server_name: node1"
 
   # Remove the leader, via the stand-by node
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster rm node1 || true
+
+  # Wait some time to possibly allow for a leadership change.
+  sleep 15
 
   # Ensure the remaining node is working
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list | grep -qv "node1"
@@ -3019,6 +3025,9 @@ test_clustering_remove_leader() {
   chmod +x "${LXD_THREE_DIR}"
   ns3="${prefix}3"
   spawn_lxd_and_join_cluster "${ns3}" "${bridge}" "${cert}" 3 2 "${LXD_THREE_DIR}"
+
+  # Wait some time to possibly allow for a leadership change.
+  sleep 15
 
   # Ensure successful communication
   LXD_DIR="${LXD_TWO_DIR}" lxc info --target node3 | grep -q "server_name: node3"

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -615,6 +615,7 @@ test_container_devices_nic_bridged_filtering() {
   lxc start "${ctPrefix}A"
   lxc exec "${ctPrefix}A" -- ip a add 192.0.2.2/24 dev eth0
   lxc exec "${ctPrefix}A" -- ip a add 2001:db8::2/64 dev eth0
+  sleep 2 # Wait for DAD.
 
   # Check basic connectivity without any filtering.
   lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.1
@@ -624,6 +625,7 @@ test_container_devices_nic_bridged_filtering() {
   lxc exec "${ctPrefix}A" -- ip a flush dev eth0
   lxc exec "${ctPrefix}A" -- ip a add 192.0.2.3/24 dev eth0
   lxc exec "${ctPrefix}A" -- ip a add 2001:db8::3/64 dev eth0
+  sleep 2 # Wait for DAD.
 
   ! lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.1 || false
   ! lxc exec "${ctPrefix}A" -- ping -c2 -W1 2001:db8::1 || false

--- a/test/suites/static_analysis.sh
+++ b/test/suites/static_analysis.sh
@@ -162,7 +162,7 @@ test_static_analysis() {
 
     ## misspell
     if which misspell >/dev/null 2>&1; then
-      OUT=$(misspell ./ | grep -v po/ | grep -v lxd/include/ | grep -v .git/ | grep -Ev "test/includes/lxd.sh.*monitord" | grep -Ev "test/suites/static_analysis.sh.*monitord" | grep -v shared/usbid/load_data.go || true)
+      OUT=$(misspell ./ | grep -v po/ | grep -v lxd/include/ | grep -v .git/ | grep -Ev "test/includes/lxd.sh.*monitord" | grep -Ev "test/suites/static_analysis.sh.*monitord" | grep -v shared/usbid/load_data.go | grep -v server.key || true)
       if [ -n "${OUT}" ]; then
         echo "Found some typos"
         echo "${OUT}"


### PR DESCRIPTION
This PR tries to improve the daemon shutdown process with a view to making the clustering tests more reliable.

There doesn't appear (to me at least, based on reading the code) to be clear process as to what should happen (and in which order) to shutdown a member that has been separated from the cluster database.

* This PR tries to improve the speed at which a cluster member will shutdown in that scenario by detecting DB access errors and then reacting to them earlier in the process to try and prevent further long waits when trying to access the DB. It also adds in some timeouts that would otherwise have lead to long waits.
* It also differentiates between leader and non-leader heartbeat hook tasks and doesn't attempt to perform cluster member tasks for non-members (these tasks would fail anyway, its just avoiding the DB lookups).
* Additionally this PR also fixes an issue whereby the storage pools were trying to be unmounted before shutting down any instances.
* Increases sleep time on some clustering tests to account for a full heartbeat interval (so they don't intermittently fail).

There is still more to do to make the daemon shutdown process clear and predictable, but hopefully this will be enough for now to improve things.

Future work:

- Handle local instance shutdown of VMs as well as containers when no DB available.
- Review use of locking of cluster/gateway operations when doing a node refresh from heartbeat, as this can delay member shutdown. Should we cancel ongoing heartbeats/rebalances?
- When is safe/proper to `Kill()` to the cluster and gateway
- Add a global context for indicating if DB is available so each function that needs to can use it.