### PR TITLE
lxd/qemu: Disable large decrementor on ppc64le

### DIFF
--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -18,6 +18,7 @@ gic-version = "max"
 {{end -}}
 {{if eq .architecture "ppc64le" -}}
 type = "pseries"
+cap-large-decr = "off"
 {{end -}}
 {{if eq .architecture "s390x" -}}
 type = "s390-ccw-virtio"


### PR DESCRIPTION
This appears to be required on P9 and compatible with P8.

Closes #9306

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>