### PR TITLE
Cluster: Error when no leader address found during handover

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2079,10 +2079,7 @@ findLeader:
 		return err
 	}
 	if leader == "" {
-		// Give up.
-		//
-		// TODO: retry a few times?
-		return nil
+		return fmt.Errorf("No leader address found")
 	}
 
 	if leader == address {

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2171,6 +2171,11 @@ func internalClusterPostHandover(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.InternalError(err)
 	}
+
+	if leader == "" {
+		return response.SmartError(fmt.Errorf("No leader address found"))
+	}
+
 	if address != leader {
 		logger.Debugf("Redirect handover request to %s", leader)
 		url := &url.URL{

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -266,7 +266,7 @@ func (g *Gateway) HandlerFuncs(nodeRefreshTask func(*APIHeartbeat), trustedCerts
 
 			// Only perform node refresh task if we have received a full state list from leader.
 			if !heartbeatData.FullStateList {
-				logger.Debugf("Partial node list heartbeat received, skipping full update")
+				logger.Info("Partial node list heartbeat received, skipping full update")
 				return
 			}
 
@@ -427,7 +427,7 @@ func (g *Gateway) DialFunc() client.DialFunc {
 		// leader is ourselves, and we were recently elected. In that case
 		// trigger a full heartbeat now: it will be a no-op if we aren't
 		// actually leaders.
-		logger.Debug("Triggering an out of schedule hearbeat", log.Ctx{"address": address})
+		logger.Info("Triggering an out of schedule hearbeat", log.Ctx{"address": address})
 		go g.heartbeat(g.ctx, hearbeatInitial)
 
 		return conn, nil

--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -246,7 +246,6 @@ func (g *Gateway) heartbeatRestart() {
 
 	// There is a cancellable heartbeat round ongoing.
 	if g.heartbeatCancel != nil {
-		logger.Info("Restarting heartbeat", log.Ctx{"member": g.Cluster.GetNodeID()})
 		g.heartbeatCancel()            // Request ongoing hearbeat round cancel itself.
 		g.heartbeatCancel = nil        // Indicate there is no further cancellable heartbeat round.
 		g.heartbeatCancelLock.Unlock() // Release lock ready for g.heartbeat to acquire it.

--- a/test/includes/lxd.sh
+++ b/test/includes/lxd.sh
@@ -133,36 +133,36 @@ kill_lxd() {
     if [ -e "${daemon_dir}/unix.socket" ]; then
         # Delete all containers
         echo "==> Deleting all containers"
-        for container in $(lxc list --fast --force-local | tail -n+3 | grep "^| " | cut -d' ' -f2); do
-            lxc delete "${container}" --force-local -f || true
+        for container in $(timeout -k 2 2 lxc list --fast --force-local | tail -n+3 | grep "^| " | cut -d' ' -f2); do
+            timeout -k 10 10 lxc delete "${container}" --force-local -f || true
         done
 
         # Delete all images
         echo "==> Deleting all images"
-        for image in $(lxc image list --force-local | tail -n+3 | grep "^| " | cut -d'|' -f3 | sed "s/^ //g"); do
-            lxc image delete "${image}" --force-local || true
+        for image in $(timeout -k 2 2 lxc image list --force-local | tail -n+3 | grep "^| " | cut -d'|' -f3 | sed "s/^ //g"); do
+            timeout -k 10 10 lxc image delete "${image}" --force-local || true
         done
 
         # Delete all profiles
         echo "==> Deleting all profiles"
-        for profile in $(lxc profile list --force-local | tail -n+3 | grep "^| " | cut -d' ' -f2); do
-            lxc profile delete "${profile}" --force-local || true
+        for profile in $(timeout -k 2 2 lxc profile list --force-local | tail -n+3 | grep "^| " | cut -d' ' -f2); do
+            timeout -k 10 10 lxc profile delete "${profile}" --force-local || true
         done
 
         # Delete all networks
         echo "==> Deleting all networks"
-        for network in $(lxc network list --force-local | grep YES | grep "^| " | cut -d' ' -f2); do
-            lxc network delete "${network}" --force-local || true
+        for network in $(timeout -k 2 2 lxc network list --force-local | grep YES | grep "^| " | cut -d' ' -f2); do
+            timeout -k 10 10 lxc network delete "${network}" --force-local || true
         done
 
         # Clear config of the default profile since the profile itself cannot
         # be deleted.
         echo "==> Clearing config of default profile"
-        printf 'config: {}\ndevices: {}' | lxc profile edit default
+        printf 'config: {}\ndevices: {}' | timeout -k 5 5 lxc profile edit default
 
         echo "==> Deleting all storage pools"
-        for storage in $(lxc storage list --force-local | tail -n+3 | grep "^| " | cut -d' ' -f2); do
-            lxc storage delete "${storage}" --force-local || true
+        for storage in $(timeout -k 2 2 lxc storage list --force-local | tail -n+3 | grep "^| " | cut -d' ' -f2); do
+            timeout -k 10 10 lxc storage delete "${storage}" --force-local || true
         done
 
         echo "==> Checking for locked DB tables"
@@ -171,7 +171,7 @@ kill_lxd() {
         done
 
         # Kill the daemon
-        lxd shutdown || kill -9 "${daemon_pid}" 2>/dev/null || true
+        timeout -k 30 30 lxd shutdown || kill -9 "${daemon_pid}" 2>/dev/null || true
 
         sleep 2
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -1580,8 +1580,12 @@ test_clustering_shutdown_nodes() {
   LXD_DIR="${LXD_THREE_DIR}" lxd shutdown
   wait "${daemon_pid3}"
 
+  # Wait for raft election to take place and become aware that quorum has been lost (should take 3-6s).
+  sleep 10
+
   # Make sure the database is not available to the first node
-  sleep 15
+  ! LXD_DIR="${LXD_ONE_DIR}" timeout -k 5 5 lxc cluster ls || false
+
   LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
 
   # Wait for LXD to terminate, otherwise the db will not be empty, and the


### PR DESCRIPTION
Also log partial and initial heartbeats as these should only be sent when cluster state changes.

Also adds additional logging and removes sleeps from cluster handover tests to allow us to get a better understanding of how much time role handover actually needs.