### PR TITLE
Allow changing QEMU Gpu driver

### DIFF
--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -185,17 +185,12 @@ multifunction = "on"
 var qemuGPU = template.Must(template.New("qemuGPU").Parse(`
 # GPU
 [device "qemu_gpu"]
-{{- if eq .bus "pci" "pcie"}}
-{{if eq .architecture "x86_64" -}}
-driver = "virtio-vga"
-{{- else}}
-driver = "virtio-gpu-pci"
+{{if ne .driver "" -}}
+driver = "{{.driver}}"
 {{- end}}
+{{- if eq .bus "pci" "pcie"}}
 bus = "{{.devBus}}"
 addr = "{{.devAddr}}"
-{{- end}}
-{{if eq .bus "ccw" -}}
-driver = "virtio-gpu-ccw"
 {{- end}}
 {{if .multifunction -}}
 multifunction = "on"

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -267,6 +267,7 @@ var InstanceConfigKeysVM = map[string]func(value string) error{
 
 	// Caller is responsible for full validation of any raw.* value.
 	"raw.qemu": validate.IsAny,
+	"raw.qemu.gpu.driver": validate.IsAny,
 
 	"security.secureboot": validate.Optional(validate.IsBool),
 }


### PR DESCRIPTION
I'm using this locally to set gpu driver to `qxl-vga` for windows 10 guests. The main reason is that there are no windows guest drivers for `virtio-vga`, and qxl-vga simply works better for windows guests (auto resize resize to match window size works, for example).

If you are OK with the implementation, I will follow with more commits for test/docs