### PR TITLE
Remove the last 'which' occurence.

### DIFF
--- a/test/includes/lxc.sh
+++ b/test/includes/lxc.sh
@@ -10,8 +10,8 @@ lxc_remote() {
     local injected cmd arg
 
     injected=0
-    # shellcheck disable=SC2230
-    cmd=$(which lxc)
+    # find the path to lxc binary, not the shell wrapper function
+    cmd=$(unset -f lxc; command -v lxc)
 
     # shellcheck disable=SC2048,SC2068
     for arg in "$@"; do


### PR DESCRIPTION
In recent versions of debianutils, `which` prints a deprecation warning and
there are discussions to remove it completely at some point.

Signed-off-by: Simon Deziel <simon.deziel@canonical.com>