### PR TITLE
VM: fix usb pass-through with more than one device

### DIFF
--- a/lxd/device/config/device_runconfig.go
+++ b/lxd/device/config/device_runconfig.go
@@ -33,6 +33,12 @@ type RootFSEntryItem struct {
 	Opts []string // Describes the mount options associated with the filesystem.
 }
 
+// USBDeviceItem represents a single USB device matched from LXD USB device specification.
+type USBDeviceItem struct {
+	DeviceName     string
+	HostDevicePath string
+}
+
 // RunConfig represents LXD defined run-time config used for device setup/cleanup.
 type RunConfig struct {
 	RootFS           RootFSEntryItem  // RootFS to setup.
@@ -42,7 +48,7 @@ type RunConfig struct {
 	Uevents          [][]string       // Uevents to inject.
 	PostHooks        []func() error   // Functions to be run after device attach/detach.
 	GPUDevice        []RunConfigItem  // GPU device configuration settings.
-	USBDevice        []RunConfigItem  // USB device configuration settings.
+	USBDevice        []USBDeviceItem  // USB device configuration settings.
 	TPMDevice        []RunConfigItem  // TPM device configuration settings.
 	PCIDevice        []RunConfigItem  // PCI device configuration settings.
 }

--- a/lxd/device/usb.go
+++ b/lxd/device/usb.go
@@ -171,14 +171,12 @@ func (d *usb) startVM() (*deviceConfig.RunConfig, error) {
 	runConf.PostHooks = []func() error{d.Register}
 
 	for _, usb := range usbs {
-		if !usbIsOurDevice(d.config, &usb) {
-			continue
+		if usbIsOurDevice(d.config, &usb) {
+			runConf.USBDevice = append(runConf.USBDevice, deviceConfig.USBDeviceItem{
+				DeviceName:     fmt.Sprintf("%s-%d", d.name, len(runConf.USBDevice)),
+				HostDevicePath: fmt.Sprintf("/dev/bus/usb/%03d/%03d", usb.BusNum, usb.DevNum),
+			})
 		}
-
-		runConf.USBDevice = append(runConf.USBDevice, []deviceConfig.RunConfigItem{
-			{Key: "devName", Value: d.name},
-			{Key: "hostDevice", Value: fmt.Sprintf("/dev/bus/usb/%03d/%03d", usb.BusNum, usb.DevNum)},
-		}...)
 	}
 
 	if d.isRequired() && len(runConf.USBDevice) <= 0 {


### PR DESCRIPTION
When multiple matching devices are passed through a VM using one
device/usb rule, the logic would pass the random last one that
enumerated.

Fix this by adding each one in sequence. Only tested with Qemu.

To test this, attach multiple devices with the same vedor:product pair,
for example a number of FTDI devices, and bridge them to the virtual
machine with profile or instance configuration.

I'm using an LXD virtual machine to work with development boards
and serial/usb adapters. All of our serial adapters use the vendor:product
pair of 0403:6001 (a common FTDI device). The other devices are 96 Boards
Nitrogen devices with 0d28:0204 pair. There are multiple of those attached
to the host and they are all meant to be forwarded to the virtual machine.

The example profile I'm using with this:
```
$ lxc profile show nitrogen-vm 
config: {}
description: ""
devices:
  ftdi-usb:
    productid: "6001"
    type: usb
    vendorid: "0403"
  nitrogen-usb:
    productid: "0204"
    type: usb
    vendorid: 0d28
name: nitrogen-vm
used_by:
- /1.0/instances/guiding-shiner
```

A small modification to log the contents of `runConf.USBDevice` prints the following output:
```
runConf.USBDevice: []config.RunConfigItem{config.RunConfigItem{Key:"devName", Value:"ftdi"}, config.RunConfigItem{Key:"hostDevice", Value:"/dev/bus/usb/001/041"}, config.RunConfigItem{Key:"devName", Value:"ftdi"}, config.RunConfigItem{Key:"hostDevice", Value:"/dev/bus/usb/001/043"}, config.RunConfigItem{Key:"devName", Value:"ftdi"}, config.RunConfigItem{Key:"hostDevice", Value:"/dev/bus/usb/001/004"}, config.RunConfigItem{Key:"devName", Value:"ftdi"}, config.RunConfigItem{Key:"hostDevice", Value:"/dev/bus/usb/001/009"}, config.RunConfigItem{Key:"devName", Value:"ftdi"}, config.RunConfigItem{Key:"hostDevice", Value:"/dev/bus/usb/001/012"}, config.RunConfigItem{Key:"devName", Value:"ftdi"}, config.RunConfigItem{Key:"hostDevice", Value:"/dev/bus/usb/001/005"}}
```

Note that cursory inspection of the USB matching code makes it trivial to see that this is bound to happen when vendor:product pair is not unique in the system. Ideally LXD would also allow matching on other attributes, like USB device path, but this is beyond the scope of the pull request.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@huawei.com>