### PR TITLE
doc/rest-api: Add missing entry for 112 (error)

### DIFF
--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -133,6 +133,7 @@ Code  | Meaning
 109   | Freezing
 110   | Frozen
 111   | Thawed
+112   | Error
 200   | Success
 400   | Failure
 401   | Cancelled


### PR DESCRIPTION
Closes #9271

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>