### PR TITLE
Storage: Fix filesystem detection to work on 32bit platforms

### DIFF
--- a/lxd-agent/metrics.go
+++ b/lxd-agent/metrics.go
@@ -268,7 +268,7 @@ func getFilesystemMetrics(d *Daemon) (map[string]metrics.FilesystemMetrics, erro
 			return nil, fmt.Errorf("Failed to stat %s: %w", stats.Mountpoint, err)
 		}
 
-		fsType, err := filesystem.FSTypeToName(statfs.Type)
+		fsType, err := filesystem.FSTypeToName(int32(statfs.Type))
 		if err == nil {
 			stats.FSType = fsType
 		}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -7135,7 +7135,7 @@ func (d *lxc) getFSStats() (*metrics.MetricSet, error) {
 		labels["device"] = realDev
 		labels["mountpoint"] = dev["path"]
 
-		fsType, err := filesystem.FSTypeToName(statfs.Type)
+		fsType, err := filesystem.FSTypeToName(int32(statfs.Type))
 		if err == nil {
 			labels["fstype"] = fsType
 		}

--- a/lxd/storage/filesystem/fs.go
+++ b/lxd/storage/filesystem/fs.go
@@ -37,24 +37,34 @@ func Detect(path string) (string, error) {
 		return "", err
 	}
 
-	return FSTypeToName(fs.Type)
+	return FSTypeToName(int32(fs.Type))
 }
 
 // FSTypeToName returns the name of the given fs type.
-func FSTypeToName(fsType int64) (string, error) {
+// The fsType is from the Type field of unix.Statfs_t. We use int32 so that this function behaves the same on both
+// 32bit and 64bit platforms by requiring any 64bit FS types to be overflowed before being passed in. They will
+// then be compared with equally overflowed FS type constant values.
+func FSTypeToName(fsType int32) (string, error) {
+	// This function is needed to allow FS type constants that overflow an int32 to be overflowed without a
+	// compile error on 32bit platforms. This allows us to use any 64bit constants from the unix package on
+	// both 64bit and 32bit platforms without having to define the constant in its rolled over form on 32bit.
+	to32 := func(fsType int64) int32 {
+		return int32(fsType)
+	}
+
 	switch fsType {
-	case FilesystemSuperMagicBtrfs:
+	case to32(unix.BTRFS_SUPER_MAGIC): // BTRFS' constant required overflowing to an int32.
 		return "btrfs", nil
+	case unix.TMPFS_MAGIC:
+		return "tmpfs", nil
+	case unix.EXT4_SUPER_MAGIC:
+		return "ext4", nil
+	case unix.XFS_SUPER_MAGIC:
+		return "xfs", nil
+	case unix.NFS_SUPER_MAGIC:
+		return "nfs", nil
 	case FilesystemSuperMagicZfs:
 		return "zfs", nil
-	case FilesystemSuperMagicTmpfs:
-		return "tmpfs", nil
-	case FilesystemSuperMagicExt4:
-		return "ext4", nil
-	case FilesystemSuperMagicXfs:
-		return "xfs", nil
-	case FilesystemSuperMagicNfs:
-		return "nfs", nil
 	}
 
 	logger.Debugf("Unknown backing filesystem type: 0x%x", fsType)

--- a/lxd/storage/filesystem/fs.go
+++ b/lxd/storage/filesystem/fs.go
@@ -15,11 +15,7 @@ import (
 
 // Filesystem magic numbers.
 const (
-	FilesystemSuperMagicTmpfs = 0x01021994
-	FilesystemSuperMagicExt4  = 0xEF53
-	FilesystemSuperMagicXfs   = 0x58465342
-	FilesystemSuperMagicNfs   = 0x6969
-	FilesystemSuperMagicZfs   = 0x2fc12fc1
+	FilesystemSuperMagicZfs = 0x2fc12fc1
 )
 
 // StatVFS retrieves Virtual File System (VFS) info about a path.

--- a/lxd/storage/filesystem/fs_32bit.go
+++ b/lxd/storage/filesystem/fs_32bit.go
@@ -1,9 +1,0 @@
-//go:build 386 || arm || ppc || s390 || mips || mipsle
-// +build 386 arm ppc s390 mips mipsle
-
-package filesystem
-
-const (
-	// FilesystemSuperMagicBtrfs is the 32bit magic for Btrfs (as signed constant)
-	FilesystemSuperMagicBtrfs = -1859950530
-)

--- a/lxd/storage/filesystem/fs_64bit.go
+++ b/lxd/storage/filesystem/fs_64bit.go
@@ -1,9 +1,0 @@
-//go:build amd64 || ppc64 || ppc64le || arm64 || s390x || mips64 || mips64le || riscv64
-// +build amd64 ppc64 ppc64le arm64 s390x mips64 mips64le riscv64
-
-package filesystem
-
-const (
-	// FilesystemSuperMagicBtrfs is the 64bit magic for Btrfs
-	FilesystemSuperMagicBtrfs = 0x9123683E
-)


### PR DESCRIPTION
Continues on with the concept from https://github.com/lxc/lxd/pull/9056 in order to fix #9275

Tested this script on 64bit and 32bit plaforms:

```go
package main

import (
	"fmt"
	"os"

	"golang.org/x/sys/unix"
)

// Filesystem magic numbers.
const (
	FilesystemSuperMagicZfs = 0x2fc12fc1
)

// StatVFS retrieves Virtual File System (VFS) info about a path.
func StatVFS(path string) (*unix.Statfs_t, error) {
	var st unix.Statfs_t

	err := unix.Statfs(path, &st)
	if err != nil {
		return nil, err
	}

	return &st, nil
}

// Detect returns the filesystem on which the passed-in path sits.
func Detect(path string) (string, error) {
	fs, err := StatVFS(path)
	if err != nil {
		return "", err
	}

	return FSTypeToName(int32(fs.Type))
}

// FSTypeToName returns the name of the given fs type.
// The fsType is from the Type field of unix.Statfs_t. We use int32 so that this function behaves the same on both
// 32bit and 64bit platforms by requiring any 64bit FS types to be overflowed before being passed in. They will
// then be compared with equally overflowed FS type constant values.
func FSTypeToName(fsType int32) (string, error) {
	// This function is needed to allow FS type constants that overflow an int32 to be overflowed without a
	// compile error on 32bit platforms. This allows us to use any 64bit constants from the unix package on
	// both 64bit and 32bit platforms without having to define the constant in its rolled over form on 32bit.
	to32 := func(fsType int64) int32 {
		return int32(fsType)
	}

	switch fsType {
	case to32(unix.BTRFS_SUPER_MAGIC): // BTRFS' constant required overflowing to an int32.
		return "btrfs", nil
	case unix.TMPFS_MAGIC:
		return "tmpfs", nil
	case unix.EXT4_SUPER_MAGIC:
		return "ext4", nil
	case unix.XFS_SUPER_MAGIC:
		return "xfs", nil
	case unix.NFS_SUPER_MAGIC:
		return "nfs", nil
	case FilesystemSuperMagicZfs:
		return "zfs", nil
	}

	return fmt.Sprintf("0x%x", fsType), nil
}

func main() {
	fsType, err := Detect(os.Args[1])
	if err != nil {
		fmt.Println(err)
	}

	fmt.Println(fsType)
}
```


armhf:

```
CGO_ENABLED=0 GOARCH=arm go build ./fstype.go 

go version
go version go1.13.8 linux/arm
grep btrfs
/var/snap/lxd/common/lxd/disks/default.img on / type btrfs (rw,relatime,space_cache,user_subvol_rm_allowed,subvolid=18338,subvol=/containers/tpc1)

./fstype /
btrfs

./fstype /var/snap/lxd/common/ns
tmpfs
```

amd64:

```
go version
go version go1.13.8 linux/amd64

 ./fstype /var/lib/lxd
ext4

./fstype /var/lib/lxd/storage-pools/btrfs
btrfs
```