### PR TITLE
Support for lxc storage volume {copy,move} --target and --destination-target flag 

### DIFF
--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -411,7 +411,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 		return nil, fmt.Errorf("Failed to get destination connection info: %v", err)
 	}
 
-	if destInfo.URL == sourceInfo.URL && destInfo.SocketPath == sourceInfo.SocketPath {
+	if destInfo.URL == sourceInfo.URL && destInfo.SocketPath == sourceInfo.SocketPath && volume.Location == r.clusterTarget {
 		// Project handling
 		if destInfo.Project != sourceInfo.Project {
 			if !r.HasExtension("storage_api_project") {

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -32,8 +32,9 @@ type volumeColumn struct {
 }
 
 type cmdStorageVolume struct {
-	global  *cmdGlobal
-	storage *cmdStorage
+	global                *cmdGlobal
+	storage               *cmdStorage
+	flagDestinationTarget string
 }
 
 func (c *cmdStorageVolume) Command() *cobra.Command {
@@ -333,6 +334,7 @@ func (c *cmdStorageVolumeCopy) Command() *cobra.Command {
 
 	cmd.Flags().StringVar(&c.flagMode, "mode", "pull", i18n.G("Transfer mode. One of pull (default), push or relay.")+"``")
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
+	cmd.Flags().StringVar(&c.storageVolume.flagDestinationTarget, "destination-target", "", i18n.G("Destination cluster member name")+"``")
 	cmd.Flags().BoolVar(&c.flagVolumeOnly, "volume-only", false, i18n.G("Copy the volume without its snapshots"))
 	cmd.Flags().StringVar(&c.flagTargetProject, "target-project", "", i18n.G("Copy to a project different from the source")+"``")
 	cmd.Flags().BoolVar(&c.flagRefresh, "refresh", false, i18n.G("Refresh and update the existing storage volume copies"))
@@ -362,6 +364,11 @@ func (c *cmdStorageVolumeCopy) Run(cmd *cobra.Command, args []string) error {
 
 	srcServer := srcResource.server
 	srcPath := srcResource.name
+
+	// If a target was specified, specify the volume on the given member.
+	if c.storage.flagTarget != "" {
+		srcServer = srcServer.UseTarget(c.storage.flagTarget)
+	}
 
 	// Destination
 	dstResource := resources[1]
@@ -417,6 +424,19 @@ func (c *cmdStorageVolumeCopy) Run(cmd *cobra.Command, args []string) error {
 	}
 	if err != nil {
 		return err
+	}
+
+	// If destination target was specified, copy the volume onto the given member.
+	// If no destination target is specified, this will be the same as the source.
+	if c.storageVolume.flagDestinationTarget != "" {
+		dstServer = dstServer.UseTarget(c.storageVolume.flagDestinationTarget)
+	} else {
+		dstServer = dstServer.UseTarget(srcVol.Location)
+	}
+
+	// If no target is specified, use the member that contains the source volume.
+	if c.storage.flagTarget == "" {
+		srcServer = srcServer.UseTarget(srcVol.Location)
 	}
 
 	if cmd.Name() == "move" && srcServer == dstServer {
@@ -1380,6 +1400,7 @@ func (c *cmdStorageVolumeMove) Command() *cobra.Command {
 
 	cmd.Flags().StringVar(&c.storageVolumeCopy.flagMode, "mode", "pull", i18n.G("Transfer mode, one of pull (default), push or relay")+"``")
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
+	cmd.Flags().StringVar(&c.storageVolume.flagDestinationTarget, "destination-target", "", i18n.G("Destination cluster member name")+"``")
 	cmd.Flags().StringVar(&c.storageVolumeCopy.flagTargetProject, "target-project", "", i18n.G("Move to a project different from the source")+"``")
 	cmd.RunE = c.Run
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -568,7 +568,7 @@ msgstr "Ungültiges Ziel %s"
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 #, fuzzy
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
@@ -576,7 +576,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 #, fuzzy
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
@@ -776,12 +776,12 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -831,12 +831,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
@@ -852,7 +852,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -892,7 +892,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -984,7 +984,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,14 +1044,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -1059,7 +1059,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Spalten"
@@ -1099,8 +1099,8 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
@@ -1109,7 +1109,7 @@ msgstr "YAML Analyse Fehler %v\n"
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1161,12 +1161,12 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Copy the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1264,7 +1264,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1345,7 +1345,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1430,7 +1430,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -1499,20 +1499,25 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+#, fuzzy
+msgid "Destination cluster member name"
+msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/network.go:409 lxc/network.go:410
 #, fuzzy
@@ -1523,12 +1528,12 @@ msgstr "Netzwerkschnittstellen an Container anbinden"
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1717,7 +1722,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1726,7 +1731,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1830,7 +1835,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1845,12 +1850,12 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Export instances as backup tarballs."
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -1979,7 +1984,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -2091,7 +2096,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -2151,7 +2156,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2165,7 +2170,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2213,7 +2218,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2221,7 +2226,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2242,7 +2247,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2392,7 +2397,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2656,12 +2661,12 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2900,12 +2905,12 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Manage storage pools and volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 #, fuzzy
 msgid "Manage storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3046,14 +3051,14 @@ msgid "Missing peer name"
 msgstr "Fehlende Zusammenfassung."
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -3073,7 +3078,7 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -3108,8 +3113,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3123,7 +3128,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -3133,11 +3138,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -3155,7 +3160,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -3326,16 +3331,16 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3349,15 +3354,15 @@ msgstr "kein Wert in %q gefunden\n"
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3369,7 +3374,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3480,7 +3485,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3662,7 +3667,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3811,17 +3816,17 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3872,7 +3877,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -4129,12 +4134,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4252,12 +4257,12 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
@@ -4314,7 +4319,7 @@ msgstr "Größe: %.2vMB\n"
 msgid "Size: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4405,22 +4410,22 @@ msgstr "Profil %s erstellt\n"
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Profil %s erstellt\n"
@@ -4471,7 +4476,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4549,8 +4554,8 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -4623,7 +4628,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "unbekannter entfernter Instanz Name: %q"
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4631,7 +4636,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4687,13 +4692,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4711,7 +4716,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4793,7 +4798,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -4819,7 +4824,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4919,7 +4924,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -4927,7 +4932,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
@@ -5588,7 +5593,7 @@ msgstr ""
 "lxd %s <Name>\n"
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5596,7 +5601,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -5628,7 +5633,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -5639,7 +5644,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -5647,7 +5652,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -5655,7 +5660,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
@@ -5663,7 +5668,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
@@ -5671,7 +5676,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
@@ -5679,7 +5684,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -5688,7 +5693,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -5697,7 +5702,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -5706,7 +5711,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -5714,8 +5719,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -5724,7 +5729,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
@@ -6151,19 +6156,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -36,7 +36,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -361,11 +361,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -546,11 +546,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -598,12 +598,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -618,7 +618,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -658,7 +658,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -795,14 +795,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -810,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -847,8 +847,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -898,7 +898,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -923,7 +923,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1073,7 +1073,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1089,7 +1089,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1154,7 +1154,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1222,20 +1222,25 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+#, fuzzy
+msgid "Destination cluster member name"
+msgstr "  Χρήση δικτύου:"
 
 #: lxc/network.go:409 lxc/network.go:410
 msgid "Detach network interfaces from instances"
@@ -1245,11 +1250,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1424,7 +1429,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1432,7 +1437,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1526,7 +1531,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1538,11 +1543,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1665,7 +1670,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1772,7 +1777,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1830,7 +1835,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1844,7 +1849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1890,7 +1895,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1898,7 +1903,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1917,7 +1922,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2061,7 +2066,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2305,11 +2310,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2526,11 +2531,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2663,14 +2668,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2688,7 +2693,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2721,8 +2726,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2734,7 +2739,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2742,11 +2747,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2763,7 +2768,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2932,15 +2937,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2954,15 +2959,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2974,7 +2979,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3084,7 +3089,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3258,7 +3263,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3397,15 +3402,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3453,7 +3458,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3700,11 +3705,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3815,11 +3820,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3873,7 +3878,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3958,21 +3963,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -4021,7 +4026,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4093,8 +4098,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4163,7 +4168,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4171,7 +4176,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4226,13 +4231,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4250,7 +4255,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4327,7 +4332,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4439,11 +4444,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4770,11 +4775,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4790,54 +4795,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5171,19 +5176,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -51,7 +51,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -554,11 +554,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -742,11 +742,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -794,12 +794,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -814,7 +814,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -855,7 +855,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "NOMBRE COMÚN"
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -938,7 +938,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -994,14 +994,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
@@ -1009,7 +1009,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Columnas"
@@ -1048,8 +1048,8 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1058,7 +1058,7 @@ msgstr ""
 msgid "Console log:"
 msgstr "Log de la consola:"
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1107,11 +1107,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1125,7 +1125,7 @@ msgstr "Copiando la imagen: %s"
 msgid "Copying the image: %s"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1208,7 +1208,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1280,7 +1280,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
@@ -1296,7 +1296,7 @@ msgstr "CONTROLADOR"
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1430,20 +1430,25 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+#, fuzzy
+msgid "Destination cluster member name"
+msgstr "Nombre del Miembro del Cluster"
 
 #: lxc/network.go:409 lxc/network.go:410
 msgid "Detach network interfaces from instances"
@@ -1453,11 +1458,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1632,7 +1637,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1640,7 +1645,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1736,7 +1741,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1750,11 +1755,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Export instances as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -1878,7 +1883,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1985,7 +1990,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -2045,7 +2050,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2059,7 +2064,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2105,7 +2110,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2113,7 +2118,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2133,7 +2138,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2279,7 +2284,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2527,11 +2532,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2750,11 +2755,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2893,14 +2898,14 @@ msgid "Missing peer name"
 msgstr "Nombre del contenedor es: %s"
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2919,7 +2924,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2954,8 +2959,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2967,7 +2972,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2975,11 +2980,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2996,7 +3001,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -3163,15 +3168,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3185,15 +3190,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3205,7 +3210,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3315,7 +3320,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3492,7 +3497,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3632,15 +3637,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3691,7 +3696,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3939,11 +3944,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4054,11 +4059,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -4198,21 +4203,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -4261,7 +4266,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4335,8 +4340,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4405,7 +4410,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4413,7 +4418,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4470,13 +4475,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4494,7 +4499,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4571,7 +4576,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4596,7 +4601,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4684,12 +4689,12 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5092,12 +5097,12 @@ msgid "[<remote>:]<operation>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5117,65 +5122,65 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5530,19 +5535,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -55,7 +55,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -552,7 +552,7 @@ msgstr "Cible invalide %s"
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 #, fuzzy
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 #, fuzzy
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
@@ -765,12 +765,12 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -820,12 +820,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
@@ -841,7 +841,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -881,7 +881,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -966,7 +966,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,14 +1024,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -1039,7 +1039,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonnes"
@@ -1086,8 +1086,8 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
@@ -1096,7 +1096,7 @@ msgstr "Erreur lors de la lecture de la configuration : %s"
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1148,12 +1148,12 @@ msgstr "Copie de l'image : %s"
 msgid "Copy the instance without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr "Copie de l'image : %s"
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Copie de l'image : %s"
@@ -1268,7 +1268,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "Création du conteneur"
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1349,7 +1349,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1365,7 +1365,7 @@ msgstr "PILOTE"
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -1438,7 +1438,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1508,20 +1508,25 @@ msgstr "Récupération de l'image : %s"
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+#, fuzzy
+msgid "Destination cluster member name"
+msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/network.go:409 lxc/network.go:410
 msgid "Detach network interfaces from instances"
@@ -1531,12 +1536,12 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1722,7 +1727,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1731,7 +1736,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1845,7 +1850,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
@@ -1860,12 +1865,12 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Export instances as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -1995,7 +2000,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -2108,7 +2113,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgstr "IPv6"
 msgid "ISSUE DATE"
 msgstr "DATE D'ÉMISSION"
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2187,7 +2192,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2237,7 +2242,7 @@ msgstr "Image copiée avec succès !"
 msgid "Immediately attach to the console"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2245,7 +2250,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -2267,7 +2272,7 @@ msgstr "Import de l'image : %s"
 msgid "Import instance backups"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -2415,7 +2420,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2724,12 +2729,12 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,12 +2967,12 @@ msgstr "Rendre l'image publique"
 msgid "Manage storage pools and volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 #, fuzzy
 msgid "Manage storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3112,14 +3117,14 @@ msgid "Missing peer name"
 msgstr "Résumé manquant."
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -3139,7 +3144,7 @@ msgstr "Nom de l'ensemble de stockage"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
@@ -3175,8 +3180,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 #, fuzzy
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
@@ -3191,7 +3196,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Copie de l'image : %s"
@@ -3201,11 +3206,11 @@ msgstr "Copie de l'image : %s"
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
@@ -3223,7 +3228,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr "NOM"
 
@@ -3395,16 +3400,16 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3418,19 +3423,19 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 #, fuzzy
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 #, fuzzy
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
@@ -3445,7 +3450,7 @@ msgstr "Seules les URLs https sont supportées par simplestreams"
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 #, fuzzy
 msgid "Only instance or custom volumes are supported"
 msgstr ""
@@ -3561,7 +3566,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
@@ -3745,7 +3750,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
@@ -3894,17 +3899,17 @@ msgstr "Créé : %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3972,7 +3977,7 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -4233,12 +4238,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4361,12 +4366,12 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
@@ -4424,7 +4429,7 @@ msgstr "Taille : %.2f Mo"
 msgid "Size: %s"
 msgstr "État : %s"
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
@@ -4516,22 +4521,22 @@ msgstr "Le réseau %s a été créé"
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s créé"
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Image copiée avec succès !"
@@ -4584,7 +4589,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr "TYPE"
 
@@ -4666,8 +4671,8 @@ msgstr "Le périphérique indiqué n'existe pas"
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
@@ -4740,7 +4745,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4748,7 +4753,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4805,13 +4810,13 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
@@ -4829,7 +4834,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4914,7 +4919,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Clé de configuration invalide"
@@ -4940,7 +4945,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr "Publié : %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5037,7 +5042,7 @@ msgstr "vous devez spécifier un nom de conteneur source"
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -5045,7 +5050,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
@@ -5775,7 +5780,7 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5783,7 +5788,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -5815,7 +5820,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -5829,7 +5834,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -5837,7 +5842,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -5845,7 +5850,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
@@ -5853,7 +5858,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
@@ -5861,7 +5866,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
@@ -5869,7 +5874,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -5881,7 +5886,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -5893,7 +5898,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -5905,7 +5910,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -5913,8 +5918,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -5926,7 +5931,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
@@ -6387,19 +6392,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -51,7 +51,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -544,11 +544,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -732,11 +732,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -784,12 +784,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -804,7 +804,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -844,7 +844,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -982,14 +982,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -997,7 +997,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonne"
@@ -1034,8 +1034,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1044,7 +1044,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1093,11 +1093,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1110,7 +1110,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1267,7 +1267,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
@@ -1283,7 +1283,7 @@ msgstr "DRIVER"
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1349,7 +1349,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1417,20 +1417,25 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+#, fuzzy
+msgid "Destination cluster member name"
+msgstr "Il nome del container è: %s"
 
 #: lxc/network.go:409 lxc/network.go:410
 msgid "Detach network interfaces from instances"
@@ -1440,11 +1445,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1619,7 +1624,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1627,7 +1632,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1722,7 +1727,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1736,11 +1741,11 @@ msgstr "Creazione del container in corso"
 msgid "Export instances as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -1864,7 +1869,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1970,7 +1975,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -2029,7 +2034,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2043,7 +2048,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2090,7 +2095,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2098,7 +2103,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2118,7 +2123,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Creazione del container in corso"
@@ -2264,7 +2269,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2513,11 +2518,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2739,11 +2744,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2881,14 +2886,14 @@ msgid "Missing peer name"
 msgstr "Il nome del container è: %s"
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2907,7 +2912,7 @@ msgstr "Il nome del container è: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2941,8 +2946,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2954,7 +2959,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2962,11 +2967,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2983,7 +2988,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -3150,15 +3155,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3172,15 +3177,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3192,7 +3197,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3303,7 +3308,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3479,7 +3484,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3620,15 +3625,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3679,7 +3684,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3925,11 +3930,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4040,11 +4045,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4098,7 +4103,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -4185,21 +4190,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -4249,7 +4254,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4323,8 +4328,8 @@ msgstr "il remote %s non esiste"
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4393,7 +4398,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4401,7 +4406,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4457,13 +4462,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4481,7 +4486,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4556,7 +4561,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4581,7 +4586,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4671,12 +4676,12 @@ msgstr "Occorre specificare un nome di container come origine"
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
@@ -5079,12 +5084,12 @@ msgid "[<remote>:]<operation>"
 msgstr "Creazione del container in corso"
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
@@ -5104,65 +5109,65 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr "Creazione del container in corso"
@@ -5517,19 +5522,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: 2021-08-06 08:35+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -548,11 +548,11 @@ msgstr "<alias> <target>"
 msgid "<old alias> <new alias>"
 msgstr "<old alias> <new alias>"
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr "<pool>/<volume> <pool>/<volume>"
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 
@@ -747,11 +747,11 @@ msgstr "プロファイルにネットワークインターフェースを追加
 msgid "Attach new network interfaces to instances"
 msgstr "新たなネットワークインターフェースをインスタンスに追加します"
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr "新たにストレージボリュームをインスタンスに追加します"
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
@@ -803,12 +803,12 @@ msgstr "BASE IMAGE"
 msgid "Backing up instance: %s"
 msgstr "インスタンスのバックアップ中: %s"
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
@@ -823,7 +823,7 @@ msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
@@ -864,7 +864,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr "CONTENT-TYPE"
 
@@ -946,7 +946,7 @@ msgstr "--fast と --columns は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
@@ -1001,14 +1001,14 @@ msgstr "%s:%s のクラスターに join するためのトークンが削除さ
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
@@ -1016,7 +1016,7 @@ msgstr "クラスタメンバ名"
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "カラムレイアウト"
@@ -1057,8 +1057,8 @@ msgstr "移動先のインスタンスに適用するキー/値の設定"
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
@@ -1067,7 +1067,7 @@ msgstr "設定の構文エラー: %s"
 msgid "Console log:"
 msgstr "コンソールログ:"
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr "ストレージボリュームのタイプ、block もしくは filesystem"
 
@@ -1112,7 +1112,7 @@ msgstr "プロファイルに継承されたデバイスをコピーし、設定
 msgid "Copy profiles"
 msgstr "プロファイルをコピーします"
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr "ストレージボリュームをコピーします"
 
@@ -1120,11 +1120,11 @@ msgstr "ストレージボリュームをコピーします"
 msgid "Copy the instance without its snapshots"
 msgstr "インスタンスをコピーします。スナップショットはコピーしません"
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
@@ -1137,7 +1137,7 @@ msgstr "仮想マシンイメージをコピーします"
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr "ストレージボリュームのコピー中: %s"
@@ -1220,7 +1220,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "イメージからインスタンスを作成します"
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr "新たにカスタムストレージボリュームを作成します"
 
@@ -1293,7 +1293,7 @@ msgstr "DEFAULT TARGET ADDRESS"
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1309,7 +1309,7 @@ msgstr "DRIVER"
 msgid "DRM:"
 msgstr "DRM:"
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
@@ -1375,7 +1375,7 @@ msgstr "プロジェクトを削除します"
 msgid "Delete storage pools"
 msgstr "ストレージプールを削除します"
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr "ストレージボリュームを削除します"
 
@@ -1443,20 +1443,25 @@ msgstr "警告を削除します"
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr "説明"
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+#, fuzzy
+msgid "Destination cluster member name"
+msgstr "クラスターメンバー名がありません"
 
 #: lxc/network.go:409 lxc/network.go:410
 msgid "Detach network interfaces from instances"
@@ -1466,11 +1471,11 @@ msgstr "インスタンスからネットワークインターフェースを取
 msgid "Detach network interfaces from profiles"
 msgstr "プロファイルからネットワークインターフェースを取り外します"
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr "インスタンスからストレージボリュームを取り外します"
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr "プロファイルからストレージボリュームを取り外します"
 
@@ -1650,7 +1655,7 @@ msgstr "プロジェクト設定をYAMLで編集します"
 msgid "Edit storage pool configurations as YAML"
 msgstr "ストレージプールの設定をYAMLで編集します"
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
 
@@ -1658,7 +1663,7 @@ msgstr "ストレージボリュームの設定をYAMLで編集します"
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1777,7 +1782,7 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
@@ -1789,12 +1794,12 @@ msgstr "インスタンスのバックアップをエクスポートします"
 msgid "Export instances as backup tarballs."
 msgstr "インスタンスを tarball 形式のバックアップとしてエクスポートします。"
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -1932,7 +1937,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr "フォーマット (csv|json|table|yaml)"
 
@@ -2038,7 +2043,7 @@ msgstr "プロジェクトの設定値を取得します"
 msgid "Get values for storage pool configuration keys"
 msgstr "ストレージプールの設定値を取得します"
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr "ストレージボリュームの設定値を取得します"
 
@@ -2096,7 +2101,7 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr "ISSUE DATE"
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
@@ -2112,7 +2117,7 @@ msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行す�
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "設定されている自動でのインスタンスの有効期限設定を無視します"
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
@@ -2158,7 +2163,7 @@ msgstr "イメージの更新が成功しました!"
 msgid "Immediately attach to the console"
 msgstr "起動直後にインスタンスのコンソールに接続します"
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 "カスタムボリュームのバックアップをスナップショットを含んだ状態でインポートし"
@@ -2169,7 +2174,7 @@ msgid "Import backups of instances including their snapshots."
 msgstr ""
 "インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
@@ -2192,7 +2197,7 @@ msgstr "イメージをイメージストアにインポートします"
 msgid "Import instance backups"
 msgstr "インスタンスのバックアップをインポートします"
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr "カスタムボリュームのインポート中: %s"
@@ -2340,7 +2345,7 @@ msgid "LISTEN ADDRESS"
 msgstr "LISTEN ADDRESS"
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr "LOCATION"
 
@@ -2693,11 +2698,11 @@ msgstr "プロファイルを一覧表示します"
 msgid "List projects"
 msgstr "プロジェクトを一覧表示します"
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2962,11 +2967,11 @@ msgstr "プロジェクトを管理します"
 msgid "Manage storage pools and volumes"
 msgstr "ストレージプール、ストレージボリュームを管理します"
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr "ストレージボリュームを管理します"
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3103,14 +3108,14 @@ msgid "Missing peer name"
 msgstr "名前を指定する必要があります"
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -3128,7 +3133,7 @@ msgstr "プロジェクト名を指定する必要があります"
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
@@ -3165,8 +3170,8 @@ msgstr ""
 "\n"
 "デフォルトではすべてのタイプのメッセージをモニタリングします。"
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
@@ -3180,7 +3185,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr "LXD サーバ内もしくはサーバ間でインスタンスを移動します"
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
 
@@ -3188,11 +3193,11 @@ msgstr "プール間でストレージボリュームを移動します"
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトに移動します"
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
@@ -3209,7 +3214,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr "NAME"
 
@@ -3377,15 +3382,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr "このストレージボリュームに対するデバイスがありません"
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr "コピー元のボリュームに対するストレージプールが指定されていません"
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr "コピー先のボリュームに対するストレージプールが指定されていません"
 
@@ -3399,15 +3404,15 @@ msgstr "%q に設定する値が指定されていません"
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
@@ -3419,7 +3424,7 @@ msgstr "simplestreams は https の URL のみサポートします"
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr "インスタンスもしくはカスタムボリュームのみをサポートしています"
 
@@ -3529,7 +3534,7 @@ msgstr "ポート:"
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 "再度エディタを開くためには Enter キーを、変更を取り消すには ctrl+c を入力しま"
@@ -3705,7 +3710,7 @@ msgstr "読み取り専用: %v"
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
@@ -3844,16 +3849,16 @@ msgstr "プロジェクト名を変更します"
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr "ストレージボリューム名を変更します"
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 "ストレージボリューム名とストレージボリュームのスナップショット名を変更します"
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
@@ -3907,7 +3912,7 @@ msgstr ""
 "\n"
 "--stateful オプションを指定すると、インスタンスの実行状態もリストアします。"
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
@@ -4199,11 +4204,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行うには次の形式でも設定できます:\n"
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4318,11 +4323,11 @@ msgstr "プロジェクトの設定を表示します"
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
@@ -4376,7 +4381,7 @@ msgstr "サイズ: %.2fMB"
 msgid "Size: %s"
 msgstr "サイズ: %s"
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
@@ -4461,21 +4466,21 @@ msgstr "ストレージプール %s はメンバ %s 上でペンディング状�
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr "ストレージボリューム %s を作成しました"
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr "ストレージボリューム %s を削除しました"
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr "ストレージボリュームのコピーが成功しました!"
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr "ストレージボリュームの移動が成功しました!"
 
@@ -4524,7 +4529,7 @@ msgstr "TOKEN"
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr "TYPE"
 
@@ -4603,8 +4608,8 @@ msgstr "プロファイルのデバイスが存在しません"
 msgid "The source LXD server is not clustered"
 msgstr "移動元の LXD サーバはクラスタに属していません"
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
@@ -4692,7 +4697,7 @@ msgstr "合計: %v"
 msgid "Transceiver type: %s"
 msgstr "トランシーバータイプ: %s"
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
@@ -4700,7 +4705,7 @@ msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpu
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)。"
 
@@ -4757,13 +4762,13 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr "USAGE"
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr "USED BY"
 
@@ -4781,7 +4786,7 @@ msgstr "UUID: %v"
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4856,7 +4861,7 @@ msgstr "プロジェクトの設定を削除します"
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr "ストレージボリュームの設定を削除します"
 
@@ -4881,7 +4886,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr "アップロード日時: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4976,11 +4981,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
@@ -5323,11 +5328,11 @@ msgid "[<remote>:]<operation>"
 msgstr "[<remote>:]<operation>"
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
@@ -5343,7 +5348,7 @@ msgstr "[<remote>:]<pool> <key>"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -5351,48 +5356,48 @@ msgstr ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr "[<remote>:]<pool> <volume> <key>"
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "[<remote>:]<pool> <volume> [key=value...]"
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 
@@ -5834,7 +5839,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
@@ -5842,7 +5847,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -5850,7 +5855,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2021-11-14 00:43+0100\n"
+        "POT-Creation-Date: 2021-11-18 15:25-0600\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,7 +32,7 @@ msgid   "### This is a YAML representation of a storage pool.\n"
         "###   zfs.pool_name: default"
 msgstr  ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid   "### This is a YAML representation of a storage volume.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -340,11 +340,11 @@ msgstr  ""
 msgid   "<old alias> <new alias>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid   "<pool>/<volume> <pool>/<volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid   "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr  ""
 
@@ -520,11 +520,11 @@ msgstr  ""
 msgid   "Attach new network interfaces to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid   "Attach new storage volumes to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid   "Attach new storage volumes to profiles"
 msgstr  ""
 
@@ -571,12 +571,12 @@ msgstr  ""
 msgid   "Backing up instance: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid   "Backup exported successfully!"
 msgstr  ""
 
@@ -589,7 +589,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179 lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179 lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -629,7 +629,7 @@ msgstr  ""
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid   "CONTENT-TYPE"
 msgstr  ""
 
@@ -710,7 +710,7 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
@@ -756,7 +756,7 @@ msgstr  ""
 msgid   "Cluster join token for %s:%s deleted"
 msgstr  ""
 
-#: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617 lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764 lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:389 lxc/network_forward.go:490 lxc/network_forward.go:631 lxc/network_forward.go:708 lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339 lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757 lxc/storage_volume.go:335 lxc/storage_volume.go:504 lxc/storage_volume.go:583 lxc/storage_volume.go:825 lxc/storage_volume.go:1022 lxc/storage_volume.go:1110 lxc/storage_volume.go:1382 lxc/storage_volume.go:1413 lxc/storage_volume.go:1529 lxc/storage_volume.go:1608 lxc/storage_volume.go:1701 lxc/storage_volume.go:1738 lxc/storage_volume.go:1832 lxc/storage_volume.go:1904 lxc/storage_volume.go:2043
+#: lxc/config.go:98 lxc/config.go:367 lxc/config.go:470 lxc/config.go:617 lxc/config.go:736 lxc/copy.go:52 lxc/info.go:47 lxc/init.go:55 lxc/move.go:58 lxc/network.go:288 lxc/network.go:706 lxc/network.go:764 lxc/network.go:1061 lxc/network.go:1128 lxc/network.go:1190 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:389 lxc/network_forward.go:490 lxc/network_forward.go:631 lxc/network_forward.go:708 lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339 lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757 lxc/storage_volume.go:336 lxc/storage_volume.go:524 lxc/storage_volume.go:603 lxc/storage_volume.go:845 lxc/storage_volume.go:1042 lxc/storage_volume.go:1130 lxc/storage_volume.go:1402 lxc/storage_volume.go:1434 lxc/storage_volume.go:1550 lxc/storage_volume.go:1629 lxc/storage_volume.go:1722 lxc/storage_volume.go:1759 lxc/storage_volume.go:1853 lxc/storage_volume.go:1925 lxc/storage_volume.go:2064
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -764,7 +764,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193 lxc/warning.go:93
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213 lxc/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -795,7 +795,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444 lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958 lxc/storage_volume.go:988
+#: lxc/cluster.go:668 lxc/config.go:258 lxc/config.go:331 lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444 lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595 lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501 lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978 lxc/storage_volume.go:1008
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -804,7 +804,7 @@ msgstr  ""
 msgid   "Console log:"
 msgstr  ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid   "Content type, block or filesystem"
 msgstr  ""
 
@@ -844,7 +844,7 @@ msgstr  ""
 msgid   "Copy profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid   "Copy storage volumes"
 msgstr  ""
 
@@ -852,11 +852,11 @@ msgstr  ""
 msgid   "Copy the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -869,7 +869,7 @@ msgstr  ""
 msgid   "Copying the image: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid   "Copying the storage volume: %s"
 msgstr  ""
@@ -947,7 +947,7 @@ msgstr  ""
 msgid   "Create instances from images"
 msgstr  ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid   "Create new custom storage volumes"
 msgstr  ""
 
@@ -1014,7 +1014,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490 lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145 lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577 lxc/storage_volume.go:1288
+#: lxc/cluster.go:174 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490 lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145 lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577 lxc/storage_volume.go:1308
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1030,7 +1030,7 @@ msgstr  ""
 msgid   "DRM:"
 msgstr  ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
@@ -1094,7 +1094,7 @@ msgstr  ""
 msgid   "Delete storage pools"
 msgstr  ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid   "Delete storage volumes"
 msgstr  ""
 
@@ -1102,8 +1102,12 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192 lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369 lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738 lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083 lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79 lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368 lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476 lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288 lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50 lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005 lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187 lxc/network_acl.go:30 lxc/network_acl.go:91 lxc/network_acl.go:161 lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346 lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564 lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677 lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:82 lxc/network_zone.go:152 lxc/network_zone.go:205 lxc/network_zone.go:254 lxc/network_zone.go:335 lxc/network_zone.go:395 lxc/network_zone.go:422 lxc/network_zone.go:541 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:501 lxc/storage_volume.go:580 lxc/storage_volume.go:656 lxc/storage_volume.go:738 lxc/storage_volume.go:819 lxc/storage_volume.go:1019 lxc/storage_volume.go:1107 lxc/storage_volume.go:1194 lxc/storage_volume.go:1378 lxc/storage_volume.go:1410 lxc/storage_volume.go:1523 lxc/storage_volume.go:1599 lxc/storage_volume.go:1698 lxc/storage_volume.go:1732 lxc/storage_volume.go:1830 lxc/storage_volume.go:1897 lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:192 lxc/cluster.go:241 lxc/cluster.go:288 lxc/cluster.go:340 lxc/cluster.go:369 lxc/cluster.go:419 lxc/cluster.go:502 lxc/cluster.go:587 lxc/cluster.go:738 lxc/cluster.go:800 lxc/cluster.go:898 lxc/cluster.go:977 lxc/cluster.go:1083 lxc/cluster.go:1102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79 lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368 lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476 lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288 lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:50 lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005 lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187 lxc/network_acl.go:30 lxc/network_acl.go:91 lxc/network_acl.go:161 lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346 lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564 lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677 lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:82 lxc/network_zone.go:152 lxc/network_zone.go:205 lxc/network_zone.go:254 lxc/network_zone.go:335 lxc/network_zone.go:395 lxc/network_zone.go:422 lxc/network_zone.go:541 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166 lxc/storage_volume.go:241 lxc/storage_volume.go:332 lxc/storage_volume.go:521 lxc/storage_volume.go:600 lxc/storage_volume.go:676 lxc/storage_volume.go:758 lxc/storage_volume.go:839 lxc/storage_volume.go:1039 lxc/storage_volume.go:1127 lxc/storage_volume.go:1214 lxc/storage_volume.go:1398 lxc/storage_volume.go:1431 lxc/storage_volume.go:1544 lxc/storage_volume.go:1620 lxc/storage_volume.go:1719 lxc/storage_volume.go:1753 lxc/storage_volume.go:1851 lxc/storage_volume.go:1918 lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid   "Description"
+msgstr  ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid   "Destination cluster member name"
 msgstr  ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1114,11 +1118,11 @@ msgstr  ""
 msgid   "Detach network interfaces from profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid   "Detach storage volumes from instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid   "Detach storage volumes from profiles"
 msgstr  ""
 
@@ -1281,7 +1285,7 @@ msgstr  ""
 msgid   "Edit storage pool configurations as YAML"
 msgstr  ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid   "Edit storage volume configurations as YAML"
 msgstr  ""
 
@@ -1289,7 +1293,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310 lxc/warning.go:234
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330 lxc/warning.go:234
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1375,7 +1379,7 @@ msgid   "Export and download images\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid   "Export custom storage volume"
 msgstr  ""
 
@@ -1387,11 +1391,11 @@ msgstr  ""
 msgid   "Export instances as backup tarballs."
 msgstr  ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -1501,7 +1505,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801 lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016 lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938 lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518 lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:801 lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016 lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938 lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518 lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
@@ -1604,7 +1608,7 @@ msgstr  ""
 msgid   "Get values for storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid   "Get values for storage volume configuration keys"
 msgstr  ""
 
@@ -1662,7 +1666,7 @@ msgstr  ""
 msgid   "ISSUE DATE"
 msgstr  ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
@@ -1674,7 +1678,7 @@ msgstr  ""
 msgid   "Ignore any configured auto-expiry for the instance"
 msgstr  ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
@@ -1720,7 +1724,7 @@ msgstr  ""
 msgid   "Immediately attach to the console"
 msgstr  ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid   "Import backups of custom volumes including their snapshots."
 msgstr  ""
 
@@ -1728,7 +1732,7 @@ msgstr  ""
 msgid   "Import backups of instances including their snapshots."
 msgstr  ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid   "Import custom storage volumes"
 msgstr  ""
 
@@ -1746,7 +1750,7 @@ msgstr  ""
 msgid   "Import instance backups"
 msgstr  ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid   "Importing custom volume: %s"
 msgstr  ""
@@ -1888,7 +1892,7 @@ msgstr  ""
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151 lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151 lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid   "LOCATION"
 msgstr  ""
 
@@ -2122,11 +2126,11 @@ msgstr  ""
 msgid   "List projects"
 msgstr  ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid   "List storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid   "List storage volumes\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -2339,11 +2343,11 @@ msgstr  ""
 msgid   "Manage storage pools and volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid   "Manage storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid   "Manage storage volumes\n"
         "\n"
         "Unless specified through a prefix, all volume operations affect \"custom\" (user created) volumes."
@@ -2449,7 +2453,7 @@ msgstr  ""
 msgid   "Missing peer name"
 msgstr  ""
 
-#: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422 lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189 lxc/storage_volume.go:264 lxc/storage_volume.go:527 lxc/storage_volume.go:604 lxc/storage_volume.go:680 lxc/storage_volume.go:762 lxc/storage_volume.go:861 lxc/storage_volume.go:1044 lxc/storage_volume.go:1132 lxc/storage_volume.go:1235 lxc/storage_volume.go:1435 lxc/storage_volume.go:1550 lxc/storage_volume.go:1630 lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422 lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190 lxc/storage_volume.go:265 lxc/storage_volume.go:547 lxc/storage_volume.go:624 lxc/storage_volume.go:700 lxc/storage_volume.go:782 lxc/storage_volume.go:881 lxc/storage_volume.go:1064 lxc/storage_volume.go:1152 lxc/storage_volume.go:1255 lxc/storage_volume.go:1456 lxc/storage_volume.go:1571 lxc/storage_volume.go:1651 lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid   "Missing pool name"
 msgstr  ""
 
@@ -2465,7 +2469,7 @@ msgstr  ""
 msgid   "Missing source profile name"
 msgstr  ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid   "Missing source volume name"
 msgstr  ""
 
@@ -2497,7 +2501,7 @@ msgid   "Monitor a local or remote LXD server\n"
         "By default the monitor will listen to all message types."
 msgstr  ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700 lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720 lxc/storage_volume.go:801
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
@@ -2509,7 +2513,7 @@ msgstr  ""
 msgid   "Move instances within or in between LXD servers"
 msgstr  ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid   "Move storage volumes between pools"
 msgstr  ""
 
@@ -2517,11 +2521,11 @@ msgstr  ""
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid   "Move to a project different from the source"
 msgstr  ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid   "Moving the storage volume: %s"
 msgstr  ""
@@ -2534,7 +2538,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346 lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143 lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623 lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570 lxc/storage_volume.go:1287
+#: lxc/cluster.go:169 lxc/cluster.go:881 lxc/config_trust.go:346 lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143 lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623 lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570 lxc/storage_volume.go:1307
 msgid   "NAME"
 msgstr  ""
 
@@ -2698,15 +2702,15 @@ msgstr  ""
 msgid   "No device found for this network"
 msgstr  ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid   "No device found for this storage volume"
 msgstr  ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid   "No storage pool for source volume specified"
 msgstr  ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid   "No storage pool for target volume specified"
 msgstr  ""
 
@@ -2720,15 +2724,15 @@ msgstr  ""
 msgid   "Node %d:\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid   "Only \"custom\" volumes can be attached to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
@@ -2740,7 +2744,7 @@ msgstr  ""
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid   "Only instance or custom volumes are supported"
 msgstr  ""
 
@@ -2845,7 +2849,7 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206 lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675 lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574 lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/cluster.go:669 lxc/config.go:259 lxc/config.go:332 lxc/config_metadata.go:146 lxc/config_template.go:206 lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675 lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574 lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313 lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -3019,7 +3023,7 @@ msgstr  ""
 msgid   "Recursively transfer files"
 msgstr  ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
@@ -3156,15 +3160,15 @@ msgstr  ""
 msgid   "Rename remotes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid   "Rename storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid   "Rename storage volumes and storage volume snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
@@ -3210,7 +3214,7 @@ msgid   "Restore instances from snapshots\n"
         "If --stateful is passed, then the running state will be restored too."
 msgstr  ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
@@ -3430,11 +3434,11 @@ msgid   "Set storage pool configuration keys\n"
         "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid   "Set storage volume configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -3541,11 +3545,11 @@ msgstr  ""
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid   "Show storage volume configurations"
 msgstr  ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid   "Show storage volume state information"
 msgstr  ""
 
@@ -3599,7 +3603,7 @@ msgstr  ""
 msgid   "Size: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
@@ -3684,21 +3688,21 @@ msgstr  ""
 msgid   "Storage pool name"
 msgstr  ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid   "Storage volume %s created"
 msgstr  ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid   "Storage volume %s deleted"
 msgstr  ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid   "Storage volume copied successfully!"
 msgstr  ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid   "Storage volume moved successfully!"
 msgstr  ""
 
@@ -3745,7 +3749,7 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236 lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162 lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236 lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162 lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid   "TYPE"
 msgstr  ""
 
@@ -3815,7 +3819,7 @@ msgstr  ""
 msgid   "The source LXD server is not clustered"
 msgstr  ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714 lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734 lxc/storage_volume.go:815
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
@@ -3878,7 +3882,7 @@ msgstr  ""
 msgid   "Transceiver type: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
@@ -3886,7 +3890,7 @@ msgstr  ""
 msgid   "Transfer mode. One of pull (default), push or relay"
 msgstr  ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid   "Transfer mode. One of pull (default), push or relay."
 msgstr  ""
 
@@ -3939,11 +3943,11 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136 lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578 lxc/storage_volume.go:1290
+#: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136 lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578 lxc/storage_volume.go:1310
 msgid   "USED BY"
 msgstr  ""
 
@@ -3961,7 +3965,7 @@ msgstr  ""
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317 lxc/warning.go:241
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337 lxc/warning.go:241
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -4031,7 +4035,7 @@ msgstr  ""
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid   "Unset storage volume configuration keys"
 msgstr  ""
 
@@ -4053,7 +4057,7 @@ msgstr  ""
 msgid   "Uploaded: %s"
 msgstr  ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -4135,11 +4139,11 @@ msgstr  ""
 msgid   "You must specify a source instance name"
 msgstr  ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
@@ -4451,11 +4455,11 @@ msgstr  ""
 msgid   "[<remote>:]<operation>"
 msgstr  ""
 
-#: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668 lxc/storage_volume.go:1188
+#: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668 lxc/storage_volume.go:1208
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
@@ -4471,51 +4475,51 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid   "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid   "[<remote>:]<pool> <volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid   "[<remote>:]<pool> <volume> <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid   "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid   "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid   "[<remote>:]<pool> <volume> [key=value...]"
 msgstr  ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837 lxc/storage_volume.go:1618
 msgid   "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid   "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr  ""
 
@@ -4812,17 +4816,17 @@ msgid   "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
         "    Update a storage pool using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid   "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
         "    Update a storage volume using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid   "lxc storage volume show default data\n"
         "    Will show the properties of a custom volume called \"data\" in the \"default\" pool.\n"
         "\n"

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -50,7 +50,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -535,11 +535,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -720,11 +720,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -772,12 +772,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -792,7 +792,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -832,7 +832,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -913,7 +913,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -968,14 +968,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1020,8 +1020,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1030,7 +1030,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -1071,7 +1071,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1079,11 +1079,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1246,7 +1246,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1326,7 +1326,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1394,19 +1394,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1417,11 +1421,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1591,7 +1595,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1599,7 +1603,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1693,7 +1697,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1705,11 +1709,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1832,7 +1836,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1935,7 +1939,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1993,7 +1997,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2007,7 +2011,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2053,7 +2057,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2061,7 +2065,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2080,7 +2084,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2224,7 +2228,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2468,11 +2472,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2688,11 +2692,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2823,14 +2827,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2848,7 +2852,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2881,8 +2885,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2894,7 +2898,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2902,11 +2906,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2923,7 +2927,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -3090,15 +3094,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3112,15 +3116,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3132,7 +3136,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3242,7 +3246,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3416,7 +3420,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3555,15 +3559,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3611,7 +3615,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3854,11 +3858,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3967,11 +3971,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4025,7 +4029,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -4110,21 +4114,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -4173,7 +4177,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4245,8 +4249,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4315,7 +4319,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4378,13 +4382,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4402,7 +4406,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4473,7 +4477,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4497,7 +4501,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4585,11 +4589,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4916,11 +4920,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4936,54 +4940,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5317,19 +5321,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -48,7 +48,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -561,11 +561,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -746,11 +746,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -798,12 +798,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -818,7 +818,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -858,7 +858,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -939,7 +939,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -994,14 +994,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1046,8 +1046,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1056,7 +1056,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1105,11 +1105,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1122,7 +1122,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1272,7 +1272,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1288,7 +1288,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1352,7 +1352,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1420,19 +1420,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1443,11 +1447,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1617,7 +1621,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1625,7 +1629,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1719,7 +1723,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1731,11 +1735,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1858,7 +1862,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1961,7 +1965,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -2019,7 +2023,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2033,7 +2037,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2079,7 +2083,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2087,7 +2091,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2106,7 +2110,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2250,7 +2254,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2494,11 +2498,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2714,11 +2718,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2849,14 +2853,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2874,7 +2878,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2907,8 +2911,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2920,7 +2924,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2928,11 +2932,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2949,7 +2953,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -3116,15 +3120,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3138,15 +3142,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3158,7 +3162,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3268,7 +3272,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3442,7 +3446,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3581,15 +3585,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3637,7 +3641,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3880,11 +3884,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3993,11 +3997,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4051,7 +4055,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -4136,21 +4140,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -4199,7 +4203,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4271,8 +4275,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4341,7 +4345,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4349,7 +4353,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4404,13 +4408,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4428,7 +4432,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4499,7 +4503,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4523,7 +4527,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4611,11 +4615,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4942,11 +4946,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4962,54 +4966,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5343,19 +5347,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -51,7 +51,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -562,11 +562,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -756,12 +756,12 @@ msgstr "Anexar interfaces de rede aos perfis"
 msgid "Attach new network interfaces to instances"
 msgstr "Anexar uma nova interface de rede aos containers"
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -811,12 +811,12 @@ msgstr "IMAGEM BASE"
 msgid "Backing up instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
@@ -831,7 +831,7 @@ msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
@@ -871,7 +871,7 @@ msgstr "CANCELÁVEL"
 msgid "COMMON NAME"
 msgstr "NOME COMUM"
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
@@ -1009,14 +1009,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
@@ -1024,7 +1024,7 @@ msgstr "Nome de membro do cluster"
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colunas"
@@ -1069,8 +1069,8 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erro de análise de configuração: %s"
@@ -1079,7 +1079,7 @@ msgstr "Erro de análise de configuração: %s"
 msgid "Console log:"
 msgstr "Log de Console:"
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr "Copiar perfis"
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1129,11 +1129,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1147,7 +1147,7 @@ msgstr "Copiar a imagem: %s"
 msgid "Copying the image: %s"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1232,7 +1232,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1309,7 +1309,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1325,7 +1325,7 @@ msgstr "DRIVER"
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -1398,7 +1398,7 @@ msgstr "Apagar projetos"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1466,20 +1466,25 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr "Descrição"
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+#, fuzzy
+msgid "Destination cluster member name"
+msgstr "Nome de membro do cluster"
 
 #: lxc/network.go:409 lxc/network.go:410
 #, fuzzy
@@ -1490,12 +1495,12 @@ msgstr "Desconectar interfaces de rede dos containers"
 msgid "Detach network interfaces from profiles"
 msgstr "Desconectar interfaces de rede dos perfis"
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
@@ -1678,7 +1683,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1687,7 +1692,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1782,7 +1787,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1794,11 +1799,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1921,7 +1926,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -2033,7 +2038,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -2091,7 +2096,7 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2105,7 +2110,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2153,7 +2158,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2161,7 +2166,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2180,7 +2185,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Editar arquivos no container"
@@ -2324,7 +2329,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2570,11 +2575,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2800,11 +2805,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2943,14 +2948,14 @@ msgid "Missing peer name"
 msgstr "Nome de membro do cluster"
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2968,7 +2973,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -3002,8 +3007,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3015,7 +3020,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3023,11 +3028,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3044,7 +3049,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -3211,15 +3216,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3233,15 +3238,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3253,7 +3258,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3363,7 +3368,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3542,7 +3547,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3685,15 +3690,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3748,7 +3753,7 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4001,11 +4006,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4123,11 +4128,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -4183,7 +4188,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -4268,21 +4273,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -4332,7 +4337,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4408,8 +4413,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4478,7 +4483,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4486,7 +4491,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4542,13 +4547,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4566,7 +4571,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4649,7 +4654,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4674,7 +4679,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4762,11 +4767,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
@@ -5123,11 +5128,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
@@ -5144,57 +5149,57 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5531,19 +5536,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: 2020-10-08 08:16+0000\n"
 "Last-Translator: Artem <KovalevArtem.ru@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -51,7 +51,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 #, fuzzy
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
@@ -568,7 +568,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 #, fuzzy
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
@@ -761,12 +761,12 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -815,12 +815,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -835,7 +835,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -875,7 +875,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -958,7 +958,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1014,14 +1014,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -1029,7 +1029,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Столбцы"
@@ -1066,8 +1066,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -1117,7 +1117,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Копирование образа: %s"
@@ -1126,11 +1126,11 @@ msgstr "Копирование образа: %s"
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr "Копирование образа: %s"
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -1227,7 +1227,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -1306,7 +1306,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Копирование образа: %s"
@@ -1459,20 +1459,25 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
 msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+#, fuzzy
+msgid "Destination cluster member name"
+msgstr "Копирование образа: %s"
 
 #: lxc/network.go:409 lxc/network.go:410
 msgid "Detach network interfaces from instances"
@@ -1482,12 +1487,12 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1664,7 +1669,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1672,7 +1677,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1771,7 +1776,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
@@ -1786,12 +1791,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Export instances as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -1914,7 +1919,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -2021,7 +2026,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -2080,7 +2085,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2094,7 +2099,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2141,7 +2146,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2149,7 +2154,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -2171,7 +2176,7 @@ msgstr "Копирование образа: %s"
 msgid "Import instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2317,7 +2322,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2567,12 +2572,12 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2798,12 +2803,12 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 #, fuzzy
 msgid "Manage storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2943,14 +2948,14 @@ msgid "Missing peer name"
 msgstr "Имя контейнера: %s"
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2969,7 +2974,7 @@ msgstr "Имя контейнера: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
@@ -3004,8 +3009,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3017,7 +3022,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Копирование образа: %s"
@@ -3026,11 +3031,11 @@ msgstr "Копирование образа: %s"
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -3047,7 +3052,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -3216,16 +3221,16 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3239,15 +3244,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3259,7 +3264,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3369,7 +3374,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3543,7 +3548,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
@@ -3686,17 +3691,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3747,7 +3752,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -3996,11 +4001,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4114,11 +4119,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
@@ -4174,7 +4179,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
@@ -4263,21 +4268,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -4327,7 +4332,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4399,8 +4404,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4469,7 +4474,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4477,7 +4482,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4533,13 +4538,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4557,7 +4562,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4634,7 +4639,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4659,7 +4664,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4747,7 +4752,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -4755,7 +4760,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
@@ -5390,7 +5395,7 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -5398,7 +5403,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -5430,7 +5435,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -5440,7 +5445,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -5448,7 +5453,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -5456,7 +5461,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
@@ -5464,7 +5469,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
@@ -5472,7 +5477,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
@@ -5480,7 +5485,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -5488,7 +5493,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -5496,7 +5501,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -5504,7 +5509,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -5512,8 +5517,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -5521,7 +5526,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
@@ -5939,19 +5944,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: 2020-11-05 02:45+0000\n"
 "Last-Translator: wdggg <wdggg7@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -49,7 +49,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -441,11 +441,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -626,11 +626,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -678,12 +678,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -698,7 +698,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -738,7 +738,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -819,7 +819,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -874,14 +874,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -889,7 +889,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -926,8 +926,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -936,7 +936,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -977,7 +977,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -985,11 +985,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1081,7 +1081,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1152,7 +1152,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1168,7 +1168,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1232,7 +1232,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1300,19 +1300,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1323,11 +1327,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1505,7 +1509,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1599,7 +1603,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1611,11 +1615,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1738,7 +1742,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1841,7 +1845,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1899,7 +1903,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1913,7 +1917,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1967,7 +1971,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1986,7 +1990,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2130,7 +2134,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2374,11 +2378,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2594,11 +2598,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2729,14 +2733,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2754,7 +2758,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2787,8 +2791,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2800,7 +2804,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2808,11 +2812,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2829,7 +2833,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2996,15 +3000,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3018,15 +3022,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3038,7 +3042,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3148,7 +3152,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3322,7 +3326,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3461,15 +3465,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3517,7 +3521,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3760,11 +3764,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3873,11 +3877,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3931,7 +3935,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -4016,21 +4020,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -4079,7 +4083,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4151,8 +4155,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4221,7 +4225,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4229,7 +4233,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4284,13 +4288,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4308,7 +4312,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4379,7 +4383,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4403,7 +4407,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4491,11 +4495,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4822,11 +4826,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4842,54 +4846,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5223,19 +5227,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-11-14 00:43+0100\n"
+"POT-Creation-Date: 2021-11-18 15:25-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:832
+#: lxc/storage_volume.go:852
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -358,11 +358,11 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/storage_volume.go:1375
+#: lxc/storage_volume.go:1395
 msgid "<pool>/<volume> <pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:328
+#: lxc/storage_volume.go:329
 msgid "<pool>/<volume>[/<snapshot>] <pool>/<volume>"
 msgstr ""
 
@@ -543,11 +543,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:164 lxc/storage_volume.go:165
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:166
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:239 lxc/storage_volume.go:240
+#: lxc/storage_volume.go:240 lxc/storage_volume.go:241
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -595,12 +595,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:1978
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:158 lxc/storage_volume.go:2023
+#: lxc/export.go:158 lxc/storage_volume.go:2044
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:126 lxc/init.go:208 lxc/project.go:129 lxc/publish.go:179
-#: lxc/storage.go:126 lxc/storage_volume.go:545
+#: lxc/storage.go:126 lxc/storage_volume.go:565
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -655,7 +655,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1289
+#: lxc/storage_volume.go:1309
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1299 lxc/warning.go:223
+#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -791,14 +791,14 @@ msgstr ""
 #: lxc/network_forward.go:631 lxc/network_forward.go:708
 #: lxc/network_forward.go:774 lxc/storage.go:95 lxc/storage.go:339
 #: lxc/storage.go:400 lxc/storage.go:602 lxc/storage.go:674 lxc/storage.go:757
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:504
-#: lxc/storage_volume.go:583 lxc/storage_volume.go:825
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1110
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1413
-#: lxc/storage_volume.go:1529 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1701 lxc/storage_volume.go:1738
-#: lxc/storage_volume.go:1832 lxc/storage_volume.go:1904
-#: lxc/storage_volume.go:2043
+#: lxc/storage_volume.go:336 lxc/storage_volume.go:524
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:845
+#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1402 lxc/storage_volume.go:1434
+#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1722 lxc/storage_volume.go:1759
+#: lxc/storage_volume.go:1853 lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:2064
 msgid "Cluster member name"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1193
+#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -843,8 +843,8 @@ msgstr ""
 #: lxc/config_metadata.go:145 lxc/config_trust.go:254 lxc/image.go:444
 #: lxc/network.go:674 lxc/network_acl.go:531 lxc/network_forward.go:595
 #: lxc/network_peer.go:573 lxc/network_zone.go:508 lxc/profile.go:501
-#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:958
-#: lxc/storage_volume.go:988
+#: lxc/project.go:312 lxc/storage.go:306 lxc/storage_volume.go:978
+#: lxc/storage_volume.go:1008
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:505
+#: lxc/storage_volume.go:525
 msgid "Content type, block or filesystem"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:331
+#: lxc/storage_volume.go:331 lxc/storage_volume.go:332
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -902,11 +902,11 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:336
+#: lxc/storage_volume.go:338
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:337
+#: lxc/copy.go:53 lxc/move.go:59 lxc/storage_volume.go:339
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:400
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_volume.go:500 lxc/storage_volume.go:501
+#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
-#: lxc/storage_volume.go:1288
+#: lxc/storage_volume.go:1308
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
-#: lxc/storage_volume.go:1903
+#: lxc/storage_volume.go:1924
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:579 lxc/storage_volume.go:580
+#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1217,19 +1217,23 @@ msgstr ""
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33
 #: lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336
 #: lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670
-#: lxc/storage.go:754 lxc/storage_volume.go:43 lxc/storage_volume.go:165
-#: lxc/storage_volume.go:240 lxc/storage_volume.go:331
-#: lxc/storage_volume.go:501 lxc/storage_volume.go:580
-#: lxc/storage_volume.go:656 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:819 lxc/storage_volume.go:1019
-#: lxc/storage_volume.go:1107 lxc/storage_volume.go:1194
-#: lxc/storage_volume.go:1378 lxc/storage_volume.go:1410
-#: lxc/storage_volume.go:1523 lxc/storage_volume.go:1599
-#: lxc/storage_volume.go:1698 lxc/storage_volume.go:1732
-#: lxc/storage_volume.go:1830 lxc/storage_volume.go:1897
-#: lxc/storage_volume.go:2038 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166
+#: lxc/storage_volume.go:241 lxc/storage_volume.go:332
+#: lxc/storage_volume.go:521 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:676 lxc/storage_volume.go:758
+#: lxc/storage_volume.go:839 lxc/storage_volume.go:1039
+#: lxc/storage_volume.go:1127 lxc/storage_volume.go:1214
+#: lxc/storage_volume.go:1398 lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1544 lxc/storage_volume.go:1620
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1753
+#: lxc/storage_volume.go:1851 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid "Description"
+msgstr ""
+
+#: lxc/storage_volume.go:337 lxc/storage_volume.go:1403
+msgid "Destination cluster member name"
 msgstr ""
 
 #: lxc/network.go:409 lxc/network.go:410
@@ -1240,11 +1244,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:655 lxc/storage_volume.go:656
+#: lxc/storage_volume.go:675 lxc/storage_volume.go:676
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:737 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:758
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1414,7 +1418,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:818 lxc/storage_volume.go:819
+#: lxc/storage_volume.go:838 lxc/storage_volume.go:839
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1310
+#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1516,7 +1520,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1917 lxc/storage_volume.go:1918
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1528,11 +1532,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:1900
+#: lxc/storage_volume.go:1921
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:142 lxc/storage_volume.go:2007
+#: lxc/export.go:142 lxc/storage_volume.go:2028
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1655,7 +1659,7 @@ msgstr ""
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
-#: lxc/storage_volume.go:1212 lxc/warning.go:94
+#: lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1018 lxc/storage_volume.go:1019
+#: lxc/storage_volume.go:1038 lxc/storage_volume.go:1039
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
@@ -1816,7 +1820,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1737
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1758
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -1830,7 +1834,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1736
+#: lxc/storage_volume.go:1757
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -1876,7 +1880,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2038
+#: lxc/storage_volume.go:2059
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -1884,7 +1888,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2058
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -1903,7 +1907,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2112
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2047,7 +2051,7 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
-#: lxc/operation.go:168 lxc/storage_volume.go:1295 lxc/warning.go:219
+#: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
 
@@ -2291,11 +2295,11 @@ msgstr ""
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_volume.go:1190
+#: lxc/storage_volume.go:1210
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1194
+#: lxc/storage_volume.go:1214
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2511,11 +2515,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:42
+#: lxc/storage_volume.go:43
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:43
+#: lxc/storage_volume.go:44
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -2646,14 +2650,14 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:190 lxc/storage.go:260 lxc/storage.go:361 lxc/storage.go:422
-#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:189
-#: lxc/storage_volume.go:264 lxc/storage_volume.go:527
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:680
-#: lxc/storage_volume.go:762 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:1044 lxc/storage_volume.go:1132
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1435
-#: lxc/storage_volume.go:1550 lxc/storage_volume.go:1630
-#: lxc/storage_volume.go:1758 lxc/storage_volume.go:1854
+#: lxc/storage.go:625 lxc/storage.go:702 lxc/storage_volume.go:190
+#: lxc/storage_volume.go:265 lxc/storage_volume.go:547
+#: lxc/storage_volume.go:624 lxc/storage_volume.go:700
+#: lxc/storage_volume.go:782 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1152
+#: lxc/storage_volume.go:1255 lxc/storage_volume.go:1456
+#: lxc/storage_volume.go:1571 lxc/storage_volume.go:1651
+#: lxc/storage_volume.go:1779 lxc/storage_volume.go:1875
 msgid "Missing pool name"
 msgstr ""
 
@@ -2671,7 +2675,7 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:360
+#: lxc/storage_volume.go:362
 msgid "Missing source volume name"
 msgstr ""
 
@@ -2704,8 +2708,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:700
-#: lxc/storage_volume.go:781
+#: lxc/network.go:454 lxc/network.go:539 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:801
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1378
+#: lxc/storage_volume.go:1397 lxc/storage_volume.go:1398
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -2725,11 +2729,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1404
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:404
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -2746,7 +2750,7 @@ msgstr ""
 #: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
-#: lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1307
 msgid "NAME"
 msgstr ""
 
@@ -2913,15 +2917,15 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:709 lxc/storage_volume.go:790
+#: lxc/storage_volume.go:729 lxc/storage_volume.go:810
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: lxc/storage_volume.go:374
+#: lxc/storage_volume.go:381
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:381
+#: lxc/storage_volume.go:388
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -2935,15 +2939,15 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:209 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:210 lxc/storage_volume.go:285
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:1939
+#: lxc/storage_volume.go:1960
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1792
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1150
+#: lxc/storage_volume.go:1170
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3065,7 +3069,7 @@ msgstr ""
 #: lxc/config_trust.go:255 lxc/image.go:445 lxc/network.go:675
 #: lxc/network_acl.go:532 lxc/network_forward.go:596 lxc/network_peer.go:574
 #: lxc/network_zone.go:509 lxc/profile.go:502 lxc/project.go:313
-#: lxc/storage.go:307 lxc/storage_volume.go:959 lxc/storage_volume.go:989
+#: lxc/storage.go:307 lxc/storage_volume.go:979 lxc/storage_volume.go:1009
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -3239,7 +3243,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:338
+#: lxc/storage_volume.go:340
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -3378,15 +3382,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1410
+#: lxc/storage_volume.go:1431
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1409
+#: lxc/storage_volume.go:1430
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1486 lxc/storage_volume.go:1506
+#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1527
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -3434,7 +3438,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1830
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1851
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -3677,11 +3681,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1522
+#: lxc/storage_volume.go:1543
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1544
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -3790,11 +3794,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1598 lxc/storage_volume.go:1599
+#: lxc/storage_volume.go:1619 lxc/storage_volume.go:1620
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1106 lxc/storage_volume.go:1107
+#: lxc/storage_volume.go:1126 lxc/storage_volume.go:1127
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -3848,7 +3852,7 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1731 lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1752 lxc/storage_volume.go:1753
 msgid "Snapshot storage volumes"
 msgstr ""
 
@@ -3933,21 +3937,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:562
+#: lxc/storage_volume.go:582
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:639
+#: lxc/storage_volume.go:659
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:401
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:405
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -3996,7 +4000,7 @@ msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
 #: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
-#: lxc/storage_volume.go:1286 lxc/warning.go:214
+#: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
 
@@ -4068,8 +4072,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:714
-#: lxc/storage_volume.go:795
+#: lxc/network.go:468 lxc/network.go:553 lxc/storage_volume.go:734
+#: lxc/storage_volume.go:815
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -4138,7 +4142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1401
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -4146,7 +4150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:334
+#: lxc/move.go:55 lxc/storage_volume.go:335
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -4201,13 +4205,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:808 lxc/storage_volume.go:1291
+#: lxc/project.go:808 lxc/storage_volume.go:1311
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:915 lxc/network_acl.go:145 lxc/network_zone.go:136
 #: lxc/profile.go:625 lxc/project.go:474 lxc/storage.go:578
-#: lxc/storage_volume.go:1290
+#: lxc/storage_volume.go:1310
 msgid "USED BY"
 msgstr ""
 
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1317
+#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4296,7 +4300,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1698
+#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1719
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:1902
+#: lxc/export.go:42 lxc/storage_volume.go:1923
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -4408,11 +4412,11 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:736
+#: lxc/storage_volume.go:756
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:238
+#: lxc/storage_volume.go:239
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -4739,11 +4743,11 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:163 lxc/storage.go:214 lxc/storage.go:394 lxc/storage.go:668
-#: lxc/storage_volume.go:1188
+#: lxc/storage_volume.go:1208
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2036
+#: lxc/storage_volume.go:2057
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -4759,54 +4763,54 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1408
+#: lxc/storage_volume.go:1429
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1105
+#: lxc/storage_volume.go:1125
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:654
+#: lxc/storage_volume.go:674
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:163
+#: lxc/storage_volume.go:164
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1696
+#: lxc/storage_volume.go:1717
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1521
+#: lxc/storage_volume.go:1542
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1828
+#: lxc/storage_volume.go:1849
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:1895
+#: lxc/storage_volume.go:1916
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1751
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:499
+#: lxc/storage_volume.go:519
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:577 lxc/storage_volume.go:817
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:597 lxc/storage_volume.go:837
+#: lxc/storage_volume.go:1618
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1037
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
@@ -5140,19 +5144,19 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:821
+#: lxc/storage_volume.go:841
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2061
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1622
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "


### PR DESCRIPTION
Closes #9041 

These changes add support for the `--target` flag with lxc storage volume {copy, move}, as well as introduce a new flag, `--destination-target` to specify _where_ the storage volume should be copied/moved to.

Without specifying a `--target`, the targeted cluster member (source) is by default the member which contains a given source volume. This works in scenarios where there are no duplicate source volume names across the cluster. In the case of duplicates, disambiguation with `--target` is necessary.

Output of initial testing that illustrates functionality has been attached.
[output.txt](https://github.com/lxc/lxd/files/7543406/output.txt)
 