### PR TITLE
VM: Use socket file descriptors for virtfs-proxy-helper and virtiofsd

### DIFF
--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -317,6 +317,26 @@ func DiskVMVirtfsProxyStart(pidPath string, sharePath string) (func(), *os.File,
 	return revertExternal.Fail, cDialUnixFile, err
 }
 
+// DiskVMVirtfsProxyStop stops the virtfs-proxy-helper process.
+func DiskVMVirtfsProxyStop(pidPath string) error {
+	if shared.PathExists(pidPath) {
+		proc, err := subprocess.ImportProcess(pidPath)
+		if err != nil {
+			return err
+		}
+
+		err = proc.Stop()
+		if err != nil && err != subprocess.ErrNotRunning {
+			return err
+		}
+
+		// Remove PID file.
+		os.Remove(pidPath)
+	}
+
+	return nil
+}
+
 // DiskVMVirtiofsdStart starts a new virtiofsd process.
 // Returns UnsupportedError error if the host system or instance does not support virtiosfd, returns normal error
 // type if process cannot be started for other reasons.

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"strings"
@@ -233,6 +234,87 @@ func diskCephfsOptions(clusterName string, userName string, fsName string, fsPat
 	srcpath += fmt.Sprintf(":/%s", fsPath)
 
 	return srcpath, fsOptions, nil
+}
+
+// DiskVMVirtfsProxyStart starts a new virtfs-proxy-helper process.
+// Returns a revert function, and a file handle to the proxy process.
+func DiskVMVirtfsProxyStart(pidPath string, sharePath string) (func(), *os.File, error) {
+	revert := revert.New()
+	defer revert.Fail()
+
+	// Locate virtfs-proxy-helper.
+	cmd, err := exec.LookPath("virtfs-proxy-helper")
+	if err != nil {
+		if shared.PathExists("/usr/lib/qemu/virtfs-proxy-helper") {
+			cmd = "/usr/lib/qemu/virtfs-proxy-helper"
+		}
+	}
+
+	if cmd == "" {
+		return nil, nil, fmt.Errorf(`Required binary "virtfs-proxy-helper" couldn't be found`)
+	}
+
+	listener, err := net.Listen("unix", "")
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to create unix listener for virtfs-proxy-helper: %w", err)
+	}
+	revert.Add(func() { listener.Close() })
+
+	cDial, err := net.Dial("unix", listener.Addr().String())
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to connect to virtfs-proxy-helper unix listener: %w", err)
+	}
+	revert.Add(func() { cDial.Close() })
+
+	cDialUnix, ok := cDial.(*net.UnixConn)
+	if !ok {
+		return nil, nil, fmt.Errorf("Dialled virtfs-proxy-helper connection isn't unix socket")
+	}
+
+	cDialUnixFile, err := cDialUnix.File()
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed getting virtfs-proxy-helper unix dialed file: %w", err)
+	}
+
+	cAccept, err := listener.Accept()
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to accept connection to virtfs-proxy-helper unix listener: %w", err)
+	}
+	revert.Add(func() { cAccept.Close() })
+	listener.Close()
+
+	cAcceptUnix, ok := cAccept.(*net.UnixConn)
+	if !ok {
+		return nil, nil, fmt.Errorf("Accepted virtfs-proxy-helper connection isn't unix socket")
+	}
+
+	acceptFile, err := cAcceptUnix.File()
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed getting virtfs-proxy-helper unix listener file: %w", err)
+	}
+
+	// Start the virtfs-proxy-helper process in non-daemon mode and as root so that when the VM process is
+	// started as an unprivileged user, we can still share directories that process cannot access.
+	proc, err := subprocess.NewProcess(cmd, []string{"--nodaemon", "--fd", "3", "--path", sharePath}, "", "")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = proc.StartWithFiles([]*os.File{acceptFile})
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "Failed to start virtfs-proxy-helper")
+	}
+
+	revert.Add(func() { proc.Stop() })
+
+	err = proc.Save(pidPath)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "Failed to save virtfs-proxy-helper state")
+	}
+
+	revertExternal := revert.Clone()
+	revert.Success()
+	return revertExternal.Fail, cDialUnixFile, err
 }
 
 // DiskVMVirtiofsdStart starts a new virtiofsd process.

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -745,7 +745,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					logPath := filepath.Join(d.inst.LogPath(), fmt.Sprintf("disk.%s.log", d.name))
 					os.Remove(logPath) // Remove old log if needed.
 
-					revertFunc, err := DiskVMVirtiofsdStart(d.inst, sockPath, pidPath, logPath, srcPath)
+					revertFunc, unixListener, err := DiskVMVirtiofsdStart(d.inst, sockPath, pidPath, logPath, srcPath)
 					if err != nil {
 						var errUnsupported UnsupportedError
 						if errors.As(err, &errUnsupported) {
@@ -764,6 +764,9 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 						return err
 					}
 					revert.Add(revertFunc)
+
+					// Request the unix listener is closed after QEMU has connected on startup.
+					runConf.PostHooks = append(runConf.PostHooks, unixListener.Close)
 
 					// Resolve previous warning
 					warnings.ResolveWarningsByLocalNodeAndProjectAndType(d.state.Cluster, d.inst.Project(), db.WarningMissingVirtiofsd)

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -30,7 +30,6 @@ import (
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/idmap"
 	log "github.com/lxc/lxd/shared/log15"
-	"github.com/lxc/lxd/shared/subprocess"
 	"github.com/lxc/lxd/shared/units"
 	"github.com/lxc/lxd/shared/validate"
 )
@@ -1505,25 +1504,7 @@ func (d *disk) Stop() (*deviceConfig.RunConfig, error) {
 
 func (d *disk) stopVM() (*deviceConfig.RunConfig, error) {
 	// Stop the virtfs-proxy-helper process and clean up.
-	err := func() error {
-		pidPath := d.vmVirtfsProxyHelperPaths()
-		if shared.PathExists(pidPath) {
-			proc, err := subprocess.ImportProcess(pidPath)
-			if err != nil {
-				return err
-			}
-
-			err = proc.Stop()
-			if err != nil && err != subprocess.ErrNotRunning {
-				return err
-			}
-
-			// Remove PID file.
-			os.Remove(pidPath)
-		}
-
-		return nil
-	}()
+	err := DiskVMVirtfsProxyStop(d.vmVirtfsProxyHelperPaths())
 	if err != nil {
 		return &deviceConfig.RunConfig{}, errors.Wrapf(err, "Failed cleaning up virtfs-proxy-helper")
 	}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
@@ -597,12 +596,11 @@ func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 	return &runConf, nil
 }
 
-// vmVirtfsProxyHelperPaths returns the path for the socket and PID file to use with virtfs-proxy-helper process.
-func (d *disk) vmVirtfsProxyHelperPaths() (string, string) {
-	sockPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("%s.sock", d.name))
+// vmVirtfsProxyHelperPaths returns the path for PID file to use with virtfs-proxy-helper process.
+func (d *disk) vmVirtfsProxyHelperPaths() string {
 	pidPath := filepath.Join(d.inst.DevicesPath(), fmt.Sprintf("%s.pid", d.name))
 
-	return sockPath, pidPath
+	return pidPath
 }
 
 // vmVirtiofsdPaths returns the path for the socket and PID file to use with virtiofsd process.
@@ -723,61 +721,17 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 
 				// Start virtfs-proxy-helper for 9p share.
 				err = func() error {
-					sockPath, pidPath := d.vmVirtfsProxyHelperPaths()
-
-					// Use 9p socket path as dev path so qemu can connect to the proxy.
-					mount.DevPath = sockPath
-
-					// Remove old socket if needed.
-					os.Remove(sockPath)
-
-					// Locate virtfs-proxy-helper.
-					cmd, err := exec.LookPath("virtfs-proxy-helper")
-					if err != nil {
-						if shared.PathExists("/usr/lib/qemu/virtfs-proxy-helper") {
-							cmd = "/usr/lib/qemu/virtfs-proxy-helper"
-						}
-					}
-
-					if cmd == "" {
-						return fmt.Errorf(`Required binary "virtfs-proxy-helper" couldn't be found`)
-					}
-
-					// Start the virtfs-proxy-helper process in non-daemon mode and as root so
-					// that when the VM process is started as an unprivileged user, we can
-					// still share directories that process cannot access.
-					proc, err := subprocess.NewProcess(cmd, []string{"-n", "-u", "0", "-g", "0", "-s", sockPath, "-p", srcPath}, "", "")
+					revertFunc, sockFile, err := DiskVMVirtfsProxyStart(d.vmVirtfsProxyHelperPaths(), srcPath)
 					if err != nil {
 						return err
 					}
+					revert.Add(revertFunc)
 
-					err = proc.Start()
-					if err != nil {
-						return errors.Wrapf(err, "Failed to start virtfs-proxy-helper")
-					}
+					// Request the unix socket is closed after QEMU has connected on startup.
+					runConf.PostHooks = append(runConf.PostHooks, sockFile.Close)
 
-					revert.Add(func() { proc.Stop() })
-
-					err = proc.Save(pidPath)
-					if err != nil {
-						return errors.Wrapf(err, "Failed to save virtfs-proxy-helper state")
-					}
-
-					// Wait for socket file to exist (as otherwise qemu can race the creation
-					// of this file).
-					waitDuration := time.Second * time.Duration(10)
-					waitUntil := time.Now().Add(waitDuration)
-					for {
-						if shared.PathExists(sockPath) {
-							break
-						}
-
-						if time.Now().After(waitUntil) {
-							return fmt.Errorf("virtfs-proxy-helper failed to bind socket after %v", waitDuration)
-						}
-
-						time.Sleep(50 * time.Millisecond)
-					}
+					// Use 9p socket FD number as dev path so qemu can connect to the proxy.
+					mount.DevPath = fmt.Sprintf("%d", sockFile.Fd())
 
 					return nil
 				}()
@@ -1552,7 +1506,7 @@ func (d *disk) Stop() (*deviceConfig.RunConfig, error) {
 func (d *disk) stopVM() (*deviceConfig.RunConfig, error) {
 	// Stop the virtfs-proxy-helper process and clean up.
 	err := func() error {
-		sockPath, pidPath := d.vmVirtfsProxyHelperPaths()
+		pidPath := d.vmVirtfsProxyHelperPaths()
 		if shared.PathExists(pidPath) {
 			proc, err := subprocess.ImportProcess(pidPath)
 			if err != nil {
@@ -1567,9 +1521,6 @@ func (d *disk) stopVM() (*deviceConfig.RunConfig, error) {
 			// Remove PID file.
 			os.Remove(pidPath)
 		}
-
-		// Remove socket file.
-		os.Remove(sockPath)
 
 		return nil
 	}()

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -579,20 +579,18 @@ func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 			options = append(options, "create=dir")
 		}
 
-		if sourceDevPath != "" {
-			// Instruct LXD to perform the mount.
-			runConf.Mounts = append(runConf.Mounts, deviceConfig.MountEntryItem{
-				DevName:    d.name,
-				DevPath:    sourceDevPath,
-				TargetPath: relativeDestPath,
-				FSType:     "none",
-				Opts:       options,
-				OwnerShift: ownerShift,
-			})
+		// Instruct LXD to perform the mount.
+		runConf.Mounts = append(runConf.Mounts, deviceConfig.MountEntryItem{
+			DevName:    d.name,
+			DevPath:    sourceDevPath,
+			TargetPath: relativeDestPath,
+			FSType:     "none",
+			Opts:       options,
+			OwnerShift: ownerShift,
+		})
 
-			// Unmount host-side mount once instance is started.
-			runConf.PostHooks = append(runConf.PostHooks, d.postStart)
-		}
+		// Unmount host-side mount once instance is started.
+		runConf.PostHooks = append(runConf.PostHooks, d.postStart)
 	}
 
 	revert.Success()

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -743,6 +743,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				err = func() error {
 					sockPath, pidPath := d.vmVirtiofsdPaths()
 					logPath := filepath.Join(d.inst.LogPath(), fmt.Sprintf("disk.%s.log", d.name))
+					os.Remove(logPath) // Remove old log if needed.
 
 					revertFunc, err := DiskVMVirtiofsdStart(d.inst, sockPath, pidPath, logPath, srcPath)
 					if err != nil {

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -754,7 +754,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 							if errUnsupported == ErrMissingVirtiofsd {
 								d.state.Cluster.UpsertWarningLocalNode(d.inst.Project(), cluster.TypeInstance, d.inst.ID(), db.WarningMissingVirtiofsd, "Using 9p as a fallback")
 							} else {
-								// Resolve previous warning
+								// Resolve previous warning.
 								warnings.ResolveWarningsByLocalNodeAndProjectAndType(d.state.Cluster, d.inst.Project(), db.WarningMissingVirtiofsd)
 							}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3415,7 +3415,9 @@ func (d *qemu) Stop(stateful bool) error {
 	if err != nil {
 		// If we fail to connect, it's most likely because the VM is already off, but it could also be
 		// because the qemu process is not responding, check if process still exists and kill it if needed.
-		return d.forceStop()
+		err = d.forceStop()
+		op.Done(err)
+		return err
 	}
 
 	// Get the wait channel.
@@ -3425,7 +3427,9 @@ func (d *qemu) Stop(stateful bool) error {
 			// If we fail to wait, it's most likely because the VM is already off, but it could also be
 			// because the qemu process is not responding, check if process still exists and kill it if
 			// needed.
-			return d.forceStop()
+			err = d.forceStop()
+			op.Done(err)
+			return err
 		}
 
 		op.Done(err)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1151,14 +1151,14 @@ func (d *qemu) Start(stateful bool) error {
 			d.logger.Warn("Unable to use virtio-fs for config drive, using 9p as a fallback", log.Ctx{"err": errUnsupported})
 
 			if errUnsupported == device.ErrMissingVirtiofsd {
-				// Create a warning if virtiofsd is missing
+				// Create a warning if virtiofsd is missing.
 				d.state.Cluster.UpsertWarning(d.node, d.project, dbCluster.TypeInstance, d.ID(), db.WarningMissingVirtiofsd, "Using 9p as a fallback")
 			} else {
-				// Resolve previous warning
+				// Resolve previous warning.
 				warnings.ResolveWarningsByNodeAndProjectAndType(d.state.Cluster, d.node, d.project, db.WarningMissingVirtiofsd)
 			}
 		} else {
-			// Resolve previous warning
+			// Resolve previous warning.
 			warnings.ResolveWarningsByNodeAndProjectAndType(d.state.Cluster, d.node, d.project, db.WarningMissingVirtiofsd)
 			op.Done(err)
 			return errors.Wrapf(err, "Failed to setup virtiofsd for config drive")

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1144,7 +1144,7 @@ func (d *qemu) Start(stateful bool) error {
 	// This is used by the lxd-agent in preference to 9p (due to its improved performance) and in scenarios
 	// where 9p isn't available in the VM guest OS.
 	configSockPath, configPIDPath := d.configVirtiofsdPaths()
-	err = device.DiskVMVirtiofsdStart(d, configSockPath, configPIDPath, "", configMntPath)
+	revertFunc, err := device.DiskVMVirtiofsdStart(d, configSockPath, configPIDPath, "", configMntPath)
 	if err != nil {
 		var errUnsupported device.UnsupportedError
 		if errors.As(err, &errUnsupported) {
@@ -1164,7 +1164,7 @@ func (d *qemu) Start(stateful bool) error {
 			return errors.Wrapf(err, "Failed to setup virtiofsd for config drive")
 		}
 	}
-	revert.Add(func() { device.DiskVMVirtiofsdStop(configSockPath, configPIDPath) })
+	revert.Add(revertFunc)
 
 	// Get qemu configuration and check qemu is installed.
 	qemuPath, qemuBus, err := d.qemuArchConfig(d.architecture)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1498,21 +1498,6 @@ func (d *qemu) Start(stateful bool) error {
 	return nil
 }
 
-// openUnixSocket connects to a UNIX socket and returns the connection.
-func (d *qemu) openUnixSocket(sockPath string) (*net.UnixConn, error) {
-	addr, err := net.ResolveUnixAddr("unix", sockPath)
-	if err != nil {
-		return nil, err
-	}
-
-	c, err := net.DialUnix("unix", nil, addr)
-	if err != nil {
-		return nil, err
-	}
-
-	return c, nil
-}
-
 func (d *qemu) setupNvram() error {
 	// UEFI only on x86_64 and aarch64.
 	if !shared.IntInSlice(d.architecture, []int{osarch.ARCH_64BIT_INTEL_X86, osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN}) {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2943,7 +2943,7 @@ func (d *qemu) addDriveConfig(sb *strings.Builder, fdFiles *[]*os.File, bootInde
 			// Expect devPath in format "fd:<fdNum>:<devPath>".
 			devPathParts := strings.SplitN(driveConf.DevPath, ":", 3)
 			if len(devPathParts) != 3 || !strings.HasPrefix(driveConf.DevPath, fmt.Sprintf("%s:", device.DiskFileDescriptorMountPrefix)) {
-				return fmt.Errorf("Unexpected devPath file descriptor format %q", driveConf.DevPath)
+				return fmt.Errorf("Unexpected devPath file descriptor format %q for drive %q", driveConf.DevPath, driveConf.DevName)
 			}
 
 			// Map the file descriptor to the file descriptor path it will be in the QEMU process.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1163,8 +1163,9 @@ func (d *qemu) Start(stateful bool) error {
 			op.Done(err)
 			return errors.Wrapf(err, "Failed to setup virtiofsd for config drive")
 		}
+	} else {
+		revert.Add(revertFunc)
 	}
-	revert.Add(revertFunc)
 
 	// Get qemu configuration and check qemu is installed.
 	qemuPath, qemuBus, err := d.qemuArchConfig(d.architecture)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1144,7 +1144,7 @@ func (d *qemu) Start(stateful bool) error {
 	// This is used by the lxd-agent in preference to 9p (due to its improved performance) and in scenarios
 	// where 9p isn't available in the VM guest OS.
 	configSockPath, configPIDPath := d.configVirtiofsdPaths()
-	revertFunc, err := device.DiskVMVirtiofsdStart(d, configSockPath, configPIDPath, "", configMntPath)
+	revertFunc, unixListener, err := device.DiskVMVirtiofsdStart(d, configSockPath, configPIDPath, "", configMntPath)
 	if err != nil {
 		var errUnsupported device.UnsupportedError
 		if errors.As(err, &errUnsupported) {
@@ -1165,6 +1165,9 @@ func (d *qemu) Start(stateful bool) error {
 		}
 	} else {
 		revert.Add(revertFunc)
+
+		// Request the unix listener is closed after QEMU has connected on startup.
+		defer unixListener.Close()
 	}
 
 	// Get qemu configuration and check qemu is installed.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1337,6 +1337,7 @@ func (d *qemu) Start(stateful bool) error {
 	// be used for instance cleanup.
 	err = d.UpdateBackupFile()
 	if err != nil {
+		op.Done(err)
 		return err
 	}
 

--- a/lxd/main_daemon.go
+++ b/lxd/main_daemon.go
@@ -86,11 +86,11 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 			logger.Info("Received signal", log.Ctx{"signal": sig})
 			if d.shutdownCtx.Err() != nil {
 				logger.Warn("Ignoring signal, shutdown already in progress", log.Ctx{"signal": sig})
+			} else {
+				go func() {
+					d.shutdownDoneCh <- d.Stop(context.Background(), sig)
+				}()
 			}
-
-			go func() {
-				d.shutdownDoneCh <- d.Stop(context.Background(), sig)
-			}()
 		case err = <-d.shutdownDoneCh:
 			return err
 		}

--- a/lxd/main_forkusernsexec.go
+++ b/lxd/main_forkusernsexec.go
@@ -144,10 +144,10 @@ __attribute__ ((noinline)) int __forkusernsexec(void)
 		return EXIT_SUCCESS;
 
 	if (!fhas_fs_type(FD_PIPE_UIDMAP, PIPEFS_MAGIC))
-		return EXIT_FAILURE;
+		return log_error(EXIT_FAILURE, "Error: Missing UID map FD");
 
 	if (!fhas_fs_type(FD_PIPE_GIDMAP, PIPEFS_MAGIC))
-		return EXIT_FAILURE;
+		return log_error(EXIT_FAILURE, "Error: Missing GID map FD");
 
 	ret = socketpair(AF_LOCAL, SOCK_STREAM | SOCK_CLOEXEC, 0, fd_socket);
 	if (ret < 0)

--- a/shared/subprocess/proc.go
+++ b/shared/subprocess/proc.go
@@ -171,11 +171,13 @@ func (p *Process) start(fds []*os.File) error {
 	p.chExit = make(chan struct{})
 	p.hasMonitor = true
 	go func() {
+		defer close(p.chExit)
+
 		procstate, err := cmd.Process.Wait()
 		if err != nil {
 			p.exitCode = -1
 			p.exitErr = err
-			close(p.chExit)
+
 			return
 		}
 
@@ -184,7 +186,6 @@ func (p *Process) start(fds []*os.File) error {
 		if p.exitCode != 0 {
 			p.exitErr = fmt.Errorf("Process exited with non-zero value %d", p.exitCode)
 		}
-		close(p.chExit)
 	}()
 
 	return nil


### PR DESCRIPTION
Continues #9496

This is a prerequisite for running these disk share proxy processes in a user namespace (using #9536) in order to properly secure restricted disk device paths.

The 9p `virtfs-proxy-helper` process accepts an already opened unix socket FD (not a listener FD), whereas the virtio-fs `virtiofsd` accepts a listener FD.

So for the `virtfs-proxy-helper` share we create an abstract unix listener, connect to it, and accept from it. This creates file handlers for either end of the unix socket, and then close the listener. We then pass one end of the connection to `virtfs-proxy-helper` and the other to QEMU via the `proxyFD` config setting.

And for the `virtiofsd` share we create a real unix listener with a path, get the FD of that listener and pass it to the `virtiofsd` process, and then pass the filename of unix listener path to QEMU via the socket backend `path` config setting. Then once the VM is started and connected to the `virtiofsd` process, we close the listener.

