### PR TITLE
Network: Add lxc network forward get command

### DIFF
--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -234,7 +234,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -623,7 +623,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -782,7 +782,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -975,10 +975,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -1033,7 +1033,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, fuzzy, c-format
@@ -1213,7 +1213,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1262,12 +1262,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1324,7 +1324,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1388,37 +1388,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1598,7 +1598,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -1868,7 +1868,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1948,6 +1948,11 @@ msgstr "Profil %s erstellt\n"
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
 msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+#, fuzzy
+msgid "Get values for network forward configuration keys"
+msgstr "Profil %s erstellt\n"
 
 #: lxc/profile.go:530 lxc/profile.go:531
 msgid "Get values for profile configuration keys"
@@ -2258,11 +2263,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2334,7 +2339,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2724,7 +2729,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2847,10 +2852,10 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Missing instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 #, fuzzy
 msgid "Missing listen address"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2872,10 +2877,11 @@ msgstr "Profilname kann nicht geändert werden"
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -3076,12 +3082,12 @@ msgstr "Profil %s gelöscht\n"
 msgid "Network ACL %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -3205,7 +3211,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -3271,7 +3277,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3532,7 +3538,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3545,7 +3551,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3833,12 +3839,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3984,7 +3990,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Profil %s erstellt\n"
@@ -4495,12 +4501,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5094,7 +5100,7 @@ msgstr ""
 "lxd %s <Name>\n"
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -5134,8 +5140,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -5143,7 +5149,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -5151,7 +5157,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -5159,13 +5165,13 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -5173,7 +5179,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -141,7 +141,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,7 +433,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -759,10 +759,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -814,7 +814,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1025,12 +1025,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1084,7 +1084,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1146,37 +1146,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1341,7 +1341,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1589,7 +1589,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1665,6 +1665,11 @@ msgstr ""
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
 msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+#, fuzzy
+msgid "Get values for network forward configuration keys"
+msgstr "  Χρήση δικτύου:"
 
 #: lxc/profile.go:530 lxc/profile.go:531
 msgid "Get values for profile configuration keys"
@@ -1962,11 +1967,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2035,7 +2040,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2391,7 +2396,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2505,10 +2510,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2527,10 +2532,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2723,12 +2729,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "  Χρήση δικτύου:"
@@ -2849,7 +2855,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2914,7 +2920,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3164,7 +3170,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3176,7 +3182,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3445,12 +3451,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3587,7 +3593,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4070,12 +4076,12 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "  Χρήση δικτύου:"
@@ -4421,7 +4427,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4441,30 +4447,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -239,7 +239,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -598,7 +598,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -928,10 +928,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -985,7 +985,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1202,12 +1202,12 @@ msgstr "Creando el contenedor"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1262,7 +1262,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1324,37 +1324,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1519,7 +1519,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1772,7 +1772,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1848,6 +1848,11 @@ msgstr ""
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
 msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+#, fuzzy
+msgid "Get values for network forward configuration keys"
+msgstr "Perfil %s creado"
 
 #: lxc/profile.go:530 lxc/profile.go:531
 msgid "Get values for profile configuration keys"
@@ -2150,11 +2155,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2226,7 +2231,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2585,7 +2590,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2701,10 +2706,10 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Missing instance name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nombre del contenedor es: %s"
@@ -2725,10 +2730,11 @@ msgstr "Nombre del contenedor es: %s"
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2923,12 +2929,12 @@ msgstr "Perfil %s eliminado"
 msgid "Network ACL %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Perfil %s eliminado"
@@ -3047,7 +3053,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -3112,7 +3118,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3365,7 +3371,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3377,7 +3383,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3651,12 +3657,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3793,7 +3799,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4279,12 +4285,12 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Perfil %s creado"
@@ -4682,7 +4688,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4707,34 +4713,34 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -235,7 +235,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -619,7 +619,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr "Image copiée avec succès !"
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -960,10 +960,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -1025,7 +1025,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -1222,7 +1222,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Copie de l'image : %s"
@@ -1271,12 +1271,12 @@ msgstr "Création du conteneur"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1336,7 +1336,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1401,37 +1401,37 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1606,7 +1606,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -1888,7 +1888,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1967,6 +1967,11 @@ msgstr "Clé de configuration invalide"
 #: lxc/network.go:694 lxc/network.go:695
 #, fuzzy
 msgid "Get values for network configuration keys"
+msgstr "Clé de configuration invalide"
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+#, fuzzy
+msgid "Get values for network forward configuration keys"
 msgstr "Clé de configuration invalide"
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -2285,11 +2290,11 @@ msgstr "DERNIÈRE UTILISATION À"
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2361,7 +2366,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2791,7 +2796,7 @@ msgstr "Copie de l'image : %s"
 msgid "Manage network ACLs"
 msgstr "Nom du réseau"
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Copie de l'image : %s"
@@ -2916,10 +2921,10 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Missing instance name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2941,10 +2946,11 @@ msgstr "Nom du réseau"
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 #, fuzzy
 msgid "Missing network name"
 msgstr "Nom du réseau"
@@ -3149,12 +3155,12 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Network ACL %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -3289,7 +3295,7 @@ msgstr "PID"
 msgid "PID: %d"
 msgstr "Pid : %d"
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -3356,7 +3362,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 #, fuzzy
@@ -3620,7 +3626,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3633,7 +3639,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Création du conteneur"
@@ -3940,12 +3946,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -4095,7 +4101,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show network configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Afficher la configuration étendue"
@@ -4619,12 +4625,12 @@ msgstr "Clé de configuration invalide"
 msgid "Unset network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Nom du réseau"
@@ -5283,7 +5289,7 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -5323,8 +5329,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -5332,7 +5338,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -5340,7 +5346,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -5348,13 +5354,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -5362,7 +5368,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -232,7 +232,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -588,7 +588,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -916,10 +916,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -971,7 +971,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -1145,7 +1145,7 @@ msgstr "Creazione del container in corso"
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1189,12 +1189,12 @@ msgstr "Creazione del container in corso"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1250,7 +1250,7 @@ msgstr "Creazione del container in corso"
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1312,37 +1312,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1760,7 +1760,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1835,6 +1835,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -2138,11 +2142,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2214,7 +2218,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2576,7 +2580,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2691,10 +2695,10 @@ msgstr "Il nome del container è: %s"
 msgid "Missing instance name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Il nome del container è: %s"
@@ -2715,10 +2719,11 @@ msgstr "Il nome del container è: %s"
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2912,12 +2917,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -3036,7 +3041,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -3102,7 +3107,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3354,7 +3359,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3367,7 +3372,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3641,11 +3646,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3782,7 +3787,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4272,11 +4277,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4675,7 +4680,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr "Creazione del container in corso"
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr "Creazione del container in corso"
@@ -4700,34 +4705,34 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr "Creazione del container in corso"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: 2021-08-06 08:35+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -235,7 +235,7 @@ msgstr ""
 "### Note that only the ingress and egress rules, description and "
 "configuration keys can be changed."
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -603,7 +603,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr "バックアップのエクスポートが成功しました!"
 msgid "Backups:"
 msgstr "バックアップ:"
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
@@ -935,10 +935,10 @@ msgstr "%s:%s のクラスターに join するためのトークンが削除さ
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -994,7 +994,7 @@ msgstr "移動先のインスタンスに適用するキー/値の設定"
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -1170,7 +1170,7 @@ msgstr "新たにインスタンスのファイルテンプレートを作成し
 msgid "Create new network ACLs"
 msgstr "新たにネットワーク ACL を作成します"
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "新たにネットワークを作成します"
@@ -1214,12 +1214,12 @@ msgstr "インスタンスを作成中"
 msgid "Current number of VFs: %d"
 msgstr "現在の VF 数: %d"
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1273,7 +1273,7 @@ msgstr "インスタンスとスナップショットを削除します"
 msgid "Delete network ACLs"
 msgstr "ネットワーク ACL を削除します"
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 #, fuzzy
 msgid "Delete network forwards"
 msgstr "ネットワークを削除します"
@@ -1336,37 +1336,37 @@ msgstr "警告を削除します"
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr "説明"
 
@@ -1536,7 +1536,7 @@ msgstr "ネットワーク ACL をYAMLで編集します"
 msgid "Edit network configurations as YAML"
 msgstr "ネットワーク設定をYAMLで編集します"
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "ネットワーク設定をYAMLで編集します"
@@ -1826,7 +1826,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1901,6 +1901,11 @@ msgstr "ネットワーク ACL の設定値を取得します"
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr "ネットワークの設定値を取得します"
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+#, fuzzy
+msgid "Get values for network forward configuration keys"
 msgstr "ネットワークの設定値を取得します"
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -2212,12 +2217,12 @@ msgstr "LAST USED AT"
 msgid "LIMIT"
 msgstr "LIMIT"
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 #, fuzzy
 msgid "LISTEN ADDRESS"
 msgstr "IP ADDRESS"
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr "LOCATION"
@@ -2288,7 +2293,7 @@ msgstr "利用可能なネットワーク ACL を一覧表示します"
 msgid "List available network ACLS"
 msgstr "利用可能なネットワーク ACL を一覧表示します"
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 #, fuzzy
 msgid "List available network forwards"
 msgstr "利用可能なネットワークを一覧表示します"
@@ -2796,7 +2801,7 @@ msgstr "ネットワーク ACL ルールを管理します"
 msgid "Manage network ACLs"
 msgstr "ネットワーク ACL を管理します"
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "ネットワーク ACL ルールを管理します"
@@ -2914,10 +2919,10 @@ msgstr "クラスターメンバー名がありません"
 msgid "Missing instance name"
 msgstr "インスタンス名を指定する必要があります"
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 #, fuzzy
 msgid "Missing listen address"
 msgstr "インスタンス名を指定する必要があります"
@@ -2937,10 +2942,11 @@ msgstr "ネットワーク ACL 名を指定する必要があります"
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr "ネットワーク名を指定する必要があります"
 
@@ -3138,12 +3144,12 @@ msgstr "ネットワーク ACL %s を削除しました"
 msgid "Network ACL %s renamed to %s"
 msgstr "ネットワーク ACL 名 %s を %s に変更しました"
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "ネットワーク %s を作成しました"
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "ネットワーク %s を削除しました"
@@ -3263,7 +3269,7 @@ msgstr "PID"
 msgid "PID: %d"
 msgstr "PID: %d"
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -3328,7 +3334,7 @@ msgstr "ポート:"
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3581,7 +3587,7 @@ msgstr "クラスタからメンバを削除します"
 msgid "Remove aliases"
 msgstr "エイリアスを削除します"
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 #, fuzzy
 msgid "Remove all ports that match"
 msgstr "マッチするルールをすべて削除します"
@@ -3594,7 +3600,7 @@ msgstr "マッチするルールをすべて削除します"
 msgid "Remove instance devices"
 msgstr "インスタンスのデバイスを削除します"
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "ACL からルールを削除します"
@@ -3891,12 +3897,12 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <key> <value>"
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "ネットワークを削除します"
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 #, fuzzy
 msgid ""
 "Set network forward keys\n"
@@ -4054,7 +4060,7 @@ msgstr "ネットワーク ACL の設定を表示します"
 msgid "Show network configurations"
 msgstr "ネットワークの設定を表示します"
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "ネットワークの設定を表示します"
@@ -4564,12 +4570,12 @@ msgstr "ネットワーク ACL の設定を削除します"
 msgid "Unset network configuration keys"
 msgstr "ネットワークの設定を削除します"
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "ネットワークの設定を削除します"
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "ネットワークを削除します"
@@ -4926,7 +4932,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr "[<remote>:]<member> <new-name>"
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr "[<remote>:]<network>"
 
@@ -4946,34 +4952,34 @@ msgstr "[<remote>:]<network> <key>"
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "[<remote>:]<network> <key>=<value>..."
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "[<remote>:]<network> <new-name>"
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "[<remote>:]<network> <new-name>"
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "[<remote>:]<network> <key>=<value>..."
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr "[<remote>:]<network> <new-name>"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2021-09-20 12:08+0200\n"
+        "POT-Creation-Date: 2021-09-24 18:04+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -130,7 +130,7 @@ msgid   "### This is a YAML representation of the network ACL.\n"
         "### Note that only the ingress and egress rules, description and configuration keys can be changed."
 msgstr  ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid   "### This is a YAML representation of the network forward.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -409,7 +409,7 @@ msgid   "Add new trusted clients\n"
         "- metrics\n"
 msgstr  ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid   "Add ports to a forward"
 msgstr  ""
 
@@ -556,7 +556,7 @@ msgstr  ""
 msgid   "Backups:"
 msgstr  ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
@@ -728,7 +728,7 @@ msgstr  ""
 msgid   "Cluster join token for %s:%s deleted"
 msgstr  ""
 
-#: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617 lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55 lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756 lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182 lxc/network_forward.go:166 lxc/network_forward.go:230 lxc/network_forward.go:330 lxc/network_forward.go:431 lxc/network_forward.go:572 lxc/network_forward.go:649 lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339 lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757 lxc/storage_volume.go:335 lxc/storage_volume.go:503 lxc/storage_volume.go:582 lxc/storage_volume.go:824 lxc/storage_volume.go:1021 lxc/storage_volume.go:1109 lxc/storage_volume.go:1381 lxc/storage_volume.go:1412 lxc/storage_volume.go:1528 lxc/storage_volume.go:1607 lxc/storage_volume.go:1700 lxc/storage_volume.go:1737 lxc/storage_volume.go:1831 lxc/storage_volume.go:1903 lxc/storage_volume.go:2042
+#: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617 lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55 lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756 lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:389 lxc/network_forward.go:490 lxc/network_forward.go:631 lxc/network_forward.go:708 lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339 lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757 lxc/storage_volume.go:335 lxc/storage_volume.go:503 lxc/storage_volume.go:582 lxc/storage_volume.go:824 lxc/storage_volume.go:1021 lxc/storage_volume.go:1109 lxc/storage_volume.go:1381 lxc/storage_volume.go:1412 lxc/storage_volume.go:1528 lxc/storage_volume.go:1607 lxc/storage_volume.go:1700 lxc/storage_volume.go:1737 lxc/storage_volume.go:1831 lxc/storage_volume.go:1903 lxc/storage_volume.go:2042
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -767,7 +767,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434 lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536 lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:957 lxc/storage_volume.go:987
+#: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434 lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595 lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -931,7 +931,7 @@ msgstr  ""
 msgid   "Create new network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid   "Create new network forwards"
 msgstr  ""
 
@@ -974,11 +974,11 @@ msgstr  ""
 msgid   "Current number of VFs: %d"
 msgstr  ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490 lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141 lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577 lxc/storage_volume.go:1287
+#: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490 lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145 lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1030,7 +1030,7 @@ msgstr  ""
 msgid   "Delete network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid   "Delete network forwards"
 msgstr  ""
 
@@ -1058,7 +1058,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:102 lxc/cluster.go:180 lxc/cluster.go:230 lxc/cluster.go:280 lxc/cluster.go:363 lxc/cluster.go:448 lxc/cluster.go:599 lxc/cluster.go:661 lxc/cluster.go:759 lxc/cluster.go:838 lxc/cluster.go:944 lxc/cluster.go:963 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79 lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368 lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:108 lxc/file.go:157 lxc/file.go:220 lxc/file.go:410 lxc/image.go:38 lxc/image.go:144 lxc/image.go:290 lxc/image.go:341 lxc/image.go:466 lxc/image.go:625 lxc/image.go:845 lxc/image.go:980 lxc/image.go:1278 lxc/image.go:1357 lxc/image.go:1416 lxc/image.go:1468 lxc/image.go:1524 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50 lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33 lxc/network.go:120 lxc/network.go:205 lxc/network.go:278 lxc/network.go:352 lxc/network.go:402 lxc/network.go:487 lxc/network.go:572 lxc/network.go:695 lxc/network.go:753 lxc/network.go:833 lxc/network.go:928 lxc/network.go:997 lxc/network.go:1047 lxc/network.go:1117 lxc/network.go:1179 lxc/network_acl.go:30 lxc/network_acl.go:91 lxc/network_acl.go:161 lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346 lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564 lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677 lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83 lxc/network_forward.go:163 lxc/network_forward.go:227 lxc/network_forward.go:323 lxc/network_forward.go:401 lxc/network_forward.go:428 lxc/network_forward.go:569 lxc/network_forward.go:631 lxc/network_forward.go:646 lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:500 lxc/storage_volume.go:579 lxc/storage_volume.go:655 lxc/storage_volume.go:737 lxc/storage_volume.go:818 lxc/storage_volume.go:1018 lxc/storage_volume.go:1106 lxc/storage_volume.go:1193 lxc/storage_volume.go:1377 lxc/storage_volume.go:1409 lxc/storage_volume.go:1522 lxc/storage_volume.go:1598 lxc/storage_volume.go:1697 lxc/storage_volume.go:1731 lxc/storage_volume.go:1829 lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:102 lxc/cluster.go:180 lxc/cluster.go:230 lxc/cluster.go:280 lxc/cluster.go:363 lxc/cluster.go:448 lxc/cluster.go:599 lxc/cluster.go:661 lxc/cluster.go:759 lxc/cluster.go:838 lxc/cluster.go:944 lxc/cluster.go:963 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79 lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368 lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:72 lxc/file.go:108 lxc/file.go:157 lxc/file.go:220 lxc/file.go:410 lxc/image.go:38 lxc/image.go:144 lxc/image.go:290 lxc/image.go:341 lxc/image.go:466 lxc/image.go:625 lxc/image.go:845 lxc/image.go:980 lxc/image.go:1278 lxc/image.go:1357 lxc/image.go:1416 lxc/image.go:1468 lxc/image.go:1524 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50 lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33 lxc/network.go:120 lxc/network.go:205 lxc/network.go:278 lxc/network.go:352 lxc/network.go:402 lxc/network.go:487 lxc/network.go:572 lxc/network.go:695 lxc/network.go:753 lxc/network.go:833 lxc/network.go:928 lxc/network.go:997 lxc/network.go:1047 lxc/network.go:1117 lxc/network.go:1179 lxc/network_acl.go:30 lxc/network_acl.go:91 lxc/network_acl.go:161 lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346 lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564 lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677 lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:500 lxc/storage_volume.go:579 lxc/storage_volume.go:655 lxc/storage_volume.go:737 lxc/storage_volume.go:818 lxc/storage_volume.go:1018 lxc/storage_volume.go:1106 lxc/storage_volume.go:1193 lxc/storage_volume.go:1377 lxc/storage_volume.go:1409 lxc/storage_volume.go:1522 lxc/storage_volume.go:1598 lxc/storage_volume.go:1697 lxc/storage_volume.go:1731 lxc/storage_volume.go:1829 lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid   "Description"
 msgstr  ""
 
@@ -1213,7 +1213,7 @@ msgstr  ""
 msgid   "Edit network configurations as YAML"
 msgstr  ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid   "Edit network forward configurations as YAML"
 msgstr  ""
 
@@ -1444,7 +1444,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662 lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006 lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930 lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107 lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
+#: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662 lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006 lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930 lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107 lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
@@ -1517,6 +1517,10 @@ msgstr  ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid   "Get values for network configuration keys"
+msgstr  ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid   "Get values for network forward configuration keys"
 msgstr  ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1811,11 +1815,11 @@ msgstr  ""
 msgid   "LIMIT"
 msgstr  ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147 lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151 lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid   "LOCATION"
 msgstr  ""
 
@@ -1883,7 +1887,7 @@ msgstr  ""
 msgid   "List available network ACLS"
 msgstr  ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid   "List available network forwards"
 msgstr  ""
 
@@ -2226,7 +2230,7 @@ msgstr  ""
 msgid   "Manage network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid   "Manage network forward ports"
 msgstr  ""
 
@@ -2332,7 +2336,7 @@ msgstr  ""
 msgid   "Missing instance name"
 msgstr  ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255 lxc/network_forward.go:355 lxc/network_forward.go:478 lxc/network_forward.go:597 lxc/network_forward.go:674 lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259 lxc/network_forward.go:354 lxc/network_forward.go:414 lxc/network_forward.go:537 lxc/network_forward.go:656 lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid   "Missing listen address"
 msgstr  ""
 
@@ -2344,7 +2348,7 @@ msgstr  ""
 msgid   "Missing network ACL name"
 msgstr  ""
 
-#: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426 lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779 lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076 lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187 lxc/network_forward.go:251 lxc/network_forward.go:351 lxc/network_forward.go:474 lxc/network_forward.go:593 lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426 lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779 lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076 lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191 lxc/network_forward.go:255 lxc/network_forward.go:350 lxc/network_forward.go:410 lxc/network_forward.go:533 lxc/network_forward.go:652 lxc/network_forward.go:729 lxc/network_forward.go:795
 msgid   "Missing network name"
 msgstr  ""
 
@@ -2520,12 +2524,12 @@ msgstr  ""
 msgid   "Network ACL %s renamed to %s"
 msgstr  ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid   "Network forward %s created"
 msgstr  ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid   "Network forward %s deleted"
 msgstr  ""
@@ -2644,7 +2648,7 @@ msgstr  ""
 msgid   "PID: %d"
 msgstr  ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid   "PORTS"
 msgstr  ""
 
@@ -2706,7 +2710,7 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206 lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667 lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502 lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958 lxc/storage_volume.go:988
+#: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206 lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667 lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502 lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958 lxc/storage_volume.go:988
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -2953,7 +2957,7 @@ msgstr  ""
 msgid   "Remove aliases"
 msgstr  ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid   "Remove all ports that match"
 msgstr  ""
 
@@ -2965,7 +2969,7 @@ msgstr  ""
 msgid   "Remove instance devices"
 msgstr  ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid   "Remove ports from a forward"
 msgstr  ""
 
@@ -3221,11 +3225,11 @@ msgid   "Set network configuration keys\n"
         "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr  ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid   "Set network forward keys"
 msgstr  ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid   "Set network forward keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -3352,7 +3356,7 @@ msgstr  ""
 msgid   "Show network configurations"
 msgstr  ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid   "Show network forward configurations"
 msgstr  ""
 
@@ -3821,11 +3825,11 @@ msgstr  ""
 msgid   "Unset network configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid   "Unset network forward configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid   "Unset network forward keys"
 msgstr  ""
 
@@ -4153,7 +4157,7 @@ msgstr  ""
 msgid   "[<remote>:]<member> <new-name>"
 msgstr  ""
 
-#: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926 lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926 lxc/network.go:1115 lxc/network_forward.go:84
 msgid   "[<remote>:]<network>"
 msgstr  ""
 
@@ -4173,27 +4177,27 @@ msgstr  ""
 msgid   "[<remote>:]<network> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426 lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485 lxc/network_forward.go:625
 msgid   "[<remote>:]<network> <listen_address>"
 msgstr  ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid   "[<remote>:]<network> <listen_address> <key>"
 msgstr  ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid   "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid   "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr  ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid   "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -230,7 +230,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -582,7 +582,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -730,7 +730,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -907,10 +907,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -962,7 +962,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -1130,7 +1130,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1173,12 +1173,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1232,7 +1232,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1294,37 +1294,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1734,7 +1734,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1809,6 +1809,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -2107,11 +2111,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2180,7 +2184,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2536,7 +2540,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2648,10 +2652,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2670,10 +2674,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2866,12 +2871,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2990,7 +2995,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -3055,7 +3060,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3305,7 +3310,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3317,7 +3322,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3586,11 +3591,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3727,7 +3732,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4210,11 +4215,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4559,7 +4564,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4579,30 +4584,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -240,7 +240,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -604,7 +604,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -752,7 +752,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -929,10 +929,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -984,7 +984,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1195,12 +1195,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1254,7 +1254,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1316,37 +1316,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1756,7 +1756,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1831,6 +1831,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -2129,11 +2133,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2202,7 +2206,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2558,7 +2562,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2670,10 +2674,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2692,10 +2696,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2888,12 +2893,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -3012,7 +3017,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -3077,7 +3082,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3327,7 +3332,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3339,7 +3344,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3608,11 +3613,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3749,7 +3754,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4232,11 +4237,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4581,7 +4586,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4601,30 +4606,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -238,7 +238,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -609,7 +609,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr "Backup exportado com sucesso!"
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
@@ -945,10 +945,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -1008,7 +1008,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -1186,7 +1186,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "Create new network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Criar novas redes"
@@ -1231,12 +1231,12 @@ msgstr "Criando %s"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1296,7 +1296,7 @@ msgstr "Apagar nomes alternativos da imagem"
 msgid "Delete network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 #, fuzzy
 msgid "Delete network forwards"
 msgstr "Criar novas redes"
@@ -1359,37 +1359,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr "Descrição"
 
@@ -1562,7 +1562,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit network configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -1814,7 +1814,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1894,6 +1894,11 @@ msgstr "Editar configurações de perfil como YAML"
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
 msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+#, fuzzy
+msgid "Get values for network forward configuration keys"
+msgstr "Editar configurações de perfil como YAML"
 
 #: lxc/profile.go:530 lxc/profile.go:531
 msgid "Get values for profile configuration keys"
@@ -2194,11 +2199,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2268,7 +2273,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2631,7 +2636,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Criar novas redes"
@@ -2749,10 +2754,10 @@ msgstr "Nome de membro do cluster"
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nome de membro do cluster"
@@ -2773,10 +2778,11 @@ msgstr "Nome de membro do cluster"
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2969,12 +2975,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -3093,7 +3099,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -3158,7 +3164,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3413,7 +3419,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3425,7 +3431,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Adicionar perfis aos containers"
@@ -3710,12 +3716,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3859,7 +3865,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -4355,12 +4361,12 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Criar novas redes"
@@ -4722,7 +4728,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4742,33 +4748,33 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr "Criar perfis"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: 2020-10-08 08:16+0000\n"
 "Last-Translator: Artem <KovalevArtem.ru@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -237,7 +237,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -615,7 +615,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -946,10 +946,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -1001,7 +1001,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -1177,7 +1177,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 #, fuzzy
 msgid "Create new network forwards"
 msgstr "Копирование образа: %s"
@@ -1224,12 +1224,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1286,7 +1286,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1349,37 +1349,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1547,7 +1547,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1804,7 +1804,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1880,6 +1880,11 @@ msgstr ""
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
 msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+#, fuzzy
+msgid "Get values for network forward configuration keys"
+msgstr "Копирование образа: %s"
 
 #: lxc/profile.go:530 lxc/profile.go:531
 msgid "Get values for profile configuration keys"
@@ -2184,11 +2189,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2260,7 +2265,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2625,7 +2630,7 @@ msgstr "Копирование образа: %s"
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Копирование образа: %s"
@@ -2746,10 +2751,10 @@ msgstr "Копирование образа: %s"
 msgid "Missing instance name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Имя контейнера: %s"
@@ -2770,10 +2775,11 @@ msgstr "Имя контейнера: %s"
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2969,12 +2975,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr " Использование сети:"
@@ -3096,7 +3102,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -3161,7 +3167,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3413,7 +3419,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3426,7 +3432,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3703,12 +3709,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3847,7 +3853,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 #, fuzzy
 msgid "Show network forward configurations"
 msgstr "Копирование образа: %s"
@@ -4339,12 +4345,12 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Копирование образа: %s"
@@ -4899,7 +4905,7 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 #, fuzzy
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -4939,8 +4945,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -4948,7 +4954,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -4956,7 +4962,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -4964,13 +4970,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -4978,7 +4984,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: 2020-11-05 02:45+0000\n"
 "Last-Translator: wdggg <wdggg7@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -192,7 +192,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -484,7 +484,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -809,10 +809,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -864,7 +864,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -1032,7 +1032,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1075,12 +1075,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1134,7 +1134,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1196,37 +1196,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1388,7 +1388,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1636,7 +1636,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1711,6 +1711,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -2009,11 +2013,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2082,7 +2086,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2438,7 +2442,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2550,10 +2554,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2572,10 +2576,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2768,12 +2773,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2892,7 +2897,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2957,7 +2962,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3207,7 +3212,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3219,7 +3224,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3488,11 +3493,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3629,7 +3634,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4112,11 +4117,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4461,7 +4466,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4481,30 +4486,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-20 12:08+0200\n"
+"POT-Creation-Date: 2021-09-24 18:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -138,7 +138,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:437
+#: lxc/network_forward.go:496
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,7 +430,7 @@ msgid ""
 "- metrics\n"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:704 lxc/network_forward.go:705
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Backups:"
 msgstr ""
 
-#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:280
+#: lxc/network.go:313 lxc/network_acl.go:318 lxc/network_forward.go:284
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -755,10 +755,10 @@ msgstr ""
 #: lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55
 #: lxc/move.go:58 lxc/network.go:280 lxc/network.go:698 lxc/network.go:756
 #: lxc/network.go:1053 lxc/network.go:1120 lxc/network.go:1182
-#: lxc/network_forward.go:166 lxc/network_forward.go:230
-#: lxc/network_forward.go:330 lxc/network_forward.go:431
-#: lxc/network_forward.go:572 lxc/network_forward.go:649
-#: lxc/network_forward.go:715 lxc/storage.go:95 lxc/storage.go:339
+#: lxc/network_forward.go:170 lxc/network_forward.go:234
+#: lxc/network_forward.go:389 lxc/network_forward.go:490
+#: lxc/network_forward.go:631 lxc/network_forward.go:708
+#: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
 #: lxc/storage_volume.go:335 lxc/storage_volume.go:503
 #: lxc/storage_volume.go:582 lxc/storage_volume.go:824
@@ -810,7 +810,7 @@ msgstr ""
 
 #: lxc/cluster.go:529 lxc/config.go:258 lxc/config.go:331
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:434
-#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:536
+#: lxc/network.go:666 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306
 #: lxc/storage_volume.go:957 lxc/storage_volume.go:987
 #, c-format
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Create new network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:226 lxc/network_forward.go:227
+#: lxc/network_forward.go:230 lxc/network_forward.go:231
 msgid "Create new network forwards"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/network_forward.go:142
+#: lxc/network_forward.go:146
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/cluster.go:162 lxc/image.go:1019 lxc/image_alias.go:237 lxc/list.go:490
-#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:141
+#: lxc/network.go:906 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473
 #: lxc/storage.go:577 lxc/storage_volume.go:1287
 msgid "DESCRIPTION"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:568 lxc/network_forward.go:569
+#: lxc/network_forward.go:627 lxc/network_forward.go:628
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1142,37 +1142,37 @@ msgstr ""
 #: lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346
 #: lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564
 #: lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677
-#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:83
-#: lxc/network_forward.go:163 lxc/network_forward.go:227
-#: lxc/network_forward.go:323 lxc/network_forward.go:401
-#: lxc/network_forward.go:428 lxc/network_forward.go:569
-#: lxc/network_forward.go:631 lxc/network_forward.go:646
-#: lxc/network_forward.go:711 lxc/operation.go:24 lxc/operation.go:56
-#: lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29
-#: lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303
-#: lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580
-#: lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825
-#: lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159
-#: lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491
-#: lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688
-#: lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33
-#: lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613
-#: lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
-#: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396
-#: lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
-#: lxc/storage_volume.go:331 lxc/storage_volume.go:500
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:655
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:818
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1106
-#: lxc/storage_volume.go:1193 lxc/storage_volume.go:1377
-#: lxc/storage_volume.go:1409 lxc/storage_volume.go:1522
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1697
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1829
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:2037 lxc/version.go:22
-#: lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301
-#: lxc/warning.go:355
+#: lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:327 lxc/network_forward.go:382
+#: lxc/network_forward.go:460 lxc/network_forward.go:487
+#: lxc/network_forward.go:628 lxc/network_forward.go:690
+#: lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
+#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
+#: lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766
+#: lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392
+#: lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635
+#: lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32
+#: lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527
+#: lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
+#: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
+#: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
+#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:500 lxc/storage_volume.go:579
+#: lxc/storage_volume.go:655 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818 lxc/storage_volume.go:1018
+#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1193
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1522 lxc/storage_volume.go:1598
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1731
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:2037 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:427 lxc/network_forward.go:428
+#: lxc/network_forward.go:486 lxc/network_forward.go:487
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: lxc/alias.go:105 lxc/cluster.go:104 lxc/cluster.go:662
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1006
 #: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:837 lxc/network.go:930
-#: lxc/network_acl.go:94 lxc/network_forward.go:86 lxc/operation.go:107
+#: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/operation.go:107
 #: lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531
 #: lxc/storage.go:518 lxc/storage_volume.go:1211 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
@@ -1657,6 +1657,10 @@ msgstr ""
 
 #: lxc/network.go:694 lxc/network.go:695
 msgid "Get values for network configuration keys"
+msgstr ""
+
+#: lxc/network_forward.go:326 lxc/network_forward.go:327
+msgid "Get values for network forward configuration keys"
 msgstr ""
 
 #: lxc/profile.go:530 lxc/profile.go:531
@@ -1955,11 +1959,11 @@ msgstr ""
 msgid "LIMIT"
 msgstr ""
 
-#: lxc/network_forward.go:140
+#: lxc/network_forward.go:144
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:147
+#: lxc/list.go:518 lxc/network.go:980 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1294 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "List available network ACLS"
 msgstr ""
 
-#: lxc/network_forward.go:82 lxc/network_forward.go:83
+#: lxc/network_forward.go:86 lxc/network_forward.go:87
 msgid "List available network forwards"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:630 lxc/network_forward.go:631
+#: lxc/network_forward.go:689 lxc/network_forward.go:690
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -2496,10 +2500,10 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/network_forward.go:191 lxc/network_forward.go:255
-#: lxc/network_forward.go:355 lxc/network_forward.go:478
-#: lxc/network_forward.go:597 lxc/network_forward.go:674
-#: lxc/network_forward.go:740
+#: lxc/network_forward.go:195 lxc/network_forward.go:259
+#: lxc/network_forward.go:354 lxc/network_forward.go:414
+#: lxc/network_forward.go:537 lxc/network_forward.go:656
+#: lxc/network_forward.go:733 lxc/network_forward.go:799
 msgid "Missing listen address"
 msgstr ""
 
@@ -2518,10 +2522,11 @@ msgstr ""
 #: lxc/network.go:144 lxc/network.go:229 lxc/network.go:376 lxc/network.go:426
 #: lxc/network.go:511 lxc/network.go:616 lxc/network.go:721 lxc/network.go:779
 #: lxc/network.go:953 lxc/network.go:1021 lxc/network.go:1076
-#: lxc/network.go:1143 lxc/network_forward.go:112 lxc/network_forward.go:187
-#: lxc/network_forward.go:251 lxc/network_forward.go:351
-#: lxc/network_forward.go:474 lxc/network_forward.go:593
-#: lxc/network_forward.go:670 lxc/network_forward.go:736
+#: lxc/network.go:1143 lxc/network_forward.go:116 lxc/network_forward.go:191
+#: lxc/network_forward.go:255 lxc/network_forward.go:350
+#: lxc/network_forward.go:410 lxc/network_forward.go:533
+#: lxc/network_forward.go:652 lxc/network_forward.go:729
+#: lxc/network_forward.go:795
 msgid "Missing network name"
 msgstr ""
 
@@ -2714,12 +2719,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: lxc/network_forward.go:307
+#: lxc/network_forward.go:311
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:614
+#: lxc/network_forward.go:673
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/network_forward.go:143
+#: lxc/network_forward.go:147
 msgid "PORTS"
 msgstr ""
 
@@ -2903,7 +2908,7 @@ msgstr ""
 #: lxc/cluster.go:530 lxc/config.go:259 lxc/config.go:332
 #: lxc/config_metadata.go:146 lxc/config_template.go:206
 #: lxc/config_trust.go:255 lxc/image.go:435 lxc/network.go:667
-#: lxc/network_acl.go:532 lxc/network_forward.go:537 lxc/profile.go:502
+#: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/profile.go:502
 #: lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:958
 #: lxc/storage_volume.go:988
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -3153,7 +3158,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:712
+#: lxc/network_forward.go:771
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -3165,7 +3170,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/network_forward.go:710 lxc/network_forward.go:711
+#: lxc/network_forward.go:769 lxc/network_forward.go:770
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -3434,11 +3439,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:322
+#: lxc/network_forward.go:381
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:323
+#: lxc/network_forward.go:382
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -3575,7 +3580,7 @@ msgstr ""
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/network_forward.go:162 lxc/network_forward.go:163
+#: lxc/network_forward.go:166 lxc/network_forward.go:167
 msgid "Show network forward configurations"
 msgstr ""
 
@@ -4058,11 +4063,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:400
+#: lxc/network_forward.go:459
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:401
+#: lxc/network_forward.go:460
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -4407,7 +4412,7 @@ msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
 #: lxc/network.go:349 lxc/network.go:570 lxc/network.go:751 lxc/network.go:926
-#: lxc/network.go:1115 lxc/network_forward.go:80
+#: lxc/network.go:1115 lxc/network_forward.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -4427,30 +4432,30 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:161 lxc/network_forward.go:426
-#: lxc/network_forward.go:566
+#: lxc/network_forward.go:165 lxc/network_forward.go:485
+#: lxc/network_forward.go:625
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: lxc/network_forward.go:399
+#: lxc/network_forward.go:325 lxc/network_forward.go:458
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:321
+#: lxc/network_forward.go:380
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:644
+#: lxc/network_forward.go:703
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:709
+#: lxc/network_forward.go:768
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:225
+#: lxc/network_forward.go:229
 msgid "[<remote>:]<network> <listen_address> [key=value...]"
 msgstr ""
 


### PR DESCRIPTION
This got missed in the original implementation.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>