### PR TITLE
lxd/device: Clean up mdev vGPU on failure

### DIFF
--- a/lxd/device/gpu_mdev.go
+++ b/lxd/device/gpu_mdev.go
@@ -17,7 +17,6 @@ import (
 	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/shared"
 	log "github.com/lxc/lxd/shared/log15"
-	"github.com/lxc/lxd/shared/logger"
 )
 
 type gpuMdev struct {
@@ -196,7 +195,7 @@ func (d *gpuMdev) postStop() error {
 		if shared.PathExists(path) {
 			err := ioutil.WriteFile(filepath.Join(path, "remove"), []byte("1\n"), 0200)
 			if err != nil {
-				logger.Debugf("Failed to remove vgpu %q", v["vgpu.uuid"])
+				d.logger.Error("Failed to remove vgpu", log.Ctx{"device": v["vgpu.uuid"], "err": err})
 			}
 		}
 	}

--- a/lxd/device/gpu_mdev.go
+++ b/lxd/device/gpu_mdev.go
@@ -14,7 +14,9 @@ import (
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/resources"
+	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/shared"
+	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -54,6 +56,9 @@ func (d *gpuMdev) startVM() (*deviceConfig.RunConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	revert := revert.New()
+	defer revert.Fail()
 
 	var pciAddress string
 	for _, gpu := range gpus.Cards {
@@ -127,6 +132,17 @@ func (d *gpuMdev) startVM() (*deviceConfig.RunConfig, error) {
 
 				return nil, errors.Wrapf(err, "Failed to create virtual gpu %q", mdevUUID)
 			}
+
+			revert.Add(func() {
+				path := fmt.Sprintf("/sys/bus/mdev/devices/%s", mdevUUID)
+
+				if shared.PathExists(path) {
+					err := ioutil.WriteFile(filepath.Join(path, "remove"), []byte("1\n"), 0200)
+					if err != nil {
+						d.logger.Error("Failed to remove vgpu", log.Ctx{"device": mdevUUID, "err": err})
+					}
+				}
+			})
 		}
 	}
 
@@ -158,6 +174,8 @@ func (d *gpuMdev) startVM() (*deviceConfig.RunConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	revert.Success()
 
 	return &runConf, nil
 }


### PR DESCRIPTION
This fixes #9499.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
