### PR TITLE
lxd-agent: Drop aggregated cpu stats in metrics

### DIFF
--- a/lxd-agent/metrics.go
+++ b/lxd-agent/metrics.go
@@ -89,8 +89,9 @@ func getCPUMetrics(d *Daemon) (map[string]metrics.CPUMetrics, error) {
 	for scanner.Scan() {
 		fields := strings.Fields(scanner.Text())
 
-		// Only consider CPU info, skip everything else.
-		if !strings.HasPrefix(fields[0], "cpu") {
+		// Only consider CPU info, skip everything else. Skip aggregated CPU stats since there will
+		// be stats for each individual CPU.
+		if !strings.HasPrefix(fields[0], "cpu") || fields[0] == "cpu" {
 			continue
 		}
 


### PR DESCRIPTION
The aggregated CPU stats should be dropped for two reasons:

1) To be consistent as containers don't have them
2) These stats can be calculated using the other CPU stats

This resolves #9322.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
