### PR TITLE
Fix documented HTTP return code in console POST

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -7392,7 +7392,7 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
+        "202":
           $ref: '#/responses/Operation'
         "400":
           $ref: '#/responses/BadRequest'

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -390,7 +390,7 @@ func (s *consoleWs) doVGA(op *operations.Operation) error {
 //     schema:
 //       $ref: "#/definitions/InstanceConsolePost"
 // responses:
-//   "200":
+//   "202":
 //     $ref: "#/responses/Operation"
 //   "400":
 //     $ref: "#/responses/BadRequest"


### PR DESCRIPTION
Addresses #9260.

Looking at instance GET (just above instance PATCH) I thought I saw another return-code/example mismatch, and I figured I might as well just PR a fix. When grepping, I realized my mistake, but also found an actual mismatch :grin: This PR fixes that one.