### PR TITLE
Network: Add ACL integration for OVN peer connections

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -2452,6 +2452,16 @@ definitions:
         readOnly: true
         type: string
         x-go-name: TargetProject
+      used_by:
+        description: List of URLs of objects using this network peering
+        example:
+        - /1.0/network-acls/test
+        - /1.0/network-acls/foo
+        items:
+          type: string
+        readOnly: true
+        type: array
+        x-go-name: UsedBy
     title: NetworkPeer used for displaying a LXD network peering.
     type: object
     x-go-package: github.com/lxc/lxd/shared/api

--- a/lxd/network/acl/driver_common.go
+++ b/lxd/network/acl/driver_common.go
@@ -523,6 +523,15 @@ func (d *common) validateRuleSubjects(fieldName string, direction ruleDirection,
 			}
 		}
 
+		// Check if it looks like a network peer connection name.
+		if strings.HasPrefix(subject, "@") {
+			if allowSubjectNames {
+				return 0, nil // Found valid subject.
+			}
+
+			return 0, fmt.Errorf("Named subjects not allowed in %q for %q rules", fieldName, direction)
+		}
+
 		return 0, fmt.Errorf("Invalid subject %q", subject)
 	}
 

--- a/lxd/network/acl/driver_common.go
+++ b/lxd/network/acl/driver_common.go
@@ -304,7 +304,7 @@ func (d *common) validateRule(direction ruleDirection, rule api.NetworkACLRule) 
 		return errors.Wrapf(err, "Failed getting network ACLs for security ACL subject validation")
 	}
 
-	validSubjectNames := make([]string, 0, len(acls)+2)
+	validSubjectNames := make([]string, 0, len(acls)+len(ruleSubjectInternalAliases)+len(ruleSubjectExternalAliases))
 	validSubjectNames = append(validSubjectNames, ruleSubjectInternalAliases...)
 	validSubjectNames = append(validSubjectNames, ruleSubjectExternalAliases...)
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -4504,6 +4504,15 @@ func (n *ovn) PeerDelete(peerName string) error {
 		return err
 	}
 
+	isUsed, err := n.peerIsUsed(peer.Name)
+	if err != nil {
+		return err
+	}
+
+	if isUsed {
+		return fmt.Errorf("Cannot delete a Peer that is in use")
+	}
+
 	if peer.Status == api.NetworkStatusCreated {
 		targetNet, err := LoadByName(n.state, peer.TargetProject, peer.TargetNetwork)
 		if err != nil {

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2180,8 +2180,11 @@ func (n *ovn) setup(update bool) error {
 }
 
 // logicalRouterPolicySetup applies the security policy to the logical router (clearing any existing policies).
-func (n *ovn) logicalRouterPolicySetup(client *openvswitch.OVN) error {
-	//extRouterPort := n.getRouterExtPortName()
+// Optionally excludePeers takes a list of peer network IDs to exclude from the router policy. This is useful
+// when removing a peer connection as it allows the security policy to be removed from OVN for that peer before the
+// peer connection has been removed from the database.
+func (n *ovn) logicalRouterPolicySetup(client *openvswitch.OVN, excludePeers ...int64) error {
+	extRouterPort := n.getRouterExtPortName()
 	intRouterPort := n.getRouterIntPortName()
 	addrSetPrefix := acl.OVNIntSwitchPortGroupAddressSetPrefix(n.ID())
 
@@ -2207,6 +2210,35 @@ func (n *ovn) logicalRouterPolicySetup(client *openvswitch.OVN) error {
 			Match:    fmt.Sprintf(`(inport == "%s")`, intRouterPort),
 			Action:   "drop",
 		},
+	}
+
+	// Add rules to drop inbound traffic arriving on external uplink port from peer connection addresses.
+	// This prevents source address spoofing of peer connection routes from the external network, which in
+	// turn allows us to use the peer connection's address set for referencing traffic from the peer in ACL.
+	var err error
+	err = n.forPeers(func(targetOVNNet *ovn) error {
+		if shared.Int64InSlice(targetOVNNet.ID(), excludePeers) {
+			return nil // Don't setup rules for this peer network connection.
+		}
+
+		targetAddrSetPrefix := acl.OVNIntSwitchPortGroupAddressSetPrefix(targetOVNNet.ID())
+
+		// Associate the rules with the local peering port so we can identify them later if needed.
+		comment := n.getLogicRouterPeerPortName(targetOVNNet.ID())
+		policies = append(policies, openvswitch.OVNRouterPolicy{
+			Priority: ovnRouterPolicyPeerDropPriority,
+			Match:    fmt.Sprintf(`(inport == "%s" && ip6 && ip6.src == $%s_ip6) // %s`, extRouterPort, targetAddrSetPrefix, comment),
+			Action:   "drop",
+		}, openvswitch.OVNRouterPolicy{
+			Priority: ovnRouterPolicyPeerDropPriority,
+			Match:    fmt.Sprintf(`(inport == "%s" && ip4 && ip4.src == $%s_ip4) // %s`, extRouterPort, targetAddrSetPrefix, comment),
+			Action:   "drop",
+		})
+
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	return client.LogicalRouterPolicyApply(n.getRouterName(), policies...)

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -4531,6 +4531,16 @@ func (n *ovn) PeerDelete(peerName string) error {
 		if err != nil {
 			return fmt.Errorf("Failed deleting OVN network peering: %w", err)
 		}
+
+		err = n.logicalRouterPolicySetup(client, targetOVNNet.ID())
+		if err != nil {
+			return fmt.Errorf("Failed applying local router security policy: %w", err)
+		}
+
+		err = targetOVNNet.logicalRouterPolicySetup(client, n.ID())
+		if err != nil {
+			return fmt.Errorf("Failed applying target router security policy: %w", err)
+		}
 	}
 
 	err = n.state.Cluster.DeleteNetworkPeer(n.ID(), peerID)

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -4403,7 +4403,7 @@ func (n *ovn) peerSetup(client *openvswitch.OVN, targetOVNNet *ovn, opts openvsw
 		return fmt.Errorf("Failed getting instance NIC routes on target network: %w", err)
 	}
 
-	// Ensure routes are added target switch address sets.
+	// Ensure routes are added to target switch address sets.
 	err = client.AddressSetAdd(acl.OVNIntSwitchPortGroupAddressSetPrefix(targetOVNNet.ID()), opts.LocalRouterRoutes...)
 	if err != nil {
 		return fmt.Errorf("Failed adding target swith subnet address set entries: %w", err)

--- a/lxd/network/network_interface.go
+++ b/lxd/network/network_interface.go
@@ -65,4 +65,5 @@ type Network interface {
 	PeerCreate(forward api.NetworkPeersPost) error
 	PeerUpdate(peerName string, newPeer api.NetworkPeerPut) error
 	PeerDelete(peerName string) error
+	PeerUsedBy(peerName string) ([]string, error)
 }

--- a/lxd/network_peer.go
+++ b/lxd/network_peer.go
@@ -151,6 +151,7 @@ func networkPeersGet(d *Daemon, r *http.Request) response.Response {
 
 		peers := make([]*api.NetworkPeer, 0, len(records))
 		for _, record := range records {
+			record.UsedBy, _ = n.PeerUsedBy(record.Name)
 			peers = append(peers, record)
 		}
 
@@ -364,6 +365,8 @@ func networkPeerGet(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.SmartError(err)
 	}
+
+	peer.UsedBy, _ = n.PeerUsedBy(peer.Name)
 
 	return response.SyncResponseETag(true, peer, peer.Etag())
 }

--- a/shared/api/network_peer.go
+++ b/shared/api/network_peer.go
@@ -63,6 +63,11 @@ type NetworkPeer struct {
 	// Read only: true
 	// Example: Pending
 	Status string `json:"status" yaml:"status"`
+
+	// List of URLs of objects using this network peering
+	// Read only: true
+	// Example: ["/1.0/network-acls/test", "/1.0/network-acls/foo"]
+	UsedBy []string `json:"used_by" yaml:"used_by"`
 }
 
 // Etag returns the values used for etag generation.


### PR DESCRIPTION
This PR adds the following:

- When a peer connection is established, router security rules are added to prevent packets with source address of IPs in the peer's target network routes from being allowed in via the router's external uplink port. This prevents spoofed packets coming in from the external network that would appear to come from the peer connection's routes.
- When a peer connection is deleted, these security rules are removed (by way of rebuilding both sides' security rules and excluding the removed peer networks from the allowed list). Combined with the existing egress network IP spoof protection means that we can trust that packets with a source address in the peer's target network's address set truly did come via the peer connection.
- Building on the above trust scenario, it then adds support for using `@<network_name>/<peer_name>` in OVN ACL subjects (source and destination). This is then converted to an IP address set rule that uses the peer's target network's address sets (IPv4 and IPv6).
- Checks that ACLs with rule(s) containing peer references can only be applied to networks/NICs that have the needed peer connections. In practice this means that ACLs that use peer references can only be applied that particular network or NICs connected to that network.
