### PR TITLE
[GH-9248] Restrict protocol version

### DIFF
--- a/lxd/endpoints/network_test.go
+++ b/lxd/endpoints/network_test.go
@@ -105,5 +105,8 @@ func TestEndpoints_NetworkCreateTCPSocketIPv4(t *testing.T) {
 	ipv6Address := fmt.Sprintf("[::1]:%s", parts[1])
 	message := fmt.Sprintf("Get https://%s/: dial tcp %s: connect: connection refused", ipv6Address, ipv6Address)
 
+	assert.NoError(t, httpGetOverTLSSocket(address, certificate))
+
+	// Check accessibility over IPv6 request
 	assert.EqualError(t, httpGetOverTLSSocket(ipv6Address, certificate), message)
 }

--- a/lxd/endpoints/network_test.go
+++ b/lxd/endpoints/network_test.go
@@ -1,7 +1,9 @@
 package endpoints_test
 
 import (
+	"fmt"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/lxc/lxd/shared"
@@ -87,4 +89,21 @@ func newTCPListener(t *testing.T) *net.TCPListener {
 
 	require.NoError(t, err)
 	return listener
+}
+
+// Create IPv4 0.0.0.0 listener using random port
+// and ensure it is not accessible via IPv6 request.
+func TestEndpoints_NetworkCreateTCPSocketIPv4(t *testing.T) {
+	endpoints, config, cleanup := newEndpoints(t)
+	defer cleanup()
+
+	config.NetworkAddress = "0.0.0.0:0"
+	require.NoError(t, endpoints.Up(config))
+
+	address, certificate := endpoints.NetworkAddressAndCert()
+	parts := strings.Split(address, ":")
+	ipv6Address := fmt.Sprintf("[::1]:%s", parts[1])
+	message := fmt.Sprintf("Get https://%s/: dial tcp %s: connect: connection refused", ipv6Address, ipv6Address)
+
+	assert.EqualError(t, httpGetOverTLSSocket(ipv6Address, certificate), message)
 }


### PR DESCRIPTION
Apparently the problem is [here](https://github.com/lxc/lxd/blob/0458d0b4df8c1d4316c17172d6e66825d8156e12/lxd/endpoints/network.go#L182) – `tcp` covers both `tcp4` and `tcp6`. It is possible to do the checks directly in that function, something like this:

```
func networkCreateListener(address string, cert *shared.CertInfo) (net.Listener, error) {
	// In case 0.0.0.0 has been passed as an address only IPv4
	// interfaces should be taken in consideration.
	var networkType string
	var err error

	contextError := "Bind network address"

	if util.IsWildCardAddress(address) {
		networkType, err = util.ParseNetworkVersion(address)

		if err != nil {
			return nil, errors.Wrap(err, contextError)
		}
	} else {
		networkType = "tcp"
	}

	listener, err := net.Listen(networkType, util.CanonicalNetworkAddress(address, shared.HTTPSDefaultPort))
	if err != nil {
		return nil, errors.Wrap(err, contextError)
	}
	return networkTLSListener(listener, cert), nil
}
```
However I believe it is not the best way how to handle this problem, so I came up with following code. Let me know what do you think. Thank you!

Fixes #9248 