### PR TITLE
Instance: Rework instancesOnDisk to load config from backup.yaml if available

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -281,7 +281,14 @@ func internalContainerHookLoadFromReference(s *state.State, r *http.Request) (in
 	} else {
 		inst, err = instance.LoadByProjectAndName(s, projectName, instanceRef)
 		if err != nil {
-			return nil, err
+			// If DB not available, try loading from backup file.
+			logger.Warn("Failed loading instance from database, trying backup file", log.Ctx{"project": projectName, "instance": instanceRef, "err": err})
+
+			instancePath := filepath.Join(shared.VarPath("containers"), project.Instance(projectName, instanceRef))
+			inst, err = instance.LoadFromBackup(s, projectName, instancePath, false)
+			if err != nil {
+				return inst, err
+			}
 		}
 	}
 

--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -474,37 +474,19 @@ func internalRecoverImportInstance(s *state.State, pool storagePools.Pool, proje
 
 	internalImportRootDevicePopulate(pool.Name(), poolVol.Container.Devices, poolVol.Container.ExpandedDevices, profiles)
 
-	arch, err := osarch.ArchitectureId(poolVol.Container.Architecture)
-	if err != nil {
-		return nil, err
-	}
-
-	instanceType, err := instancetype.New(poolVol.Container.Type)
-	if err != nil {
-		return nil, err
-	}
-
 	// Extract volume config from backup file if present.
 	var volConfig map[string]string
 	if poolVol.Volume != nil {
 		volConfig = poolVol.Volume.Config
 	}
 
-	inst, instOp, err := instance.CreateInternal(s, db.InstanceArgs{
-		Project:      projectName,
-		Architecture: arch,
-		BaseImage:    poolVol.Container.Config["volatile.base_image"],
-		Config:       poolVol.Container.Config,
-		CreationDate: poolVol.Container.CreatedAt,
-		Type:         instanceType,
-		Description:  poolVol.Container.Description,
-		Devices:      deviceConfig.NewDevices(poolVol.Container.Devices),
-		Ephemeral:    poolVol.Container.Ephemeral,
-		LastUsedDate: poolVol.Container.LastUsedAt,
-		Name:         poolVol.Container.Name,
-		Profiles:     poolVol.Container.Profiles,
-		Stateful:     poolVol.Container.Stateful,
-	}, false, volConfig, revert)
+	dbInst := poolVol.ToInstanceDBArgs(projectName)
+
+	if dbInst.Type < 0 {
+		return nil, fmt.Errorf("Invalid instance type")
+	}
+
+	inst, instOp, err := instance.CreateInternal(s, *dbInst, false, volConfig, revert)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed creating instance record")
 	}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1501,10 +1501,24 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 		}
 	}
 
+	s := d.State()
+
+	var err error
+	var instances []instance.Instance // If this is left as nil this indicates an error loading instances.
+	if d.cluster != nil {
+		instances, err = instance.LoadNodeAll(s, instancetype.Any)
+		if err != nil {
+			// List all instances on disk.
+			logger.Warn("Loading local instances from disk as database is not available", log.Ctx{"err": err})
+			instances, err = instancesOnDisk(s)
+			if err != nil {
+				logger.Warn("Failed loading instances from disk", log.Ctx{"err": err})
+			}
+		}
+	}
+
 	// Handle shutdown (unix.SIGPWR) and reload (unix.SIGTERM) signals.
 	if sig == unix.SIGPWR || sig == unix.SIGTERM {
-		s := d.State()
-
 		// waitForOperations will block until all operations are done, or it's forced to shut down.
 		// For the latter case, we re-use the shutdown channel which is filled when a shutdown is
 		// initiated using `lxd shutdown`.
@@ -1533,7 +1547,7 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 		// Full shutdown requested.
 		if sig == unix.SIGPWR {
 			logger.Info("Stopping instances")
-			instancesShutdown(s)
+			instancesShutdown(s, instances)
 
 			logger.Info("Stopping networks")
 			networkShutdown(s)
@@ -1575,28 +1589,10 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 	trackError(d.tasks.Stop(3*time.Second), "Stop tasks")                // Give tasks a bit of time to cleanup.
 	trackError(d.clusterTasks.Stop(3*time.Second), "Stop cluster tasks") // Give tasks a bit of time to cleanup.
 
-	shouldUnmount := false
-	if d.cluster != nil {
-		// It might be that database nodes are all down, in that case
-		// we don't want to wait too much.
-		//
-		// FIXME: it should be possible to provide a context or a
-		//        timeout for database queries.
-		ch := make(chan bool)
-		go func() {
-			n, err := d.numRunningInstances()
-			if err != nil {
-				logger.Warn("Failed to get number of running instances", log.Ctx{"err": err})
-			}
-			ch <- err != nil || n == 0
-		}()
-		select {
-		case shouldUnmount = <-ch:
-		case <-time.After(2 * time.Second):
-			logger.Warn("Give up waiting to get number of running instances")
-			shouldUnmount = true
-		}
+	n := d.numRunningInstances(instances)
+	shouldUnmount := instances != nil && n <= 0
 
+	if d.cluster != nil {
 		logger.Info("Closing the database")
 		err := d.cluster.Close()
 		if err != nil {
@@ -1630,7 +1626,6 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 		trackError(d.seccomp.Stop(), "Stop seccomp")
 	}
 
-	var err error
 	if n := len(errs); n > 0 {
 		format := "%v"
 		if n > 1 {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1510,6 +1510,10 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 			if err != nil {
 				logger.Warn("Failed loading instances from disk", log.Ctx{"err": err})
 			}
+
+			// Make all future queries fail fast as DB is not available.
+			d.gateway.Kill()
+			d.cluster.Close()
 		}
 	}
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1139,9 +1139,15 @@ func (d *Daemon) init() error {
 		}
 
 		logger.Debug("Restarting all the containers following directory rename")
+
 		s := d.State()
-		instancesShutdown(s)
-		instancesRestart(s)
+		instances, err := instance.LoadNodeAll(s, instancetype.Container)
+		if err != nil {
+			return fmt.Errorf("Failed loading containers to restart: %w", err)
+		}
+
+		instancesShutdown(s, instances)
+		instancesStart(s, instances)
 	}
 
 	// Setup the user-agent.

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1596,7 +1596,7 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 		logger.Info("Closing the database")
 		err := d.cluster.Close()
 		if err != nil {
-			logger.Debug("Could not close remote database cleanly", log.Ctx{"err": err})
+			logger.Debug("Could not close global database cleanly", log.Ctx{"err": err})
 		}
 	}
 	if d.db != nil {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1468,20 +1468,16 @@ func (d *Daemon) Ready() error {
 	return nil
 }
 
-func (d *Daemon) numRunningInstances() (int, error) {
-	results, err := instance.LoadNodeAll(d.State(), instancetype.Any)
-	if err != nil {
-		return 0, err
-	}
-
+// numRunningInstances returns the number of running instances.
+func (d *Daemon) numRunningInstances(instances []instance.Instance) int {
 	count := 0
-	for _, instance := range results {
+	for _, instance := range instances {
 		if instance.IsRunning() {
 			count = count + 1
 		}
 	}
 
-	return count, nil
+	return count
 }
 
 // Stop stops the shared daemon.

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1449,9 +1449,14 @@ func (d *Daemon) Ready() error {
 	// Get daemon state struct
 	s := d.State()
 
-	// Restore containers
+	// Restore instances
 	if !d.cluster.LocalNodeIsEvacuated() {
-		instancesRestart(s)
+		instances, err := instance.LoadNodeAll(s, instancetype.Any)
+		if err != nil {
+			return fmt.Errorf("Failed loading instances to restore: %w", err)
+		}
+
+		instancesStart(s, instances)
 	}
 
 	// Re-balance in case things changed while LXD was down

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -855,15 +855,6 @@ WHERE type=? ORDER BY instances.name, instances_snapshots.name
 	return ret, nil
 }
 
-// UpdateInstancePowerState sets the the power state of the instance with the
-// given ID.
-func (c *Cluster) UpdateInstancePowerState(id int, state string) error {
-	err := c.Transaction(func(tx *ClusterTx) error {
-		return tx.UpdateInstancePowerState(id, state)
-	})
-	return err
-}
-
 // UpdateInstanceSnapshotCreationDate updates the creation_date field of the instance snapshot with ID.
 func (c *Cluster) UpdateInstanceSnapshotCreationDate(instanceID int, date time.Time) error {
 	stmt := `UPDATE instances_snapshots SET creation_date=? WHERE id=?`

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -855,13 +855,6 @@ WHERE type=? ORDER BY instances.name, instances_snapshots.name
 	return ret, nil
 }
 
-// ResetInstancesPowerState resets the power state of all instances.
-func (c *Cluster) ResetInstancesPowerState() error {
-	// Reset all container states
-	err := exec(c, "DELETE FROM instances_config WHERE key='volatile.last_state.power'")
-	return err
-}
-
 // UpdateInstancePowerState sets the the power state of the instance with the
 // given ID.
 func (c *Cluster) UpdateInstancePowerState(id int, state string) error {

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -934,3 +934,31 @@ func (d *common) isMigratable(inst instance.Instance) bool {
 
 	return true
 }
+
+// recordLastState records last power and used time into local config and database config.
+func (d *common) recordLastState() error {
+	var err error
+
+	// Record power state.
+	d.localConfig["volatile.last_state.power"] = "RUNNING"
+	d.expandedConfig["volatile.last_state.power"] = "RUNNING"
+
+	// Database updates
+	return d.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
+		// Record power state.
+		err = tx.UpdateInstancePowerState(d.id, "RUNNING")
+		if err != nil {
+			err = errors.Wrap(err, "Error updating instance power state")
+			return err
+		}
+
+		// Update time instance last started time.
+		err = tx.UpdateInstanceLastUsedDate(d.id, time.Now().UTC())
+		if err != nil {
+			err = errors.Wrap(err, "Error updating instance last used")
+			return err
+		}
+
+		return nil
+	})
+}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2897,12 +2897,11 @@ func (d *lxc) onStop(args map[string]string) error {
 	// Make sure we can't call go-lxc functions by mistake
 	d.fromHook = true
 
-	// Record power state
-	err = d.state.Cluster.UpdateInstancePowerState(d.id, "STOPPED")
+	// Record power state.
+	err = d.VolatileSet(map[string]string{"volatile.last_state.power": "STOPPED"})
 	if err != nil {
-		err = errors.Wrap(err, "Failed to set container state")
-		op.Done(err)
-		return err
+		// Don't return an error here as we still want to cleanup the instance even if DB not available.
+		d.logger.Error("Failed recording last power state", log.Ctx{"err": err})
 	}
 
 	go func(d *lxc, target string, op *operationlock.InstanceOperation) {

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2571,22 +2571,8 @@ func (d *lxc) onStart(_ map[string]string) error {
 		}(d)
 	}
 
-	// Database updates
-	err = d.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
-		// Record current state
-		err = tx.UpdateInstancePowerState(d.id, "RUNNING")
-		if err != nil {
-			return errors.Wrap(err, "Error updating container state")
-		}
-
-		// Update time container last started time
-		err = tx.UpdateInstanceLastUsedDate(d.id, time.Now().UTC())
-		if err != nil {
-			return errors.Wrap(err, "Error updating last used")
-		}
-
-		return nil
-	})
+	// Record last start state.
+	err = d.recordLastState()
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2282,12 +2282,6 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 		return "", nil, err
 	}
 
-	// Update the backup.yaml file
-	err = d.UpdateBackupFile()
-	if err != nil {
-		return "", nil, err
-	}
-
 	// If starting stateless, wipe state
 	if !d.IsStateful() && shared.PathExists(d.StatePath()) {
 		os.RemoveAll(d.StatePath())
@@ -2443,6 +2437,15 @@ func (d *lxc) Start(stateful bool) error {
 			op.Done(err)
 			return errors.Wrap(err, "Persist stateful flag")
 		}
+	}
+
+	// Update the backup.yaml file just before starting the instance process, but after all devices have been
+	// setup, so that the backup file contains the volatile keys used for this instance start, so that they
+	// can be used for instance cleanup.
+	err = d.UpdateBackupFile()
+	if err != nil {
+		op.Done(err)
+		return err
 	}
 
 	name := project.Instance(d.Project(), d.name)
@@ -4980,6 +4983,14 @@ func (d *lxc) Migrate(args *instance.CriuMigrationArgs) error {
 
 		if args.DumpDir != "" {
 			finalStateDir = fmt.Sprintf("%s/%s", args.StateDir, args.DumpDir)
+		}
+
+		// Update the backup.yaml file just before starting the instance process, but after all devices
+		// have been setup, so that the backup file contains the volatile keys used for this instance
+		// start, so that they can be used for instance cleanup.
+		err = d.UpdateBackupFile()
+		if err != nil {
+			return err
 		}
 
 		_, migrateErr = shared.RunCommand(

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -643,10 +643,10 @@ func (d *qemu) onStop(target string) error {
 	d.unmount()
 
 	// Record power state.
-	err = d.state.Cluster.UpdateInstancePowerState(d.id, "STOPPED")
+	err = d.VolatileSet(map[string]string{"volatile.last_state.power": "STOPPED"})
 	if err != nil {
-		op.Done(err)
-		return err
+		// Don't return an error here as we still want to cleanup the instance even if DB not available.
+		d.logger.Error("Failed recording last power state", log.Ctx{"err": err})
 	}
 
 	// Unload the apparmor profile

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1013,12 +1013,6 @@ func (d *qemu) Start(stateful bool) error {
 		return errors.Wrapf(err, "Failed setting volatile keys")
 	}
 
-	// Update the backup.yaml file (must come after volatile keys have been updated).
-	err = d.UpdateBackupFile()
-	if err != nil {
-		return err
-	}
-
 	// Generate the config drive.
 	err = d.generateConfigShare()
 	if err != nil {
@@ -1325,6 +1319,14 @@ func (d *qemu) Start(stateful bool) error {
 		}
 
 		files = append(files, f)
+	}
+
+	// Update the backup.yaml file just before starting the instance process, but after all devices have been
+	// setup, so that the backup file contains the volatile keys used for this instance start, so that they can
+	// be used for instance cleanup.
+	err = d.UpdateBackupFile()
+	if err != nil {
+		return err
 	}
 
 	// Reset timeout to 30s.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1450,26 +1450,8 @@ func (d *qemu) Start(stateful bool) error {
 		}
 	}
 
-	// Database updates
-	err = d.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
-		// Record current state
-		err = tx.UpdateInstancePowerState(d.id, "RUNNING")
-		if err != nil {
-			err = errors.Wrap(err, "Error updating instance state")
-			op.Done(err)
-			return err
-		}
-
-		// Update time instance last started time
-		err = tx.UpdateInstanceLastUsedDate(d.id, time.Now().UTC())
-		if err != nil {
-			err = errors.Wrap(err, "Error updating instance last used")
-			op.Done(err)
-			return err
-		}
-
-		return nil
-	})
+	// Record last start state.
+	err = d.recordLastState()
 	if err != nil {
 		op.Done(err)
 		return err

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -427,18 +427,16 @@ func instancesShutdown(s *state.State) error {
 
 		// Stop the container
 		if lastState != "ERROR" && lastState != "STOPPED" {
-			// Determinate how long to wait for the instance to shutdown cleanly
-			var timeoutSeconds int
-			value, ok := inst.ExpandedConfig()["boot.host_shutdown_timeout"]
-			if ok {
-				timeoutSeconds, _ = strconv.Atoi(value)
-			} else {
-				timeoutSeconds = 30
-			}
-
 			// Stop the instance
 			wg.Add(1)
 			go func(c instance.Instance, lastState string) {
+				// Determine how long to wait for the instance to shutdown cleanly.
+				timeoutSeconds := 30
+				value, ok := inst.ExpandedConfig()["boot.host_shutdown_timeout"]
+				if ok {
+					timeoutSeconds, _ = strconv.Atoi(value)
+				}
+
 				c.Shutdown(time.Second * time.Duration(timeoutSeconds))
 				c.Stop(false)
 

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -395,27 +395,11 @@ func instancesShutdown(s *state.State) error {
 	if err != nil {
 		// Mark database as offline
 		dbAvailable = false
-		instances = []instance.Instance{}
 
 		// List all instances on disk
-		instanceNames, err := instancesOnDisk()
+		instances, err = instancesOnDisk(s)
 		if err != nil {
 			return err
-		}
-
-		for project, names := range instanceNames {
-			for _, name := range names {
-				inst, err := instance.Load(s, db.InstanceArgs{
-					Project: project,
-					Name:    name,
-					Config:  make(map[string]string),
-				}, nil)
-				if err != nil {
-					return err
-				}
-
-				instances = append(instances, inst)
-			}
 		}
 	}
 

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -405,14 +405,6 @@ func instancesShutdown(s *state.State) error {
 
 	sort.Sort(instanceStopList(instances))
 
-	if dbAvailable {
-		// Reset all instances states
-		err = s.Cluster.ResetInstancesPowerState()
-		if err != nil {
-			return err
-		}
-	}
-
 	var lastPriority int
 
 	if len(instances) != 0 {

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -212,20 +212,8 @@ func (slice instanceAutostartList) Swap(i, j int) {
 	slice[i], slice[j] = slice[j], slice[i]
 }
 
-func instancesRestart(s *state.State) error {
-	// Get all the instances
-	result, err := instance.LoadNodeAll(s, instancetype.Any)
-	if err != nil {
-		return err
-	}
-
-	instances := []instance.Instance{}
-
-	for _, c := range result {
-		instances = append(instances, c)
-	}
-
-	sort.Sort(containerAutostartList(instances))
+func instancesStart(s *state.State, instances []instance.Instance) {
+	sort.Sort(instanceAutostartList(instances))
 
 	maxAttempts := 3
 
@@ -293,7 +281,7 @@ func instancesRestart(s *state.State) error {
 		}
 	}
 
-	return nil
+	return
 }
 
 type instanceStopList []instance.Instance

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -385,23 +385,8 @@ func instancesOnDisk(s *state.State) ([]instance.Instance, error) {
 	return instances, nil
 }
 
-func instancesShutdown(s *state.State) error {
+func instancesShutdown(s *state.State, instances []instance.Instance) error {
 	var wg sync.WaitGroup
-
-	dbAvailable := true
-
-	// Get all the instances
-	instances, err := instance.LoadNodeAll(s, instancetype.Any)
-	if err != nil {
-		// Mark database as offline
-		dbAvailable = false
-
-		// List all instances on disk
-		instances, err = instancesOnDisk(s)
-		if err != nil {
-			return err
-		}
-	}
 
 	sort.Sort(instanceStopList(instances))
 
@@ -442,7 +427,7 @@ func instancesShutdown(s *state.State) error {
 					}
 				}
 
-				if dbAvailable {
+				if inst.ID() > 0 {
 					// If DB was available then the instance shutdown process will have set
 					// the last power state to STOPPED, so set that back to RUNNING so that
 					// when LXD restarts the instance will be started again.

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -422,14 +422,10 @@ func instancesShutdown(s *state.State) error {
 			wg.Wait()
 		}
 
-		// Record the current state
-		lastState := inst.State()
-
-		// Stop the container
-		if lastState != "ERROR" && lastState != "STOPPED" {
-			// Stop the instance
+		// Stop the instance if running.
+		if inst.IsRunning() {
 			wg.Add(1)
-			go func(c instance.Instance, lastState string) {
+			go func(inst instance.Instance) {
 				// Determine how long to wait for the instance to shutdown cleanly.
 				timeoutSeconds := 30
 				value, ok := inst.ExpandedConfig()["boot.host_shutdown_timeout"]
@@ -437,17 +433,24 @@ func instancesShutdown(s *state.State) error {
 					timeoutSeconds, _ = strconv.Atoi(value)
 				}
 
-				c.Shutdown(time.Second * time.Duration(timeoutSeconds))
-				c.Stop(false)
+				err := inst.Shutdown(time.Second * time.Duration(timeoutSeconds))
+				if err != nil {
+					logger.Warn("Failed shutting down instance, forcefully stopping", log.Ctx{"project": inst.Project(), "instance": inst.Name(), "err": err})
+					err = inst.Stop(false)
+					if err != nil {
+						logger.Warn("Failed forcefully stopping instance", log.Ctx{"project": inst.Project(), "instance": inst.Name(), "err": err})
+					}
+				}
 
 				if dbAvailable {
-					c.VolatileSet(map[string]string{"volatile.last_state.power": lastState})
+					// If DB was available then the instance shutdown process will have set
+					// the last power state to STOPPED, so set that back to RUNNING so that
+					// when LXD restarts the instance will be started again.
+					inst.VolatileSet(map[string]string{"volatile.last_state.power": "RUNNING"})
 				}
 
 				wg.Done()
-			}(inst, lastState)
-		} else if dbAvailable {
-			inst.VolatileSet(map[string]string{"volatile.last_state.power": lastState})
+			}(inst)
 		}
 	}
 	wg.Wait()

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -189,13 +189,13 @@ var instanceBackupExportCmd = APIEndpoint{
 	Get: APIEndpointAction{Handler: instanceBackupExportGet, AccessHandler: allowProjectPermission("containers", "view")},
 }
 
-type containerAutostartList []instance.Instance
+type instanceAutostartList []instance.Instance
 
-func (slice containerAutostartList) Len() int {
+func (slice instanceAutostartList) Len() int {
 	return len(slice)
 }
 
-func (slice containerAutostartList) Less(i, j int) bool {
+func (slice instanceAutostartList) Less(i, j int) bool {
 	iOrder := slice[i].ExpandedConfig()["boot.autostart.priority"]
 	jOrder := slice[j].ExpandedConfig()["boot.autostart.priority"]
 
@@ -208,7 +208,7 @@ func (slice containerAutostartList) Less(i, j int) bool {
 	return slice[i].Name() < slice[j].Name()
 }
 
-func (slice containerAutostartList) Swap(i, j int) {
+func (slice instanceAutostartList) Swap(i, j int) {
 	slice[i], slice[j] = slice[j], slice[i]
 }
 

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -4087,16 +4087,23 @@ func patchUpdateFromV10(_ *sql.Tx) error {
 }
 
 func patchUpdateFromV11(_ *sql.Tx) error {
-	containers, err := instancesOnDisk()
+	instances, err := instancesOnDisk(nil)
 	if err != nil {
 		return err
 	}
 
 	errors := 0
 
-	cNames := containers["default"]
+	// tomp TODO this whole patch seems to be oriented around snapshots, and yet instancesOnDisk doesn't
+	// return snapshots, so it may do something unexpected/nothing.
+	for _, inst := range instances {
+		// Only interested in containers in default project.
+		if inst.Type() != instancetype.Container || inst.Project() != project.Default {
+			continue
+		}
 
-	for _, cName := range cNames {
+		cName := inst.Name()
+
 		snapParentName, snapOnlyName, _ := shared.InstanceGetParentAndSnapshotName(cName)
 		oldPath := shared.VarPath("containers", snapParentName, "snapshots", snapOnlyName)
 		newPath := shared.VarPath("snapshots", snapParentName, snapOnlyName)
@@ -4159,12 +4166,10 @@ func patchUpdateFromV11(_ *sql.Tx) error {
 func patchUpdateFromV15(tx *sql.Tx) error {
 	// munge all LVM-backed containers' LV names to match what is
 	// required for snapshot support
-
-	containers, err := instancesOnDisk()
+	instances, err := instancesOnDisk(nil)
 	if err != nil {
 		return err
 	}
-	cNames := containers["default"]
 
 	vgName := ""
 	config, err := query.SelectConfig(tx, "config", "")
@@ -4173,7 +4178,16 @@ func patchUpdateFromV15(tx *sql.Tx) error {
 	}
 	vgName = config["storage.lvm_vg_name"]
 
-	for _, cName := range cNames {
+	// tomp TODO this patch seems to be accounting for snapshots, and yet instancesOnDisk doesn't
+	// return snapshots, so it may do something unexpected/not enough.
+	for _, inst := range instances {
+		// Only interested in containers in default project.
+		if inst.Type() != instancetype.Container || inst.Project() != project.Default {
+			continue
+		}
+
+		cName := inst.Name()
+
 		var lvLinkPath string
 		if strings.Contains(cName, shared.SnapshotDelimiter) {
 			lvLinkPath = shared.VarPath("snapshots", fmt.Sprintf("%s.lv", cName))

--- a/lxd/project/project.go
+++ b/lxd/project/project.go
@@ -36,7 +36,7 @@ func DNS(projectName string, instanceName string) string {
 
 // InstanceParts takes a project prefixed Instance name string and returns the project and instance name.
 // If a non-project prefixed Instance name is supplied, then the project is returned as "default" and the instance
-// name is returned unmodified in the 2nd return value. This is suitable for passing back into Prefix().
+// name is returned unmodified in the 2nd return value. This is suitable for passing back into Instance().
 // Note: This should only be used with Instance names (because they cannot contain the project separator) and this
 // function relies on this rule as project names can contain the project separator.
 func InstanceParts(projectInstanceName string) (string, string) {

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1292,7 +1292,7 @@ func (d *zfs) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 						return false, fmt.Errorf("Failed to deactivate zvol after %v", waitDuration)
 					}
 
-					d.logger.Debug("Waiting for ZFS volume to deactivate", log.Ctx{"volName": vol.name, "dev": dataset})
+					d.logger.Debug("Waiting for ZFS volume to deactivate", log.Ctx{"volName": vol.name, "dev": dataset, "path": devPath})
 					time.Sleep(time.Millisecond * time.Duration(500))
 				}
 

--- a/shared/osarch/architectures.go
+++ b/shared/osarch/architectures.go
@@ -105,7 +105,7 @@ func ArchitectureId(arch string) (int, error) {
 		}
 	}
 
-	return 0, fmt.Errorf("Architecture isn't supported: %s", arch)
+	return ARCH_UNKNOWN, fmt.Errorf("Architecture isn't supported: %s", arch)
 }
 
 func ArchitecturePersonality(arch int) (string, error) {


### PR DESCRIPTION
As part of the series of fixes for #9327 this PR reworks `instancesOnDisk` to return a slice of `instance.Instance` with the `Type` field correctly populated (to allow differentiation between containers and VMs), as well as loading the config and device config from the instance's backup.yaml if available.

This PR also forcefully closes the cluster DB connection on shutdown if the loading of instances fails, which will cause all subsequent queries to fail quickly. Should help with shutdown speed when shutting down a server that has no access to the global DB.

Because of this point, device cleanup can still fail due to their validation steps requiring DB access.
But this puts in the foundations for proper clean up of instances when no DB access, and then each device type needs updating to allow cleanup when no DB available.