### PR TITLE
Instance: Improve and unify stop and shutdown error handling

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2867,14 +2867,27 @@ func (d *lxc) Shutdown(timeout time.Duration) error {
 		break
 	}
 
+	// Wait for operation lock to be Done. This is normally completed by onStop which picks up the same
+	// operation lock and then marks it as Done after the instance stops and the devices have been cleaned up.
+	// However if the operation has failed for another reason we will collect the error here.
 	err = op.Wait()
-	if err != nil && d.IsRunning() {
-		return err
+	status := d.statusCode()
+	if status != api.Stopped {
+		errPrefix := fmt.Errorf("Failed shutting down instance, status is %q", status)
+
+		if err != nil {
+			return fmt.Errorf("%s: %w", errPrefix.Error(), err)
+		}
+
+		return errPrefix
+	} else if op.Action() == "stop" {
+		// If instance stopped, send lifecycle event (even if there has been an error cleaning up).
+		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceShutdown.Event(d, nil))
 	}
 
-	if op.Action() == "stop" {
-		d.logger.Info("Shut down container", ctxMap)
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceShutdown.Event(d, nil))
+	// Now handle errors from shutdown sequence and return to caller if wasn't completed cleanly.
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2751,22 +2751,27 @@ func (d *lxc) Stop(stateful bool) error {
 		return err
 	}
 
-	// Wait for onStop and liblxc to stop.
+	// Wait for operation lock to be Done. This is normally completed by onStop which picks up the same
+	// operation lock and then marks it as Done after the instance stops and the devices have been cleaned up.
+	// However if the operation has failed for another reason we will collect the error here.
 	err = op.Wait()
 	status := d.statusCode()
 	if status != api.Stopped {
 		errPrefix := fmt.Errorf("Failed stopping instance, status is %q", status)
 
 		if err != nil {
-			return errors.Wrap(err, errPrefix.Error())
+			return fmt.Errorf("%s: %w", errPrefix.Error(), err)
 		}
 
 		return errPrefix
+	} else if op.Action() == "stop" {
+		// If instance stopped, send lifecycle event (even if there has been an error cleaning up).
+		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceStopped.Event(d, nil))
 	}
 
-	if op.Action() == "stop" {
-		d.logger.Info("Stopped container", ctxMap)
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceStopped.Event(d, nil))
+	// Now handle errors from stop sequence and return to caller if wasn't completed cleanly.
+	if err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Previously any instance stop or shutdown errors would be masked if the instance had been stopped successfully (but perhaps some of the device or storage clean up had still failed). 

This PR changes it so that any error in the stop or shutdown sequences are returned to the caller, but even if there are errors if the instance is successfully stopped then the associated lifecycle event is still generated.