### PR TITLE
Migrate: Only use pointers to migration.MigrationControl to avoid shallow copies

### DIFF
--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -114,8 +114,8 @@ func (c *migrationFields) sendControl(err error) {
 	}
 }
 
-func (c *migrationFields) controlChannel() <-chan migration.MigrationControl {
-	ch := make(chan migration.MigrationControl)
+func (c *migrationFields) controlChannel() <-chan *migration.MigrationControl {
+	ch := make(chan *migration.MigrationControl)
 	go func() {
 		msg := migration.MigrationControl{}
 		err := c.recv(&msg)
@@ -124,7 +124,7 @@ func (c *migrationFields) controlChannel() <-chan migration.MigrationControl {
 			close(ch)
 			return
 		}
-		ch <- msg
+		ch <- &msg
 	}()
 
 	return ch

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -1211,7 +1211,7 @@ func (c *migrationSink) Do(state *state.State, revert *revert.Reverter, migrateO
 		restore <- nil
 	}(c)
 
-	var source <-chan migration.MigrationControl
+	var source <-chan *migration.MigrationControl
 	if c.push {
 		source = c.dest.controlChannel()
 	} else {

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -419,7 +419,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 		restore <- nil
 	}(c)
 
-	var source <-chan migration.MigrationControl
+	var source <-chan *migration.MigrationControl
 	if c.push {
 		source = c.dest.controlChannel()
 	} else {


### PR DESCRIPTION
Otherwise it will cause govet to fail on the pragma.DoNotCopy in protoimpl.MessageState

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>