### PR TITLE
Storage: Use normal mount rather than zfs mount for ZFS volumes

### DIFF
--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1174,7 +1174,7 @@ func (d *zfs) MountVolume(vol Volume, op *operations.Operation) error {
 			}
 
 			// Mount the dataset.
-			_, err = shared.RunCommand("zfs", "mount", dataset)
+			err = TryMount(dataset, mountPath, "zfs", 0, "")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Seems to work better inside the snap than zfs mount.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>