### PR TITLE
Draft: Allow USB pass through of specific port path

### DIFF
--- a/doc/instances.md
+++ b/doc/instances.md
@@ -826,10 +826,16 @@ Key         | Type      | Default           | Required  | Description
 :--         | :--       | :--               | :--       | :--
 vendorid    | string    | -                 | no        | The vendor id of the USB device
 productid   | string    | -                 | no        | The product id of the USB device
+portglob    | string    | -                 | no        | Glob matching to physical USB port
 uid         | int       | 0                 | no        | UID of the device owner in the instance
 gid         | int       | 0                 | no        | GID of the device owner in the instance
 mode        | int       | 0660              | no        | Mode of the device in the instance
 required    | boolean   | false             | no        | Whether or not this device is required to start the instance. (The default is false, and all devices are hot-pluggable)
+
+USB ports are represented as a sequence of numbers separated by dashes. Each
+number is a physical port on a USB hub. For example the port path 1-2-3
+represents following the 1st port on the root hub, then the 2nd port on the
+next hub and finally the 3rd port on final hub.
 
 ### Type: gpu
 
@@ -993,6 +999,7 @@ Key         | Type      | Default           | Required  | Description
 :--         | :--       | :--               | :--       | :--
 vendorid    | string    | -                 | no        | The vendor id of the unix device
 productid   | string    | -                 | no        | The product id of the unix device
+portglob    | string    | -                 | no        | Glob matching to physical USB port
 uid         | int       | 0                 | no        | UID of the device owner in the instance
 gid         | int       | 0                 | no        | GID of the device owner in the instance
 mode        | int       | 0660              | no        | Mode of the device in the instance

--- a/lxd/device/device_utils_unix_hotplug_events.go
+++ b/lxd/device/device_utils_unix_hotplug_events.go
@@ -26,6 +26,8 @@ type UnixHotplugEvent struct {
 	Subsystem   string
 	UeventParts []string
 	UeventLen   int
+
+	PortPath string
 }
 
 // unixHotplugHandlers stores the event handler callbacks for Unix hotplug events.
@@ -95,7 +97,7 @@ func UnixHotplugRunHandlers(state *state.State, event *UnixHotplugEvent) {
 }
 
 // UnixHotplugNewEvent instantiates a new UnixHotplugEvent struct.
-func UnixHotplugNewEvent(action string, vendor string, product string, major string, minor string, subsystem string, devname string, ueventParts []string, ueventLen int) (UnixHotplugEvent, error) {
+func UnixHotplugNewEvent(action string, vendor string, product string, major string, minor string, subsystem string, devname string, ueventParts []string, ueventLen int, portPath string) (UnixHotplugEvent, error) {
 	majorInt, err := strconv.ParseUint(major, 10, 32)
 	if err != nil {
 		return UnixHotplugEvent{}, err
@@ -116,5 +118,6 @@ func UnixHotplugNewEvent(action string, vendor string, product string, major str
 		subsystem,
 		ueventParts,
 		ueventLen,
+		portPath,
 	}, nil
 }

--- a/lxd/device/device_utils_usb_events.go
+++ b/lxd/device/device_utils_usb_events.go
@@ -29,6 +29,8 @@ type USBEvent struct {
 
 	BusNum int
 	DevNum int
+
+	PortPath string
 }
 
 // usbHandlers stores the event handler callbacks for USB events.
@@ -98,7 +100,7 @@ func USBRunHandlers(state *state.State, event *USBEvent) {
 }
 
 // USBNewEvent instantiates a new USBEvent struct.
-func USBNewEvent(action string, vendor string, product string, major string, minor string, busnum string, devnum string, devname string, ueventParts []string, ueventLen int) (USBEvent, error) {
+func USBNewEvent(action string, vendor string, product string, major string, minor string, busnum string, devnum string, devname string, ueventParts []string, ueventLen int, portPath string) (USBEvent, error) {
 	majorInt, err := strconv.ParseUint(major, 10, 32)
 	if err != nil {
 		return USBEvent{}, err
@@ -140,5 +142,6 @@ func USBNewEvent(action string, vendor string, product string, major string, min
 		ueventLen,
 		busnumInt,
 		devnumInt,
+		portPath,
 	}, nil
 }

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -210,6 +210,11 @@ func deviceNetlinkListener() (chan []string, chan []string, chan device.USBEvent
 					continue
 				}
 
+				devpath, ok := props["DEVPATH"]
+				if !ok {
+					continue
+				}
+
 				zeroPad := func(s string, l int) string {
 					return strings.Repeat("0", l-len(s)) + s
 				}
@@ -229,6 +234,7 @@ func deviceNetlinkListener() (chan []string, chan []string, chan device.USBEvent
 					devname,
 					ueventParts[:len(ueventParts)-1],
 					ueventLen,
+					filepath.Base(devpath),
 				)
 				if err != nil {
 					logger.Error("Error reading usb device", log.Ctx{"err": err, "path": props["PHYSDEVPATH"]})
@@ -261,6 +267,11 @@ func deviceNetlinkListener() (chan []string, chan []string, chan device.USBEvent
 				}
 
 				minor, ok := props["MINOR"]
+				if !ok {
+					continue
+				}
+
+				devpath, ok := props["DEVPATH"]
 				if !ok {
 					continue
 				}
@@ -301,6 +312,7 @@ func deviceNetlinkListener() (chan []string, chan []string, chan device.USBEvent
 					devname,
 					ueventParts[:len(ueventParts)-1],
 					ueventLen,
+					filepath.Base(devpath),
 				)
 				if err != nil {
 					logger.Error("Error reading unix device", log.Ctx{"err": err, "path": props["PHYSDEVPATH"]})

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -718,4 +719,10 @@ func IsListenAddress(allowDNS bool, allowWildcard bool, requirePort bool) func(v
 
 		return nil
 	}
+}
+
+// IsGlob validates whether the value is a valid glob.
+func IsGlob(value string) error {
+	_, err := path.Match("", value)
+	return err
 }


### PR DESCRIPTION
With the fixes to USB device pass-through, allowing multiple identical
devices to be used inside one virtual machine, users may want to route
specific USB devices to specific instances. This can be done by
following the physical topology of hubs and ports.

The new `portglob` property can be used to optionally match the port
path to a glob. Port path is a sequence of numbers separated with
dashes, with each number representing a port and dash representing
connections between hubs.

This allows adding arbitrary device plugged to a physical port or a
particular hub to a specific instance. The property is supported for
`usb` device type both virtual machines and on containers and for
`unix-hotplug` on containers only.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@huawei.com>