### PR TITLE
Cluster: Shutdown improvements

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2056,6 +2056,8 @@ func handoverMemberRole(d *Daemon) error {
 		return nil
 	}
 
+	logger.Info("Handing over cluster member role")
+
 	// Figure out our own cluster address.
 	address, err := node.ClusterAddress(d.db)
 	if err != nil {

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2056,8 +2056,6 @@ func handoverMemberRole(d *Daemon) error {
 		return nil
 	}
 
-	logger.Info("Handing over cluster member role")
-
 	// Figure out our own cluster address.
 	address, err := node.ClusterAddress(d.db)
 	if err != nil {
@@ -2067,6 +2065,8 @@ func handoverMemberRole(d *Daemon) error {
 	post := &internalClusterPostHandoverRequest{
 		Address: address,
 	}
+
+	logCtx := log.Ctx{"address": address}
 
 	// Find the cluster leader.
 findLeader:
@@ -2082,7 +2082,7 @@ findLeader:
 	}
 
 	if leader == address {
-		logger.Info("Transfer leadership")
+		logger.Info("Transferring leadership", logCtx)
 		err := d.gateway.TransferLeadership()
 		if err != nil {
 			return errors.Wrapf(err, "Failed to transfer leadership")
@@ -2090,9 +2090,10 @@ findLeader:
 		goto findLeader
 	}
 
+	logger.Info("Handing over cluster member role", logCtx)
 	client, err := cluster.Connect(leader, d.endpoints.NetworkCert(), d.serverCert(), nil, true)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "Failed handing over cluster member role")
 	}
 
 	_, _, err = client.RawQuery("POST", "/internal/cluster/handover", post, "")

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1613,7 +1613,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	logger.Debugf("Deleting member %s from cluster (force=%d)", name, force)
+	logger.Info("Deleting member from cluster", log.Ctx{"name": name, "force": force})
 
 	err = autoSyncImages(d.shutdownCtx, d)
 	if err != nil {

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1953,7 +1953,7 @@ func internalClusterPostRebalance(d *Daemon, r *http.Request) response.Response 
 // Check if there's a dqlite node whose role should be changed, and post a
 // change role request if so.
 func rebalanceMemberRoles(d *Daemon, r *http.Request) error {
-	if d.clusterMembershipClosing {
+	if d.shutdownCtx.Err() != nil {
 		return nil
 	}
 
@@ -1998,6 +1998,10 @@ again:
 // Check if there are nodes not part of the raft configuration and add them in
 // case.
 func upgradeNodesWithoutRaftRole(d *Daemon) error {
+	if d.shutdownCtx.Err() != nil {
+		return nil
+	}
+
 	var allNodes []db.NodeInfo
 	err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
 		var err error

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -303,6 +303,8 @@ func clusterPut(d *Daemon, r *http.Request) response.Response {
 }
 
 func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) response.Response {
+	logger.Info("Bootstrapping cluster", log.Ctx{"serverName": req.ServerName})
+
 	run := func(op *operations.Operation) error {
 		// Start clustering tasks
 		d.startClusterTasks()
@@ -364,6 +366,8 @@ func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) respons
 }
 
 func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Response {
+	logger.Info("Joining cluster", log.Ctx{"serverName": req.ServerName})
+
 	// Make sure basic pre-conditions are met.
 	if len(req.ClusterCertificate) == 0 {
 		return response.BadRequest(fmt.Errorf("No target cluster member certificate provided"))
@@ -713,7 +717,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 
 // Disable clustering on a node.
 func clusterPutDisable(d *Daemon, r *http.Request, req api.ClusterPut) response.Response {
-	logger.Info("Disabling clustering on local member")
+	logger.Info("Disabling clustering", log.Ctx{"serverName": req.ServerName})
 
 	// Close the cluster database
 	err := d.cluster.Close()

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 
 	"github.com/lxc/lxd/lxd/backup"
 	"github.com/lxc/lxd/lxd/db"
@@ -214,10 +216,7 @@ func internalRefreshImage(d *Daemon, r *http.Request) response.Response {
 
 func internalWaitReady(d *Daemon, r *http.Request) response.Response {
 	// Check that we're not shutting down.
-	var isClosing bool
-	d.clusterMembershipMutex.RLock()
-	isClosing = d.clusterMembershipClosing
-	d.clusterMembershipMutex.RUnlock()
+	isClosing := d.shutdownCtx.Err() != nil
 	if isClosing {
 		return response.Unavailable(fmt.Errorf("LXD daemon is shutting down"))
 	}

--- a/lxd/cluster/heartbeat_test.go
+++ b/lxd/cluster/heartbeat_test.go
@@ -221,9 +221,7 @@ func (f *heartbeatFixture) node() (*state.State, *cluster.Gateway, string) {
 	require.NoError(f.t, state.Cluster.Close())
 	store := gateway.NodeStore()
 	dial := gateway.DialFunc()
-	state.Cluster, err = db.OpenCluster(
-		"db.bin", store, address, "/unused/db/dir", 5*time.Second, nil,
-		driver.WithDialFunc(dial))
+	state.Cluster, err = db.OpenCluster(context.Background(), "db.bin", store, address, "/unused/db/dir", 5*time.Second, nil, driver.WithDialFunc(dial))
 	require.NoError(f.t, err)
 
 	f.gateways[len(f.gateways)] = gateway

--- a/lxd/cluster/membership_test.go
+++ b/lxd/cluster/membership_test.go
@@ -1,6 +1,7 @@
 package cluster_test
 
 import (
+	"context"
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
@@ -279,7 +280,7 @@ func TestJoin(t *testing.T) {
 	targetDialFunc := targetGateway.DialFunc()
 
 	var err error
-	targetState.Cluster, err = db.OpenCluster("db.bin", targetStore, targetAddress, "/unused/db/dir", 10*time.Second, nil, driver.WithDialFunc(targetDialFunc))
+	targetState.Cluster, err = db.OpenCluster(context.Background(), "db.bin", targetStore, targetAddress, "/unused/db/dir", 10*time.Second, nil, driver.WithDialFunc(targetDialFunc))
 	targetState.ServerCert = func() *shared.CertInfo { return targetCert }
 	require.NoError(t, err)
 
@@ -314,7 +315,7 @@ func TestJoin(t *testing.T) {
 	store := gateway.NodeStore()
 	dialFunc := gateway.DialFunc()
 
-	state.Cluster, err = db.OpenCluster("db.bin", store, address, "/unused/db/dir", 5*time.Second, nil, driver.WithDialFunc(dialFunc))
+	state.Cluster, err = db.OpenCluster(context.Background(), "db.bin", store, address, "/unused/db/dir", 5*time.Second, nil, driver.WithDialFunc(dialFunc))
 	require.NoError(t, err)
 
 	f := &membershipFixtures{t: t, state: state}

--- a/lxd/cluster/upgrade_test.go
+++ b/lxd/cluster/upgrade_test.go
@@ -1,6 +1,7 @@
 package cluster_test
 
 import (
+	"context"
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
@@ -153,9 +154,7 @@ func TestUpgradeMembersWithoutRole(t *testing.T) {
 	require.NoError(t, state.Cluster.Close())
 	store := gateway.NodeStore()
 	dial := gateway.DialFunc()
-	state.Cluster, err = db.OpenCluster(
-		"db.bin", store, address, "/unused/db/dir", 5*time.Second, nil,
-		driver.WithDialFunc(dial))
+	state.Cluster, err = db.OpenCluster(context.Background(), "db.bin", store, address, "/unused/db/dir", 5*time.Second, nil, driver.WithDialFunc(dial))
 	require.NoError(t, err)
 	gateway.Cluster = state.Cluster
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1905,7 +1905,6 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat) {
 			if node.RaftID == 0 {
 				hasNodesNotPartOfRaft = true
 			}
-
 		}
 
 		nodeListChanged := d.hasNodeListChanged(heartbeatData)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -725,6 +725,7 @@ func setupSharedMounts() error {
 	return nil
 }
 
+// Init starts daemon process.
 func (d *Daemon) Init() error {
 	d.startTime = time.Now()
 
@@ -734,11 +735,12 @@ func (d *Daemon) Init() error {
 	// cleanup any state we produced so far. Errors happening here will be
 	// ignored.
 	if err != nil {
-		logger.Errorf("Failed to start the daemon: %v", err)
-		d.Stop()
+		logger.Error("Failed to start the daemon", log.Ctx{"err": err})
+		d.Stop(context.Background(), unix.SIGPWR)
+		return err
 	}
 
-	return err
+	return nil
 }
 
 func (d *Daemon) init() error {
@@ -1464,26 +1466,83 @@ func (d *Daemon) numRunningInstances() (int, error) {
 	return count, nil
 }
 
-// Kill signals the daemon that we want to shutdown, and that any work
-// initiated from this point (e.g. database queries over gRPC) should not be
-// retried in case of failure.
-func (d *Daemon) Kill() {
+// Stop stops the shared daemon.
+func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
+	logger.Info("Starting shutdown sequence")
+
+	// Cancelling the context will make everyone aware that we're shutting down.
+	d.shutdownCancel()
+
 	if d.gateway != nil {
-		d.clusterMembershipMutex.Lock()
-		d.clusterMembershipClosing = true
-		d.clusterMembershipMutex.Unlock()
 		err := handoverMemberRole(d)
 		if err != nil {
-			logger.Warnf("Could not handover member's responsibilities: %v", err)
+			logger.Warn("Could not handover member's responsibilities", log.Ctx{"err": err})
+			d.gateway.Kill()
 		}
-		d.gateway.Kill()
-		d.cluster.Kill()
 	}
-}
 
-// Stop stops the shared daemon.
-func (d *Daemon) Stop() error {
-	logger.Info("Starting shutdown sequence")
+	// Handle shutdown (unix.SIGPWR) and reload (unix.SIGTERM) signals.
+	if sig == unix.SIGPWR || sig == unix.SIGTERM {
+		s := d.State()
+
+		// waitForOperations will block until all operations are done, or it's forced to shut down.
+		// For the latter case, we re-use the shutdown channel which is filled when a shutdown is
+		// initiated using `lxd shutdown`.
+		logger.Info("Waiting for operations to finish")
+		waitForOperations(ctx, s)
+
+		// Unmount daemon image and backup volumes if set.
+		logger.Info("Stopping daemon storage volumes")
+		done := make(chan struct{})
+		go func() {
+			err := daemonStorageVolumesUnmount(s)
+			if err != nil {
+				logger.Error("Failed to unmount image and backup volumes", log.Ctx{"err": err})
+			}
+
+			done <- struct{}{}
+		}()
+
+		// Only wait 60 seconds in case the storage backend is unreachable.
+		select {
+		case <-time.After(time.Minute):
+			logger.Error("Timed out waiting for image and backup volume")
+		case <-done:
+		}
+
+		// Full shutdown requested.
+		if sig == unix.SIGPWR {
+			logger.Info("Stopping instances")
+			instancesShutdown(s)
+
+			logger.Info("Stopping networks")
+			networkShutdown(s)
+
+			// Unmount storage pools after instances stopped.
+			logger.Info("Stopping storage pools")
+			pools, err := s.Cluster.GetStoragePoolNames()
+			if err != nil && err != db.ErrNoSuchObject {
+				logger.Error("Failed to get storage pools", log.Ctx{"err": err})
+			}
+
+			for _, poolName := range pools {
+				pool, err := storagePools.GetPoolByName(s, poolName)
+				if err != nil {
+					logger.Error("Failed to get storage pool", log.Ctx{"pool": poolName, "err": err})
+					continue
+				}
+
+				_, err = pool.Unmount()
+				if err != nil {
+					logger.Error("Unable to unmount storage pool", log.Ctx{"pool": poolName, "err": err})
+					continue
+				}
+			}
+		}
+	}
+
+	d.gateway.Kill()
+
 	errs := []error{}
 	trackError := func(err error, desc string) {
 		if err != nil {
@@ -1547,8 +1606,7 @@ func (d *Daemon) Stop() error {
 
 		logger.Infof("Done unmounting temporary filesystems")
 	} else {
-		logger.Debugf(
-			"Not unmounting temporary filesystems (containers are still running)")
+		logger.Debugf("Not unmounting temporary filesystems (containers are still running)")
 	}
 
 	if d.seccomp != nil {
@@ -1566,6 +1624,7 @@ func (d *Daemon) Stop() error {
 	if err != nil {
 		logger.Errorf("Failed to cleanly shutdown daemon: %v", err)
 	}
+
 	return err
 }
 
@@ -1894,9 +1953,6 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat) {
 				time.Sleep(5 * time.Second)
 				d.clusterMembershipMutex.Lock()
 				defer d.clusterMembershipMutex.Unlock()
-				if d.clusterMembershipClosing {
-					return
-				}
 				err := rebalanceMemberRoles(d, nil)
 				if err != nil && errors.Cause(err) != cluster.ErrNotLeader {
 					logger.Warnf("Could not rebalance cluster member roles: %v", err)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1357,6 +1357,8 @@ func (d *Daemon) init() error {
 		return err
 	}
 
+	logger.Info("Daemon started")
+
 	return nil
 }
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1474,6 +1474,8 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 	d.shutdownCancel()
 
 	if d.gateway != nil {
+		d.stopClusterTasks()
+
 		err := handoverMemberRole(d)
 		if err != nil {
 			logger.Warn("Could not handover member's responsibilities", log.Ctx{"err": err})

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1080,10 +1080,7 @@ func (d *Daemon) init() error {
 			options = append(options, driver.WithTracing(dqliteclient.LogDebug))
 		}
 
-		d.cluster, err = db.OpenCluster(
-			"db.bin", store, clusterAddress, dir,
-			d.config.DqliteSetupTimeout, dump, options...,
-		)
+		d.cluster, err = db.OpenCluster(context.Background(), "db.bin", store, clusterAddress, dir, d.config.DqliteSetupTimeout, dump, options...)
 		if err == nil {
 			break
 		}

--- a/lxd/daemon_integration_test.go
+++ b/lxd/daemon_integration_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
 	"testing"
 	"time"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/sys"
@@ -41,7 +44,7 @@ func newTestDaemon(t *testing.T) (*Daemon, func()) {
 	require.NoError(t, daemon.Init())
 
 	cleanup := func() {
-		daemon.Stop()
+		daemon.Stop(context.Background(), unix.SIGQUIT)
 		osCleanup()
 		resetLogger()
 	}

--- a/lxd/db/migration_test.go
+++ b/lxd/db/migration_test.go
@@ -56,9 +56,7 @@ func TestImportPreClusteringData(t *testing.T) {
 		return net.Dial("unix", address)
 	}
 
-	cluster, err := db.OpenCluster(
-		"test.db", store, "1", dir, 5*time.Second, dump,
-		driver.WithDialFunc(dial))
+	cluster, err := db.OpenCluster(context.Background(), "test.db", store, "1", dir, 5*time.Second, dump, driver.WithDialFunc(dial))
 	require.NoError(t, err)
 	defer cluster.Close()
 

--- a/lxd/db/testing.go
+++ b/lxd/db/testing.go
@@ -68,9 +68,7 @@ func NewTestCluster(t *testing.T) (*Cluster, func()) {
 		return net.Dial("unix", address)
 	}
 
-	cluster, err := OpenCluster(
-		"test.db", store, "1", dir, 5*time.Second, nil,
-		driver.WithLogFunc(log), driver.WithDialFunc(dial))
+	cluster, err := OpenCluster(context.Background(), "test.db", store, "1", dir, 5*time.Second, nil, driver.WithLogFunc(log), driver.WithDialFunc(dial))
 	require.NoError(t, err)
 
 	cleanup := func() {

--- a/lxd/devlxd_test.go
+++ b/lxd/devlxd_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -9,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/lxc/lxd/lxd/sys"
 	"github.com/lxc/lxd/lxd/ucred"
@@ -141,7 +144,7 @@ func TestHttpRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer d.Stop()
+	defer d.Stop(context.Background(), unix.SIGQUIT)
 
 	c := http.Client{Transport: &http.Transport{Dial: DevLxdDialer{Path: fmt.Sprintf("%s/devlxd/sock", testDir)}.DevLxdDial}}
 

--- a/lxd/main_test.go
+++ b/lxd/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"github.com/lxc/lxd/lxd/sys"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/sys/unix"
 
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/shared"
@@ -98,7 +100,7 @@ func (suite *lxdTestSuite) SetupTest() {
 }
 
 func (suite *lxdTestSuite) TearDownTest() {
-	err := suite.d.Stop()
+	err := suite.d.Stop(context.Background(), unix.SIGQUIT)
 	if err != nil {
 		suite.T().Errorf("failed to stop daemon: %v", err)
 	}

--- a/test/includes/lxd.sh
+++ b/test/includes/lxd.sh
@@ -47,7 +47,7 @@ spawn_lxd() {
     echo "==> Spawned LXD (PID is ${LXD_PID})"
 
     echo "==> Confirming lxd is responsive"
-    LXD_DIR="${lxddir}" lxd waitready --timeout=300
+    LXD_DIR="${lxddir}" lxd waitready --timeout=300 || (kill -9 "${LXD_PID}" ; false)
 
     if [ "${LXD_NETNS}" = "" ]; then
         echo "==> Binding to network"

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2124,6 +2124,8 @@ test_clustering_handover() {
   # The fourth node has been promoted, while the first one demoted.
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster list
   LXD_DIR="${LXD_THREE_DIR}" lxc cluster list
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster show node4
+  LXD_DIR="${LXD_THREE_DIR}" lxc cluster show node1
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster show node4 | grep -q "\- database$"
   LXD_DIR="${LXD_THREE_DIR}" lxc cluster show node1 | grep -q "database: false"
 

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -82,10 +82,10 @@ test_container_devices_nic_bridged() {
   # Add IP alias to container and check routes actually work.
   lxc exec "${ctName}" -- ip -4 addr add "192.0.2.1${ipRand}/32" dev eth0
   lxc exec "${ctName}" -- ip -4 route add default dev eth0
-  ping -c2 -W1 "192.0.2.1${ipRand}"
+  ping -c2 -W5 "192.0.2.1${ipRand}"
   lxc exec "${ctName}" -- ip -6 addr add "2001:db8::1${ipRand}/128" dev eth0
   sleep 2 # Wait for link local gateway advert.
-  ping6 -c2 -W1 "2001:db8::1${ipRand}"
+  ping6 -c2 -W5 "2001:db8::1${ipRand}"
 
   # Test hot plugging a container nic with different settings to profile with the same name.
   lxc config device add "${ctName}" eth0 nic \

--- a/test/suites/container_devices_nic_bridged_acl.sh
+++ b/test/suites/container_devices_nic_bridged_acl.sh
@@ -130,14 +130,14 @@ test_container_devices_nic_bridged_acl() {
   lxc exec "${ctPrefix}A" -- ip a add 2001:db8::2/64 dev eth0
 
   # Check ICMP to bridge is blocked.
-  ! lxc exec "${ctPrefix}A" -- ping -c1 -4 -W2 192.0.2.1 || false
-  ! lxc exec "${ctPrefix}A" -- ping -c1 -6 -W2 2001:db8::1 || false
+  ! lxc exec "${ctPrefix}A" -- ping -c2 -4 -W5 192.0.2.1 || false
+  ! lxc exec "${ctPrefix}A" -- ping -c2 -6 -W5 2001:db8::1 || false
 
   # Allow ICMP to bridge host.
   lxc network acl rule add "${brName}A" egress action=allow destination=192.0.2.1/32 protocol=icmp4 icmp_type=8
   lxc network acl rule add "${brName}A" egress action=allow destination=2001:db8::1/128 protocol=icmp6 icmp_type=128
-  lxc exec "${ctPrefix}A" -- ping -c1 -4 -W2 192.0.2.1
-  lxc exec "${ctPrefix}A" -- ping -c1 -6 -W2 2001:db8::1
+  lxc exec "${ctPrefix}A" -- ping -c2 -4 -W5 192.0.2.1
+  lxc exec "${ctPrefix}A" -- ping -c2 -6 -W5 2001:db8::1
 
   # Check DNS resolution (and connection tracking in the process).
   lxc exec "${ctPrefix}A" -- nslookup -type=a testhost.test 192.0.2.1
@@ -153,8 +153,8 @@ test_container_devices_nic_bridged_acl() {
   lxc network set "${brName}" security.acls="${brName}A,${brName}B"
 
   # Check egress ICMP ping to bridge is blocked.
-  ! lxc exec "${ctPrefix}A" -- ping -c1 -4 -W2 192.0.2.1 || false
-  ! lxc exec "${ctPrefix}A" -- ping -c1 -6 -W2 2001:db8::1 || false
+  ! lxc exec "${ctPrefix}A" -- ping -c2 -4 -W5 192.0.2.1 || false
+  ! lxc exec "${ctPrefix}A" -- ping -c2 -6 -W5 2001:db8::1 || false
 
   # Check ingress ICMPv4 ping is blocked.
   ! ping -c1 -4 192.0.2.2 || false

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -51,8 +51,8 @@ test_container_devices_nic_bridged_filtering() {
   lxc exec "${ctPrefix}B" -- ip a add 192.0.2.3/24 dev eth0
 
   # Check basic connectivity without any filtering.
-  lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.1
-  lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.3
+  lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1
+  lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.3
 
   # Enable MAC filtering on CT A and test.
   lxc config device set "${ctPrefix}A" eth0 security.mac_filtering true
@@ -90,13 +90,13 @@ test_container_devices_nic_bridged_filtering() {
   lxc exec "${ctPrefix}A" -- ip link set dev eth0 address 00:11:22:33:44:56 up
 
   # Check that ping is no longer working (i.e its filtered after fake MAC setup).
-  if lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.1; then
+  if lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1; then
       echo "MAC filter not working to host"
       false
   fi
 
   # Check that ping is no longer working (i.e its filtered after fake MAC setup).
-  if lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.3; then
+  if lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.3; then
       echo "MAC filter not working to other container"
       false
   fi
@@ -105,8 +105,8 @@ test_container_devices_nic_bridged_filtering() {
   lxc exec "${ctPrefix}A" -- ip link set dev eth0 address "${ctAMAC}" up
 
   # Check basic connectivity with MAC filtering but real MAC configured.
-  lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.1
-  lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.3
+  lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1
+  lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.3
 
   # Stop CT A and check filters are cleaned up.
   lxc stop -f "${ctPrefix}A"
@@ -129,8 +129,8 @@ test_container_devices_nic_bridged_filtering() {
   lxc start "${ctPrefix}A"
   lxc exec "${ctPrefix}A" -- ip link set dev eth0 address "${ctAMAC}" up
   lxc exec "${ctPrefix}A" -- ip a add 192.0.2.254/24 dev eth0
-  lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.1
-  lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.3
+  lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1
+  lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.3
 
   # Enable IPv4 filtering on CT A and test (disable security.mac_filtering to check its applied too).
   lxc config device set "${ctPrefix}A" eth0 ipv4.address 192.0.2.2
@@ -177,21 +177,21 @@ test_container_devices_nic_bridged_filtering() {
   lxc exec "${ctPrefix}A" -- ip a add 192.0.2.2/24 dev eth0
 
   # Check basic connectivity with IPv4 filtering and real IPs configured.
-  lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.1
-  lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.3
+  lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1
+  lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.3
 
   # Add a fake IP
   lxc exec "${ctPrefix}A" -- ip a flush dev eth0
   lxc exec "${ctPrefix}A" -- ip a add 192.0.2.254/24 dev eth0
 
   # Check that ping is no longer working (i.e its filtered after fake IP setup).
-  if lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.1; then
+  if lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1; then
       echo "IPv4 filter not working to host"
       false
   fi
 
   # Check that ping is no longer working (i.e its filtered after fake IP setup).
-  if lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.3; then
+  if lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.3; then
       echo "IPv4 filter not working to other container"
       false
   fi
@@ -265,8 +265,8 @@ test_container_devices_nic_bridged_filtering() {
   lxc exec "${ctPrefix}A" -- ip link set dev eth0 address "${ctAMAC}" up
   lxc exec "${ctPrefix}A" -- ip -6 a add 2001:db8::254 dev eth0
   sleep 2 # Wait for DAD.
-  lxc exec "${ctPrefix}A" -- ping6 -c2 -W1 2001:db8::1
-  lxc exec "${ctPrefix}A" -- ping6 -c2 -W1 2001:db8::3
+  lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8::1
+  lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8::3
 
   # Enable IPv6 filtering on CT A and test (disable security.mac_filtering to check its applied too).
   lxc config device set "${ctPrefix}A" eth0 ipv6.address 2001:db8::2
@@ -356,21 +356,21 @@ test_container_devices_nic_bridged_filtering() {
   sleep 2 # Wait for DAD.
 
   # Check basic connectivity with IPv6 filtering and real IPs configured.
-  lxc exec "${ctPrefix}A" -- ping6 -c2 -W1 2001:db8::2
-  lxc exec "${ctPrefix}A" -- ping6 -c2 -W1 2001:db8::3
+  lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8::2
+  lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8::3
 
   # Add a fake IP
   lxc exec "${ctPrefix}A" -- ip -6 a flush dev eth0
   lxc exec "${ctPrefix}A" -- ip -6 a add 2001:db8::254/64 dev eth0
 
   # Check that ping is no longer working (i.e its filtered after fake IP setup).
-  if lxc exec "${ctPrefix}A" -- ping6 -c2 -W1 2001:db8::2; then
+  if lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8::2; then
       echo "IPv6 filter not working to host"
       false
   fi
 
   # Check that ping is no longer working (i.e its filtered after fake IP setup).
-  if lxc exec "${ctPrefix}A" -- ping6 -c2 -W1 2001:db8::3; then
+  if lxc exec "${ctPrefix}A" -- ping6 -c2 -W5 2001:db8::3; then
       echo "IPv6 filter not working to other container"
       false
   fi
@@ -617,16 +617,16 @@ test_container_devices_nic_bridged_filtering() {
   lxc exec "${ctPrefix}A" -- ip a add 2001:db8::2/64 dev eth0
 
   # Check basic connectivity without any filtering.
-  lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.1
-  lxc exec "${ctPrefix}A" -- ping -c2 -W1 2001:db8::1
+  lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1
+  lxc exec "${ctPrefix}A" -- ping -c2 -W5 2001:db8::1
 
   # Check fraudulent IPs are blocked.
   lxc exec "${ctPrefix}A" -- ip a flush dev eth0
   lxc exec "${ctPrefix}A" -- ip a add 192.0.2.3/24 dev eth0
   lxc exec "${ctPrefix}A" -- ip a add 2001:db8::3/64 dev eth0
 
-  ! lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.1 || false
-  ! lxc exec "${ctPrefix}A" -- ping -c2 -W1 2001:db8::1 || false
+  ! lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1 || false
+  ! lxc exec "${ctPrefix}A" -- ping -c2 -W5 2001:db8::1 || false
 
   lxc delete -f "${ctPrefix}A"
   ip link delete "${brName}2"

--- a/test/suites/container_devices_nic_bridged_vlan.sh
+++ b/test/suites/container_devices_nic_bridged_vlan.sh
@@ -43,8 +43,8 @@ test_container_devices_nic_bridged_vlan() {
   lxc exec "${prefix}-ctB" -- ip link add link eth0 name eth0.2 type vlan id 2
   lxc exec "${prefix}-ctB" -- ip link set eth0.2 up
   lxc exec "${prefix}-ctB" -- ip a add 192.0.2.2/24 dev eth0.2
-  lxc exec "${prefix}-ctA" -- ping -c2 -W1 192.0.2.2
-  lxc exec "${prefix}-ctB" -- ping -c2 -W1 192.0.2.1
+  lxc exec "${prefix}-ctA" -- ping -c2 -W5 192.0.2.2
+  lxc exec "${prefix}-ctB" -- ping -c2 -W5 192.0.2.1
   lxc stop -f "${prefix}-ctA"
 
   # Test tagged VLAN traffic is filtered when IP filtering is enabled.
@@ -54,8 +54,8 @@ test_container_devices_nic_bridged_vlan() {
     lxc exec "${prefix}-ctA" -- ip link add link eth0 name eth0.2 type vlan id 2
     lxc exec "${prefix}-ctA" -- ip link set eth0.2 up
     lxc exec "${prefix}-ctA" -- ip a add 192.0.2.1/24 dev eth0.2
-    ! lxc exec "${prefix}-ctA" -- ping -c2 -W1 192.0.2.2 || false
-    ! lxc exec "${prefix}-ctB" -- ping -c2 -W1 192.0.2.1 || false
+    ! lxc exec "${prefix}-ctA" -- ping -c2 -W5 192.0.2.2 || false
+    ! lxc exec "${prefix}-ctB" -- ping -c2 -W5 192.0.2.1 || false
     lxc stop -f "${prefix}-ctA"
     lxc config device remove "${prefix}-ctA" eth0
   fi
@@ -68,8 +68,8 @@ test_container_devices_nic_bridged_vlan() {
     lxc exec "${prefix}-ctA" -- ip link set eth0.2 up
     lxc exec "${prefix}-ctA" -- ip a add 192.0.2.1/24 dev eth0.2
     lxc exec "${prefix}-ctA" -- ip link set eth0.2 address 00:16:3e:92:f3:c1
-    ! lxc exec "${prefix}-ctA" -- ping -c2 -W1 192.0.2.2 || false
-    ! lxc exec "${prefix}-ctB" -- ping -c2 -W1 192.0.2.1 || false
+    ! lxc exec "${prefix}-ctA" -- ping -c2 -W5 192.0.2.2 || false
+    ! lxc exec "${prefix}-ctB" -- ping -c2 -W5 192.0.2.1 || false
     lxc stop -f "${prefix}-ctA"
     lxc config device remove "${prefix}-ctA" eth0
   fi
@@ -108,10 +108,10 @@ test_container_devices_nic_bridged_vlan() {
   lxc exec "${prefix}-ctB" -- ip link add link eth0 name eth0.3 type vlan id 3
   lxc exec "${prefix}-ctB" -- ip link set eth0.3 up
   lxc exec "${prefix}-ctB" -- ip a add 192.0.3.2/24 dev eth0.3
-  lxc exec "${prefix}-ctA" -- ping -c2 -W1 192.0.2.2
-  lxc exec "${prefix}-ctB" -- ping -c2 -W1 192.0.2.1
-  ! lxc exec "${prefix}-ctA" -- ping -c2 -W1 192.0.3.2 || false
-  ! lxc exec "${prefix}-ctB" -- ping -c2 -W1 192.0.3.1 || false
+  lxc exec "${prefix}-ctA" -- ping -c2 -W5 192.0.2.2
+  lxc exec "${prefix}-ctB" -- ping -c2 -W5 192.0.2.1
+  ! lxc exec "${prefix}-ctA" -- ping -c2 -W5 192.0.3.2 || false
+  ! lxc exec "${prefix}-ctB" -- ping -c2 -W5 192.0.3.1 || false
   lxc stop -f "${prefix}-ctA"
   lxc config device remove "${prefix}-ctA" eth0
   lxc stop -f "${prefix}-ctB"
@@ -136,10 +136,10 @@ test_container_devices_nic_bridged_vlan() {
   lxc exec "${prefix}-ctB" -- ip link add link eth0 name eth0.2 type vlan id 2
   lxc exec "${prefix}-ctB" -- ip link set eth0.2 up
   lxc exec "${prefix}-ctB" -- ip a add 192.0.2.2/24 dev eth0.2
-  lxc exec "${prefix}-ctA" -- ping -c2 -W1 192.0.2.2
-  lxc exec "${prefix}-ctB" -- ping -c2 -W1 192.0.2.1
-  ! lxc exec "${prefix}-ctA" -- ping -c2 -W1 192.0.3.2 || false
-  ! lxc exec "${prefix}-ctB" -- ping -c2 -W1 192.0.3.1 || false
+  lxc exec "${prefix}-ctA" -- ping -c2 -W5 192.0.2.2
+  lxc exec "${prefix}-ctB" -- ping -c2 -W5 192.0.2.1
+  ! lxc exec "${prefix}-ctA" -- ping -c2 -W5 192.0.3.2 || false
+  ! lxc exec "${prefix}-ctB" -- ping -c2 -W5 192.0.3.1 || false
   lxc stop -f "${prefix}-ctA"
   lxc config device remove "${prefix}-ctA" eth0
   lxc stop -f "${prefix}-ctB"
@@ -161,8 +161,8 @@ test_container_devices_nic_bridged_vlan() {
     lxc start "${prefix}-ctB"
     lxc exec "${prefix}-ctB" -- ip link set eth0 up
     lxc exec "${prefix}-ctB" -- ip a add 192.0.2.2/24 dev eth0
-    lxc exec "${prefix}-ctA" -- ping -c2 -W1 192.0.2.2
-    lxc exec "${prefix}-ctB" -- ping -c2 -W1 192.0.2.1
+    lxc exec "${prefix}-ctA" -- ping -c2 -W5 192.0.2.2
+    lxc exec "${prefix}-ctB" -- ping -c2 -W5 192.0.2.1
     lxc stop -f "${prefix}-ctA"
     lxc config device remove "${prefix}-ctA" eth0
     lxc stop -f "${prefix}-ctB"

--- a/test/suites/container_devices_nic_ipvlan.sh
+++ b/test/suites/container_devices_nic_ipvlan.sh
@@ -58,12 +58,12 @@ test_container_devices_nic_ipvlan() {
   lxc start "${ctName}2"
 
   # Check comms between containers.
-  lxc exec "${ctName}" -- ping -c2 -W1 "192.0.2.2${ipRand}"
-  lxc exec "${ctName}" -- ping -c2 -W1 "192.0.2.3${ipRand}"
-  lxc exec "${ctName}" -- ping6 -c2 -W1 "2001:db8::2${ipRand}"
-  lxc exec "${ctName}" -- ping6 -c2 -W1 "2001:db8::3${ipRand}"
-  lxc exec "${ctName}2" -- ping -c2 -W1 "192.0.2.1${ipRand}"
-  lxc exec "${ctName}2" -- ping6 -c2 -W1 "2001:db8::1${ipRand}"
+  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.2${ipRand}"
+  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.3${ipRand}"
+  lxc exec "${ctName}" -- ping6 -c2 -W5 "2001:db8::2${ipRand}"
+  lxc exec "${ctName}" -- ping6 -c2 -W5 "2001:db8::3${ipRand}"
+  lxc exec "${ctName}2" -- ping -c2 -W5 "192.0.2.1${ipRand}"
+  lxc exec "${ctName}2" -- ping6 -c2 -W5 "2001:db8::1${ipRand}"
   lxc stop -f "${ctName}2"
 
   # Check IPVLAN ontop of VLAN parent with custom routing tables.
@@ -132,14 +132,14 @@ test_container_devices_nic_ipvlan() {
   lxc exec "${ctName}2" -- ip -6 addr add "2001:db8::4${ipRand}/128" dev eth0
 
   # Check comms between containers.
-  lxc exec "${ctName}" -- ping -c2 -W1 "192.0.2.3${ipRand}"
-  lxc exec "${ctName}" -- ping -c2 -W1 "192.0.2.4${ipRand}"
-  lxc exec "${ctName}" -- ping6 -c2 -W1 "2001:db8::3${ipRand}"
-  lxc exec "${ctName}" -- ping6 -c2 -W1 "2001:db8::4${ipRand}"
-  lxc exec "${ctName}2" -- ping -c2 -W1 "192.0.2.1${ipRand}"
-  lxc exec "${ctName}2" -- ping -c2 -W1 "192.0.2.2${ipRand}"
-  lxc exec "${ctName}2" -- ping6 -c2 -W1 "2001:db8::1${ipRand}"
-  lxc exec "${ctName}2" -- ping6 -c2 -W1 "2001:db8::2${ipRand}"
+  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.3${ipRand}"
+  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.4${ipRand}"
+  lxc exec "${ctName}" -- ping6 -c2 -W5 "2001:db8::3${ipRand}"
+  lxc exec "${ctName}" -- ping6 -c2 -W5 "2001:db8::4${ipRand}"
+  lxc exec "${ctName}2" -- ping -c2 -W5 "192.0.2.1${ipRand}"
+  lxc exec "${ctName}2" -- ping -c2 -W5 "192.0.2.2${ipRand}"
+  lxc exec "${ctName}2" -- ping6 -c2 -W5 "2001:db8::1${ipRand}"
+  lxc exec "${ctName}2" -- ping6 -c2 -W5 "2001:db8::2${ipRand}"
 
   lxc stop -f "${ctName}"
   lxc stop -f "${ctName}2"

--- a/test/suites/container_devices_nic_macvlan.sh
+++ b/test/suites/container_devices_nic_macvlan.sh
@@ -37,10 +37,10 @@ test_container_devices_nic_macvlan() {
   lxc exec "${ctName}2" -- ip addr add "2001:db8::2${ipRand}/64" dev eth0
 
   # Check comms between containers.
-  lxc exec "${ctName}" -- ping -c2 -W1 "192.0.2.2${ipRand}"
-  lxc exec "${ctName}" -- ping6 -c2 -W1 "2001:db8::2${ipRand}"
-  lxc exec "${ctName}2" -- ping -c2 -W1 "192.0.2.1${ipRand}"
-  lxc exec "${ctName}2" -- ping6 -c2 -W1 "2001:db8::1${ipRand}"
+  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.2${ipRand}"
+  lxc exec "${ctName}" -- ping6 -c2 -W5 "2001:db8::2${ipRand}"
+  lxc exec "${ctName}2" -- ping -c2 -W5 "192.0.2.1${ipRand}"
+  lxc exec "${ctName}2" -- ping6 -c2 -W5 "2001:db8::1${ipRand}"
 
   # Test hot plugging a container nic with different settings to profile with the same name.
   lxc config device add "${ctName}" eth0 nic \
@@ -112,8 +112,8 @@ test_container_devices_nic_macvlan() {
   lxc exec "${ctName}" -- ip addr add "192.0.2.1${ipRand}/24" dev eth0
   lxc exec "${ctName}" -- ip addr add "2001:db8::1${ipRand}/64" dev eth0
   lxc exec "${ctName}" -- ip link set eth0 up
-  lxc exec "${ctName}" -- ping -c2 -W1 "192.0.2.2${ipRand}"
-  lxc exec "${ctName}" -- ping6 -c2 -W1 "2001:db8::2${ipRand}"
+  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.2${ipRand}"
+  lxc exec "${ctName}" -- ping6 -c2 -W5 "2001:db8::2${ipRand}"
   lxc config device remove "${ctName}" eth0
   lxc network delete "${ctName}net"
 

--- a/test/suites/container_devices_nic_p2p.sh
+++ b/test/suites/container_devices_nic_p2p.sh
@@ -65,12 +65,12 @@ test_container_devices_nic_p2p() {
   lxc exec "${ctName}" -- ip -4 addr add "192.0.2.1${ipRand}/32" dev eth0
   lxc exec "${ctName}" -- ip -4 route add default dev eth0
   sleep 1
-  ping -c2 -W1 "192.0.2.1${ipRand}"
+  ping -c2 -W5 "192.0.2.1${ipRand}"
   ip -6 addr add 2001:db8::1/128 dev "${vethHostName}"
   lxc exec "${ctName}" -- ip -6 addr add "2001:db8::1${ipRand}/128" dev eth0
   lxc exec "${ctName}" -- ip -6 route add default dev eth0
   sleep 1
-  ping6 -c2 -W1 "2001:db8::1${ipRand}"
+  ping6 -c2 -W5 "2001:db8::1${ipRand}"
 
   # Test hot plugging a container nic with different settings to profile with the same name.
   lxc config device add "${ctName}" eth0 nic \


### PR DESCRIPTION
- Reworks daemon shutdown process to handover cluster roll earlier.
- If handover fails, then server shutting down closes gateway and cluster connection to avoid delayed queries.
- Makes `/internal/shutdown` return a valid response as LXD shuts down and updates `lxd shutdown` to check for it.
- Improves logging.
- Reduces amount of separate shutdown context/channels/locks.