### PR TITLE
lxd: add forkusernsexec()

### DIFF
--- a/lxd/include/file_utils.h
+++ b/lxd/include/file_utils.h
@@ -1,0 +1,33 @@
+#ifndef __LXD_FILE_UTILS_H
+#define __LXD_FILE_UTILS_H
+
+#include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+static inline ssize_t read_nointr(int fd, void *buf, size_t count)
+{
+	ssize_t ret;
+
+	do {
+		ret = read(fd, buf, count);
+	} while (ret < 0 && errno == EINTR);
+
+	return ret;
+}
+
+static inline ssize_t write_nointr(int fd, const void *buf, size_t count)
+{
+	ssize_t ret;
+
+	do {
+		ret = write(fd, buf, count);
+	} while (ret < 0 && errno == EINTR);
+
+	return ret;
+}
+
+#endif /* __LXD_FILE_UTILS_H */

--- a/lxd/include/lxd.h
+++ b/lxd/include/lxd.h
@@ -17,6 +17,7 @@ __hidden extern void forknet();
 __hidden extern void forkproxy();
 __hidden extern void forksyscall();
 __hidden extern void forkuevent();
+__hidden extern void forkusernsexec();
 __hidden extern int mount_detach_idmap(const char *path, int fd_userns);
 __hidden extern int pidfd_nsfd(int pidfd, pid_t pid);
 __hidden extern int preserve_ns(pid_t pid, int ns_fd, const char *ns);

--- a/lxd/include/macro.h
+++ b/lxd/include/macro.h
@@ -315,4 +315,24 @@ enum {
 #define hweight32(w) __const_hweight32(w)
 #define hweight64(w) __const_hweight64(w)
 
+/*
+ * /proc/           = 6
+ *                  +
+ * <pid-as_str>     = INTTYPE_TO_STRLEN(pid_t)
+ *                  +
+ * /.id_map         = 8
+ *                  +
+ * \0               = 1
+ */
+#define PROC_PID_IDMAP_LEN (6 + INTTYPE_TO_STRLEN(pid_t) + 8 + 1)
+
+#define strnprintf(buf, buf_size, ...)                                                    \
+	({                                                                                \
+		int __ret_strnprintf;                                                     \
+		__ret_strnprintf = snprintf(buf, buf_size, ##__VA_ARGS__);                \
+		if (__ret_strnprintf < 0 || (size_t)__ret_strnprintf >= (size_t)buf_size) \
+			__ret_strnprintf = ret_errno(EIO);				  \
+		__ret_strnprintf;                                                         \
+	})
+
 #endif /* __LXC_MACRO_H */

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -170,6 +170,10 @@ func main() {
 	forkueventCmd := cmdForkuevent{global: &globalCmd}
 	app.AddCommand(forkueventCmd.Command())
 
+	// forkusernsexec sub-command
+	forkusernsexecCmd := cmdForkusernsexec{global: &globalCmd}
+	app.AddCommand(forkusernsexecCmd.Command())
+
 	// forkzfs sub-command
 	forkzfsCmd := cmdForkZFS{global: &globalCmd}
 	app.AddCommand(forkzfsCmd.Command())

--- a/lxd/main_forkusernsexec.go
+++ b/lxd/main_forkusernsexec.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	// Used by cgo
+	_ "github.com/lxc/lxd/lxd/include"
+)
+
+/*
+#include "config.h"
+
+#include <fcntl.h>
+#include <libgen.h>
+#include <sched.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "lxd.h"
+#include "memory_utils.h"
+#include "mount_utils.h"
+#include "syscall_numbers.h"
+#include "syscall_wrappers.h"
+
+void forkusernsexec(void)
+{
+	_exit(EXIT_SUCCESS);
+}
+*/
+import "C"
+
+type cmdForkusernsexec struct {
+	global *cmdGlobal
+}
+
+func (c *cmdForkusernsexec) Command() *cobra.Command {
+	// Main subcommand
+	cmd := &cobra.Command{}
+	cmd.Use = "forkusernsexec <cmd> <args>"
+	cmd.Short = "Run command in user namespace"
+	cmd.Long = `Description:
+  Run command in user namespace
+
+  This command is used to execute a program in a new user namespace.
+`
+	cmd.RunE = c.Run
+	cmd.Hidden = true
+
+	return cmd
+}
+
+func (c *cmdForkusernsexec) Run(cmd *cobra.Command, args []string) error {
+	return fmt.Errorf("This command should have been intercepted in cgo")
+}
+

--- a/lxd/main_forkusernsexec.go
+++ b/lxd/main_forkusernsexec.go
@@ -12,26 +12,222 @@ import (
 /*
 #include "config.h"
 
+#include <errno.h>
 #include <fcntl.h>
-#include <libgen.h>
+#include <grp.h>
 #include <sched.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/prctl.h>
+#include <sys/fsuid.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/vfs.h>
 #include <unistd.h>
 
 #include "lxd.h"
+#include "file_utils.h"
+#include "macro.h"
 #include "memory_utils.h"
 #include "mount_utils.h"
+#include "process_utils.h"
 #include "syscall_numbers.h"
 #include "syscall_wrappers.h"
 
+#ifndef PIPEFS_MAGIC
+#define PIPEFS_MAGIC 0x50495045
+#endif
+
+#define FD_PIPE_UIDMAP 3
+#define FD_PIPE_GIDMAP 4
+
+#define MAP_SIZE ((ssize_t)4096)
+
+typedef __typeof__(((struct statfs *)NULL)->f_type) fs_type_magic;
+static bool is_fs_type(const struct statfs *fs, fs_type_magic magic_val)
+{
+	return (fs->f_type == (fs_type_magic)magic_val);
+}
+
+static bool fhas_fs_type(int fd, fs_type_magic magic_val)
+{
+	int ret;
+	struct statfs sb;
+
+	ret = fstatfs(fd, &sb);
+	if (ret < 0)
+		return false;
+
+	return is_fs_type(&sb, magic_val);
+}
+
+static inline bool drop_groups(void)
+{
+	return setgroups(0, NULL) == 0;
+}
+
+static inline bool switch_resids(uid_t uid, gid_t gid)
+{
+	if (setresgid(gid, gid, gid))
+		return false;
+
+	if (setresuid(uid, uid, uid))
+		return false;
+
+	if (setfsgid(-1) != gid)
+		return false;
+
+	if (setfsuid(-1) != uid)
+		return false;
+
+	return true;
+}
+
+static int write_id_mapping(bool is_uid)
+{
+	__do_close int fd_idmap = -EBADF;
+	ssize_t bytes_read, ret;
+	char buf[PROC_PID_IDMAP_LEN], idmap[LXC_IDMAPLEN];
+
+	if (is_uid)
+		ret = strnprintf(buf, sizeof(buf), "/proc/%d/uid_map", getppid());
+	else
+		ret = strnprintf(buf, sizeof(buf), "/proc/%d/gid_map", getppid());
+	if (ret < 0)
+		return -errno;
+
+	fd_idmap = open(buf, O_WRONLY | O_CLOEXEC | O_NOCTTY | O_NOFOLLOW);
+	if (fd_idmap < 0)
+		return -1;
+
+	if (is_uid)
+		bytes_read = read_nointr(FD_PIPE_UIDMAP, idmap, sizeof(idmap));
+	else
+		bytes_read = read_nointr(FD_PIPE_GIDMAP, idmap, sizeof(idmap));
+	if (bytes_read < 0 || bytes_read >= sizeof(idmap))
+		return -errno;
+
+	ret = write_nointr(fd_idmap, idmap, bytes_read);
+	if (ret < 0 || ret != bytes_read)
+		return -errno;
+
+	return 0;
+}
+
+static int write_id_mappings(void)
+{
+	int ret;
+
+	ret = write_id_mapping(true);
+	if (!ret)
+		ret = write_id_mapping(false);
+	return ret;
+}
+
+__attribute__ ((noinline)) int __forkusernsexec(void)
+{
+	__do_free_string_list char **argvp = NULL;
+	pid_t pid;
+	ssize_t ret;
+	int fd_socket[2];
+	char c;
+	char *cur;
+
+	if (geteuid() != 0)
+		return log_error(EXIT_FAILURE, "Error: forkexec requires root privileges");
+
+	cur = advance_arg(false);
+	if (!cur || (strcmp(cur, "--help") == 0 ||
+	     strcmp(cur, "--version") == 0 || strcmp(cur, "-h") == 0))
+		return EXIT_SUCCESS;
+
+	if (!fhas_fs_type(FD_PIPE_UIDMAP, PIPEFS_MAGIC))
+		return EXIT_FAILURE;
+
+	if (!fhas_fs_type(FD_PIPE_GIDMAP, PIPEFS_MAGIC))
+		return EXIT_FAILURE;
+
+	ret = socketpair(AF_LOCAL, SOCK_STREAM | SOCK_CLOEXEC, 0, fd_socket);
+	if (ret < 0)
+		return EXIT_FAILURE;
+
+	pid = fork();
+	if (pid < 0)
+		return EXIT_FAILURE;
+
+	if (pid == 0) {
+		close_prot_errno_disarm(fd_socket[0]);
+
+		ret = read_nointr(fd_socket[1], &c, 1);
+		if (ret != 1)
+			_exit(EXIT_FAILURE);
+
+		ret = write_id_mappings();
+		if (ret < 0)
+			_exit(EXIT_FAILURE);
+
+		ret = write_nointr(fd_socket[1], &c, 1);
+		if (ret != 1)
+			_exit(EXIT_FAILURE);
+
+		_exit(EXIT_SUCCESS);
+	}
+
+	close_prot_errno_disarm(fd_socket[1]);
+
+	ret = unshare(CLONE_NEWUSER);
+	if (ret) {
+		kill(pid, SIGKILL);
+		goto out_reap;
+	}
+
+	ret = write_nointr(fd_socket[0], &c, 1);
+	if (ret == 1)
+		ret = read_nointr(fd_socket[0], &c, 1);
+	if (ret != 1) {
+		kill(pid, SIGKILL);
+		goto out_reap;
+	}
+
+	if (!drop_groups()) {
+		kill(pid, SIGKILL);
+		goto out_reap;
+	}
+
+	if (!switch_resids(0, 0)) {
+		kill(pid, SIGKILL);
+		goto out_reap;
+	}
+
+	close_prot_errno_disarm(fd_socket[0]);
+
+out_reap:
+	ret = wait_for_pid(pid);
+	if (ret)
+		return EXIT_FAILURE;
+
+	ret = push_vargs(&argvp, cur);
+	if (ret < 0)
+		return log_error(EXIT_FAILURE, "Failed to add %s to arg array", cur);
+
+	for (cur = NULL; (cur = advance_arg(false)); ) {
+		ret = push_vargs(&argvp, cur);
+		if (ret < 0)
+			return log_error(EXIT_FAILURE, "Failed to add %s to arg array", cur);
+	}
+
+	if (!argvp || !*argvp)
+		return log_error(EXIT_FAILURE, "No command specified");
+
+	execvp(argvp[0], argvp);
+	return EXIT_FAILURE;
+}
+
 void forkusernsexec(void)
 {
-	_exit(EXIT_SUCCESS);
+	_exit(__forkusernsexec());
 }
 */
 import "C"
@@ -59,4 +255,3 @@ func (c *cmdForkusernsexec) Command() *cobra.Command {
 func (c *cmdForkusernsexec) Run(cmd *cobra.Command, args []string) error {
 	return fmt.Errorf("This command should have been intercepted in cgo")
 }
-

--- a/lxd/main_nsexec.go
+++ b/lxd/main_nsexec.go
@@ -24,9 +24,8 @@ import (
 )
 
 /*
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE 1
-#endif
+#include "config.h"
+
 #include <errno.h>
 #include <fcntl.h>
 #include <grp.h>


### PR DESCRIPTION
Use from LXD like:

```
args := []string{
	d.os.ExecPath,
	"forkusernsexec",
	"touch",
	"/tmp/MUHU",
}
cmd := exec.Cmd{}
cmd.Path = d.os.ExecPath
cmd.Args = args

rUidMapPipe, wUidMapPipe, err := os.Pipe()
if err != nil {
	return err
}
defer rUidMapPipe.Close()

// Make sure the string is \x00 terminated so it's parseable as a C string
_, err = wUidMapPipe.WriteString("0 100000 1\n\x00")
if err != nil {
	return err
}

rGidMapPipe, wGidMapPipe, err := os.Pipe()
if err != nil {
	return err
}
defer rGidMapPipe.Close()

// Make sure the string is \x00 terminated so it's parseable as a C string
_, err = wGidMapPipe.WriteString("0 100000 1\n\x00")
if err != nil {
	return err
}

cmd.ExtraFiles = []*os.File{rUidMapPipe, rGidMapPipe}
err = cmd.Run()
if err != nil {
	return err
}
```

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>