### PR TITLE
API: Adds URL builder and updates network UsedBy to use it

### DIFF
--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -125,12 +125,7 @@ func UsedBy(s *state.State, networkProjectName string, networkName string, first
 				// The network's config references the network we are searching for. Either by
 				// directly referencing our network or by referencing our interface as its parent.
 				if network.Config["network"] == networkName || network.Config["parent"] == networkName {
-					uri := fmt.Sprintf("/%s/networks/%s", version.APIVersion, network.Name)
-					if projectName != project.Default {
-						uri += fmt.Sprintf("?project=%s", projectName)
-					}
-
-					usedBy = append(usedBy, uri)
+					usedBy = append(usedBy, api.NewURL().Path(version.APIVersion, "networks", network.Name).Project(projectName).String())
 
 					if firstOnly {
 						return usedBy, nil
@@ -161,12 +156,7 @@ func UsedBy(s *state.State, networkProjectName string, networkName string, first
 		}
 
 		if inUse {
-			uri := fmt.Sprintf("/%s/profiles/%s", version.APIVersion, profile.Name)
-			if profile.Project != project.Default {
-				uri += fmt.Sprintf("?project=%s", profile.Project)
-			}
-
-			usedBy = append(usedBy, uri)
+			usedBy = append(usedBy, api.NewURL().Path(version.APIVersion, "profiles", profile.Name).Project(profile.Project).String())
 
 			if firstOnly {
 				return usedBy, nil
@@ -193,12 +183,7 @@ func UsedBy(s *state.State, networkProjectName string, networkName string, first
 			}
 
 			if inUse {
-				uri := fmt.Sprintf("/%s/instances/%s", version.APIVersion, inst.Name)
-				if inst.Project != project.Default {
-					uri += fmt.Sprintf("?project=%s", inst.Project)
-				}
-
-				usedBy = append(usedBy, uri)
+				usedBy = append(usedBy, api.NewURL().Path(version.APIVersion, "instances", inst.Name).Project(inst.Project).String())
 
 				if firstOnly {
 					return db.ErrInstanceListStop

--- a/shared/api/url.go
+++ b/shared/api/url.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"net/url"
+	"strings"
+)
+
+// URL represents an endpoint for the LXD API.
+type URL struct {
+	url.URL
+}
+
+// NewURL creates a new URL.
+func NewURL() *URL {
+	return &URL{}
+}
+
+// Scheme sets the scheme of the URL.
+func (u *URL) Scheme(scheme string) *URL {
+	u.URL.Scheme = scheme
+
+	return u
+}
+
+// Host sets the host of the URL.
+func (u *URL) Host(host string) *URL {
+	u.URL.Host = host
+
+	return u
+}
+
+// Path sets the path of the URL from one or more path parts.
+// It appends each of the pathParts (escaped using url.PathEscape) prefixed with "/" to the URL path.
+func (u *URL) Path(pathParts ...string) *URL {
+	var b strings.Builder
+
+	for _, pathPart := range pathParts {
+		b.WriteString("/") // Build an absolute URL.
+		b.WriteString(url.PathEscape(pathPart))
+	}
+
+	u.URL.Path = b.String()
+
+	return u
+}
+
+// Project sets the "project" query parameter in the URL if the projectName is not empty or "default".
+func (u *URL) Project(projectName string) *URL {
+	if projectName != "default" && projectName != "" {
+		queryArgs := u.Query()
+		queryArgs.Add("project", projectName)
+		u.RawQuery = queryArgs.Encode()
+	}
+
+	return u
+}
+
+// Target sets the "target" query parameter in the URL if the clusterMemberName is not empty or "default".
+func (u *URL) Target(clusterMemberName string) *URL {
+	if clusterMemberName != "" {
+		queryArgs := u.Query()
+		queryArgs.Add("target", clusterMemberName)
+		u.RawQuery = queryArgs.Encode()
+	}
+
+	return u
+}

--- a/shared/api/url_test.go
+++ b/shared/api/url_test.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"fmt"
+)
+
+func ExampleURL() {
+	u := NewURL()
+	fmt.Println(u.Path("1.0", "networks", "name-with-/-in-it"))
+	fmt.Println(u.Project("default"))
+	fmt.Println(u.Project("project-with-%-in-it"))
+	fmt.Println(u.Target(""))
+	fmt.Println(u.Target("member-with-%-in-it"))
+	fmt.Println(u.Host("linuxcontainers.org"))
+	fmt.Println(u.Scheme("https"))
+
+	// Output: /1.0/networks/name-with-%252F-in-it
+	// /1.0/networks/name-with-%252F-in-it
+	// /1.0/networks/name-with-%252F-in-it?project=project-with-%25-in-it
+	// /1.0/networks/name-with-%252F-in-it?project=project-with-%25-in-it
+	// /1.0/networks/name-with-%252F-in-it?project=project-with-%25-in-it&target=member-with-%25-in-it
+	// //linuxcontainers.org/1.0/networks/name-with-%252F-in-it?project=project-with-%25-in-it&target=member-with-%25-in-it
+	// https://linuxcontainers.org/1.0/networks/name-with-%252F-in-it?project=project-with-%25-in-it&target=member-with-%25-in-it
+}


### PR DESCRIPTION
I've come across the pattern of manually building URLs in LXD quite a bit.
Whilst updating the network `UsedBy` for another project I thought it might be useful to add a generic helper function for building resource URLs that would:

- Avoid the repetition of whether or not to add a URL query string parameter for `project` based on the project name.
- Escape the `project` and `target` parameters if needed.
- Escape the path parts if needed.

The URL builder type `api.URL` embeds the stdlib's `url.URL` type making it easier to add additional manipulations for more complicated scenarios.

I added it to `shared/api` package as I thought it could also be useful in the LXC client package when building URLs too, as well as on the LXD server side.