### PR TITLE
NIC: Reworks routed NIC to not depend on liblxc's router NIC type

### DIFF
--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -74,7 +74,7 @@ test_container_devices_nic_bridged() {
   fi
 
   # Check profile custom MAC is applied in container on boot.
-  if ! lxc exec "${ctName}" -- grep -i "${ctMAC}" /sys/class/net/eth0/address ; then
+  if ! lxc exec "${ctName}" -- grep -Fix "${ctMAC}" /sys/class/net/eth0/address ; then
     echo "mac invalid"
     false
   fi
@@ -143,7 +143,7 @@ test_container_devices_nic_bridged() {
   fi
 
   # Check custom MAC is applied on hot-plug.
-  if ! lxc exec "${ctName}" -- grep -i "${ctMAC}" /sys/class/net/eth0/address ; then
+  if ! lxc exec "${ctName}" -- grep -Fix "${ctMAC}" /sys/class/net/eth0/address ; then
     echo "mac invalid"
     false
   fi
@@ -270,7 +270,7 @@ test_container_devices_nic_bridged() {
   fi
 
   # Check custom MAC is applied update.
-  if ! lxc exec "${ctName}" -- grep -i "${ctMAC}" /sys/class/net/eth0/address ; then
+  if ! lxc exec "${ctName}" -- grep -Fix "${ctMAC}" /sys/class/net/eth0/address ; then
     echo "mac invalid"
     false
   fi

--- a/test/suites/container_devices_nic_p2p.sh
+++ b/test/suites/container_devices_nic_p2p.sh
@@ -55,7 +55,7 @@ test_container_devices_nic_p2p() {
   fi
 
   # Check profile custom MAC is applied in container on boot.
-  if ! lxc exec "${ctName}" -- grep -i "${ctMAC}" /sys/class/net/eth0/address ; then
+  if ! lxc exec "${ctName}" -- grep -Fix "${ctMAC}" /sys/class/net/eth0/address ; then
     echo "mac invalid"
     false
   fi
@@ -117,7 +117,7 @@ test_container_devices_nic_p2p() {
   fi
 
   # Check custom MAC is applied on hot-plug.
-  if ! lxc exec "${ctName}" -- grep -i "${ctMAC}" /sys/class/net/eth0/address ; then
+  if ! lxc exec "${ctName}" -- grep -Fix "${ctMAC}" /sys/class/net/eth0/address ; then
     echo "mac invalid"
     false
   fi
@@ -197,7 +197,7 @@ test_container_devices_nic_p2p() {
   fi
 
   # Check custom MAC is applied update.
-  if ! lxc exec "${ctName}" -- grep -i "${ctMAC}" /sys/class/net/eth0/address ; then
+  if ! lxc exec "${ctName}" -- grep -Fix "${ctMAC}" /sys/class/net/eth0/address ; then
     echo "mac invalid"
     false
   fi

--- a/test/suites/container_devices_nic_physical.sh
+++ b/test/suites/container_devices_nic_physical.sh
@@ -35,7 +35,7 @@ test_container_devices_nic_physical() {
   fi
 
   # Check custom MAC is applied in container.
-  if ! lxc exec "${ctName}" -- grep -i "${ctMAC}" /sys/class/net/eth0/address ; then
+  if ! lxc exec "${ctName}" -- grep -Fix "${ctMAC}" /sys/class/net/eth0/address ; then
     echo "mac invalid"
     false
   fi
@@ -56,7 +56,7 @@ test_container_devices_nic_physical() {
   fi
 
   # Check original MAC is restored on physical device.
-   if ! grep -i "${dummyMAC}" /sys/class/net/"${ctName}"/address ; then
+   if ! grep -Fix "${dummyMAC}" /sys/class/net/"${ctName}"/address ; then
     echo "mac invalid"
     false
   fi
@@ -74,7 +74,7 @@ test_container_devices_nic_physical() {
   fi
 
   # Check original MAC is restored on physical device.
-   if ! grep -i "${dummyMAC}" /sys/class/net/"${ctName}"/address ; then
+   if ! grep -Fix "${dummyMAC}" /sys/class/net/"${ctName}"/address ; then
     echo "mac invalid"
     false
   fi
@@ -100,7 +100,7 @@ test_container_devices_nic_physical() {
   fi
 
   # Check custom MAC is applied in container.
-  if ! lxc exec "${ctName}" -- grep -i "${ctMAC}" /sys/class/net/eth0/address ; then
+  if ! lxc exec "${ctName}" -- grep -Fix "${ctMAC}" /sys/class/net/eth0/address ; then
     echo "mac invalid"
     false
   fi
@@ -117,7 +117,7 @@ test_container_devices_nic_physical() {
   fi
 
   # Check original MAC is restored on physical device.
-   if ! grep -i "${dummyMAC}" /sys/class/net/"${ctName}"/address ; then
+   if ! grep -Fix "${dummyMAC}" /sys/class/net/"${ctName}"/address ; then
     echo "mac invalid"
     false
   fi
@@ -141,7 +141,7 @@ test_container_devices_nic_physical() {
   fi
 
   # Check custom MAC is applied in container.
-  if ! lxc exec "${ctName}" -- grep -i "${ctMAC}" /sys/class/net/eth0/address ; then
+  if ! lxc exec "${ctName}" -- grep -Fix "${ctMAC}" /sys/class/net/eth0/address ; then
     echo "mac invalid"
     false
   fi
@@ -158,7 +158,7 @@ test_container_devices_nic_physical() {
   fi
 
   # Check original MAC is restored on physical device.
-   if ! grep -i "${dummyMAC}" /sys/class/net/"${ctName}"/address ; then
+   if ! grep -Fix "${dummyMAC}" /sys/class/net/"${ctName}"/address ; then
     echo "mac invalid"
     false
   fi
@@ -182,7 +182,7 @@ test_container_devices_nic_physical() {
   fi
 
   # Check original MAC is restored on physical device.
-   if ! grep -i "${dummyMAC}" /sys/class/net/"${ctName}"/address ; then
+   if ! grep -Fix "${dummyMAC}" /sys/class/net/"${ctName}"/address ; then
     echo "mac invalid"
     false
   fi

--- a/test/suites/container_devices_nic_routed.sh
+++ b/test/suites/container_devices_nic_routed.sh
@@ -76,6 +76,13 @@ test_container_devices_nic_routed() {
     false
   fi
 
+  # Check MAC address is applied.
+  ctMAC=$(lxc config get "${ctName}" volatile.eth0.hwaddr)
+  if ! lxc exec "${ctName}" -- grep -Fix "${ctMAC}" /sys/class/net/eth0/address ; then
+    echo "mac invalid"
+    false
+  fi
+
   lxc stop "${ctName}" --force
 
   # Check neighbour proxy entries removed from parent interface.

--- a/test/suites/container_devices_nic_routed.sh
+++ b/test/suites/container_devices_nic_routed.sh
@@ -66,6 +66,10 @@ test_container_devices_nic_routed() {
   # Check IP is assigned and doesn't have a broadcast address set.
   lxc exec "${ctName}" -- ip a | grep "inet 192.0.2.1${ipRand}/32 scope global eth0"
 
+  # Check neighbour proxy entries added to parent interface.
+  ip neigh show proxy dev "${ctName}" | grep "192.0.2.1${ipRand}"
+  ip neigh show proxy dev "${ctName}" | grep "2001:db8::1${ipRand}"
+
   # Check custom MTU is applied.
   if ! lxc exec "${ctName}" -- ip link show eth0 | grep "mtu 1600" ; then
     echo "mtu invalid"
@@ -73,6 +77,10 @@ test_container_devices_nic_routed() {
   fi
 
   lxc stop "${ctName}" --force
+
+  # Check neighbour proxy entries removed from parent interface.
+  ! ip neigh show proxy dev "${ctName}" | grep "192.0.2.1${ipRand}" || false
+  ! ip neigh show proxy dev "${ctName}" | grep "2001:db8::1${ipRand}" || false
 
   # Check that MTU is inherited from parent device when not specified on device.
   ip link set "${ctName}" mtu 1605


### PR DESCRIPTION
Instead it configures a veth pair itself and then uses liblxc's phys NIC type to pass one end of the veth pair into the container.

This is part of adding routed NIC support for VMs by moving the common functionality into LXD.

Continues work started in https://github.com/lxc/lxd/pull/9367