### PR TITLE
Daemon: Shutdown storage fixes

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1447,8 +1447,8 @@ func (d *Daemon) Ready() error {
 	return nil
 }
 
-func (d *Daemon) numRunningContainers() (int, error) {
-	results, err := instance.LoadNodeAll(d.State(), instancetype.Container)
+func (d *Daemon) numRunningInstances() (int, error) {
+	results, err := instance.LoadNodeAll(d.State(), instancetype.Any)
 	if err != nil {
 		return 0, err
 	}
@@ -1502,16 +1502,16 @@ func (d *Daemon) Stop() error {
 		//        timeout for database queries.
 		ch := make(chan bool)
 		go func() {
-			n, err := d.numRunningContainers()
+			n, err := d.numRunningInstances()
 			if err != nil {
-				logger.Warnf("Failed to get number of running containers: %v", err)
+				logger.Warn("Failed to get number of running instances", log.Ctx{"err": err})
 			}
 			ch <- err != nil || n == 0
 		}()
 		select {
 		case shouldUnmount = <-ch:
 		case <-time.After(2 * time.Second):
-			logger.Warnf("Give up waiting to get number of running containers")
+			logger.Warn("Give up waiting to get number of running instances")
 			shouldUnmount = true
 		}
 

--- a/lxd/daemon_storage.go
+++ b/lxd/daemon_storage.go
@@ -19,7 +19,7 @@ import (
 	"github.com/lxc/lxd/shared"
 )
 
-func daemonStorageUnmount(s *state.State) error {
+func daemonStorageVolumesUnmount(s *state.State) error {
 	var storageBackups string
 	var storageImages string
 
@@ -73,27 +73,6 @@ func daemonStorageUnmount(s *state.State) error {
 		err := unmount("images", storageImages)
 		if err != nil {
 			return errors.Wrap(err, "Failed to unmount images storage")
-		}
-	}
-
-	pools, err := s.Cluster.GetStoragePoolNames()
-	if err != nil {
-		return fmt.Errorf("Failed to get storage pools: %w", err)
-	}
-
-	for _, poolName := range pools {
-		pool, err := storagePools.GetPoolByName(s, poolName)
-		if err != nil {
-			return fmt.Errorf("Failed to get storage pool %q: %w", poolName, err)
-		}
-
-		if pool.Driver().Info().Name == "lvm" {
-			continue // TODO figure out the intermittent issue with LVM tests when this is removed.
-		}
-
-		_, err = pool.Unmount()
-		if err != nil {
-			return fmt.Errorf("Unable to unmount storage pool %q: %w", poolName, err)
 		}
 	}
 

--- a/lxd/main_daemon.go
+++ b/lxd/main_daemon.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
 
+	"github.com/lxc/lxd/lxd/db"
+	storagePools "github.com/lxc/lxd/lxd/storage"
 	"github.com/lxc/lxd/lxd/sys"
 	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
@@ -80,32 +82,70 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 
 	s := d.State()
 
-	cleanStop := func() {
+	stop := func(sig os.Signal) {
 		// Cancelling the context will make everyone aware that we're shutting down.
 		d.cancel()
 
-		// waitForOperations will block until all operations are done, or it's forced to shut down.
-		// For the latter case, we re-use the shutdown channel which is filled when a shutdown is
-		// initiated using `lxd shutdown`.
-		waitForOperations(s, d.shutdownChan)
+		// Handle shutdown (unix.SIGPWR) and reload (unix.SIGTERM) signals.
+		if sig == unix.SIGPWR || sig == unix.SIGTERM {
+			// waitForOperations will block until all operations are done, or it's forced to shut down.
+			// For the latter case, we re-use the shutdown channel which is filled when a shutdown is
+			// initiated using `lxd shutdown`.
+			logger.Info("Waiting for operations to finish")
+			waitForOperations(s, d.shutdownChan)
 
-		done := make(chan struct{})
+			// Unmount daemon image and backup volumes if set.
+			logger.Info("Stopping daemon storage volumes")
+			done := make(chan struct{})
+			go func() {
+				err := daemonStorageVolumesUnmount(s)
+				if err != nil {
+					logger.Warn("Failed to unmount image and backup volumes", log.Ctx{"err": err})
+				}
 
-		// Unmount image and backup volumes if set.
-		go func() {
-			err := daemonStorageUnmount(s)
-			if err != nil {
-				logger.Warn("Failed to unmount image and backup volumes", log.Ctx{"err": err})
+				done <- struct{}{}
+			}()
+
+			// Only wait 60 seconds in case the storage backend is unreachable.
+			select {
+			case <-time.After(time.Minute):
+				logger.Warn("Timed out waiting for image and backup volume")
+			case <-done:
 			}
 
-			done <- struct{}{}
-		}()
+			// Full shutdown requested.
+			if sig == unix.SIGPWR {
+				logger.Info("Stopping instances")
+				instancesShutdown(s)
 
-		// Only wait 60 seconds in case the storage backend is unreachable.
-		select {
-		case <-time.After(time.Minute):
-			logger.Warn("Timed out waiting for image and backup volume")
-		case <-done:
+				logger.Info("Stopping networks")
+				networkShutdown(s)
+
+				// Unmount storage pools after instances stopped.
+				logger.Info("Stopping storage pools")
+				pools, err := s.Cluster.GetStoragePoolNames()
+				if err != nil && err != db.ErrNoSuchObject {
+					logger.Error("Failed to get storage pools", log.Ctx{"err": err})
+				}
+
+				for _, poolName := range pools {
+					pool, err := storagePools.GetPoolByName(s, poolName)
+					if err != nil {
+						logger.Error("Failed to get storage pool", log.Ctx{"pool": poolName, "err": err})
+						continue
+					}
+
+					if pool.Driver().Info().Name == "lvm" {
+						continue // TODO figure out the intermittent issue with LVM tests when this is removed.
+					}
+
+					_, err = pool.Unmount()
+					if err != nil {
+						logger.Error("Unable to unmount storage pool", log.Ctx{"pool": poolName, "err": err})
+						continue
+					}
+				}
+			}
 		}
 
 		d.Kill()
@@ -113,26 +153,11 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 
 	select {
 	case sig := <-ch:
-		if sig == unix.SIGPWR {
-			logger.Infof("Received '%s signal', waiting for all operations to finish", sig)
-			cleanStop()
-
-			instancesShutdown(s)
-			networkShutdown(s)
-		} else if sig == unix.SIGTERM {
-			logger.Infof("Received '%s signal', waiting for all operations to finish", sig)
-			cleanStop()
-		} else {
-			logger.Infof("Received '%s signal', exiting", sig)
-			d.Kill()
-		}
-
+		logger.Info("Received signal", log.Ctx{"signal": sig})
+		stop(sig)
 	case <-d.shutdownChan:
-		logger.Infof("Asked to shutdown by API, waiting for all operations to finish")
-		cleanStop()
-
-		instancesShutdown(s)
-		networkShutdown(s)
+		logger.Info("Asked to shutdown by API")
+		stop(unix.SIGPWR)
 	}
 
 	return d.Stop()

--- a/lxd/main_daemon.go
+++ b/lxd/main_daemon.go
@@ -135,10 +135,6 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 						continue
 					}
 
-					if pool.Driver().Info().Name == "lvm" {
-						continue // TODO figure out the intermittent issue with LVM tests when this is removed.
-					}
-
 					_, err = pool.Unmount()
 					if err != nil {
 						logger.Error("Unable to unmount storage pool", log.Ctx{"pool": poolName, "err": err})


### PR DESCRIPTION
This PR takes just the clear fixes from https://github.com/lxc/lxd/pull/9258 (whilst maintaining the work around that skips unmounting the LVM storage pools at shutdown).

This PR fixes the following issues:

- Stops LXD daemon shutdown from trying to unmount storage pools before instances are stopped during full shutdown.
- Stops LXD daemon unmounting storage pools during a reload (rather than just the LXD daemon storage volumes as originally intended).
- Detects running VMs when considering if to unmount LXD shared mounts during stop.
