### PR TITLE
Container: Release liblxc cache when stopping or shutting down

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2687,6 +2687,11 @@ func (d *lxc) Stop(stateful bool) error {
 		os.RemoveAll(d.StatePath())
 	}
 
+	// Release liblxc container once done.
+	defer func() {
+		d.release()
+	}()
+
 	// Load the go-lxc struct
 	if d.expandedConfig["raw.lxc"] != "" {
 		err = d.initLXC(true)
@@ -2805,6 +2810,11 @@ func (d *lxc) Shutdown(timeout time.Duration) error {
 	if op.Action() == "stop" {
 		d.logger.Info("Shutting down container", ctxMap)
 	}
+
+	// Release liblxc container once done.
+	defer func() {
+		d.release()
+	}()
 
 	// Load the go-lxc struct
 	if d.expandedConfig["raw.lxc"] != "" {


### PR DESCRIPTION
This ensures that when restarting we use a freshly generated config rather than the config loaded during stop/shutdown (which was having the raw.lxc config added to it in order to handle shutdown signalling requirements).

This reuse of config was resulting in duplicated raw.lxc config lines being added to the config file on restart, as the raw.lxc lines were adding again during start.

Introduced by https://github.com/lxc/lxd/pull/9270