### PR TITLE
Container: Fix liblxc handle leak in renderState

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3343,6 +3343,8 @@ func (d *lxc) renderState(statusCode api.StatusCode) (*api.InstanceState, error)
 
 	status.Disk = d.diskState()
 
+	d.release()
+
 	return &status, nil
 }
 


### PR DESCRIPTION
We were leaking liblxc file handles to the container's log file when querying the state of a container, and relying on the Go garbage collector to release it. Lets not do that, as it can end up leaving FDs around for a while.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>