### PR TITLE
Daemon: Makes /internal/shutdown synchronous

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -695,7 +695,7 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		case "candid.api.url":
 			candidChanged = true
 		case "cluster.images_minimal_replica":
-			autoSyncImages(d.ctx, d)
+			autoSyncImages(d.shutdownCtx, d)
 		case "cluster.offline_threshold":
 			d.gateway.HeartbeatOfflineThreshold = clusterConfig.OfflineThreshold()
 			d.taskClusterHeartbeat.Reset()

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -689,7 +689,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		}
 
 		// Ensure all images are available after this node has joined.
-		err = autoSyncImages(d.ctx, d)
+		err = autoSyncImages(d.shutdownCtx, d)
 		if err != nil {
 			logger.Warn("Failed to sync images")
 		}
@@ -1595,7 +1595,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 
 	logger.Debugf("Deleting member %s from cluster (force=%d)", name, force)
 
-	err = autoSyncImages(d.ctx, d)
+	err = autoSyncImages(d.shutdownCtx, d)
 	if err != nil {
 		if force == 0 {
 			return response.SmartError(errors.Wrap(err, "Failed to sync images"))
@@ -1694,7 +1694,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 	updateCertificateCache(d)
 
 	// Ensure all images are available after this node has been deleted.
-	err = autoSyncImages(d.ctx, d)
+	err = autoSyncImages(d.shutdownCtx, d)
 	if err != nil {
 		logger.Warn("Failed to sync images")
 	}

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -204,7 +204,7 @@ func internalOptimizeImage(d *Daemon, r *http.Request) response.Response {
 }
 
 func internalRefreshImage(d *Daemon, r *http.Request) response.Response {
-	err := autoUpdateImages(d.ctx, d)
+	err := autoUpdateImages(d.shutdownCtx, d)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -240,6 +240,8 @@ func internalShutdown(d *Daemon, r *http.Request) response.Response {
 		d.shutdownChan <- struct{}{}
 	}
 
+	<-d.shutdownDoneCtx.Done()
+
 	return response.EmptySyncResponse
 }
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -67,17 +67,14 @@ import (
 
 // A Daemon can respond to requests from a shared client.
 type Daemon struct {
-	clientCerts  *certificateCache
-	os           *sys.OS
-	db           *db.Node
-	firewall     firewall.Firewall
-	maas         *maas.Controller
-	bgp          *bgp.Server
-	rbac         *rbac.Server
-	cluster      *db.Cluster
-	setupChan    chan struct{} // Closed when basic Daemon setup is completed
-	readyChan    chan struct{} // Closed when LXD is fully ready
-	shutdownChan chan struct{}
+	clientCerts *certificateCache
+	os          *sys.OS
+	db          *db.Node
+	firewall    firewall.Firewall
+	maas        *maas.Controller
+	bgp         *bgp.Server
+	rbac        *rbac.Server
+	cluster     *db.Cluster
 
 	// Event servers
 	devlxdEvents *events.Server
@@ -115,8 +112,14 @@ type Daemon struct {
 	serverCert    func() *shared.CertInfo
 	serverCertInt *shared.CertInfo // Do not use this directly, use servertCert func.
 
-	ctx    context.Context
-	cancel context.CancelFunc
+	// Status control.
+	setupChan          chan struct{}      // Closed when basic Daemon setup is completed
+	readyChan          chan struct{}      // Closed when LXD is fully ready
+	shutdownChan       chan struct{}      // Shutdown requests arrive here
+	shutdownCtx        context.Context    // Closed when shutdown starts.
+	shutdownCancel     context.CancelFunc // Closes the shutdownCtx to indicate shutdown starting.
+	shutdownDoneCtx    context.Context    // Closed when shutdown completes
+	shutdownDoneCancel context.CancelFunc // Closes the shutdownDoneCtx to indicate shutdown has finished.
 
 	// Stores the time the metrics were last fetched. This will be used to prevent stressing the instances too much.
 	metricsLastBuildTime time.Time
@@ -175,19 +178,22 @@ func (m *IdentityClientWrapper) DeclaredIdentity(ctx context.Context, declared m
 func newDaemon(config *DaemonConfig, os *sys.OS) *Daemon {
 	lxdEvents := events.NewServer(daemon.Debug, daemon.Verbose)
 	devlxdEvents := events.NewServer(daemon.Debug, daemon.Verbose)
-	ctx, cancel := context.WithCancel(context.Background())
+	shutdownDoneCtx, shutdownDoneCancel := context.WithCancel(context.Background())
+	shutdownCtx, shutdownCancel := context.WithCancel(shutdownDoneCtx)
 
 	d := &Daemon{
-		clientCerts:  &certificateCache{},
-		config:       config,
-		devlxdEvents: devlxdEvents,
-		events:       lxdEvents,
-		os:           os,
-		setupChan:    make(chan struct{}),
-		readyChan:    make(chan struct{}),
-		shutdownChan: make(chan struct{}),
-		ctx:          ctx,
-		cancel:       cancel,
+		clientCerts:        &certificateCache{},
+		config:             config,
+		devlxdEvents:       devlxdEvents,
+		events:             lxdEvents,
+		os:                 os,
+		setupChan:          make(chan struct{}),
+		readyChan:          make(chan struct{}),
+		shutdownChan:       make(chan struct{}),
+		shutdownCtx:        shutdownCtx,
+		shutdownCancel:     shutdownCancel,
+		shutdownDoneCtx:    shutdownDoneCtx,
+		shutdownDoneCancel: shutdownDoneCancel,
 	}
 
 	d.serverCert = func() *shared.CertInfo { return d.serverCertInt }
@@ -429,7 +435,7 @@ func (d *Daemon) State() *state.State {
 	}
 
 	return &state.State{
-		Context:                d.ctx,
+		Context:                d.shutdownCtx,
 		Node:                   d.db,
 		Cluster:                d.cluster,
 		MAAS:                   d.maas,
@@ -631,7 +637,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 			return false
 		}
 
-		if d.ctx.Err() == context.Canceled && !allowedDuringShutdown() {
+		if d.shutdownCtx.Err() == context.Canceled && !allowedDuringShutdown() {
 			response.Unavailable(fmt.Errorf("LXD is shutting down")).Render(w)
 			return
 		}
@@ -1098,7 +1104,7 @@ func (d *Daemon) init() error {
 			taskFunc, taskSchedule := cluster.HeartbeatTask(d.gateway)
 			hbGroup := task.Group{}
 			d.taskClusterHeartbeat = hbGroup.Add(taskFunc, taskSchedule)
-			hbGroup.Start(d.ctx)
+			hbGroup.Start(d.shutdownCtx)
 			d.gateway.WaitUpgradeNotification()
 			hbGroup.Stop(time.Second)
 			d.gateway.Cluster = nil
@@ -1370,7 +1376,7 @@ func (d *Daemon) startClusterTasks() {
 	d.clusterTasks.Add(autoSyncImagesTask(d))
 
 	// Start all background tasks
-	d.clusterTasks.Start(d.ctx)
+	d.clusterTasks.Start(d.shutdownCtx)
 }
 
 func (d *Daemon) stopClusterTasks() {
@@ -1428,7 +1434,7 @@ func (d *Daemon) Ready() error {
 	}
 
 	// Start all background tasks
-	d.tasks.Start(d.ctx)
+	d.tasks.Start(d.shutdownCtx)
 
 	// Get daemon state struct
 	s := d.State()

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3648,7 +3648,7 @@ func imageRefresh(d *Daemon, r *http.Request) response.Response {
 
 	// Begin background operation
 	run := func(op *operations.Operation) error {
-		_, err := autoUpdateImage(d.ctx, d, op, imageId, imageInfo, projectName, true)
+		_, err := autoUpdateImage(d.shutdownCtx, d, op, imageId, imageInfo, projectName, true)
 		return err
 	}
 

--- a/lxd/main_daemon.go
+++ b/lxd/main_daemon.go
@@ -85,7 +85,7 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 
 	stop := func(sig os.Signal) {
 		// Cancelling the context will make everyone aware that we're shutting down.
-		d.cancel()
+		d.shutdownCancel()
 
 		// Handle shutdown (unix.SIGPWR) and reload (unix.SIGTERM) signals.
 		if sig == unix.SIGPWR || sig == unix.SIGTERM {

--- a/lxd/main_daemon.go
+++ b/lxd/main_daemon.go
@@ -65,6 +65,7 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 	conf.Group = c.flagGroup
 	conf.Trace = c.global.flagLogTrace
 	d := newDaemon(conf, sys.DefaultOS())
+	defer d.shutdownDoneCancel()
 
 	err := d.Init()
 	if err != nil {


### PR DESCRIPTION
This helps to ensure that `lxd shutdown` doesn't exit until the LXD daemon process has finished, even if the server has lost access to the cluster database. Before this the `lxd shutdown` command tried to request access to the events API to wait until the LXD process finished, however when the cluster database wasn't available the events API request was failing, causing the `lxd shutdown` command think the LXD daemon process had finished and was exiting early.