### PR TITLE
Instance: Use project and instance name for operation locks

### DIFF
--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -455,7 +455,7 @@ func (d *common) expandDevices(profiles []api.Profile) error {
 // restartCommon handles the common part of instance restarts.
 func (d *common) restartCommon(inst instance.Instance, timeout time.Duration) error {
 	// Setup a new operation for the stop/shutdown phase.
-	op, err := operationlock.Create(d.id, "restart", true, true)
+	op, err := operationlock.Create(d.Project(), d.Name(), "restart", true, true)
 	if err != nil {
 		return errors.Wrap(err, "Create restart operation")
 	}
@@ -509,7 +509,7 @@ func (d *common) restartCommon(inst instance.Instance, timeout time.Duration) er
 	}
 
 	// Setup a new operation for the start phase.
-	op, err = operationlock.Create(d.id, "restart", true, true)
+	op, err = operationlock.Create(d.Project(), d.Name(), "restart", true, true)
 	if err != nil {
 		return errors.Wrap(err, "Create restart (for start) operation")
 	}
@@ -863,7 +863,7 @@ func (d *common) onStopOperationSetup(target string) (*operationlock.InstanceOpe
 	// Pick up the existing stop operation lock created in Stop() function.
 	// If there is another ongoing operation (such as start), wait until that has finished before proceeding
 	// to run the hook (this should be quick as it will fail showing instance is already running).
-	op := operationlock.Get(d.id)
+	op := operationlock.Get(d.Project(), d.Name())
 	if op != nil && !shared.StringInSlice(op.Action(), []string{"stop", "restart", "restore"}) {
 		d.logger.Debug("Waiting for existing operation to finish before running hook", log.Ctx{"opAction": op.Action()})
 		op.Wait()
@@ -881,7 +881,7 @@ func (d *common) onStopOperationSetup(target string) (*operationlock.InstanceOpe
 			action = "restart"
 		}
 
-		op, err = operationlock.Create(d.id, action, false, false)
+		op, err = operationlock.Create(d.Project(), d.Name(), action, false, false)
 		if err != nil {
 			return nil, false, errors.Wrapf(err, "Failed creating %s operation", action)
 		}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2346,7 +2346,7 @@ func (d *lxc) Start(stateful bool) error {
 	var ctxMap log.Ctx
 
 	// Setup a new operation
-	exists, op, err := operationlock.CreateWaitGet(d.id, "start", []string{"restart", "restore"}, false, false)
+	exists, op, err := operationlock.CreateWaitGet(d.Project(), d.Name(), "start", []string{"restart", "restore"}, false, false)
 	if err != nil {
 		return errors.Wrap(err, "Create container start operation")
 	}
@@ -2605,7 +2605,7 @@ func (d *lxc) Stop(stateful bool) error {
 	}
 
 	// Setup a new operation
-	exists, op, err := operationlock.CreateWaitGet(d.id, "stop", []string{"restart", "restore"}, false, true)
+	exists, op, err := operationlock.CreateWaitGet(d.Project(), d.Name(), "stop", []string{"restart", "restore"}, false, true)
 	if err != nil {
 		return err
 	}
@@ -2764,7 +2764,7 @@ func (d *lxc) Shutdown(timeout time.Duration) error {
 	}
 
 	// Setup a new operation
-	exists, op, err := operationlock.CreateWaitGet(d.id, "stop", []string{"restart"}, true, false)
+	exists, op, err := operationlock.CreateWaitGet(d.Project(), d.Name(), "stop", []string{"restart"}, true, false)
 	if err != nil {
 		return err
 	}
@@ -3363,7 +3363,7 @@ func (d *lxc) Snapshot(name string, expiry time.Time, stateful bool) error {
 func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 	var ctxMap log.Ctx
 
-	op, err := operationlock.Create(d.id, "restore", false, false)
+	op, err := operationlock.Create(d.Project(), d.Name(), "restore", false, false)
 	if err != nil {
 		return errors.Wrap(err, "Create restore operation")
 	}
@@ -3410,7 +3410,7 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 		}
 
 		// Refresh the operation as that one is now complete.
-		op, err = operationlock.Create(d.id, "restore", false, false)
+		op, err = operationlock.Create(d.Project(), d.Name(), "restore", false, false)
 		if err != nil {
 			return errors.Wrap(err, "Create restore operation")
 		}
@@ -5260,7 +5260,7 @@ func (d *lxc) inheritInitPidFd() (int, *os.File) {
 // FileExists returns whether file exists inside instance.
 func (d *lxc) FileExists(path string) error {
 	// Check for ongoing operations (that may involve shifting).
-	operationlock.Get(d.id).Wait()
+	operationlock.Get(d.Project(), d.Name()).Wait()
 
 	// Setup container storage if needed
 	_, err := d.mount()
@@ -5308,7 +5308,7 @@ func (d *lxc) FileExists(path string) error {
 // FilePull gets a file from the instance.
 func (d *lxc) FilePull(srcpath string, dstpath string) (int64, int64, os.FileMode, string, []string, error) {
 	// Check for ongoing operations (that may involve shifting).
-	operationlock.Get(d.id).Wait()
+	operationlock.Get(d.Project(), d.Name()).Wait()
 
 	// Setup container storage if needed
 	_, err := d.mount()
@@ -5433,7 +5433,7 @@ func (d *lxc) FilePull(srcpath string, dstpath string) (int64, int64, os.FileMod
 // FilePush sends a file into the instance.
 func (d *lxc) FilePush(fileType string, srcpath string, dstpath string, uid int64, gid int64, mode int, write string) error {
 	// Check for ongoing operations (that may involve shifting).
-	operationlock.Get(d.id).Wait()
+	operationlock.Get(d.Project(), d.Name()).Wait()
 
 	var rootUID int64
 	var rootGID int64
@@ -5526,7 +5526,7 @@ func (d *lxc) FilePush(fileType string, srcpath string, dstpath string, uid int6
 // FileRemove removes a file inside the instance.
 func (d *lxc) FileRemove(path string) error {
 	// Check for ongoing operations (that may involve shifting).
-	operationlock.Get(d.id).Wait()
+	operationlock.Get(d.Project(), d.Name()).Wait()
 
 	var errStr string
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -703,7 +703,7 @@ func (d *qemu) Shutdown(timeout time.Duration) error {
 	}
 
 	// Setup a new operation
-	exists, op, err := operationlock.CreateWaitGet(d.id, "stop", []string{"restart"}, true, false)
+	exists, op, err := operationlock.CreateWaitGet(d.Project(), d.Name(), "stop", []string{"restart"}, true, false)
 	if err != nil {
 		return err
 	}
@@ -939,7 +939,7 @@ func (d *qemu) Start(stateful bool) error {
 	}
 
 	// Setup a new operation.
-	exists, op, err := operationlock.CreateWaitGet(d.id, "start", []string{"restart", "restore"}, false, false)
+	exists, op, err := operationlock.CreateWaitGet(d.Project(), d.Name(), "start", []string{"restart", "restore"}, false, false)
 	if err != nil {
 		return errors.Wrap(err, "Create instance start operation")
 	}
@@ -3372,7 +3372,7 @@ func (d *qemu) Stop(stateful bool) error {
 	}
 
 	// Setup a new operation.
-	exists, op, err := operationlock.CreateWaitGet(d.id, "stop", []string{"restart", "restore"}, false, true)
+	exists, op, err := operationlock.CreateWaitGet(d.Project(), d.Name(), "stop", []string{"restart", "restore"}, false, true)
 	if err != nil {
 		return err
 	}
@@ -3520,7 +3520,7 @@ func (d *qemu) Snapshot(name string, expiry time.Time, stateful bool) error {
 
 // Restore restores an instance snapshot.
 func (d *qemu) Restore(source instance.Instance, stateful bool) error {
-	op, err := operationlock.Create(d.id, "restore", false, false)
+	op, err := operationlock.Create(d.Project(), d.Name(), "restore", false, false)
 	if err != nil {
 		return errors.Wrap(err, "Create restore operation")
 	}
@@ -3569,7 +3569,7 @@ func (d *qemu) Restore(source instance.Instance, stateful bool) error {
 		}
 
 		// Refresh the operation as that one is now complete.
-		op, err = operationlock.Create(d.id, "restore", false, false)
+		op, err = operationlock.Create(d.Project(), d.Name(), "restore", false, false)
 		if err != nil {
 			return errors.Wrap(err, "Create restore operation")
 		}
@@ -5377,7 +5377,7 @@ func (d *qemu) InitPID() int {
 
 func (d *qemu) statusCode() api.StatusCode {
 	// Shortcut to avoid spamming QMP during ongoing operations.
-	op := operationlock.Get(d.id)
+	op := operationlock.Get(d.Project(), d.Name())
 	if op != nil {
 		if op.Action() == "start" {
 			return api.Stopped

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -1107,7 +1107,7 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, volu
 			return errors.Wrapf(err, "Unexpected instance database ID %d", dbInst.ID)
 		}
 
-		op, err = operationlock.Create(dbInst.ID, "create", false, false)
+		op, err = operationlock.Create(dbInst.Project, dbInst.Name, "create", false, false)
 		if err != nil {
 			return err
 		}

--- a/lxd/instance/operationlock/operationlock.go
+++ b/lxd/instance/operationlock/operationlock.go
@@ -50,7 +50,7 @@ func Create(projectName string, instanceName string, action string, reusable boo
 			return op, nil
 		}
 
-		return nil, fmt.Errorf("Instance is busy running a %s operation", op.action)
+		return nil, fmt.Errorf("Instance is busy running a %q operation", op.action)
 	}
 
 	op = &InstanceOperation{}
@@ -71,7 +71,7 @@ func Create(projectName string, instanceName string, action string, reusable boo
 			case <-op.chanReset:
 				continue
 			case <-time.After(time.Second * 30):
-				op.Done(fmt.Errorf("Instance %s operation timed out after 30 seconds", op.action))
+				op.Done(fmt.Errorf("Instance %q operation timed out after 30 seconds", op.action))
 				return
 			}
 		}

--- a/lxd/instance/operationlock/operationlock.go
+++ b/lxd/instance/operationlock/operationlock.go
@@ -5,20 +5,22 @@ import (
 	"sync"
 	"time"
 
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/shared"
 )
 
 var instanceOperationsLock sync.Mutex
-var instanceOperations = make(map[int]*InstanceOperation)
+var instanceOperations = make(map[string]*InstanceOperation)
 
 // InstanceOperation operation locking.
 type InstanceOperation struct {
-	action    string
-	chanDone  chan error
-	chanReset chan bool
-	err       error
-	id        int
-	reusable  bool
+	action       string
+	chanDone     chan error
+	chanReset    chan bool
+	err          error
+	projectName  string
+	instanceName string
+	reusable     bool
 }
 
 // Action returns operation's action.
@@ -30,11 +32,17 @@ func (op InstanceOperation) Action() string {
 // The lock will be released after 30s or when Done() is called, which ever occurs first.
 // If reusable is set as true then future lock attempts can specify the reuse argument as true which
 // will then trigger a reset of the 30s timeout on the existing lock and return it.
-func Create(instanceID int, action string, reusable bool, reuse bool) (*InstanceOperation, error) {
+func Create(projectName string, instanceName string, action string, reusable bool, reuse bool) (*InstanceOperation, error) {
+	if projectName == "" || instanceName == "" {
+		return nil, fmt.Errorf("Invalid project or instance name")
+	}
+
 	instanceOperationsLock.Lock()
 	defer instanceOperationsLock.Unlock()
 
-	op := instanceOperations[instanceID]
+	opKey := project.Instance(projectName, instanceName)
+
+	op := instanceOperations[opKey]
 	if op != nil {
 		if op.reusable && reuse {
 			// Reset operation timeout without releasing lock or deadlocking using Reset() function.
@@ -46,13 +54,14 @@ func Create(instanceID int, action string, reusable bool, reuse bool) (*Instance
 	}
 
 	op = &InstanceOperation{}
-	op.id = instanceID
+	op.projectName = projectName
+	op.instanceName = instanceName
 	op.action = action
 	op.reusable = reusable
 	op.chanDone = make(chan error, 0)
 	op.chanReset = make(chan bool, 0)
 
-	instanceOperations[instanceID] = op
+	instanceOperations[opKey] = op
 
 	go func(op *InstanceOperation) {
 		for {
@@ -83,12 +92,12 @@ func Create(instanceID int, action string, reusable bool, reuse bool) (*Instance
 // If the instance doesn't have an operation, has an operation of a different
 // type that is not in the alternate list or has the right type and is
 // being reused, then this behaves as a Create call.
-func CreateWaitGet(instanceID int, action string, altActions []string, reusable bool, reuse bool) (bool, *InstanceOperation, error) {
-	op := Get(instanceID)
+func CreateWaitGet(projectName string, instanceName string, action string, altActions []string, reusable bool, reuse bool) (bool, *InstanceOperation, error) {
+	op := Get(projectName, instanceName)
 
 	// No existing operation, call create.
 	if op == nil {
-		op, err := Create(instanceID, action, reusable, reuse)
+		op, err := Create(projectName, instanceName, action, reusable, reuse)
 		return false, op, err
 	}
 
@@ -104,16 +113,19 @@ func CreateWaitGet(instanceID int, action string, altActions []string, reusable 
 	}
 
 	// Send the rest to Create
-	op, err := Create(instanceID, action, reusable, reuse)
+	op, err := Create(projectName, instanceName, action, reusable, reuse)
+
 	return false, op, err
 }
 
 // Get retrieves an existing lock or returns nil if no lock exists.
-func Get(instanceID int) *InstanceOperation {
+func Get(projectName string, instanceName string) *InstanceOperation {
 	instanceOperationsLock.Lock()
 	defer instanceOperationsLock.Unlock()
 
-	return instanceOperations[instanceID]
+	opKey := project.Instance(projectName, instanceName)
+
+	return instanceOperations[opKey]
 }
 
 // Reset resets the operation timeout.
@@ -126,8 +138,10 @@ func (op *InstanceOperation) Reset() error {
 		return nil
 	}
 
+	opKey := project.Instance(op.projectName, op.instanceName)
+
 	// Check if already done
-	runningOp, ok := instanceOperations[op.id]
+	runningOp, ok := instanceOperations[opKey]
 	if !ok || runningOp != op {
 		return fmt.Errorf("Operation is already done or expired")
 	}
@@ -158,13 +172,15 @@ func (op *InstanceOperation) Done(err error) {
 		return
 	}
 
+	opKey := project.Instance(op.projectName, op.instanceName)
+
 	// Check if already done
-	runningOp, ok := instanceOperations[op.id]
+	runningOp, ok := instanceOperations[opKey]
 	if !ok || runningOp != op {
 		return
 	}
 
 	op.err = err
-	delete(instanceOperations, op.id) // Delete before closing chanDone.
+	delete(instanceOperations, opKey) // Delete before closing chanDone.
 	close(op.chanDone)
 }

--- a/lxd/instance/operationlock/operationlock.go
+++ b/lxd/instance/operationlock/operationlock.go
@@ -130,13 +130,13 @@ func Get(projectName string, instanceName string) *InstanceOperation {
 
 // Reset resets the operation timeout.
 func (op *InstanceOperation) Reset() error {
-	instanceOperationsLock.Lock()
-	defer instanceOperationsLock.Unlock()
-
 	// This function can be called on a nil struct.
 	if op == nil {
 		return nil
 	}
+
+	instanceOperationsLock.Lock()
+	defer instanceOperationsLock.Unlock()
 
 	opKey := project.Instance(op.projectName, op.instanceName)
 
@@ -164,13 +164,13 @@ func (op *InstanceOperation) Wait() error {
 
 // Done indicates the operation has finished.
 func (op *InstanceOperation) Done(err error) {
-	instanceOperationsLock.Lock()
-	defer instanceOperationsLock.Unlock()
-
 	// This function can be called on a nil struct.
 	if op == nil {
 		return
 	}
+
+	instanceOperationsLock.Lock()
+	defer instanceOperationsLock.Unlock()
 
 	opKey := project.Instance(op.projectName, op.instanceName)
 


### PR DESCRIPTION
As part of the series of fixes for https://github.com/lxc/lxd/issues/9327 this PR moves away from using instance ID for operation locks.

This allows them to function properly when the `instance.Instance` has been initialised from a non-DB source.