### PR TITLE
VM: Add raw.idmap support for running disk device proxy processes in user namespace

### DIFF
--- a/doc/projects.md
+++ b/doc/projects.md
@@ -52,6 +52,8 @@ restricted.devices.unix-block        | string    | -                     | block
 restricted.devices.unix-char         | string    | -                     | block                     | Prevents use of devices of type "unix-char"
 restricted.devices.unix-hotplug      | string    | -                     | block                     | Prevents use of devices of type "unix-hotplug"
 restricted.devices.usb               | string    | -                     | block                     | Prevents use of devices of type "usb"
+restricted.idmap.uid                 | string    | -                     | -                         | Specifies the allowed host UID ranges allowed in the instance `raw.idmap` setting.
+restricted.idmap.gid                 | string    | -                     | -                         | Specifies the allowed host GID ranges allowed in the instance `raw.idmap` setting.
 restricted.networks.subnets          | string    | -                     | block                     | Comma delimited list of network subnets from the uplink networks (in the form `<uplink>:<subnet>`) that are allocated for use in this project
 restricted.networks.uplinks          | string    | -                     | block                     | Comma delimited list of network names that can be used as uplinks for networks in this project
 restricted.networks.zones            | string    | -                     | block                     | Comma delimited list of network zones that can be used (or something under them) in this project

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -886,6 +886,8 @@ func projectValidateConfig(s *state.State, config map[string]string) error {
 		"restricted.devices.nic":               isEitherAllowOrBlockOrManaged,
 		"restricted.devices.disk":              isEitherAllowOrBlockOrManaged,
 		"restricted.devices.disk.paths":        validate.Optional(validate.IsListOf(validate.IsAbsFilePath)),
+		"restricted.idmap.uid":                 validate.Optional(validate.IsListOf(validate.IsUint32Range)),
+		"restricted.idmap.gid":                 validate.Optional(validate.IsListOf(validate.IsUint32Range)),
 		"restricted.networks.uplinks":          validate.Optional(validate.IsListOf(validate.IsAny)),
 		"restricted.networks.subnets": validate.Optional(func(value string) error {
 			return projectValidateRestrictedSubnets(s, value)

--- a/lxd/device/device_utils_disk_test.go
+++ b/lxd/device/device_utils_disk_test.go
@@ -1,0 +1,89 @@
+package device
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lxc/lxd/shared/idmap"
+)
+
+func TestDiskAddRootUserNSEntry(t *testing.T) {
+	// Check adds a combined uid/gid root entry to an empty list.
+	var idmaps []idmap.IdmapEntry
+	idmaps = diskAddRootUserNSEntry(idmaps, 65534)
+	expected := []idmap.IdmapEntry{
+		{
+			Isuid:    true,
+			Isgid:    true,
+			Hostid:   65534,
+			Maprange: 1,
+			Nsid:     0,
+		},
+	}
+	assert.Equal(t, idmaps, expected)
+
+	// Check doesn't add another one if an existing combined entry exists.
+	idmaps = diskAddRootUserNSEntry(idmaps, 65534)
+	assert.Equal(t, idmaps, expected)
+
+	// Check adds a root gid entry if root uid entry already exists.
+	idmaps = []idmap.IdmapEntry{
+		{
+			Isuid:    true,
+			Isgid:    false,
+			Hostid:   65534,
+			Maprange: 1,
+			Nsid:     0,
+		},
+	}
+
+	idmaps = diskAddRootUserNSEntry(idmaps, 65534)
+	expected = []idmap.IdmapEntry{
+		{
+			Isuid:    true,
+			Isgid:    false,
+			Hostid:   65534,
+			Maprange: 1,
+			Nsid:     0,
+		},
+		{
+			Isuid:    false,
+			Isgid:    true,
+			Hostid:   65534,
+			Maprange: 1,
+			Nsid:     0,
+		},
+	}
+	assert.Equal(t, idmaps, expected)
+
+	// Check adds a root uid entry if root gid entry already exists.
+	idmaps = []idmap.IdmapEntry{
+		{
+			Isuid:    false,
+			Isgid:    true,
+			Hostid:   65534,
+			Maprange: 1,
+			Nsid:     0,
+		},
+	}
+
+	idmaps = diskAddRootUserNSEntry(idmaps, 65534)
+	expected = []idmap.IdmapEntry{
+		{
+			Isuid:    false,
+			Isgid:    true,
+			Hostid:   65534,
+			Maprange: 1,
+			Nsid:     0,
+		},
+		{
+			Isuid:    true,
+			Isgid:    false,
+			Hostid:   65534,
+			Maprange: 1,
+			Nsid:     0,
+		},
+	}
+	assert.Equal(t, idmaps, expected)
+}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1144,7 +1144,7 @@ func (d *qemu) Start(stateful bool) error {
 	// This is used by the lxd-agent in preference to 9p (due to its improved performance) and in scenarios
 	// where 9p isn't available in the VM guest OS.
 	configSockPath, configPIDPath := d.configVirtiofsdPaths()
-	revertFunc, unixListener, err := device.DiskVMVirtiofsdStart(d, configSockPath, configPIDPath, "", configMntPath)
+	revertFunc, unixListener, err := device.DiskVMVirtiofsdStart(d.state.OS.ExecPath, d, configSockPath, configPIDPath, "", configMntPath, nil)
 	if err != nil {
 		var errUnsupported device.UnsupportedError
 		if errors.As(err, &errUnsupported) {

--- a/lxd/project/permission_internal_test.go
+++ b/lxd/project/permission_internal_test.go
@@ -1,0 +1,74 @@
+package project
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lxc/lxd/shared/idmap"
+)
+
+func TestParseHostIDMapRange(t *testing.T) {
+	for _, mode := range []string{"uid", "gid", "both"} {
+		var isUID, isGID bool
+		switch mode {
+		case "uid":
+			isUID = true
+		case "gid":
+			isGID = true
+		case "both":
+			isUID = true
+			isGID = true
+		}
+
+		idmaps, err := parseHostIDMapRange(isUID, isGID, "foo")
+		assert.NotErrorIs(t, err, nil)
+		assert.Nil(t, idmaps)
+
+		idmaps, err = parseHostIDMapRange(isUID, isGID, "1000")
+		expected := []idmap.IdmapEntry{
+			{
+				Isuid:    isUID,
+				Isgid:    isGID,
+				Hostid:   1000,
+				Maprange: 1,
+				Nsid:     -1,
+			},
+		}
+		assert.ErrorIs(t, err, nil)
+		assert.Equal(t, idmaps, expected)
+
+		idmaps, err = parseHostIDMapRange(isUID, isGID, "1000-1001")
+		expected = []idmap.IdmapEntry{
+			{
+				Isuid:    isUID,
+				Isgid:    isGID,
+				Hostid:   1000,
+				Maprange: 2,
+				Nsid:     -1,
+			},
+		}
+		assert.ErrorIs(t, err, nil)
+		assert.Equal(t, idmaps, expected)
+
+		idmaps, err = parseHostIDMapRange(isUID, isGID, "1000-1001,1002")
+		expected = []idmap.IdmapEntry{
+			{
+				Isuid:    isUID,
+				Isgid:    isGID,
+				Hostid:   1000,
+				Maprange: 2,
+				Nsid:     -1,
+			},
+			{
+				Isuid:    isUID,
+				Isgid:    isGID,
+				Hostid:   1002,
+				Maprange: 1,
+				Nsid:     -1,
+			},
+		}
+		assert.ErrorIs(t, err, nil)
+		assert.Equal(t, idmaps, expected)
+	}
+}

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -720,6 +720,7 @@ func isVMLowLevelOptionForbidden(key string) bool {
 	if shared.StringInSlice(key, []string{
 		"boot.host_shutdown_timeout",
 		"limits.memory.hugepages",
+		"raw.idmap",
 		"raw.qemu",
 	}) {
 		return true

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -690,6 +690,8 @@ var allRestrictions = map[string]string{
 	"restricted.devices.nic":               "managed",
 	"restricted.devices.disk":              "managed",
 	"restricted.devices.disk.paths":        "",
+	"restricted.idmap.uid":                 "",
+	"restricted.idmap.gid":                 "",
 	"restricted.snapshots":                 "block",
 }
 

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -689,6 +689,7 @@ var allRestrictions = map[string]string{
 	"restricted.devices.proxy":             "block",
 	"restricted.devices.nic":               "managed",
 	"restricted.devices.disk":              "managed",
+	"restricted.devices.disk.paths":        "",
 	"restricted.snapshots":                 "block",
 }
 

--- a/lxd/project/permissions_test.go
+++ b/lxd/project/permissions_test.go
@@ -4,12 +4,13 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/shared/api"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // If there's no limit configured on the project, the check passes.

--- a/shared/idmap/idmapset_linux_test.go
+++ b/shared/idmap/idmapset_linux_test.go
@@ -6,6 +6,8 @@ package idmap
 import (
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIdmapSetAddSafe_split(t *testing.T) {
@@ -107,4 +109,94 @@ func TestIdmapSetIntersects(t *testing.T) {
 		t.Error("ranges intersect")
 		return
 	}
+}
+
+func TestIdmapHostIDMapRange(t *testing.T) {
+	// Check empty entry is not covered.
+	idmap := IdmapEntry{}
+	assert.Equal(t, false, idmap.HostIDsCoveredBy(nil, nil))
+
+	// Check nil allowed lists are not covered.
+	idmap = IdmapEntry{Isuid: true, Hostid: 1000, Maprange: 1}
+	assert.Equal(t, false, idmap.HostIDsCoveredBy(nil, nil))
+
+	// Check that UID/GID specific host IDs are covered by equivalent UID/GID specific host ID rule.
+	uidOnlyEntry := IdmapEntry{Isuid: true, Hostid: 1000, Maprange: 1}
+	gidOnlyEntry := IdmapEntry{Isgid: true, Hostid: 1000, Maprange: 1}
+
+	allowedUIDMaps := []IdmapEntry{
+		{Isuid: true, Hostid: 1000, Maprange: 1},
+	}
+
+	allowedGIDMaps := []IdmapEntry{
+		{Isgid: true, Hostid: 1000, Maprange: 1},
+	}
+
+	assert.Equal(t, true, uidOnlyEntry.HostIDsCoveredBy(allowedUIDMaps, nil))
+	assert.Equal(t, false, uidOnlyEntry.HostIDsCoveredBy(nil, allowedUIDMaps))
+	assert.Equal(t, true, uidOnlyEntry.HostIDsCoveredBy(allowedUIDMaps, allowedUIDMaps))
+
+	assert.Equal(t, false, uidOnlyEntry.HostIDsCoveredBy(allowedGIDMaps, nil))
+	assert.Equal(t, false, uidOnlyEntry.HostIDsCoveredBy(nil, allowedGIDMaps))
+	assert.Equal(t, false, uidOnlyEntry.HostIDsCoveredBy(allowedGIDMaps, allowedGIDMaps))
+
+	assert.Equal(t, false, gidOnlyEntry.HostIDsCoveredBy(allowedGIDMaps, nil))
+	assert.Equal(t, true, gidOnlyEntry.HostIDsCoveredBy(nil, allowedGIDMaps))
+	assert.Equal(t, true, gidOnlyEntry.HostIDsCoveredBy(allowedGIDMaps, allowedGIDMaps))
+
+	assert.Equal(t, false, gidOnlyEntry.HostIDsCoveredBy(allowedUIDMaps, nil))
+	assert.Equal(t, false, gidOnlyEntry.HostIDsCoveredBy(nil, allowedUIDMaps))
+	assert.Equal(t, false, gidOnlyEntry.HostIDsCoveredBy(allowedUIDMaps, allowedUIDMaps))
+
+	// Check ranges are correctly blocked when not covered by single ID allow list.
+	uidOnlyRangeEntry := IdmapEntry{Isuid: true, Hostid: 1000, Maprange: 2}
+	gidOnlyRangeEntry := IdmapEntry{Isgid: true, Hostid: 1000, Maprange: 2}
+
+	assert.Equal(t, false, uidOnlyRangeEntry.HostIDsCoveredBy(allowedUIDMaps, nil))
+	assert.Equal(t, false, uidOnlyRangeEntry.HostIDsCoveredBy(nil, allowedUIDMaps))
+	assert.Equal(t, false, uidOnlyRangeEntry.HostIDsCoveredBy(allowedUIDMaps, allowedUIDMaps))
+
+	assert.Equal(t, false, gidOnlyRangeEntry.HostIDsCoveredBy(allowedGIDMaps, nil))
+	assert.Equal(t, false, gidOnlyRangeEntry.HostIDsCoveredBy(nil, allowedGIDMaps))
+	assert.Equal(t, false, gidOnlyRangeEntry.HostIDsCoveredBy(allowedGIDMaps, allowedGIDMaps))
+
+	// Check ranges are allowed when fully covered.
+	allowedUIDMaps = []IdmapEntry{
+		{Isuid: true, Hostid: 1000, Maprange: 2},
+	}
+
+	allowedGIDMaps = []IdmapEntry{
+		{Isgid: true, Hostid: 1000, Maprange: 2},
+	}
+
+	assert.Equal(t, true, uidOnlyRangeEntry.HostIDsCoveredBy(allowedUIDMaps, nil))
+	assert.Equal(t, false, uidOnlyRangeEntry.HostIDsCoveredBy(nil, allowedUIDMaps))
+	assert.Equal(t, true, uidOnlyRangeEntry.HostIDsCoveredBy(allowedUIDMaps, allowedUIDMaps))
+
+	assert.Equal(t, false, gidOnlyRangeEntry.HostIDsCoveredBy(allowedGIDMaps, nil))
+	assert.Equal(t, true, gidOnlyRangeEntry.HostIDsCoveredBy(nil, allowedGIDMaps))
+	assert.Equal(t, true, gidOnlyRangeEntry.HostIDsCoveredBy(allowedGIDMaps, allowedGIDMaps))
+
+	// Check ranges for combined allowed ID maps are correctly validated.
+	allowedCombinedMaps := []IdmapEntry{
+		{Isuid: true, Isgid: true, Hostid: 1000, Maprange: 2},
+	}
+
+	assert.Equal(t, true, uidOnlyRangeEntry.HostIDsCoveredBy(allowedCombinedMaps, nil))
+	assert.Equal(t, false, uidOnlyRangeEntry.HostIDsCoveredBy(nil, allowedCombinedMaps))
+	assert.Equal(t, true, uidOnlyRangeEntry.HostIDsCoveredBy(allowedCombinedMaps, allowedCombinedMaps))
+
+	assert.Equal(t, false, gidOnlyRangeEntry.HostIDsCoveredBy(allowedCombinedMaps, nil))
+	assert.Equal(t, true, gidOnlyRangeEntry.HostIDsCoveredBy(nil, allowedCombinedMaps))
+	assert.Equal(t, true, gidOnlyRangeEntry.HostIDsCoveredBy(allowedCombinedMaps, allowedCombinedMaps))
+
+	combinedEntry := IdmapEntry{Isuid: true, Isgid: true, Hostid: 1000, Maprange: 1}
+
+	assert.Equal(t, false, combinedEntry.HostIDsCoveredBy(allowedCombinedMaps, nil))
+	assert.Equal(t, false, combinedEntry.HostIDsCoveredBy(nil, allowedCombinedMaps))
+	assert.Equal(t, true, combinedEntry.HostIDsCoveredBy(allowedCombinedMaps, allowedCombinedMaps))
+
+	assert.Equal(t, false, combinedEntry.HostIDsCoveredBy(allowedCombinedMaps, nil))
+	assert.Equal(t, false, combinedEntry.HostIDsCoveredBy(nil, allowedCombinedMaps))
+	assert.Equal(t, true, combinedEntry.HostIDsCoveredBy(allowedCombinedMaps, allowedCombinedMaps))
 }

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -167,6 +167,9 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	"volatile.apply_quota":      validate.IsAny,
 	"volatile.uuid":             validate.Optional(validate.IsUUID),
 	"volatile.vsock_id":         validate.Optional(validate.IsInt64),
+
+	// Caller is responsible for full validation of any raw.* value.
+	"raw.idmap": validate.IsAny,
 }
 
 // InstanceConfigKeysContainer is a map of config key to validator. (keys applying to containers only)
@@ -227,7 +230,6 @@ var InstanceConfigKeysContainer = map[string]func(value string) error{
 	"nvidia.require.driver":      validate.IsAny,
 
 	// Caller is responsible for full validation of any raw.* value.
-	"raw.idmap":   validate.IsAny,
 	"raw.lxc":     validate.IsAny,
 	"raw.seccomp": validate.IsAny,
 

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -110,7 +110,7 @@ func ParseUint32Range(value string) (uint32, uint32, error) {
 			return 0, 0, fmt.Errorf("Start number %d must be lower than end number %d", startNum, endNum)
 		}
 
-		rangeSize = uint32(endNum) - uint32(startNum)
+		rangeSize += uint32(endNum) - uint32(startNum)
 	}
 
 	return uint32(startNum), rangeSize, err

--- a/test/suites/container_devices_disk_restricted.sh
+++ b/test/suites/container_devices_disk_restricted.sh
@@ -9,11 +9,14 @@ test_container_devices_disk_restricted() {
   # Create directory for use as allowed disk source path prefix in project.
   mkdir "${testRoot}/allowed1"
   mkdir "${testRoot}/allowed2"
-  touch "${testRoot}/allowed1/foo"
+  touch "${testRoot}/allowed1/foo1"
+  touch "${testRoot}/allowed1/foo2"
+  chown 1000:1000 "${testRoot}/allowed1/foo1"
+  chown 1001:1001 "${testRoot}/allowed1/foo2"
   mkdir "${testRoot}/not-allowed1"
   ln -s "${testRoot}/not-allowed1" "${testRoot}/allowed1/not-allowed1"
   ln -s "${testRoot}/allowed2" "${testRoot}/allowed1/not-allowed2"
-  (cd "${testRoot}/allowed1" || false; ln -s foo foolink)
+  (cd "${testRoot}/allowed1" || false; ln -s foo1 foolink)
 
 
   # Create project with restricted disk source path.
@@ -50,7 +53,7 @@ test_container_devices_disk_restricted() {
   # Check adding a disk with a source path that is allowed is allowed.
   lxc config device set c1 d1 source="${testRoot}/allowed1" shift=false
   lxc start c1
-  lxc exec c1 --project restricted -- ls /mnt/foo
+  lxc exec c1 --project restricted -- ls /mnt/foo1
 
   # Check adding a disk with a source path that is allowed that symlinks to another allowed source path isn't
   # allowed at start time.
@@ -60,14 +63,39 @@ test_container_devices_disk_restricted() {
   lxc stop -f c1
   lxc config device set c1 d1 source="${testRoot}/allowed1/foolink" path=/mnt/foolink
   lxc start c1
-  lxc exec c1 --project restricted -- ls /mnt/foolink
+  [ "$(lxc exec c1 --project restricted  -- stat /mnt/foolink -c '%u:%g')" = "65534:65534" ] || false
+  lxc stop -f c1
+
+  # Check usage of raw.idmap is restricted.
+  ! lxc config set c1 raw.idmap="both 1000 1000" || false
+
+  # Allow specific raw.idmap host UID/GID.
+  lxc project set restricted restricted.idmap.uid=1000
+  ! lxc config set c1 raw.idmap="both 1000 1000" || false
+  ! lxc config set c1 raw.idmap="gid 1000 1000" || false
+  lxc config set c1 raw.idmap="uid 1000 1000"
+
+  lxc project set restricted restricted.idmap.gid=1000
+  lxc config set c1 raw.idmap="gid 1000 1000"
+  lxc config set c1 raw.idmap="both 1000 1000"
+
+  # Check conflict detection works.
+  ! lxc project unset restricted restricted.idmap.uid || false
+  ! lxc project unset restricted restricted.idmap.gid || false
+
+  # Check single entry raw.idmap has taken effect on disk share.
+  lxc config device set c1 d1 source="${testRoot}/allowed1" path=/mnt
+  lxc start c1 || (lxc info --show-log c1 ; false)
+  [ "$(lxc exec c1 --project restricted  -- stat /mnt/foo1 -c '%u:%g')" = "1000:1000" ] || false
+  [ "$(lxc exec c1 --project restricted  -- stat /mnt/foo2 -c '%u:%g')" = "65534:65534" ] || false
 
   lxc delete -f c1
   lxc project switch default
   lxc project delete restricted
   rm "${testRoot}/allowed1/not-allowed1"
   rm "${testRoot}/allowed1/not-allowed2"
-  rm "${testRoot}/allowed1/foo"
+  rm "${testRoot}/allowed1/foo1"
+  rm "${testRoot}/allowed1/foo2"
   rm "${testRoot}/allowed1/foolink"
   rmdir "${testRoot}/allowed1"
   rmdir "${testRoot}/allowed2"

--- a/test/suites/container_devices_disk_restricted.sh
+++ b/test/suites/container_devices_disk_restricted.sh
@@ -56,7 +56,7 @@ test_container_devices_disk_restricted() {
   # allowed at start time.
   ! lxc config device set c1 d1 source="${testRoot}/allowed1/not-allowed2" || false
 
-  # Check relative symlink inside allowed path is
+  # Check relative symlink inside allowed parent path is allowed.
   lxc stop -f c1
   lxc config device set c1 d1 source="${testRoot}/allowed1/foolink" path=/mnt/foolink
   lxc start c1


### PR DESCRIPTION
Uses `forkusernsexec` from @brauner in https://github.com/lxc/lxd/pull/9536 to run the VM `disk` proxy processes in their own user namespaces. This is to effectively disable the `shift=true` default behaviour for VM `disk` devices when using a restricted source path, in order to prevent the creation of root-owned setuid files which could then be used to gain root privileges on the host outside of the VM.

Also adds `restricted.idmap.uid` and `restricted.idmap.gid` project settings which will include a range of host uid/gid which the project can map disk devices to using `raw.idmap` on the instance/profile. This allows instances with restricted `disk` devices to "punch" holes through the instance's unprivileged idmap range, for certain allowed UID/GID ranges.