### PR TITLE
lxd/api/cluster: Sleep for 100ms to allow http.Flush to render

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -768,6 +768,7 @@ func clusterPutDisable(d *Daemon, r *http.Request, req api.ClusterPut) response.
 		f, ok := w.(http.Flusher)
 		if ok {
 			f.Flush()
+			time.Sleep(100 * time.Millisecond)
 		} else {
 			return fmt.Errorf("http.ResponseWriter is not type http.Flusher")
 		}


### PR DESCRIPTION
Partly addresses #9464

When calling `clusterPutDisable`, the daemon is re-execed in order to
clear the state after clustering is disabled. The response is flushed
via `response.ManualResponse`'s hook, which calls `Flush()` to render the
response before the daemon is replaced. It seems the response is not
rendered quickly enough before the daemon shuts down if a node removes
itself. Waiting for the response context to cancel still causes an `EOF`
error as the daemon still restarts too quickly. Adding a 100ms sleep
should take care of this until we can investigate why `Flush()` isn't
rendering in time.

Signed-off-by: Max Asnaashari <max.asnaashari@canonical.com>