### PR TITLE
lxd: WIP cluster heartbeat tweaks

### DIFF
--- a/lxd/cluster/heartbeat.go
+++ b/lxd/cluster/heartbeat.go
@@ -26,8 +26,13 @@ import (
 type heartbeatMode int
 
 const (
+	// HearbeatNormal normal heartbeat.
 	HearbeatNormal heartbeatMode = iota
+
+	// HearbeatImmediate immediate heartbeat.
 	HearbeatImmediate
+
+	// HearbeatInitial initial heartbeat.
 	HearbeatInitial
 )
 

--- a/lxd/cluster/heartbeat_test.go
+++ b/lxd/cluster/heartbeat_test.go
@@ -48,6 +48,7 @@ func TestHeartbeat(t *testing.T) {
 
 	// Perform the heartbeat requests.
 	leader.Cluster = leaderState.Cluster
+	leader.HeartbeatNodeHook = func(heartbeatData *cluster.APIHeartbeat, isLeader bool, unavailableMembers []string) {}
 	heartbeat, _ := cluster.HeartbeatTask(leader)
 	ctx := context.Background()
 	heartbeat(ctx)

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -525,7 +525,7 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 		}
 
 		// Generate partial heartbeat request containing just a raft node list.
-		notifyNodesUpdate(raftNodes, info, networkCert, serverCert)
+		//notifyNodesUpdate(raftNodes, info, networkCert, serverCert)
 
 		return nil
 	})
@@ -560,7 +560,9 @@ func notifyNodesUpdate(raftNodes []db.RaftNode, info *db.RaftNode, networkCert *
 
 		wg.Add(1)
 		go func(address string) {
-			HeartbeatNode(context.Background(), address, networkCert, serverCert, hbState)
+			hbCtx, hbCtxCancel := context.WithTimeout(context.Background(), time.Second*15)
+			defer hbCtxCancel()
+			HeartbeatNode(hbCtx, address, networkCert, serverCert, hbState)
 			wg.Done()
 		}(node.Address)
 	}


### PR DESCRIPTION
This PR is an attempt to try and remove the notifications sent during cluster member change events from the affected member to all other members, and instead changes the approach such that the affected member notifies the leader which then triggers a leader-generated heartbeat to all existing members.

The reason for this is to try and reduce the state "flux" that occurs during membership changes and make it easier to reason about which member is triggering rebalances of member roles.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>