### PR TITLE
lxc/list: Changed units to be IEC consistent

### DIFF
--- a/lxc/info.go
+++ b/lxc/info.go
@@ -269,7 +269,7 @@ func (c *cmdInfo) renderDisk(disk api.ResourcesStorageDisk, prefix string, initi
 		fmt.Printf(prefix+i18n.G("Type: %s")+"\n", disk.Type)
 	}
 
-	fmt.Printf(prefix+i18n.G("Size: %s")+"\n", units.GetByteSizeString(int64(disk.Size), 2))
+	fmt.Printf(prefix+i18n.G("Size: %s")+"\n", units.GetByteSizeStringIEC(int64(disk.Size), 2))
 
 	if disk.WWN != "" {
 		fmt.Printf(prefix+i18n.G("WWN: %s")+"\n", disk.WWN)
@@ -285,7 +285,7 @@ func (c *cmdInfo) renderDisk(disk api.ResourcesStorageDisk, prefix string, initi
 			fmt.Printf(prefix+"    "+i18n.G("ID: %s")+"\n", partition.ID)
 			fmt.Printf(prefix+"    "+i18n.G("Device: %s")+"\n", partition.Device)
 			fmt.Printf(prefix+"    "+i18n.G("Read-Only: %v")+"\n", partition.ReadOnly)
-			fmt.Printf(prefix+"    "+i18n.G("Size: %s")+"\n", units.GetByteSizeString(int64(partition.Size), 2))
+			fmt.Printf(prefix+"    "+i18n.G("Size: %s")+"\n", units.GetByteSizeStringIEC(int64(partition.Size), 2))
 		}
 	}
 }
@@ -302,7 +302,7 @@ func (c *cmdInfo) renderCPU(cpu api.ResourcesCPUSocket, prefix string) {
 	if cpu.Cache != nil {
 		fmt.Printf(prefix + i18n.G("Caches:") + "\n")
 		for _, cache := range cpu.Cache {
-			fmt.Printf(prefix+"  "+i18n.G("- Level %d (type: %s): %s")+"\n", cache.Level, cache.Type, units.GetByteSizeString(int64(cache.Size), 0))
+			fmt.Printf(prefix+"  "+i18n.G("- Level %d (type: %s): %s")+"\n", cache.Level, cache.Type, units.GetByteSizeStringIEC(int64(cache.Size), 0))
 		}
 	}
 
@@ -361,9 +361,9 @@ func (c *cmdInfo) remoteInfo(d lxd.InstanceServer) error {
 		fmt.Printf("\n" + i18n.G("Memory:") + "\n")
 		if resources.Memory.HugepagesTotal > 0 {
 			fmt.Printf("  " + i18n.G("Hugepages:"+"\n"))
-			fmt.Printf("    "+i18n.G("Free: %v")+"\n", units.GetByteSizeString(int64(resources.Memory.HugepagesTotal-resources.Memory.HugepagesUsed), 2))
-			fmt.Printf("    "+i18n.G("Used: %v")+"\n", units.GetByteSizeString(int64(resources.Memory.HugepagesUsed), 2))
-			fmt.Printf("    "+i18n.G("Total: %v")+"\n", units.GetByteSizeString(int64(resources.Memory.HugepagesTotal), 2))
+			fmt.Printf("    "+i18n.G("Free: %v")+"\n", units.GetByteSizeStringIEC(int64(resources.Memory.HugepagesTotal-resources.Memory.HugepagesUsed), 2))
+			fmt.Printf("    "+i18n.G("Used: %v")+"\n", units.GetByteSizeStringIEC(int64(resources.Memory.HugepagesUsed), 2))
+			fmt.Printf("    "+i18n.G("Total: %v")+"\n", units.GetByteSizeStringIEC(int64(resources.Memory.HugepagesTotal), 2))
 		}
 
 		if len(resources.Memory.Nodes) > 1 {
@@ -372,19 +372,19 @@ func (c *cmdInfo) remoteInfo(d lxd.InstanceServer) error {
 				fmt.Printf("    "+i18n.G("Node %d:"+"\n"), node.NUMANode)
 				if node.HugepagesTotal > 0 {
 					fmt.Printf("      " + i18n.G("Hugepages:"+"\n"))
-					fmt.Printf("        "+i18n.G("Free: %v")+"\n", units.GetByteSizeString(int64(node.HugepagesTotal-node.HugepagesUsed), 2))
-					fmt.Printf("        "+i18n.G("Used: %v")+"\n", units.GetByteSizeString(int64(node.HugepagesUsed), 2))
-					fmt.Printf("        "+i18n.G("Total: %v")+"\n", units.GetByteSizeString(int64(node.HugepagesTotal), 2))
+					fmt.Printf("        "+i18n.G("Free: %v")+"\n", units.GetByteSizeStringIEC(int64(node.HugepagesTotal-node.HugepagesUsed), 2))
+					fmt.Printf("        "+i18n.G("Used: %v")+"\n", units.GetByteSizeStringIEC(int64(node.HugepagesUsed), 2))
+					fmt.Printf("        "+i18n.G("Total: %v")+"\n", units.GetByteSizeStringIEC(int64(node.HugepagesTotal), 2))
 				}
-				fmt.Printf("      "+i18n.G("Free: %v")+"\n", units.GetByteSizeString(int64(node.Total-node.Used), 2))
-				fmt.Printf("      "+i18n.G("Used: %v")+"\n", units.GetByteSizeString(int64(node.Used), 2))
-				fmt.Printf("      "+i18n.G("Total: %v")+"\n", units.GetByteSizeString(int64(node.Total), 2))
+				fmt.Printf("      "+i18n.G("Free: %v")+"\n", units.GetByteSizeStringIEC(int64(node.Total-node.Used), 2))
+				fmt.Printf("      "+i18n.G("Used: %v")+"\n", units.GetByteSizeStringIEC(int64(node.Used), 2))
+				fmt.Printf("      "+i18n.G("Total: %v")+"\n", units.GetByteSizeStringIEC(int64(node.Total), 2))
 			}
 		}
 
-		fmt.Printf("  "+i18n.G("Free: %v")+"\n", units.GetByteSizeString(int64(resources.Memory.Total-resources.Memory.Used), 2))
-		fmt.Printf("  "+i18n.G("Used: %v")+"\n", units.GetByteSizeString(int64(resources.Memory.Used), 2))
-		fmt.Printf("  "+i18n.G("Total: %v")+"\n", units.GetByteSizeString(int64(resources.Memory.Total), 2))
+		fmt.Printf("  "+i18n.G("Free: %v")+"\n", units.GetByteSizeStringIEC(int64(resources.Memory.Total-resources.Memory.Used), 2))
+		fmt.Printf("  "+i18n.G("Used: %v")+"\n", units.GetByteSizeStringIEC(int64(resources.Memory.Used), 2))
+		fmt.Printf("  "+i18n.G("Total: %v")+"\n", units.GetByteSizeStringIEC(int64(resources.Memory.Total), 2))
 
 		// GPUs
 		if len(resources.GPU.Cards) == 1 {

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -720,7 +720,7 @@ func (c *cmdList) IP6ColumnData(cInfo api.InstanceFull) string {
 
 func (c *cmdList) memoryUsageColumnData(cInfo api.InstanceFull) string {
 	if cInfo.IsActive() && cInfo.State != nil && cInfo.State.Memory.Usage > 0 {
-		return units.GetByteSizeString(cInfo.State.Memory.Usage, 2)
+		return units.GetByteSizeStringIEC(cInfo.State.Memory.Usage, 2)
 	}
 
 	return ""
@@ -757,7 +757,7 @@ func (c *cmdList) diskUsageColumnData(cInfo api.InstanceFull) string {
 	rootDisk, _, _ := shared.GetRootDiskDevice(cInfo.ExpandedDevices)
 
 	if cInfo.State != nil && cInfo.State.Disk != nil && cInfo.State.Disk[rootDisk].Usage > 0 {
-		return units.GetByteSizeString(cInfo.State.Disk[rootDisk].Usage, 2)
+		return units.GetByteSizeStringIEC(cInfo.State.Disk[rootDisk].Usage, 2)
 	}
 
 	return ""

--- a/lxc/storage.go
+++ b/lxc/storage.go
@@ -480,8 +480,8 @@ func (c *cmdStorageInfo) Run(cmd *cobra.Command, args []string) error {
 		poolinfo[infostring][totalspacestring] = strconv.FormatUint(res.Space.Total, 10)
 		poolinfo[infostring][spaceusedstring] = strconv.FormatUint(res.Space.Used, 10)
 	} else {
-		poolinfo[infostring][totalspacestring] = units.GetByteSizeString(int64(res.Space.Total), 2)
-		poolinfo[infostring][spaceusedstring] = units.GetByteSizeString(int64(res.Space.Used), 2)
+		poolinfo[infostring][totalspacestring] = units.GetByteSizeStringIEC(int64(res.Space.Total), 2)
+		poolinfo[infostring][spaceusedstring] = units.GetByteSizeStringIEC(int64(res.Space.Used), 2)
 	}
 
 	poolinfodata, err := yaml.Marshal(poolinfo)

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -1355,7 +1355,7 @@ func (c *cmdStorageVolumeList) locationColumnData(vol api.StorageVolume, state a
 
 func (c *cmdStorageVolumeList) usageColumnData(vol api.StorageVolume, state api.StorageVolumeState) string {
 	if state.Usage != nil {
-		return units.GetByteSizeString(int64(state.Usage.Used), 2)
+		return units.GetByteSizeStringIEC(int64(state.Usage.Used), 2)
 	}
 
 	return ""

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -978,10 +978,10 @@ func internalGC(d *Daemon, r *http.Request) response.Response {
 
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
-	logger.Infof("Heap allocated: %s", units.GetByteSizeString(int64(m.Alloc), 2))
-	logger.Infof("Stack in use: %s", units.GetByteSizeString(int64(m.StackInuse), 2))
-	logger.Infof("Requested from system: %s", units.GetByteSizeString(int64(m.Sys), 2))
-	logger.Infof("Releasable to OS: %s", units.GetByteSizeString(int64(m.HeapIdle-m.HeapReleased), 2))
+	logger.Infof("Heap allocated: %s", units.GetByteSizeStringIEC(int64(m.Alloc), 2))
+	logger.Infof("Stack in use: %s", units.GetByteSizeStringIEC(int64(m.StackInuse), 2))
+	logger.Infof("Requested from system: %s", units.GetByteSizeStringIEC(int64(m.Sys), 2))
+	logger.Infof("Releasable to OS: %s", units.GetByteSizeStringIEC(int64(m.HeapIdle-m.HeapReleased), 2))
 
 	logger.Infof("Completed forced garbage collection run")
 

--- a/lxd/patches_utils.go
+++ b/lxd/patches_utils.go
@@ -220,7 +220,7 @@ func lvmGetLVSize(lvPath string) (string, error) {
 		return "", err
 	}
 
-	detectedSize := units.GetByteSizeString(size, 0)
+	detectedSize := units.GetByteSizeStringIEC(size, 0)
 
 	return detectedSize, nil
 }

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -1195,7 +1195,7 @@ var aggregateLimitConfigValueParsers = map[string]func(string) (int64, error){
 
 var aggregateLimitConfigValuePrinters = map[string]func(int64) string{
 	"limits.memory": func(limit int64) string {
-		return units.GetByteSizeString(limit, 1)
+		return units.GetByteSizeStringIEC(limit, 1)
 	},
 	"limits.processes": func(limit int64) string {
 		return fmt.Sprintf("%d", limit)
@@ -1204,7 +1204,7 @@ var aggregateLimitConfigValuePrinters = map[string]func(int64) string{
 		return fmt.Sprintf("%d", limit)
 	},
 	"limits.disk": func(limit int64) string {
-		return units.GetByteSizeString(limit, 1)
+		return units.GetByteSizeStringIEC(limit, 1)
 	},
 }
 


### PR DESCRIPTION
Addresses inconsistent units documented in issue #9433

While the original issue suggested changing disk, memory, and transfer units to IEC units, we opted to follow the [Ubuntu Units Policy](https://wiki.ubuntu.com/UnitsPolicy):

Base-10 (SI):

- Bandwidth (network speed/file transfer/etc.)
- Disk sizes
- File sizes

Base-2 (IEC):

- Memory Sizes

Happy to make changes if needed!