### PR TITLE
lxd/instance/drivers: Fix raw.lxc handling for shutdown/stop

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2674,6 +2674,12 @@ func (d *lxc) Stop(stateful bool) error {
 			op.Done(err)
 			return err
 		}
+
+		// Load the config.
+		err = d.loadRawLXCConfig()
+		if err != nil {
+			return err
+		}
 	} else {
 		err = d.initLXC(false)
 		if err != nil {
@@ -2784,6 +2790,11 @@ func (d *lxc) Shutdown(timeout time.Duration) error {
 		err = d.initLXC(true)
 		if err != nil {
 			op.Done(err)
+			return err
+		}
+
+		err = d.loadRawLXCConfig()
+		if err != nil {
 			return err
 		}
 	} else {

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2240,25 +2240,9 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 	}
 
 	// Load the LXC raw config.
-	if lxcConfig, ok := d.expandedConfig["raw.lxc"]; ok {
-		// Write to temp config file.
-		f, err := ioutil.TempFile("", "lxd_config_")
-		if err != nil {
-			return "", nil, err
-		}
-
-		err = shared.WriteAll(f, []byte(lxcConfig))
-		f.Close()
-		defer os.Remove(f.Name())
-		if err != nil {
-			return "", nil, err
-		}
-
-		// Load the config.
-		err = d.c.LoadConfigFile(f.Name())
-		if err != nil {
-			return "", nil, fmt.Errorf("Failed to load raw.lxc")
-		}
+	err = d.loadRawLXCConfig()
+	if err != nil {
+		return "", nil, err
 	}
 
 	// Generate the LXC config
@@ -4090,23 +4074,9 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 			return err
 		}
 
-		// Write the raw config.
-		f, err := ioutil.TempFile("", "lxd_config_")
+		err = d.loadRawLXCConfig()
 		if err != nil {
 			return err
-		}
-
-		err = shared.WriteAll(f, []byte(d.expandedConfig["raw.lxc"]))
-		f.Close()
-		defer os.Remove(f.Name())
-		if err != nil {
-			return err
-		}
-
-		// Load the raw config.
-		err = cc.LoadConfigFile(f.Name())
-		if err != nil {
-			return fmt.Errorf("Failed to load raw.lxc")
 		}
 
 		// Release the liblxc instance.
@@ -7147,4 +7117,33 @@ func (d *lxc) getFSStats() (*metrics.MetricSet, error) {
 	}
 
 	return out, nil
+}
+
+func (d *lxc) loadRawLXCConfig() error {
+	// Load the LXC raw config.
+	lxcConfig, ok := d.expandedConfig["raw.lxc"]
+	if !ok {
+		return nil
+	}
+
+	// Write to temp config file.
+	f, err := ioutil.TempFile("", "lxd_config_")
+	if err != nil {
+		return err
+	}
+
+	err = shared.WriteAll(f, []byte(lxcConfig))
+	f.Close()
+	defer os.Remove(f.Name())
+	if err != nil {
+		return err
+	}
+
+	// Load the config.
+	err = d.c.LoadConfigFile(f.Name())
+	if err != nil {
+		return fmt.Errorf("Failed to load config file %q: %w", f.Name(), err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Due to a rework of the raw.lxc handling, the config wouldn't be loaded
when stopping or shutting down a container.  This caused some keys,
e.g. `lxc.signal.*`, to be ignored.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
