### PR TITLE
LXD: Modifes errorResponse.Render function to JSON encode a api.ResponseRaw struct

### DIFF
--- a/lxd-agent/devlxd.go
+++ b/lxd-agent/devlxd.go
@@ -161,7 +161,13 @@ func hoistReq(f func(*Daemon, http.ResponseWriter, *http.Request) *devLxdRespons
 			http.Error(w, fmt.Sprintf("%s", resp.content), resp.code)
 		} else if resp.ctype == "json" {
 			w.Header().Set("Content-Type", "application/json")
-			util.WriteJSON(w, resp.content, daemon.Debug)
+
+			var debugLogger logger.Logger
+			if daemon.Debug {
+				debugLogger = logger.Logger(logger.Log)
+			}
+
+			util.WriteJSON(w, resp.content, debugLogger)
 		} else if resp.ctype != "websocket" {
 			w.Header().Set("Content-Type", "application/octet-stream")
 			fmt.Fprintf(w, resp.content.(string))

--- a/lxd-agent/server.go
+++ b/lxd-agent/server.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -14,6 +13,7 @@ import (
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
+	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -45,7 +45,7 @@ func createCmd(restAPI *mux.Router, version string, c APIEndpoint, cert *x509.Ce
 		w.Header().Set("Content-Type", "application/json")
 
 		if !authenticate(r, cert) {
-			log.Println("Not authorized")
+			log.Error("Not authorized")
 			response.InternalError(fmt.Errorf("Not authorized")).Render(w)
 			return
 		}
@@ -61,7 +61,7 @@ func createCmd(restAPI *mux.Router, version string, c APIEndpoint, cert *x509.Ce
 			}
 
 			r.Body = shared.BytesReadCloser{Buf: newBody}
-			shared.DebugJson(captured)
+			util.DebugJSON("API Request", captured, log.New())
 		}
 
 		// Actually process the request

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -330,7 +330,7 @@ func (g *Gateway) HandlerFuncs(nodeRefreshTask func(*APIHeartbeat), trustedCerts
 				http.Error(w, "500 no elected leader", http.StatusInternalServerError)
 				return
 			}
-			util.WriteJSON(w, map[string]string{"leader": leader}, false)
+			util.WriteJSON(w, map[string]string{"leader": leader}, nil)
 			return
 		}
 

--- a/lxd/cluster/notify_test.go
+++ b/lxd/cluster/notify_test.go
@@ -194,7 +194,7 @@ func newRestServer(cert *shared.CertInfo) *httptest.Server {
 		w.Header().Set("Content-Type", "application/json")
 		config := map[string]interface{}{"cluster.https_address": server.Listener.Addr().String()}
 		metadata := api.ServerPut{Config: config}
-		util.WriteJSON(w, api.ResponseRaw{Metadata: metadata}, false)
+		util.WriteJSON(w, api.ResponseRaw{Metadata: metadata}, nil)
 	})
 
 	return server

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -501,10 +501,10 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 			}
 		}
 
+		logCtx := log.Ctx{"method": r.Method, "url": r.URL.RequestURI(), "ip": r.RemoteAddr, "username": username, "protocol": protocol}
 		untrustedOk := (r.Method == "GET" && c.Get.AllowUntrusted) || (r.Method == "POST" && c.Post.AllowUntrusted)
 		if trusted {
-			logCtx := log.Ctx{"method": r.Method, "url": r.URL.RequestURI(), "ip": r.RemoteAddr, "username": username, "protocol": protocol}
-			logger.Debug("Handling", logCtx)
+			logger.Debug("Handling API request", logCtx)
 
 			// Get user access data.
 			userAccess, err := func() (*rbac.UserAccess, error) {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -601,7 +601,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 			}
 
 			r.Body = shared.BytesReadCloser{Buf: newBody}
-			shared.DebugJson(captured)
+			util.DebugJSON("API Request", captured, log.New(logCtx))
 		}
 
 		// Actually process the request

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -211,7 +211,13 @@ func hoistReq(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Requ
 			http.Error(w, fmt.Sprintf("%s", resp.content), resp.code)
 		} else if resp.ctype == "json" {
 			w.Header().Set("Content-Type", "application/json")
-			util.WriteJSON(w, resp.content, daemon.Debug)
+
+			var debugLogger logger.Logger
+			if daemon.Debug {
+				debugLogger = logger.Logger(logger.Log)
+			}
+
+			util.WriteJSON(w, resp.content, debugLogger)
 		} else if resp.ctype != "websocket" {
 			w.Header().Set("Content-Type", "application/octet-stream")
 			fmt.Fprintf(w, resp.content.(string))

--- a/lxd/endpoints/endpoints_test.go
+++ b/lxd/endpoints/endpoints_test.go
@@ -81,7 +81,7 @@ func newServer() *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/1.0/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		util.WriteJSON(w, api.ResponseRaw{}, false)
+		util.WriteJSON(w, api.ResponseRaw{}, nil)
 	})
 	return &http.Server{Handler: mux, ErrorLog: log.New(ioutil.Discard, "", 0)}
 }

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -56,7 +56,7 @@ func (c *cmdGlobal) Run(cmd *cobra.Command, args []string) error {
 	operations.Init(daemon.Debug)
 
 	// Set debug for the response package
-	response.Init(daemon.Verbose)
+	response.Init(daemon.Debug)
 
 	// Setup logger
 	syslog := ""

--- a/lxd/operations/response.go
+++ b/lxd/operations/response.go
@@ -7,6 +7,9 @@ import (
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared/api"
+	log "github.com/lxc/lxd/shared/log15"
+	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/logging"
 	"github.com/lxc/lxd/shared/version"
 )
 
@@ -40,9 +43,16 @@ func (r *operationResponse) Render(w http.ResponseWriter) error {
 	}
 
 	w.Header().Set("Location", url)
-	w.WriteHeader(202)
 
-	return util.WriteJSON(w, body, debug)
+	code := 202
+	w.WriteHeader(code)
+
+	var debugLogger logger.Logger
+	if debug {
+		debugLogger = logging.AddContext(logger.Log, log.Ctx{"http_code": code})
+	}
+
+	return util.WriteJSON(w, body, debugLogger)
 }
 
 func (r *operationResponse) String() string {

--- a/lxd/operations/response.go
+++ b/lxd/operations/response.go
@@ -96,9 +96,16 @@ func (r *forwardedOperationResponse) Render(w http.ResponseWriter) error {
 	}
 
 	w.Header().Set("Location", url)
-	w.WriteHeader(202)
 
-	return util.WriteJSON(w, body, debug)
+	code := 202
+	w.WriteHeader(code)
+
+	var debugLogger logger.Logger
+	if debug {
+		debugLogger = logging.AddContext(logger.Log, log.Ctx{"http_code": code})
+	}
+
+	return util.WriteJSON(w, body, debugLogger)
 }
 
 func (r *forwardedOperationResponse) String() string {

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -255,7 +255,8 @@ func (r *errorResponse) Render(w http.ResponseWriter) error {
 	}
 
 	if debug {
-		shared.DebugJson(captured)
+		debugLogger := logging.AddContext(logger.Log, log.Ctx{"http_code": r.code})
+		util.DebugJSON("Error Response", captured, debugLogger)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -40,12 +40,13 @@ func DebugJSON(title string, r *bytes.Buffer, logger logger.Logger) {
 }
 
 // WriteJSON encodes the body as JSON and sends it back to the client
-func WriteJSON(w http.ResponseWriter, body interface{}, debug bool) error {
+// Accepts optional debugLogger that activates debug logging if non-nil.
+func WriteJSON(w http.ResponseWriter, body interface{}, debugLogger logger.Logger) error {
 	var output io.Writer
 	var captured *bytes.Buffer
 
 	output = w
-	if debug {
+	if debugLogger != nil {
 		captured = &bytes.Buffer{}
 		output = io.MultiWriter(w, captured)
 	}
@@ -55,7 +56,7 @@ func WriteJSON(w http.ResponseWriter, body interface{}, debug bool) error {
 	err := enc.Encode(body)
 
 	if captured != nil {
-		shared.DebugJson(captured)
+		DebugJSON("WriteJSON", captured, debugLogger)
 	}
 
 	return err

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -19,11 +19,25 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	log "github.com/lxc/lxd/shared/log15"
-
 	"github.com/lxc/lxd/shared"
+	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
 )
+
+// DebugJSON helper to log JSON.
+// Accepts a title to prefix the JSON log with, a *bytes.Bufffer containing the JSON and a logger to use for
+// logging the the JSON (allowing for custom context to be added to the log).
+func DebugJSON(title string, r *bytes.Buffer, logger logger.Logger) {
+	pretty := &bytes.Buffer{}
+	if err := json.Indent(pretty, r.Bytes(), "\t", "\t"); err != nil {
+		logger.Debug("Error indenting JSON", log.Ctx{"err": err})
+		return
+	}
+
+	// Print the JSON without the last "\n"
+	str := pretty.String()
+	logger.Debug(fmt.Sprintf("%s\n\t%s", title, str[0:len(str)-1]))
+}
 
 // WriteJSON encodes the body as JSON and sends it back to the client
 func WriteJSON(w http.ResponseWriter, body interface{}, debug bool) error {

--- a/shared/json.go
+++ b/shared/json.go
@@ -1,11 +1,7 @@
 package shared
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-
-	"github.com/lxc/lxd/shared/logger"
 )
 
 type Jmap map[string]interface{}
@@ -48,16 +44,4 @@ func (m Jmap) GetBool(key string) (bool, error) {
 	} else {
 		return val, nil
 	}
-}
-
-func DebugJson(r *bytes.Buffer) {
-	pretty := &bytes.Buffer{}
-	if err := json.Indent(pretty, r.Bytes(), "\t", "\t"); err != nil {
-		logger.Debugf("error indenting json: %s", err)
-		return
-	}
-
-	// Print the JSON without the last "\n"
-	str := pretty.String()
-	logger.Debugf("\n\t%s", str[0:len(str)-1])
 }


### PR DESCRIPTION
Rather than using Jmap.

This brings it inline with `OperationResponse.Render()`, `ForwardedOperationResponse.Render()` and `syncResponse.Render()` functions.

This confused me for a while as I couldn't understand why `api.ResponseRaw.Error` wasn't referenced anywhere in the code, yet the associated `api.Response.Error` field was being used to display the error message in `lxdParseResponse`.  How did it get populated? Well it was because of the manual Jmap being used.

Includes https://github.com/lxc/lxd/pull/9280