### PR TITLE
Util: ListenAddresses improvements

### DIFF
--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -246,22 +246,15 @@ func ListenAddresses(configListenAddress string) ([]string, error) {
 					continue
 				}
 
-				if ip.To4() == nil {
-					if localHost == "0.0.0.0" {
-						continue
-					}
-					addresses = append(addresses, fmt.Sprintf("[%s]:%s", ip, localPort))
-				} else {
-					addresses = append(addresses, fmt.Sprintf("%s:%s", ip, localPort))
+				if ip.To4() == nil && localHost == "0.0.0.0" {
+					continue
 				}
+
+				addresses = append(addresses, net.JoinHostPort(ip.String(), localPort))
 			}
 		}
 	} else {
-		if strings.Contains(localHost, ":") {
-			addresses = append(addresses, fmt.Sprintf("[%s]:%s", localHost, localPort))
-		} else {
-			addresses = append(addresses, fmt.Sprintf("%s:%s", localHost, localPort))
-		}
+		addresses = append(addresses, net.JoinHostPort(localHost, localPort))
 	}
 
 	return addresses, nil

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -208,16 +208,16 @@ func IsRecursionRequest(r *http.Request) bool {
 // listen address specified. Otherwise if an empty host or wildcard address is specified then all global unicast
 // addresses actively configured on the host are returned. If an IPv4 wildcard address (0.0.0.0) is specified as
 // the host then only IPv4 addresses configured on the host are returned.
-func ListenAddresses(value string) ([]string, error) {
+func ListenAddresses(configListenAddress string) ([]string, error) {
 	addresses := make([]string, 0)
 
-	if value == "" {
+	if configListenAddress == "" {
 		return addresses, nil
 	}
 
-	localHost, localPort, err := net.SplitHostPort(value)
+	localHost, localPort, err := net.SplitHostPort(configListenAddress)
 	if err != nil {
-		localHost = value
+		localHost = configListenAddress
 		localPort = fmt.Sprintf("%d", shared.HTTPSDefaultPort)
 	}
 

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -201,8 +201,13 @@ func IsRecursionRequest(r *http.Request) bool {
 	return recursion != 0
 }
 
-// ListenAddresses returns a list of host:port combinations at which
-// this machine can be reached
+// ListenAddresses returns a list of <host>:<port> combinations at which this machine can be reached.
+// It accepts the configured listen address in the following formats: <host>, <host>:<port> or :<port>.
+// If a listen port is not specified then then shared.HTTPSDefaultPort is used instead.
+// If a non-empty and non-wildcard host is passed in then this functions returns a single element list with the
+// listen address specified. Otherwise if an empty host or wildcard address is specified then all global unicast
+// addresses actively configured on the host are returned. If an IPv4 wildcard address (0.0.0.0) is specified as
+// the host then only IPv4 addresses configured on the host are returned.
 func ListenAddresses(value string) ([]string, error) {
 	addresses := make([]string, 0)
 

--- a/lxd/util/http_test.go
+++ b/lxd/util/http_test.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"fmt"
+)
+
+func ExampleListenAddresses() {
+	listenAddressConfigs := []string{
+		"",
+		"127.0.0.1:8000",           // Valid IPv4 address with port.
+		"127.0.0.1",                // Valid IPv4 address without port.
+		"[127.0.0.1]",              // Valid wrapped IPv4 address without port.
+		"[::1]:8000",               // Valid IPv6 address with port.
+		"::1:8000",                 // Valid IPv6 address without port (that might look like a port).
+		"::1",                      // Valid IPv6 address without port.
+		"[::1]",                    // Valid wrapped IPv6 address without port.
+		"linuxcontainers.org",      // Valid hostname without port.
+		"linuxcontainers.org:8000", // Valid hostname with port.
+		"foo:8000:9000",            // Invalid host and port combination.
+		":::8000",                  // Invalid host and port combination.
+	}
+
+	for _, listlistenAddressConfig := range listenAddressConfigs {
+		listenAddress, err := ListenAddresses(listlistenAddressConfig)
+		fmt.Printf("%q: %v %v\n", listlistenAddressConfig, listenAddress, err)
+	}
+
+	// Output: "": [] <nil>
+	// "127.0.0.1:8000": [127.0.0.1:8000] <nil>
+	// "127.0.0.1": [127.0.0.1:8443] <nil>
+	// "[127.0.0.1]": [127.0.0.1:8443] <nil>
+	// "[::1]:8000": [[::1]:8000] <nil>
+	// "::1:8000": [[::1:8000]:8443] <nil>
+	// "::1": [[::1]:8443] <nil>
+	// "[::1]": [[::1]:8443] <nil>
+	// "linuxcontainers.org": [linuxcontainers.org:8443] <nil>
+	// "linuxcontainers.org:8000": [linuxcontainers.org:8000] <nil>
+	// "foo:8000:9000": [] address foo:8000:9000: too many colons in address
+	// ":::8000": [] address :::8000: too many colons in address
+}


### PR DESCRIPTION
In reviewing https://github.com/lxc/lxd/pull/9292 I needed to figure out what `ListenAddresses` was supposed to do, so I thought I would document it for future readers and add (limited) tests for its functionality.

I also slightly simplified it.