### PR TITLE
Storage: Disk mounting cleanup and improvements

### DIFF
--- a/doc/projects.md
+++ b/doc/projects.md
@@ -35,7 +35,7 @@ limits.memory                        | string    | -                     | -    
 limits.networks                      | integer   | -                     | -                         | Maximum value for the number of networks this project can have
 limits.processes                     | integer   | -                     | -                         | Maximum value for the sum of individual "limits.processes" configs set on the instances of the project
 limits.virtual-machines              | integer   | -                     | -                         | Maximum number of VMs that can be created in the project
-restricted                           | boolean   | -                     | false                     | Block access to security-sensitive features
+restricted                           | boolean   | -                     | false                     | Block access to security-sensitive features (this must be enabled to allow the `restricted.*` keys to take effect, this is so it can be tempoarily disabled if needed without having to clear the related keys)
 restricted.backups                   | string    | -                     | block                     | Prevents the creation of any instance or volume backups.
 restricted.cluster.target            | string    | -                     | block                     | Prevents direct targeting of cluster members when creating or moving instances.
 restricted.containers.lowlevel       | string    | -                     | block                     | Prevents use of low-level container options like raw.lxc, raw.idmap, volatile, etc.

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -885,7 +885,7 @@ func projectValidateConfig(s *state.State, config map[string]string) error {
 		"restricted.devices.proxy":             isEitherAllowOrBlock,
 		"restricted.devices.nic":               isEitherAllowOrBlockOrManaged,
 		"restricted.devices.disk":              isEitherAllowOrBlockOrManaged,
-		"restricted.networks.uplinks":          validate.IsListOf(validate.IsAny),
+		"restricted.networks.uplinks":          validate.Optional(validate.IsListOf(validate.IsAny)),
 		"restricted.networks.subnets": validate.Optional(func(value string) error {
 			return projectValidateRestrictedSubnets(s, value)
 		}),

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -816,10 +816,10 @@ func updateNetworkDescription(tx *sql.Tx, id int64, description string) error {
 func networkConfigAdd(tx *sql.Tx, networkID, nodeID int64, config map[string]string) error {
 	str := fmt.Sprintf("INSERT INTO networks_config (network_id, node_id, key, value) VALUES(?, ?, ?, ?)")
 	stmt, err := tx.Prepare(str)
-	defer stmt.Close()
 	if err != nil {
 		return err
 	}
+	defer stmt.Close()
 
 	for k, v := range config {
 		if v == "" {

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -854,10 +854,10 @@ func (c *Cluster) CreateStoragePool(poolName string, poolDescription string, poo
 func storagePoolConfigAdd(tx *sql.Tx, poolID, nodeID int64, poolConfig map[string]string) error {
 	str := "INSERT INTO storage_pools_config (storage_pool_id, node_id, key, value) VALUES(?, ?, ?, ?)"
 	stmt, err := tx.Prepare(str)
-	defer stmt.Close()
 	if err != nil {
 		return err
 	}
+	defer stmt.Close()
 
 	for k, v := range poolConfig {
 		if v == "" {

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -897,10 +897,10 @@ func storageVolumeConfigAdd(tx *sql.Tx, volumeID int64, volumeConfig map[string]
 		str = "INSERT INTO storage_volumes_config (storage_volume_id, key, value) VALUES(?, ?, ?)"
 	}
 	stmt, err := tx.Prepare(str)
-	defer stmt.Close()
 	if err != nil {
 		return err
 	}
+	defer stmt.Close()
 
 	for k, v := range volumeConfig {
 		if v == "" {

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -87,7 +87,7 @@ func DiskMount(srcPath string, dstPath string, readonly bool, recursive bool, pr
 			case "runbindable":
 				flags |= unix.MS_UNBINDABLE | unix.MS_REC
 			default:
-				return fmt.Errorf("Invalid propagation mode '%s'", propagation)
+				return fmt.Errorf("Invalid propagation mode %q", propagation)
 			}
 		}
 
@@ -99,7 +99,7 @@ func DiskMount(srcPath string, dstPath string, readonly bool, recursive bool, pr
 	// Mount the filesystem
 	err = unix.Mount(srcPath, dstPath, fsName, uintptr(flags), rawMountOptions)
 	if err != nil {
-		return fmt.Errorf("Unable to mount %s at %s: %s", srcPath, dstPath, err)
+		return fmt.Errorf("Unable to mount %q at %q with filesystem %q: %w", srcPath, dstPath, fsName, err)
 	}
 
 	// Remount bind mounts in readonly mode if requested
@@ -107,14 +107,14 @@ func DiskMount(srcPath string, dstPath string, readonly bool, recursive bool, pr
 		flags = unix.MS_RDONLY | unix.MS_BIND | unix.MS_REMOUNT
 		err = unix.Mount("", dstPath, fsName, uintptr(flags), "")
 		if err != nil {
-			return fmt.Errorf("Unable to mount %s in readonly mode: %s", dstPath, err)
+			return fmt.Errorf("Unable to mount %q in readonly mode: %w", dstPath, err)
 		}
 	}
 
 	flags = unix.MS_REC | unix.MS_SLAVE
 	err = unix.Mount("", dstPath, "", uintptr(flags), "")
 	if err != nil {
-		return fmt.Errorf("unable to make mount %s private: %s", dstPath, err)
+		return fmt.Errorf("Unable to make mount %q private: %w", dstPath, err)
 	}
 
 	return nil

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -58,42 +58,35 @@ func DiskMount(srcPath string, dstPath string, readonly bool, recursive bool, pr
 	}
 
 	// Detect the filesystem
-	if IsBlockdev(srcPath) {
-		fsName, err = BlockFsDetect(srcPath)
-		if err != nil {
-			return err
-		}
-	} else {
-		if fsName == "none" {
-			flags |= unix.MS_BIND
-		}
+	if fsName == "none" {
+		flags |= unix.MS_BIND
+	}
 
-		if propagation != "" {
-			switch propagation {
-			case "private":
-				flags |= unix.MS_PRIVATE
-			case "shared":
-				flags |= unix.MS_SHARED
-			case "slave":
-				flags |= unix.MS_SLAVE
-			case "unbindable":
-				flags |= unix.MS_UNBINDABLE
-			case "rprivate":
-				flags |= unix.MS_PRIVATE | unix.MS_REC
-			case "rshared":
-				flags |= unix.MS_SHARED | unix.MS_REC
-			case "rslave":
-				flags |= unix.MS_SLAVE | unix.MS_REC
-			case "runbindable":
-				flags |= unix.MS_UNBINDABLE | unix.MS_REC
-			default:
-				return fmt.Errorf("Invalid propagation mode %q", propagation)
-			}
+	if propagation != "" {
+		switch propagation {
+		case "private":
+			flags |= unix.MS_PRIVATE
+		case "shared":
+			flags |= unix.MS_SHARED
+		case "slave":
+			flags |= unix.MS_SLAVE
+		case "unbindable":
+			flags |= unix.MS_UNBINDABLE
+		case "rprivate":
+			flags |= unix.MS_PRIVATE | unix.MS_REC
+		case "rshared":
+			flags |= unix.MS_SHARED | unix.MS_REC
+		case "rslave":
+			flags |= unix.MS_SLAVE | unix.MS_REC
+		case "runbindable":
+			flags |= unix.MS_UNBINDABLE | unix.MS_REC
+		default:
+			return fmt.Errorf("Invalid propagation mode %q", propagation)
 		}
+	}
 
-		if recursive {
-			flags |= unix.MS_REC
-		}
+	if recursive {
+		flags |= unix.MS_REC
 	}
 
 	// Mount the filesystem

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1157,6 +1157,16 @@ func (d *disk) createDevice(srcPath string) (string, error) {
 			isFile = false
 		} else {
 			isFile = !shared.IsDir(srcPath) && !IsBlockdev(srcPath)
+
+			// Open file handle to local source. Has to be os.O_RDONLY for directory open support, but
+			// this won't prevent a writable mount.
+			f, err := os.OpenFile(srcPath, os.O_RDONLY, 0)
+			if err != nil {
+				return "", err
+			}
+			defer f.Close()
+
+			srcPath = fmt.Sprintf("/proc/self/fd/%d", f.Fd())
 		}
 	}
 

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1101,9 +1101,8 @@ func (d *disk) createDevice(revert *revert.Reverter, srcPath string) (string, er
 	mntOptions := d.config["raw.mount.options"]
 	fsName := "none"
 
-	isFile := false
+	var isFile bool
 	if d.config["pool"] == "" {
-		isFile = !shared.IsDir(srcPath) && !IsBlockdev(srcPath)
 		if strings.HasPrefix(d.config["source"], "cephfs:") {
 			// Get fs name and path from d.config.
 			fields := strings.SplitN(d.config["source"], ":", 2)
@@ -1156,6 +1155,8 @@ func (d *disk) createDevice(revert *revert.Reverter, srcPath string) (string, er
 
 			srcPath = rbdPath
 			isFile = false
+		} else {
+			isFile = !shared.IsDir(srcPath) && !IsBlockdev(srcPath)
 		}
 	}
 

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -49,6 +49,20 @@ type diskBlockLimit struct {
 	writeIops int64
 }
 
+// diskSourceNotFoundError error used to indicate source not found.
+type diskSourceNotFoundError struct {
+	msg string
+	err error
+}
+
+func (e diskSourceNotFoundError) Error() string {
+	return e.msg
+}
+
+func (e diskSourceNotFoundError) Unwrap() error {
+	return e.err
+}
+
 type disk struct {
 	deviceCommon
 }

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -201,12 +201,19 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 		}
 	}
 
+	srcPathIsLocal := d.config["pool"] == "" && d.sourceIsLocalPath(d.config["source"])
+	srcPathIsAbs := filepath.IsAbs(d.config["source"])
+
+	if srcPathIsLocal && !srcPathIsAbs {
+		return fmt.Errorf("Source path must be absolute for local sources")
+	}
+
 	// Check that external disk source path exists. External disk sources have a non-empty "source" property
 	// that contains the path of the external source, and do not have a "pool" property. We only check the
 	// source path exists when the disk device is required, is not an external ceph/cephfs source and is not a
 	// VM cloud-init drive. We only check this when an instance is loaded to avoid validating snapshot configs
 	// that may contain older config that no longer exists which can prevent migrations.
-	if d.inst != nil && d.config["pool"] == "" && d.isRequired(d.config) && d.sourceIsLocalPath(d.config["source"]) && !shared.PathExists(shared.HostPath(d.config["source"])) {
+	if d.inst != nil && srcPathIsLocal && d.isRequired(d.config) && !shared.PathExists(shared.HostPath(d.config["source"])) {
 		return fmt.Errorf("Missing source path %q for disk %q", d.config["source"], d.name)
 	}
 
@@ -226,7 +233,7 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 			return fmt.Errorf(`The "shift" property cannot be used with custom storage volumes`)
 		}
 
-		if filepath.IsAbs(d.config["source"]) {
+		if srcPathIsAbs {
 			return fmt.Errorf("Storage volumes cannot be specified as absolute paths")
 		}
 

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -753,10 +753,6 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				if err != nil {
 					return nil, errors.Wrapf(err, "Failed to setup virtiofsd for device %q", d.name)
 				}
-			} else if !shared.PathExists(srcPath) {
-				if isRequired {
-					return nil, fmt.Errorf("Source path %q doesn't exist for device %q", srcPath, d.name)
-				}
 			}
 
 			// Add successfully setup mount config to runConf.

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -417,13 +417,6 @@ func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 		// Option checks.
 		isRecursive := shared.IsTrue(d.config["recursive"])
 
-		// If we want to mount a storage volume from a storage pool we created via our
-		// storage api, we are always mounting a directory.
-		isFile := false
-		if d.config["pool"] == "" {
-			isFile = !shared.IsDir(srcPath) && !IsBlockdev(srcPath)
-		}
-
 		ownerShift := deviceConfig.MountOwnerShiftNone
 		if shared.IsTrue(d.config["shift"]) {
 			ownerShift = deviceConfig.MountOwnerShiftDynamic
@@ -468,12 +461,6 @@ func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 			options = append(options, d.config["propagation"])
 		}
 
-		if isFile {
-			options = append(options, "create=file")
-		} else {
-			options = append(options, "create=dir")
-		}
-
 		// Mount the pool volume and set poolVolSrcPath for createDevice below.
 		if d.config["pool"] != "" {
 			var err error
@@ -489,9 +476,15 @@ func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 		}
 
 		// Mount the source in the instance devices directory.
-		sourceDevPath, err := d.createDevice(srcPath)
+		sourceDevPath, isFile, err := d.createDevice(srcPath)
 		if err != nil {
 			return nil, err
+		}
+
+		if isFile {
+			options = append(options, "create=file")
+		} else {
+			options = append(options, "create=dir")
 		}
 
 		if sourceDevPath != "" {
@@ -630,7 +623,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				// This will ensure that if the exported directory configured as readonly that this
 				// takes effect event if using virtio-fs (which doesn't support read only mode) by
 				// having the underlying mount setup as readonly.
-				srcPath, err = d.createDevice(srcPath)
+				srcPath, _, err = d.createDevice(srcPath)
 				if err != nil {
 					return nil, err
 				}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -489,7 +489,7 @@ func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 		}
 
 		// Mount the source in the instance devices directory.
-		sourceDevPath, err := d.createDevice(revert, srcPath)
+		sourceDevPath, err := d.createDevice(srcPath)
 		if err != nil {
 			return nil, err
 		}
@@ -630,7 +630,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				// This will ensure that if the exported directory configured as readonly that this
 				// takes effect event if using virtio-fs (which doesn't support read only mode) by
 				// having the underlying mount setup as readonly.
-				srcPath, err = d.createDevice(revert, srcPath)
+				srcPath, err = d.createDevice(srcPath)
 				if err != nil {
 					return nil, err
 				}
@@ -1090,7 +1090,7 @@ func (d *disk) mountPoolVolume(revert *revert.Reverter) (string, error) {
 
 // createDevice creates a disk device mount on host.
 // The srcPath argument is the source of the disk device on the host.
-func (d *disk) createDevice(revert *revert.Reverter, srcPath string) (string, error) {
+func (d *disk) createDevice(srcPath string) (string, error) {
 	// Paths.
 	devPath := d.getDevicePath(d.name, d.config)
 
@@ -1197,7 +1197,6 @@ func (d *disk) createDevice(revert *revert.Reverter, srcPath string) (string, er
 		return "", err
 	}
 
-	revert.Success()
 	return devPath, nil
 }
 

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -310,10 +310,37 @@ func (d *disk) getDevicePath(devName string, devConfig deviceConfig.Device) stri
 	return filepath.Join(d.inst.DevicesPath(), devPath)
 }
 
+// validateEnvironmentSourcePath checks the source path property is valid.
+func (d *disk) validateEnvironmentSourcePath() error {
+	srcPathIsLocal := d.config["pool"] == "" && d.sourceIsLocalPath(d.config["source"])
+	if !srcPathIsLocal {
+		return nil
+	}
+
+	sourceHostPath := shared.HostPath(d.config["source"])
+
+	// Check local external disk source path exists and load info about it.
+	_, err := os.Lstat(sourceHostPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return diskSourceNotFoundError{msg: fmt.Sprintf("Missing source path %q", d.config["source"])}
+		}
+
+		return fmt.Errorf("Failed accessing source path %q for disk %q: %w", sourceHostPath, d.name, err)
+	}
+
+	return nil
+}
+
 // validateEnvironment checks the runtime environment for correctness.
 func (d *disk) validateEnvironment() error {
 	if d.inst.Type() != instancetype.VM && d.config["source"] == diskSourceCloudInit {
 		return fmt.Errorf("disks with source=%s are only supported by virtual machines", diskSourceCloudInit)
+	}
+
+	err := d.validateEnvironmentSourcePath()
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -30,7 +30,6 @@ import (
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/idmap"
 	log "github.com/lxc/lxd/shared/log15"
-	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/subprocess"
 	"github.com/lxc/lxd/shared/units"
 	"github.com/lxc/lxd/shared/validate"
@@ -603,7 +602,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				srcPath, err = d.mountPoolVolume(revert)
 				if err != nil {
 					if !isRequired {
-						logger.Warn(err.Error())
+						d.logger.Warn(err.Error())
 						return nil, nil
 					}
 

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1160,15 +1160,6 @@ func (d *disk) createDevice(revert *revert.Reverter, srcPath string) (string, er
 		}
 	}
 
-	// Check if the source exists unless it is a cephfs.
-	if fsName != "ceph" && !shared.PathExists(srcPath) {
-		if !isRequired {
-			return "", nil
-		}
-
-		return "", fmt.Errorf("Source path %q doesn't exist for device %q", srcPath, d.name)
-	}
-
 	// Create the devices directory if missing.
 	if !shared.PathExists(d.inst.DevicesPath()) {
 		err := os.Mkdir(d.inst.DevicesPath(), 0711)

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -475,10 +475,9 @@ func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 		}
 
 		// Mount the pool volume and set poolVolSrcPath for createDevice below.
-		var poolVolSrcPath string
 		if d.config["pool"] != "" {
 			var err error
-			poolVolSrcPath, err = d.mountPoolVolume(revert)
+			srcPath, err = d.mountPoolVolume(revert)
 			if err != nil {
 				if !isRequired {
 					d.logger.Warn(err.Error())
@@ -490,7 +489,7 @@ func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 		}
 
 		// Mount the source in the instance devices directory.
-		sourceDevPath, err := d.createDevice(revert, poolVolSrcPath)
+		sourceDevPath, err := d.createDevice(revert, srcPath)
 		if err != nil {
 			return nil, err
 		}
@@ -1090,11 +1089,10 @@ func (d *disk) mountPoolVolume(revert *revert.Reverter) (string, error) {
 }
 
 // createDevice creates a disk device mount on host.
-// The poolVolSrcPath takes the path to the mounted custom pool volume when d.config["pool"] is non-empty.
-func (d *disk) createDevice(revert *revert.Reverter, poolVolSrcPath string) (string, error) {
+// The srcPath argument is the source of the disk device on the host.
+func (d *disk) createDevice(revert *revert.Reverter, srcPath string) (string, error) {
 	// Paths.
 	devPath := d.getDevicePath(d.name, d.config)
-	srcPath := shared.HostPath(d.config["source"])
 
 	isRequired := d.isRequired(d.config)
 	isReadOnly := shared.IsTrue(d.config["readonly"])
@@ -1159,8 +1157,6 @@ func (d *disk) createDevice(revert *revert.Reverter, poolVolSrcPath string) (str
 			srcPath = rbdPath
 			isFile = false
 		}
-	} else {
-		srcPath = poolVolSrcPath // Use pool source path override.
 	}
 
 	// Check if the source exists unless it is a cephfs.

--- a/lxd/device/proxy.go
+++ b/lxd/device/proxy.go
@@ -121,6 +121,8 @@ func (d *proxy) validateConfig(instConf instance.ConfigReader) error {
 
 	if shared.IsTrue(d.config["nat"]) {
 		if d.inst != nil {
+			// Default project always has networks feature so don't bother loading the project config
+			// in that case.
 			projectName := d.inst.Project()
 			if projectName != project.Default {
 				// Prevent use of NAT mode on non-default projects with networks feature.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2928,17 +2928,10 @@ func (n *ovn) InstanceDevicePortValidateExternalRoutes(deviceInstance instance.I
 		}
 	}
 
-	err = n.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
-		// Load the project to get uplink network restrictions.
-		p, err = tx.GetProject(n.project)
-		if err != nil {
-			return errors.Wrapf(err, "Failed to load network restrictions from project %q", n.project)
-		}
-
-		return nil
-	})
+	// Load the project to get uplink network restrictions.
+	p, err = n.state.Cluster.GetProject(n.project)
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to load network restrictions from project %q: %w", n.project, err)
 	}
 
 	externalSubnetsInUse, err := n.getExternalSubnetInUse(n.config["network"])

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -1052,8 +1052,7 @@ func expandInstancesConfigAndDevices(instances []db.Instance, profiles []db.Prof
 
 		expandedInstances[i] = instance
 		expandedInstances[i].Config = db.ExpandInstanceConfig(instance.Config, profiles)
-		expandedInstances[i].Devices = db.ExpandInstanceDevices(
-			deviceconfig.NewDevices(instance.Devices), profiles).CloneNative()
+		expandedInstances[i].Devices = db.ExpandInstanceDevices(deviceconfig.NewDevices(instance.Devices), profiles).CloneNative()
 	}
 
 	return expandedInstances

--- a/shared/util.go
+++ b/shared/util.go
@@ -669,20 +669,6 @@ func StringMapHasStringKey(m map[string]string, keys ...string) bool {
 	return false
 }
 
-func IsUnixDev(path string) bool {
-	stat, err := os.Stat(path)
-	if err != nil {
-		return false
-
-	}
-
-	if (stat.Mode() & os.ModeDevice) == 0 {
-		return false
-	}
-
-	return true
-}
-
 func IsBlockdev(fm os.FileMode) bool {
 	return ((fm&os.ModeDevice != 0) && (fm&os.ModeCharDevice == 0))
 }


### PR DESCRIPTION
Some cleanup and improvements before https://github.com/lxc/lxd/pull/9496

- Switches to mounting `disk` devices via a file descriptor rather than directory passing the source path to the mount syscall (this is so we use a similar code path for both unrestricted and restricted devices (in the future)) to get more thorough testing of that approach in different scenarios.
- Moves block device filesystem detection out of `DiskMount`, requires this to be done externally and passed in via `fsName` argument. Gives more control the caller about when filesystem detection is done. This is required as one cannot to filesystem detection on a file descriptor path.
- Reduces stat syscalls when detecting if a disk source is a directory, file or block device.
- Requires absolute source path for local disk devices.
- Better handles logging warnings when disk source not found but not required.