### PR TITLE
DB: Fix upgrade from LXD 2.0/3.0 when using go-dqlite v1.10.1 NULLable fields

### DIFF
--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -885,7 +885,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?);`,
 		StorageVolumeID int
 		Name            string
 		Description     string
-		ExpiryDate      time.Time
+		ExpiryDate      sql.NullTime
 	}, count)
 
 	dest = func(i int) []interface{} {
@@ -1738,7 +1738,7 @@ CREATE VIEW instances_snapshots_devices_ref (
 		CreationDate time.Time
 		Stateful     bool
 		Description  string
-		ExpiryDate   time.Time
+		ExpiryDate   sql.NullTime
 	}, count)
 
 	dest := func(i int) []interface{} {


### PR DESCRIPTION
Required for https://github.com/lxc/lxd/pull/9485 and https://github.com/canonical/go-dqlite/issues/123

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>