### PR TITLE
Network: Add support for OVN PTMU discovery for external ingress traffic

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1815,7 +1815,7 @@ func (n *ovn) setup(update bool) error {
 		}
 
 		// Create external router port.
-		err = client.LogicalRouterPortAdd(n.getRouterName(), n.getRouterExtPortName(), routerMAC, extRouterIPs, update)
+		err = client.LogicalRouterPortAdd(n.getRouterName(), n.getRouterExtPortName(), routerMAC, bridgeMTU, extRouterIPs, update)
 		if err != nil {
 			return errors.Wrapf(err, "Failed adding external router port")
 		}
@@ -2010,7 +2010,7 @@ func (n *ovn) setup(update bool) error {
 	}
 
 	// Create internal router port.
-	err = client.LogicalRouterPortAdd(n.getRouterName(), n.getRouterIntPortName(), routerMAC, intRouterIPs, update)
+	err = client.LogicalRouterPortAdd(n.getRouterName(), n.getRouterIntPortName(), routerMAC, bridgeMTU, intRouterIPs, update)
 	if err != nil {
 		return errors.Wrapf(err, "Failed adding internal router port")
 	}


### PR DESCRIPTION
Requires host running OVN 21.09 or later (as requires https://github.com/ovn-org/ovn/commit/1c9e46ab5c05043a8cd6c47b5fec2e1ac4c962db).

Related to issue raised in https://github.com/ovn-org/ovn/issues/78

Sets the `options:gateway_mtu` option to the bridge MTU value on both external and internal logical router ports.

With thanks to @fnordahl 