### PR TITLE
Network: Separate IP neighbour and neighbour proxy management functions

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -1414,6 +1414,8 @@ func (d *nicBridged) State() (*api.InstanceStateNetwork, error) {
 		ips = append(ips, newIP)
 	}
 
+	hwAddr, _ := net.ParseMAC(d.config["hwaddr"])
+
 	if d.network != nil {
 		// Extract subnet sizes from bridge addresses if available.
 		netConfig := d.network.Config()
@@ -1442,8 +1444,7 @@ func (d *nicBridged) State() (*api.InstanceStateNetwork, error) {
 			if !shared.IsTrue(d.network.Config()["ipv6.dhcp.stateful"]) && v6subnet != nil {
 				// If stateful DHCPv6 is disabled, and IPv6 is enabled on the bridge, the the NIC
 				// is likely to use its MAC and SLAAC to configure its address.
-				hwAddr, err := net.ParseMAC(d.config["hwaddr"])
-				if err == nil {
+				if hwAddr != nil {
 					ip, err := eui64.ParseMAC(v6subnet.IP, hwAddr)
 					if err == nil {
 						ipStore(ip)
@@ -1454,25 +1455,25 @@ func (d *nicBridged) State() (*api.InstanceStateNetwork, error) {
 	}
 
 	// Get IP addresses from IP neighbour cache if present.
-	neighIPs, err := network.GetNeighbourIPs(d.config["parent"], d.config["hwaddr"])
+	neighIPs, err := network.GetNeighbourIPs(d.config["parent"], hwAddr)
 	if err == nil {
 		validStates := []string{
-			string(network.NeighbourIPStatePermanent),
-			string(network.NeighbourIPStateNoARP),
-			string(network.NeighbourIPStateReachable),
+			string(ip.NeighbourIPStatePermanent),
+			string(ip.NeighbourIPStateNoARP),
+			string(ip.NeighbourIPStateReachable),
 		}
 
 		// Add any valid-state neighbour IP entries first.
 		for _, neighIP := range neighIPs {
 			if shared.StringInSlice(string(neighIP.State), validStates) {
-				ipStore(neighIP.IP)
+				ipStore(neighIP.Addr)
 			}
 		}
 
 		// Add any non-failed-state entries.
 		for _, neighIP := range neighIPs {
-			if neighIP.State != network.NeighbourIPStateFailed && !shared.StringInSlice(string(neighIP.State), validStates) {
-				ipStore(neighIP.IP)
+			if neighIP.State != ip.NeighbourIPStateFailed && !shared.StringInSlice(string(neighIP.State), validStates) {
+				ipStore(neighIP.Addr)
 			}
 		}
 	}

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strings"
 
@@ -485,12 +486,13 @@ func (d *nicRouted) postStop() error {
 	// Delete IP neighbour proxy entries on the parent if they haven't been removed by liblxc.
 	for _, key := range []string{"ipv4.address", "ipv6.address"} {
 		if d.config[key] != "" {
-			for _, addr := range strings.Split(d.config[key], ",") {
-				neigh := &ip.Neigh{
+			for _, addr := range util.SplitNTrimSpace(d.config[key], ",", -1, true) {
+				neighProxy := &ip.NeighProxy{
 					DevName: d.config["parent"],
-					Proxy:   strings.TrimSpace(addr),
+					Addr:    net.ParseIP(addr),
 				}
-				neigh.Delete()
+
+				neighProxy.Delete()
 			}
 		}
 	}

--- a/lxd/ip/neigh.go
+++ b/lxd/ip/neigh.go
@@ -7,7 +7,6 @@ import (
 // Neigh represents arguments for neighbour manipulation
 type Neigh struct {
 	DevName string
-	Proxy   string
 }
 
 // Show list neighbour entries
@@ -16,14 +15,6 @@ func (n *Neigh) Show() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return out, nil
-}
 
-// Delete deletes a neighbour entry
-func (n *Neigh) Delete() error {
-	_, err := shared.RunCommand("ip", "neigh", "delete", "proxy", n.Proxy, "dev", n.DevName)
-	if err != nil {
-		return err
-	}
-	return nil
+	return out, nil
 }

--- a/lxd/ip/neigh.go
+++ b/lxd/ip/neigh.go
@@ -1,20 +1,90 @@
 package ip
 
 import (
+	"bytes"
+	"net"
+	"strings"
+
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 )
+
+// NeighbourIPState can be { PERMANENT | NOARP | REACHABLE | STALE | NONE | INCOMPLETE | DELAY | PROBE | FAILED }.
+type NeighbourIPState string
+
+// NeighbourIPStatePermanent the neighbour entry is valid forever and can be only be removed administratively.
+const NeighbourIPStatePermanent = "PERMANENT"
+
+// NeighbourIPStateNoARP the neighbour entry is valid. No attempts to validate this entry will be made but it can
+// be removed when its lifetime expires.
+const NeighbourIPStateNoARP = "NOARP"
+
+// NeighbourIPStateReachable the neighbour entry is valid until the reachability timeout expires.
+const NeighbourIPStateReachable = "REACHABLE"
+
+// NeighbourIPStateStale the neighbour entry is valid but suspicious.
+const NeighbourIPStateStale = "STALE"
+
+// NeighbourIPStateNone this is a pseudo state used when initially creating a neighbour entry or after trying to
+// remove it before it becomes free to do so.
+const NeighbourIPStateNone = "NONE"
+
+// NeighbourIPStateIncomplete the neighbour entry has not (yet) been validated/resolved.
+const NeighbourIPStateIncomplete = "INCOMPLETE"
+
+// NeighbourIPStateDelay neighbor entry validation is currently delayed.
+const NeighbourIPStateDelay = "DELAY"
+
+// NeighbourIPStateProbe neighbor is being probed.
+const NeighbourIPStateProbe = "PROBE"
+
+// NeighbourIPStateFailed max number of probes exceeded without success, neighbor validation has ultimately failed.
+const NeighbourIPStateFailed = "FAILED"
 
 // Neigh represents arguments for neighbour manipulation
 type Neigh struct {
 	DevName string
+	Addr    net.IP
+	MAC     net.HardwareAddr
+	State   NeighbourIPState
 }
 
-// Show list neighbour entries
-func (n *Neigh) Show() (string, error) {
+// Show list neighbour entries filtered by DevName and optionally MAC address.
+func (n *Neigh) Show() ([]Neigh, error) {
 	out, err := shared.RunCommand("ip", "neigh", "show", "dev", n.DevName)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return out, nil
+	neighbours := []Neigh{}
+
+	for _, line := range util.SplitNTrimSpace(out, "\n", -1, true) {
+		// Split fields and early validation.
+		fields := strings.Fields(line)
+		if len(fields) != 4 {
+			continue
+		}
+
+		addr := net.ParseIP(fields[0])
+		if addr == nil {
+			continue
+		}
+
+		mac, _ := net.ParseMAC(fields[2])
+
+		// Check neighbour matches desired MAC address if specified.
+		if n.MAC != nil {
+			if bytes.Compare(n.MAC, mac) != 0 {
+				continue
+			}
+		}
+
+		neighbours = append(neighbours, Neigh{
+			Addr:  addr,
+			MAC:   mac,
+			State: NeighbourIPState(fields[3]),
+		})
+	}
+
+	return neighbours, nil
 }

--- a/lxd/ip/neigh_proxy.go
+++ b/lxd/ip/neigh_proxy.go
@@ -1,0 +1,65 @@
+package ip
+
+import (
+	"net"
+	"strings"
+
+	"github.com/lxc/lxd/lxd/util"
+	"github.com/lxc/lxd/shared"
+)
+
+// NeighProxy represents arguments for neighbour proxy manipulation.
+type NeighProxy struct {
+	DevName string
+	Addr    net.IP
+}
+
+// Show list neighbour proxy entries.
+func (n *NeighProxy) Show() ([]NeighProxy, error) {
+	out, err := shared.RunCommand("ip", "neigh", "show", "proxy", "dev", n.DevName)
+	if err != nil {
+		return nil, err
+	}
+
+	lines := util.SplitNTrimSpace(out, "\n", -1, true)
+	entries := make([]NeighProxy, 0, len(lines))
+
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) <= 0 {
+			continue
+		}
+
+		ip := net.ParseIP(fields[0])
+		if ip == nil {
+			continue
+		}
+
+		entries = append(entries, NeighProxy{
+			DevName: n.DevName,
+			Addr:    ip,
+		})
+	}
+
+	return entries, nil
+}
+
+// Add a neighbour proxy entry.
+func (n *NeighProxy) Add() error {
+	_, err := shared.RunCommand("ip", "neigh", "add", "proxy", n.Addr.String(), "dev", n.DevName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete a neighbour proxy entry.
+func (n *NeighProxy) Delete() error {
+	_, err := shared.RunCommand("ip", "neigh", "delete", "proxy", n.Addr.String(), "dev", n.DevName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -755,75 +755,16 @@ func GetHostDevice(parent string, vlan string) string {
 	return defaultVlan
 }
 
-// NeighbourIPState can be { PERMANENT | NOARP | REACHABLE | STALE | NONE | INCOMPLETE | DELAY | PROBE | FAILED }.
-type NeighbourIPState string
-
-// NeighbourIPStatePermanent the neighbour entry is valid forever and can be only be removed administratively.
-const NeighbourIPStatePermanent = "PERMANENT"
-
-// NeighbourIPStateNoARP the neighbour entry is valid. No attempts to validate this entry will be made but it can
-// be removed when its lifetime expires.
-const NeighbourIPStateNoARP = "NOARP"
-
-// NeighbourIPStateReachable the neighbour entry is valid until the reachability timeout expires.
-const NeighbourIPStateReachable = "REACHABLE"
-
-// NeighbourIPStateStale the neighbour entry is valid but suspicious.
-const NeighbourIPStateStale = "STALE"
-
-// NeighbourIPStateNone this is a pseudo state used when initially creating a neighbour entry or after trying to
-// remove it before it becomes free to do so.
-const NeighbourIPStateNone = "NONE"
-
-// NeighbourIPStateIncomplete the neighbour entry has not (yet) been validated/resolved.
-const NeighbourIPStateIncomplete = "INCOMPLETE"
-
-// NeighbourIPStateDelay neighbor entry validation is currently delayed.
-const NeighbourIPStateDelay = "DELAY"
-
-// NeighbourIPStateProbe neighbor is being probed.
-const NeighbourIPStateProbe = "PROBE"
-
-// NeighbourIPStateFailed max number of probes exceeded without success, neighbor validation has ultimately failed.
-const NeighbourIPStateFailed = "FAILED"
-
-// NeighbourIP represents an IP neighbour entry.
-type NeighbourIP struct {
-	IP    net.IP
-	State NeighbourIPState
-}
-
 // GetNeighbourIPs returns the IP addresses in the neighbour cache for a particular interface and MAC.
-func GetNeighbourIPs(interfaceName string, hwaddr string) ([]NeighbourIP, error) {
-	neigh := &ip.Neigh{DevName: interfaceName}
-	out, err := neigh.Show()
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to get IP neighbours for interface %q", interfaceName)
+func GetNeighbourIPs(interfaceName string, hwaddr net.HardwareAddr) ([]ip.Neigh, error) {
+	if hwaddr == nil {
+		return nil, nil
 	}
 
-	neighbours := []NeighbourIP{}
-
-	for _, line := range strings.Split(out, "\n") {
-		// Split fields and early validation.
-		fields := strings.Fields(line)
-		if len(fields) != 4 {
-			continue
-		}
-
-		// Check neighbour matches desired MAC address.
-		if fields[2] != hwaddr {
-			continue
-		}
-
-		ip := net.ParseIP(fields[0])
-		if ip == nil {
-			continue
-		}
-
-		neighbours = append(neighbours, NeighbourIP{
-			IP:    ip,
-			State: NeighbourIPState(fields[3]),
-		})
+	neigh := &ip.Neigh{DevName: interfaceName, MAC: hwaddr}
+	neighbours, err := neigh.Show()
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to get IP neighbours for interface %q", interfaceName)
 	}
 
 	return neighbours, nil


### PR DESCRIPTION
Also makes `ip.Neigh.Show()` function return a proper struct rather than a raw multi-line output string.

This PR is part of a precursor cleanup required for adding `routed` NIC VM support (continuing on work started in PR https://github.com/lxc/lxd/pull/9367.