### PR TITLE
lxd/main/shutdown: Fix shutdown regression when running in snap

### DIFF
--- a/lxd/main_shutdown.go
+++ b/lxd/main_shutdown.go
@@ -61,14 +61,6 @@ func (c *cmdShutdown) Run(cmd *cobra.Command, args []string) error {
 			chResult <- err
 			return
 		}
-
-		// Try connecting to events endpoint to check the daemon has really shutdown.
-		monitor, err := d.GetEvents()
-		if err != nil {
-			return // Daemon has stopped.
-		}
-
-		monitor.Wait() // Wait for daemon to stop.
 	}()
 
 	if c.flagTimeout > 0 {


### PR DESCRIPTION
The change to make `/internal/shutdown` blocking has had a knock on effect to `lxd shutdown` when running inside the snap.

Because the process was:

1. Issue shutdown request to `/internal/shutdown` and then wait until LXD ends.
2. Then send request to events API endpoint to confirm LXD has ended.

When run inside the snap, the first request caused the LXD process to end, and then the second request caused the snap's socket activation to start LXD again.

So we've re-organised it so that only the shutdown request is sent.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>