### PR TITLE
lxd: Remove public facing errors that mention cluster "node"

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2362,17 +2362,17 @@ func evacuateClusterMember(d *Daemon, r *http.Request) response.Response {
 		// Get the node.
 		node, err = tx.GetNodeByName(nodeName)
 		if err != nil {
-			return errors.Wrap(err, "Failed to get node by name")
+			return errors.Wrap(err, "Failed to get cluster member by name")
 		}
 
 		if node.State == db.ClusterMemberStatePending {
-			return fmt.Errorf("Cannot evacuate or restore a pending node")
+			return fmt.Errorf("Cannot evacuate or restore a pending cluster member")
 		}
 
 		// Set node status to EVACUATED to prevent instances from being created.
 		err = tx.UpdateNodeStatus(node.ID, db.ClusterMemberStateEvacuated)
 		if err != nil {
-			return errors.Wrap(err, "Failed to update node status")
+			return errors.Wrap(err, "Failed to update cluster member status")
 		}
 
 		return nil
@@ -2383,7 +2383,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request) response.Response {
 
 	// Do nothing if the node is already evacuated.
 	if node.State == db.ClusterMemberStateEvacuated {
-		return response.SmartError(fmt.Errorf("Node is already evacuated"))
+		return response.SmartError(fmt.Errorf("Cluster member is already evacuated"))
 	}
 
 	reverter := revert.New()
@@ -2544,7 +2544,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 		// Get the node.
 		node, err = tx.GetNodeByName(originName)
 		if err != nil {
-			return errors.Wrap(err, "Failed to get node by name")
+			return errors.Wrap(err, "Failed to get cluster member by name")
 		}
 
 		return nil
@@ -2554,11 +2554,11 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if node.State == db.ClusterMemberStatePending {
-		return response.SmartError(fmt.Errorf("Cannot restore or restore a pending node"))
+		return response.SmartError(fmt.Errorf("Cannot restore or restore a pending cluster member"))
 	}
 
 	if node.State == db.ClusterMemberStateCreated {
-		return response.SmartError(fmt.Errorf("Node is not evacuated"))
+		return response.SmartError(fmt.Errorf("Cluster member not evacuated"))
 	}
 
 	var dbInstances []db.Instance
@@ -2744,7 +2744,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 		err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
 			err = tx.UpdateNodeStatus(node.ID, db.ClusterMemberStateCreated)
 			if err != nil {
-				return errors.Wrap(err, "Failed to update node status")
+				return errors.Wrap(err, "Failed to update cluster member status")
 			}
 
 			return nil

--- a/lxd/instance_state.go
+++ b/lxd/instance_state.go
@@ -143,7 +143,7 @@ func instanceStatePut(d *Daemon, r *http.Request) response.Response {
 
 	// Check if the cluster member is evacuated.
 	if d.cluster.LocalNodeIsEvacuated() {
-		return response.Forbidden(fmt.Errorf("Node is evacuated"))
+		return response.Forbidden(fmt.Errorf("Cluster member is evacuated"))
 	}
 
 	req := api.InstanceStatePut{}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -37,7 +37,7 @@ import (
 
 func createFromImage(d *Daemon, r *http.Request, projectName string, req *api.InstancesPost) response.Response {
 	if d.cluster.LocalNodeIsEvacuated() {
-		return response.Forbidden(fmt.Errorf("Node is evacuated"))
+		return response.Forbidden(fmt.Errorf("Cluster member is evacuated"))
 	}
 
 	hash, err := instance.ResolveImage(d.State(), projectName, req.Source)
@@ -148,7 +148,7 @@ func createFromImage(d *Daemon, r *http.Request, projectName string, req *api.In
 
 func createFromNone(d *Daemon, r *http.Request, projectName string, req *api.InstancesPost) response.Response {
 	if d.cluster.LocalNodeIsEvacuated() {
-		return response.Forbidden(fmt.Errorf("Node is evacuated"))
+		return response.Forbidden(fmt.Errorf("Cluster member is evacuated"))
 	}
 
 	dbType, err := instancetype.New(string(req.Type))
@@ -197,7 +197,7 @@ func createFromNone(d *Daemon, r *http.Request, projectName string, req *api.Ins
 
 func createFromMigration(d *Daemon, r *http.Request, projectName string, req *api.InstancesPost) response.Response {
 	if d.cluster.LocalNodeIsEvacuated() && r.Context().Value(request.CtxProtocol) != "cluster" {
-		return response.Forbidden(fmt.Errorf("Node is evacuated"))
+		return response.Forbidden(fmt.Errorf("Cluster member is evacuated"))
 	}
 
 	// Validate migration mode.
@@ -411,7 +411,7 @@ func createFromMigration(d *Daemon, r *http.Request, projectName string, req *ap
 
 func createFromCopy(d *Daemon, r *http.Request, projectName string, req *api.InstancesPost) response.Response {
 	if d.cluster.LocalNodeIsEvacuated() {
-		return response.Forbidden(fmt.Errorf("Node is evacuated"))
+		return response.Forbidden(fmt.Errorf("Cluster member is evacuated"))
 	}
 
 	if req.Source.Source == "" {


### PR DESCRIPTION
We use "cluster member" rather than "node" for public facing terminology.

I spotted this whilst watching the demo video https://discuss.linuxcontainers.org/t/lxd-4-17-has-been-released/11812/3?u=tomp

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>