### PR TITLE
[GH-9248] Restrict protocol version

### DIFF
--- a/lxd/endpoints/network_test.go
+++ b/lxd/endpoints/network_test.go
@@ -1,7 +1,9 @@
 package endpoints_test
 
 import (
+	"fmt"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/lxc/lxd/shared"
@@ -87,4 +89,20 @@ func newTCPListener(t *testing.T) *net.TCPListener {
 
 	require.NoError(t, err)
 	return listener
+}
+
+// Create IPv4 0.0.0.0 listener using random port
+// and ensure it is not accessible via IPv6 request.
+func TestEndpoints_NetworkCreateTCPSocketIPv4(t *testing.T) {
+	endpoints, config, cleanup := newEndpoints(t)
+	defer cleanup()
+
+	config.NetworkAddress = "0.0.0.0:0"
+	require.NoError(t, endpoints.Up(config))
+
+	address, certificate := endpoints.NetworkAddressAndCert()
+	parts := strings.Split(address, ":")
+	ipv6Address := fmt.Sprintf("[::1]:%s", parts[1])
+
+	assert.Error(t, httpGetOverTLSSocket(ipv6Address, certificate))
 }

--- a/lxd/endpoints/network_test.go
+++ b/lxd/endpoints/network_test.go
@@ -103,6 +103,11 @@ func TestEndpoints_NetworkCreateTCPSocketIPv4(t *testing.T) {
 	address, certificate := endpoints.NetworkAddressAndCert()
 	parts := strings.Split(address, ":")
 	ipv6Address := fmt.Sprintf("[::1]:%s", parts[1])
+	ipv4Address := fmt.Sprintf("127.0.0.1:%s", parts[1])
 
+	// Check accessibility over IPv4 request
+	assert.NoError(t, httpGetOverTLSSocket(ipv4Address, certificate))
+
+	// Check accessibility over IPv6 request
 	assert.Error(t, httpGetOverTLSSocket(ipv6Address, certificate))
 }


### PR DESCRIPTION
Closes #9248

Works off of https://github.com/lxc/lxd/pull/9259 by @dizlv

Seems everything was already in place, just incorrect formatting on the error message. I just changed the assertion to check for any error, since the error that was being checked isn't from us.