### PR TITLE
lxd/instance/lxc: Properly report mapped memory

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6845,7 +6845,7 @@ func (d *lxc) Metrics() (*metrics.MetricSet, error) {
 			case "dirty":
 				metricType = metrics.MemoryDirtyBytes
 			case "mapped":
-				metricType = metrics.MemoryDirtyBytes
+				metricType = metrics.MemoryMappedBytes
 			case "rss":
 				metricType = metrics.MemoryRSSBytes
 			case "shmem":


### PR DESCRIPTION
Closes #9354

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>