### PR TITLE
lxd/device/tpm: Require `path` only for containers

### DIFF
--- a/lxd/device/tpm.go
+++ b/lxd/device/tpm.go
@@ -36,8 +36,10 @@ func (d *tpm) validateConfig(instConf instance.ConfigReader) error {
 		return ErrUnsupportedDevType
 	}
 
-	rules := map[string]func(string) error{
-		"path": validate.IsNotEmpty,
+	rules := map[string]func(string) error{}
+
+	if instConf.Type() == instancetype.Container {
+		rules["path"] = validate.IsNotEmpty
 	}
 
 	err := d.config.Validate(rules)


### PR DESCRIPTION
This fixes #9240.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
