### PR TITLE
feat: add support for nixOS path

### DIFF
--- a/lxd-agent/exec.go
+++ b/lxd-agent/exec.go
@@ -56,8 +56,14 @@ func execPost(d *Daemon, r *http.Request) response.Response {
 		env["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 	}
 
+	// snap
 	if shared.PathExists("/snap/bin") {
 		env["PATH"] = fmt.Sprintf("%s:/snap/bin", env["PATH"])
+	}
+
+	// nixOS
+	if shared.PathExists("/run/current-system") {
+		env["PATH"] = fmt.Sprintf("%s:/run/current-system/sw/bin", env["PATH"])
 	}
 
 	// If running as root, set some env variables

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -519,9 +519,17 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 	_, ok := post.Environment["PATH"]
 	if !ok {
 		post.Environment["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+		// snap
 		if inst.FileExists("/snap") == nil {
 			post.Environment["PATH"] = fmt.Sprintf("%s:/snap/bin", post.Environment["PATH"])
 		}
+
+		// nixOS
+		if inst.FileExists("/run/current-system") == nil {
+			post.Environment["PATH"] = fmt.Sprintf("%s:/run/current-system/sw/bin", post.Environment["PATH"])
+		}
+
 	}
 
 	// If running as root, set some env variables.


### PR DESCRIPTION
In NixOS the path is typically entirely stored in /run/current-system/sw/bin

This patch makes LXD consider this location and allows to execute commands
in NixOS containers more seamlessly (that is without needing an absolute path specified)