### PR TITLE
Cluster: Fix cluster member remove tests

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -713,6 +713,8 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 
 // Disable clustering on a node.
 func clusterPutDisable(d *Daemon, r *http.Request, req api.ClusterPut) response.Response {
+	logger.Info("Disabling clustering on local member")
+
 	// Close the cluster database
 	err := d.cluster.Close()
 	if err != nil {

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -439,3 +439,20 @@ func (r *forwardedResponse) Render(w http.ResponseWriter) error {
 func (r *forwardedResponse) String() string {
 	return fmt.Sprintf("request to %s", r.request.URL)
 }
+
+type manualResponse struct {
+	hook func(w http.ResponseWriter) error
+}
+
+// ManualResponse creates a new manual response responder.
+func ManualResponse(hook func(w http.ResponseWriter) error) Response {
+	return &manualResponse{hook: hook}
+}
+
+func (r *manualResponse) Render(w http.ResponseWriter) error {
+	return r.hook(w)
+}
+
+func (r *manualResponse) String() string {
+	return "unknown"
+}

--- a/test/includes/clustering.sh
+++ b/test/includes/clustering.sh
@@ -103,7 +103,9 @@ teardown_clustering_netns() {
       echo "==> Teardown clustering netns ${ns}"
 
       veth1="v${ns}1"
-      ip link del "${veth1}"
+      if [ -e "/sys/class/net/${veth1}" ]; then
+        ip link del "${veth1}"
+      fi
 
       pid="$(cat "${TEST_DIR}/ns/${ns}/PID")"
       kill -9 "${pid}"

--- a/test/includes/lxd.sh
+++ b/test/includes/lxd.sh
@@ -128,7 +128,7 @@ kill_lxd() {
     daemon_pid=$(cat "${daemon_dir}/lxd.pid")
     check_leftovers="false"
     lxd_backend=$(storage_backend "$daemon_dir")
-    echo "==> Killing LXD at ${daemon_dir}"
+    echo "==> Killing LXD at ${daemon_dir} (${daemon_pid})"
 
     if [ -e "${daemon_dir}/unix.socket" ]; then
         # Delete all containers
@@ -256,7 +256,7 @@ shutdown_lxd() {
     # shellcheck disable=2034
     LXD_DIR=${daemon_dir}
     daemon_pid=$(cat "${daemon_dir}/lxd.pid")
-    echo "==> Killing LXD at ${daemon_dir}"
+    echo "==> Killing LXD at ${daemon_dir} (${daemon_pid})"
 
     # Kill the daemon
     lxd shutdown || kill -9 "${daemon_pid}" 2>/dev/null || true

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -3004,7 +3004,7 @@ test_clustering_remove_leader() {
   LXD_DIR="${LXD_TWO_DIR}" lxc info --target node1 | grep -q "server_name: node1"
 
   # Remove the leader, via the stand-by node
-  LXD_DIR="${LXD_TWO_DIR}" lxc cluster rm node1 || true
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster rm node1
 
   # Ensure the remaining node is working
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list | grep -qv "node1"

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -3025,9 +3025,18 @@ test_clustering_remove_leader() {
   LXD_DIR="${LXD_THREE_DIR}" lxc info --target node2 | grep -q "server_name: node2"
 
   # Clean up
+  daemon_pid1=$(cat "${LXD_ONE_DIR}/lxd.pid")
   shutdown_lxd "${LXD_ONE_DIR}"
+
+  daemon_pid2=$(cat "${LXD_TWO_DIR}/lxd.pid")
   shutdown_lxd "${LXD_TWO_DIR}"
+
+  daemon_pid3=$(cat "${LXD_THREE_DIR}/lxd.pid")
   shutdown_lxd "${LXD_THREE_DIR}"
+
+  wait "${daemon_pid1}"
+  wait "${daemon_pid2}"
+  wait "${daemon_pid3}"
 
   rm -f "${LXD_ONE_DIR}/unix.socket"
   rm -f "${LXD_TWO_DIR}/unix.socket"


### PR DESCRIPTION
Switches to post response hook to replace LXD process after removing a cluster member rather than use a go routine and 3s sleep.

This was causing problems as it was leaving LXD processes around after the test had run due to races in the clean up process.