### PR TITLE
Generator: Insert into certificates_projects table

### DIFF
--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -518,12 +518,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 			Projects:    req.Projects,
 		}
 
-		id, err := d.cluster.CreateCertificate(dbCert)
-		if err != nil {
-			return response.SmartError(err)
-		}
-
-		err = d.cluster.UpdateCertificateProjects(int(id), dbCert.Projects)
+		_, err := d.cluster.CreateCertificate(dbCert)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -740,11 +735,6 @@ func doCertificateUpdate(d *Daemon, dbInfo db.Certificate, fingerprint string, r
 
 		// Update the database record.
 		err = d.cluster.UpdateCertificate(fingerprint, cert)
-		if err != nil {
-			return response.SmartError(err)
-		}
-
-		err = d.cluster.UpdateCertificateProjects(dbInfo.ID, cert.Projects)
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -217,14 +217,6 @@ func (c *Cluster) UpdateCertificate(fingerprint string, cert Certificate) error 
 	return err
 }
 
-// UpdateCertificateProjects updates the list of projects on a certificate.
-func (c *Cluster) UpdateCertificateProjects(id int, projects []string) error {
-	err := c.Transaction(func(tx *ClusterTx) error {
-		return tx.UpdateCertificateProjects(id, projects)
-	})
-	return err
-}
-
 // GetCertificates returns all available local certificates.
 func (n *NodeTx) GetCertificates() ([]Certificate, error) {
 	dbCerts := []struct {

--- a/lxd/db/certificates.mapper.go
+++ b/lxd/db/certificates.mapper.go
@@ -219,6 +219,11 @@ func (c *ClusterTx) CreateCertificate(object Certificate) (int64, error) {
 		return -1, errors.Wrap(err, "Failed to fetch certificate ID")
 	}
 
+	// Update certificates_projects table.
+	err = c.UpdateCertificateProjects(int(id), object.Projects)
+	if err != nil {
+		return -1, fmt.Errorf("Could not update certificates_projects table: %w", err)
+	}
 	return id, nil
 }
 
@@ -339,5 +344,10 @@ func (c *ClusterTx) UpdateCertificate(fingerprint string, object Certificate) er
 		return fmt.Errorf("Query updated %d rows instead of 1", n)
 	}
 
+	// Update certificates_projects table.
+	err = c.UpdateCertificateProjects(int(id), object.Projects)
+	if err != nil {
+		return fmt.Errorf("Could not update certificates_projects table: %w", err)
+	}
 	return nil
 }


### PR DESCRIPTION
Closes #9317 

Coincidentally, I actually noticed this while working on the generator! The `certificates_projects` table was always updated independently of the `certificates` table. The fix I've put here should take care of the problem for now, until I finalize my reworking of how the generator handles reference tables.