### PR TITLE
Fix clustering_remove_leader calling dqlite twice

### DIFF
--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2118,6 +2118,9 @@ test_clustering_handover() {
   # Shutdown the first node.
   LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
 
+  # Wait some time to possibly allow for a leadership change.
+  sleep 10
+
   # The fourth node has been promoted, while the first one demoted.
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list
   LXD_DIR="${LXD_THREE_DIR}" lxc cluster list


### PR DESCRIPTION
Closes #9284

This issue seems to be mostly limited to the test `clustering_remove_leader` which ensures a 2-node cluster will remain functional if the leader is dropped.

Seems the biggest issue was that I was running `changeMemberRole` twice, once on the leader and once on the remaining node. There was a slight race condition where whichever node got to that function first would update the remaining node to `voter`, before that one managed to send off a request too, but other times both would send a request, which caused dqlite to freak out.

To fix it, I just moved the `changeMemberRole` block down past the forward-to-leader block. Now, if a non-leader role is asked to drop the leader in a 2-node cluster, it will forward the whole request to the leader, as opposed to changing its raft role and then forwarding the request.