### PR TITLE
lxd/instance/drivers: Don't return error if device is in use

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1643,6 +1643,11 @@ func (d *lxc) deviceStop(deviceName string, rawConfig deviceConfig.Device, insta
 		// Run post stop hooks irrespective of run state of instance.
 		err = d.runHooks(runConf.PostHooks)
 		if err != nil {
+			if errors.Is(err, storageDrivers.ErrInUse) {
+				logger.Debug("Unable to stop device as it is in use")
+				return nil
+			}
+
 			return err
 		}
 	}


### PR DESCRIPTION
Instead of returning a misleading error if a device is in use, a debug
log message should be printed.

This issue was reported in https://discuss.linuxcontainers.org/t/lxd-eror-message-failed-to-stop-device/12247.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
