### PR TITLE
lxd/cgroup: Fix logging in cgroup init

### DIFF
--- a/lxd/cgroup/init.go
+++ b/lxd/cgroup/init.go
@@ -333,7 +333,8 @@ func (info *Info) Warnings() []db.Warning {
 	return warnings
 }
 
-func init() {
+// Init initializes cgroups.
+func Init() {
 	_, err := os.Stat("/proc/self/ns/cgroup")
 	if err == nil {
 		cgNamespace = true

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -159,6 +159,7 @@ func (s *OS) Init() ([]db.Warning, error) {
 	s.RunningInUserNS = shared.RunningInUserNS()
 
 	dbWarnings = s.initAppArmor()
+	cgroup.Init()
 	s.CGInfo = cgroup.GetInfo()
 
 	return dbWarnings, nil


### PR DESCRIPTION
This replaces `init` with `Init` as the former wouldn't show log
messages at all.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
