### PR TITLE
Storage: Don't log an error when unmount of custom volume is skipped due to being in use by another instance

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -831,7 +831,7 @@ func (d *disk) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 			}
 
 			err := d.applyQuota(false)
-			if err == storageDrivers.ErrInUse {
+			if errors.Is(err, storageDrivers.ErrInUse) {
 				// Save volatile apply_quota key for next boot if cannot apply now.
 				err = d.volatileSet(map[string]string{"apply_quota": "true"})
 				if err != nil {

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1466,7 +1466,7 @@ func (d *disk) postStop() error {
 		}
 
 		_, err = pool.UnmountCustomVolume(storageProjectName, d.config["source"], nil)
-		if err != nil {
+		if err != nil && !errors.Is(err, storageDrivers.ErrInUse) {
 			return err
 		}
 	}

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -826,7 +826,12 @@ func (d *btrfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Oper
 	unlock := vol.MountLock()
 	defer unlock()
 
-	vol.MountRefCountDecrement()
+	refCount := vol.MountRefCountDecrement()
+	if refCount > 0 {
+		d.logger.Debug("Skipping unmount as in use", "refCount", refCount)
+		return false, ErrInUse
+	}
+
 	return false, nil
 }
 

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -828,7 +828,7 @@ func (d *btrfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Oper
 
 	refCount := vol.MountRefCountDecrement()
 	if refCount > 0 {
-		d.logger.Debug("Skipping unmount as in use", "refCount", refCount)
+		d.logger.Debug("Skipping unmount as in use", log.Ctx{"volName": vol.name, "refCount": refCount})
 		return false, ErrInUse
 	}
 

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -1140,7 +1140,7 @@ func (d *ceph) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Opera
 		mountPath := vol.MountPath()
 		if filesystem.IsMountPoint(mountPath) {
 			if refCount > 0 {
-				d.logger.Debug("Skipping unmount as in use", "refCount", refCount)
+				d.logger.Debug("Skipping unmount as in use", log.Ctx{"volName": vol.name, "refCount": refCount})
 				return false, ErrInUse
 			}
 
@@ -1148,7 +1148,7 @@ func (d *ceph) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Opera
 			if err != nil {
 				return false, err
 			}
-			d.logger.Debug("Unmounted RBD volume", log.Ctx{"path": mountPath, "keepBlockDev": keepBlockDev})
+			d.logger.Debug("Unmounted RBD volume", log.Ctx{"volName": vol.name, "path": mountPath, "keepBlockDev": keepBlockDev})
 
 			// Attempt to unmap.
 			if !keepBlockDev {
@@ -1175,7 +1175,7 @@ func (d *ceph) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Opera
 			_, devPath, _ := d.getRBDMappedDevPath(vol, false)
 			if devPath != "" && shared.PathExists(devPath) {
 				if refCount > 0 {
-					d.logger.Debug("Skipping unmount as in use", "refCount", refCount)
+					d.logger.Debug("Skipping unmount as in use", log.Ctx{"volName": vol.name, "refCount": refCount})
 					return false, ErrInUse
 				}
 

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/instancewriter"
 	"github.com/lxc/lxd/shared/ioprogress"
+	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/units"
 )
 
@@ -365,7 +366,7 @@ func (d *cephfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Ope
 
 	refCount := vol.MountRefCountDecrement()
 	if refCount > 0 {
-		d.logger.Debug("Skipping unmount as in use", "refCount", refCount)
+		d.logger.Debug("Skipping unmount as in use", log.Ctx{"volName": vol.name, "refCount": refCount})
 		return false, ErrInUse
 	}
 

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lxc/lxd/lxd/storage/quota"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/instancewriter"
+	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/units"
 )
 
@@ -352,7 +353,7 @@ func (d *dir) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 
 	refCount := vol.MountRefCountDecrement()
 	if refCount > 0 {
-		d.logger.Debug("Skipping unmount as in use", "refCount", refCount)
+		d.logger.Debug("Skipping unmount as in use", log.Ctx{"volName": vol.name, "refCount": refCount})
 		return false, ErrInUse
 	}
 

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -350,7 +350,12 @@ func (d *dir) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 	unlock := vol.MountLock()
 	defer unlock()
 
-	vol.MountRefCountDecrement()
+	refCount := vol.MountRefCountDecrement()
+	if refCount > 0 {
+		d.logger.Debug("Skipping unmount as in use", "refCount", refCount)
+		return false, ErrInUse
+	}
+
 	return false, nil
 }
 

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -654,7 +654,7 @@ func (d *lvm) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 		mountPath := vol.MountPath()
 		if filesystem.IsMountPoint(mountPath) {
 			if refCount > 0 {
-				d.logger.Debug("Skipping unmount as in use", "refCount", refCount)
+				d.logger.Debug("Skipping unmount as in use", log.Ctx{"volName": vol.name, "refCount": refCount})
 				return false, ErrInUse
 			}
 
@@ -662,7 +662,7 @@ func (d *lvm) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 			if err != nil {
 				return false, errors.Wrapf(err, "Failed to unmount LVM logical volume")
 			}
-			d.logger.Debug("Unmounted logical volume", log.Ctx{"path": mountPath, "keepBlockDev": keepBlockDev})
+			d.logger.Debug("Unmounted logical volume", log.Ctx{"volName": vol.name, "path": mountPath, "keepBlockDev": keepBlockDev})
 
 			// We only deactivate filesystem volumes if an unmount was needed to better align with our
 			// unmount return value indicator.
@@ -687,7 +687,7 @@ func (d *lvm) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 
 		if !keepBlockDev && shared.PathExists(volDevPath) {
 			if refCount > 0 {
-				d.logger.Debug("Skipping unmount as in use", "refCount", refCount)
+				d.logger.Debug("Skipping unmount as in use", log.Ctx{"volName": vol.name, "refCount": refCount})
 				return false, ErrInUse
 			}
 

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1233,7 +1233,7 @@ func (d *zfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 		mountPath := vol.MountPath()
 		if filesystem.IsMountPoint(mountPath) {
 			if refCount > 0 {
-				d.logger.Debug("Skipping unmount as in use", "refCount", refCount)
+				d.logger.Debug("Skipping unmount as in use", log.Ctx{"volName": vol.name, "refCount": refCount})
 				return false, ErrInUse
 			}
 
@@ -1243,7 +1243,7 @@ func (d *zfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 				return false, err
 			}
 
-			d.logger.Debug("Unmounted ZFS dataset", log.Ctx{"dev": dataset, "path": mountPath})
+			d.logger.Debug("Unmounted ZFS dataset", log.Ctx{"volName": vol.name, "dev": dataset, "path": mountPath})
 			ourUnmount = true
 		}
 	} else if vol.contentType == ContentTypeBlock {
@@ -1265,7 +1265,7 @@ func (d *zfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 
 			if current == "dev" {
 				if refCount > 0 {
-					d.logger.Debug("Skipping unmount as in use", "refCount", refCount)
+					d.logger.Debug("Skipping unmount as in use", log.Ctx{"volName": vol.name, "refCount": refCount})
 					return false, ErrInUse
 				}
 
@@ -1284,7 +1284,7 @@ func (d *zfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 					}
 
 					if !shared.PathExists(devPath) {
-						d.logger.Debug("Deactivated ZFS volume", log.Ctx{"dev": dataset})
+						d.logger.Debug("Deactivated ZFS volume", log.Ctx{"volName": vol.name, "dev": dataset})
 						break
 					}
 
@@ -1292,7 +1292,7 @@ func (d *zfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 						return false, fmt.Errorf("Failed to deactivate zvol after %v", waitDuration)
 					}
 
-					d.logger.Debug("Waiting for ZFS volume to deactivate", log.Ctx{"dev": dataset})
+					d.logger.Debug("Waiting for ZFS volume to deactivate", log.Ctx{"volName": vol.name, "dev": dataset})
 					time.Sleep(time.Millisecond * time.Duration(500))
 				}
 


### PR DESCRIPTION
Detect the `storageDrivers.ErrInUse` error in the instance `disk` device post stop hook when unmounting a custom volume to avoid logging an error like:

```
EROR[09-29|09:11:32] Failed to stop device                    instanceType=container instance=c1 project=test err="In use" devName=sharedvol
```

Instead let the `disk` device ignore it, and ensure all storage drivers have mount ref counting (even if they don't actually do mount/unmounts, for consistent behaviour across storage drivers).

The storage drivers will then log a debug message:

```
DBUG[09-29|09:39:34] Skipping unmount as in use               pool=default driver=dir volName=test_sharedvol refCount=1
```

This issue was reported in https://discuss.linuxcontainers.org/t/lxd-eror-message-failed-to-stop-device/12247.

A continuation of the work done by @monstermunchkin in https://github.com/lxc/lxd/pull/9299