### PR TITLE
lxc: update wording when a cert is successfully trusted by a remote

### DIFF
--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -462,7 +462,7 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		if c.flagAuthType == "tls" {
-			fmt.Println(i18n.G("Client certificate stored at server:")+" ", server)
+			fmt.Println(i18n.G("Client certificate now trusted by server:"), server)
 		}
 	}
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -960,7 +960,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 
 #: lxc/remote.go:465
 #, fuzzy
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
 
 #: lxc/version.go:37
@@ -4359,7 +4359,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -5676,9 +5676,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -741,7 +741,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3936,7 +3936,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4782,9 +4782,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -910,7 +910,7 @@ msgstr "Certificado de la huella digital: %s"
 
 #: lxc/remote.go:465
 #, fuzzy
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
 
 #: lxc/version.go:37
@@ -4143,7 +4143,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -5095,9 +5095,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -946,7 +946,7 @@ msgstr "Empreinte du certificat : %s"
 
 #: lxc/remote.go:465
 #, fuzzy
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr "Certificat client enregistré sur le serveur : "
 
 #: lxc/version.go:37
@@ -4481,7 +4481,7 @@ msgstr ""
 
 #: lxc/main.go:346
 #, fuzzy
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
@@ -5907,9 +5907,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -898,7 +898,7 @@ msgstr ""
 
 #: lxc/remote.go:465
 #, fuzzy
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
 
 #: lxc/version.go:37
@@ -4135,7 +4135,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -5087,9 +5087,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: 2021-08-06 08:35+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -917,7 +917,8 @@ msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+#, fuzzy
+msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに格納されました:"
 
 #: lxc/version.go:37
@@ -4423,7 +4424,8 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+#, fuzzy
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 "初めてインスタンスを起動するには、\"lxc launch ubuntu:18.04\" と実行してみて"
 "ください"
@@ -5339,10 +5341,11 @@ msgstr ""
 "    config.yaml の設定を使ってインスタンスを作成します"
 
 #: lxc/launch.go:27
+#, fuzzy
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 "lxc launch ubuntu:18.04 u1\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2021-10-04 12:18-0400\n"
+        "POT-Creation-Date: 2021-10-04 12:28-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -715,7 +715,7 @@ msgid   "Certificate fingerprint: %s"
 msgstr  ""
 
 #: lxc/remote.go:465
-msgid   "Client certificate stored at server:"
+msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
 #: lxc/version.go:37

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -889,7 +889,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -4075,7 +4075,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4919,9 +4919,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -911,7 +911,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -4097,7 +4097,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4941,9 +4941,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -928,7 +928,7 @@ msgstr "Certificado fingerprint: %s"
 
 #: lxc/remote.go:465
 #, fuzzy
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
 
 #: lxc/version.go:37
@@ -4216,7 +4216,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -5096,9 +5096,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: 2020-10-08 08:16+0000\n"
 "Last-Translator: Artem <KovalevArtem.ru@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -928,7 +928,7 @@ msgstr ""
 
 #: lxc/remote.go:465
 #, fuzzy
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
 
 #: lxc/version.go:37
@@ -4204,7 +4204,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -5468,9 +5468,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: 2020-11-05 02:45+0000\n"
 "Last-Translator: wdggg <wdggg7@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -791,7 +791,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3977,7 +3977,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4821,9 +4821,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-09-30 16:08+0200\n"
+"POT-Creation-Date: 2021-10-04 12:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -737,7 +737,7 @@ msgid "Certificate fingerprint: %s"
 msgstr ""
 
 #: lxc/remote.go:465
-msgid "Client certificate stored at server:"
+msgid "Client certificate now trusted by server:"
 msgstr ""
 
 #: lxc/version.go:37
@@ -3923,7 +3923,7 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: lxc/main.go:346
-msgid "To start your first instance, try: lxc launch ubuntu:18.04"
+msgid "To start your first instance, try: lxc launch ubuntu:20.04"
 msgstr ""
 
 #: lxc/config.go:281 lxc/config.go:419 lxc/config.go:569 lxc/config.go:655
@@ -4767,9 +4767,9 @@ msgstr ""
 
 #: lxc/launch.go:27
 msgid ""
-"lxc launch ubuntu:18.04 u1\n"
+"lxc launch ubuntu:20.04 u1\n"
 "\n"
-"lxc launch ubuntu:18.04 u1 < config.yaml\n"
+"lxc launch ubuntu:20.04 u1 < config.yaml\n"
 "    Create and start the instance with configuration from config.yaml"
 msgstr ""
 


### PR DESCRIPTION
"stored" is a bit ambiguous and there shouldn't be 2 spaces between ":" and the remote name.

```
$ lxc remote add tryit 2602:fc62:a:2000:216:3eff:fe61:c4ef --password=measured
Certificate fingerprint: 2e42726e563dfbc761b5d073427ef686b2d4f3103a07ff30b5f794645fad1e2b
ok (y/n/[fingerprint])? 2e42726e563dfbc761b5d073427ef686b2d4f3103a07ff30b5f794645fad1e2b
Client certificate stored at server:  tryit
```