### PR TITLE
Daemon: Updates instancesOnDisk to allow differentation of instance type

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1132,9 +1132,15 @@ func (d *Daemon) init() error {
 		}
 
 		logger.Debug("Restarting all the containers following directory rename")
+
 		s := d.State()
-		instancesShutdown(s)
-		instancesRestart(s)
+		instances, err := instance.LoadNodeAll(s, instancetype.Container)
+		if err != nil {
+			return fmt.Errorf("Failed loading containers to restart: %w", err)
+		}
+
+		instancesShutdown(s, instances)
+		instancesStart(s, instances)
 	}
 
 	// Setup the user-agent.

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1461,20 +1461,16 @@ func (d *Daemon) Ready() error {
 	return nil
 }
 
-func (d *Daemon) numRunningInstances() (int, error) {
-	results, err := instance.LoadNodeAll(d.State(), instancetype.Any)
-	if err != nil {
-		return 0, err
-	}
-
+// numRunningInstances returns the number of running instances.
+func (d *Daemon) numRunningInstances(instances []instance.Instance) int {
 	count := 0
-	for _, instance := range results {
+	for _, instance := range instances {
 		if instance.IsRunning() {
 			count = count + 1
 		}
 	}
 
-	return count, nil
+	return count
 }
 
 // Stop stops the shared daemon.

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1442,9 +1442,14 @@ func (d *Daemon) Ready() error {
 	// Get daemon state struct
 	s := d.State()
 
-	// Restore containers
+	// Restore instances
 	if !d.cluster.LocalNodeIsEvacuated() {
-		instancesRestart(s)
+		instances, err := instance.LoadNodeAll(s, instancetype.Any)
+		if err != nil {
+			return fmt.Errorf("Failed loading instances to restore: %w", err)
+		}
+
+		instancesStart(s, instances)
 	}
 
 	// Re-balance in case things changed while LXD was down

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1586,7 +1586,7 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 		// it's likely that the other node shutdown. Let's just log the
 		// event and return cleanly.
 		if errors.Cause(err) == sqldriver.ErrBadConn {
-			logger.Debugf("Could not close remote database cleanly: %v", err)
+			logger.Debugf("Could not close remote database cleanly", log.Ctx{"err": err})
 		} else {
 			trackError(err, "Close cluster database")
 		}
@@ -1626,7 +1626,7 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 		err = fmt.Errorf(format, errs[0])
 	}
 	if err != nil {
-		logger.Errorf("Failed to cleanly shutdown daemon: %v", err)
+		logger.Errorf("Failed to cleanly shutdown daemon", log.Ctx{"err": err})
 	}
 
 	return err

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1490,10 +1490,24 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 		}
 	}
 
+	s := d.State()
+
+	var err error
+	var instances []instance.Instance // If this is left as nil this indicates an error loading instances.
+	if d.cluster != nil {
+		instances, err = instance.LoadNodeAll(s, instancetype.Any)
+		if err != nil {
+			// List all instances on disk.
+			logger.Warn("Loading local instances from disk as database is not available", log.Ctx{"err": err})
+			instances, err = instancesOnDisk()
+			if err != nil {
+				logger.Warn("Failed loading instances from disk", log.Ctx{"err": err})
+			}
+		}
+	}
+
 	// Handle shutdown (unix.SIGPWR) and reload (unix.SIGTERM) signals.
 	if sig == unix.SIGPWR || sig == unix.SIGTERM {
-		s := d.State()
-
 		// waitForOperations will block until all operations are done, or it's forced to shut down.
 		// For the latter case, we re-use the shutdown channel which is filled when a shutdown is
 		// initiated using `lxd shutdown`.
@@ -1522,7 +1536,7 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 		// Full shutdown requested.
 		if sig == unix.SIGPWR {
 			logger.Info("Stopping instances")
-			instancesShutdown(s)
+			instancesShutdown(s, instances)
 
 			logger.Info("Stopping networks")
 			networkShutdown(s)
@@ -1562,28 +1576,10 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 	trackError(d.tasks.Stop(3*time.Second), "Stop tasks")                // Give tasks a bit of time to cleanup.
 	trackError(d.clusterTasks.Stop(3*time.Second), "Stop cluster tasks") // Give tasks a bit of time to cleanup.
 
-	shouldUnmount := false
-	if d.cluster != nil {
-		// It might be that database nodes are all down, in that case
-		// we don't want to wait too much.
-		//
-		// FIXME: it should be possible to provide a context or a
-		//        timeout for database queries.
-		ch := make(chan bool)
-		go func() {
-			n, err := d.numRunningInstances()
-			if err != nil {
-				logger.Warn("Failed to get number of running instances", log.Ctx{"err": err})
-			}
-			ch <- err != nil || n == 0
-		}()
-		select {
-		case shouldUnmount = <-ch:
-		case <-time.After(2 * time.Second):
-			logger.Warn("Give up waiting to get number of running instances")
-			shouldUnmount = true
-		}
+	n := d.numRunningInstances(instances)
+	shouldUnmount := instances != nil && n <= 0
 
+	if d.cluster != nil {
 		logger.Infof("Closing the database")
 		err := d.cluster.Close()
 		// If we got io.EOF the network connection was interrupted and
@@ -1615,14 +1611,13 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 
 		logger.Infof("Done unmounting temporary filesystems")
 	} else {
-		logger.Debugf("Not unmounting temporary filesystems (containers are still running)")
+		logger.Debugf("Not unmounting temporary filesystems (instances are still running)")
 	}
 
 	if d.seccomp != nil {
 		trackError(d.seccomp.Stop(), "Stop seccomp")
 	}
 
-	var err error
 	if n := len(errs); n > 0 {
 		format := "%v"
 		if n > 1 {

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -188,13 +188,13 @@ var instanceBackupExportCmd = APIEndpoint{
 	Get: APIEndpointAction{Handler: instanceBackupExportGet, AccessHandler: allowProjectPermission("containers", "view")},
 }
 
-type containerAutostartList []instance.Instance
+type instanceAutostartList []instance.Instance
 
-func (slice containerAutostartList) Len() int {
+func (slice instanceAutostartList) Len() int {
 	return len(slice)
 }
 
-func (slice containerAutostartList) Less(i, j int) bool {
+func (slice instanceAutostartList) Less(i, j int) bool {
 	iOrder := slice[i].ExpandedConfig()["boot.autostart.priority"]
 	jOrder := slice[j].ExpandedConfig()["boot.autostart.priority"]
 
@@ -207,7 +207,7 @@ func (slice containerAutostartList) Less(i, j int) bool {
 	return slice[i].Name() < slice[j].Name()
 }
 
-func (slice containerAutostartList) Swap(i, j int) {
+func (slice instanceAutostartList) Swap(i, j int) {
 	slice[i], slice[j] = slice[j], slice[i]
 }
 

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -211,20 +211,8 @@ func (slice instanceAutostartList) Swap(i, j int) {
 	slice[i], slice[j] = slice[j], slice[i]
 }
 
-func instancesRestart(s *state.State) error {
-	// Get all the instances
-	result, err := instance.LoadNodeAll(s, instancetype.Any)
-	if err != nil {
-		return err
-	}
-
-	instances := []instance.Instance{}
-
-	for _, c := range result {
-		instances = append(instances, c)
-	}
-
-	sort.Sort(containerAutostartList(instances))
+func instancesStart(s *state.State, instances []instance.Instance) {
+	sort.Sort(instanceAutostartList(instances))
 
 	maxAttempts := 3
 
@@ -292,7 +280,7 @@ func instancesRestart(s *state.State) error {
 		}
 	}
 
-	return nil
+	return
 }
 
 type instanceStopList []instance.Instance


### PR DESCRIPTION
In PR https://github.com/lxc/lxd/pull/9285 `instancesOnDisk()` was updated to return VM instances.

Unfortunately because just the project and instance name was returned, when it was passed to `instance.Load()` it would have got converted to container, which would mean we would not be able to check if it was running.

This PR converts it to return a list of `instance.Instance` with the `Type` correctly populated.

It also renames `instancesRestart()` to `instancesStart()` because there was no "restarting" taking place in that function.
It then updates both `instancesStop()` and `instancesStart()` to accept a list of instances, which reduces the amount of DB queries that need to be made.

It also fixes an issue where the patch `patchUpdateFromV10` that was moved to `init()` was also restarting VMs even when it only needed to restart containers due to the `lxc` directory rename.

Finally, it also updates `patchUpdateFromV11` and `patchUpdateFromV15` to use the updated `instancesOnDisk()` function.
**Note: However I have concerns that these patches haven't been doing what is expected of them for some time and this needs further investigation.** 

See also:
https://github.com/lxc/lxd/commit/9e19255198b766263c2892c013c56d07b025a7f6
https://github.com/lxc/lxd/commit/199a503db242ecb7279acdb9a76e7a841c2581b9