### PR TITLE
Project: Separate checking if a project can support snapshots from the project DB lookup

### DIFF
--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -227,10 +227,20 @@ func instanceSnapshotsPost(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 	name := mux.Vars(r)["name"]
 
+	var proj *db.Project
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
-		err := project.AllowSnapshotCreation(tx, projectName)
+		proj, err = tx.GetProject(projectName)
+		if err != nil {
+			return err
+		}
+
 		return err
 	})
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	err = project.AllowSnapshotCreation(proj)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -1327,14 +1327,9 @@ func AllowBackupCreation(tx *db.ClusterTx, projectName string) error {
 
 // AllowSnapshotCreation returns an error if any project-specific restriction is violated
 // when creating a new snapshot in a project.
-func AllowSnapshotCreation(tx *db.ClusterTx, projectName string) error {
-	project, err := tx.GetProject(projectName)
-	if err != nil {
-		return err
-	}
-
+func AllowSnapshotCreation(project *db.Project) error {
 	if projectHasRestriction(project, "restricted.snapshots", "block") {
-		return fmt.Errorf("Project %s doesn't allow for snapshot creation", projectName)
+		return fmt.Errorf("Project %s doesn't allow for snapshot creation", project.Name)
 	}
 	return nil
 }

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -110,10 +110,20 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 		return response.SmartError(err)
 	}
 
+	var proj *db.Project
 	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
-		err := project.AllowSnapshotCreation(tx, projectName)
+		proj, err = tx.GetProject(projectName)
+		if err != nil {
+			return err
+		}
+
 		return err
 	})
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	err = project.AllowSnapshotCreation(proj)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -1043,6 +1043,27 @@ func pruneExpiredCustomVolumeSnapshots(ctx context.Context, d *Daemon, expiredSn
 
 func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 	f := func(ctx context.Context) {
+		// Get projects.
+		var projects map[string]*db.Project
+		err := d.State().Cluster.Transaction(func(tx *db.ClusterTx) error {
+			var err error
+			projs, err := tx.GetProjects(db.ProjectFilter{})
+			if err != nil {
+				return fmt.Errorf("Failed loading projects: %w", err)
+			}
+
+			// Key by project name for lookup later.
+			projects = make(map[string]*db.Project, len(projs))
+			for _, p := range projs {
+				projects[p.Name] = &p
+			}
+
+			return err
+		})
+		if err != nil {
+			return
+		}
+
 		allVolumes, err := d.cluster.GetStoragePoolVolumesWithType(db.StoragePoolVolumeTypeCustom)
 		if err != nil {
 			logger.Error("Failed getting volumes for auto custom volume snapshot task", log.Ctx{"err": err})
@@ -1063,10 +1084,7 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 				continue
 			}
 
-			err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
-				err := project.AllowSnapshotCreation(tx, v.ProjectName)
-				return err
-			})
+			err = project.AllowSnapshotCreation(projects[v.ProjectName])
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
I kept seeing this debug error in my local logs:

```
DBUG[11-17|10:02:51] Database error: &errors.errorString{s:"Project test doesn't allow for snapshot creation"} 
```

On further inspection this also revealed some very inefficient query techniques, so have optimised them in the process.