### PR TITLE
lxc/file: Don't use HostPath on temp files

### DIFF
--- a/lxc/file.go
+++ b/lxc/file.go
@@ -187,7 +187,7 @@ func (c *cmdFileEdit) Run(cmd *cobra.Command, args []string) error {
 	fname := f.Name()
 	f.Close()
 	os.Remove(fname)
-	defer os.Remove(shared.HostPathFollow(fname))
+	defer os.Remove(fname)
 
 	// Extract current value
 	err = c.filePull.Run(cmd, append([]string{args[0]}, fname))
@@ -196,7 +196,7 @@ func (c *cmdFileEdit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Spawn the editor
-	_, err = shared.TextEditor(shared.HostPathFollow(fname), []byte{})
+	_, err = shared.TextEditor(fname, []byte{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
HostPath is meant for accessing user provided paths which may not be
accessible when LXD is run in a confined environment. It shouldn't be
used to access files that are generated within LXD's environment.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>