### PR TITLE
Instance: Reset operation lock timeout when unmounting instance and increase ZFS unmount wait

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2867,14 +2867,27 @@ func (d *lxc) Shutdown(timeout time.Duration) error {
 		break
 	}
 
+	// Wait for operation lock to be Done. This is normally completed by onStop which picks up the same
+	// operation lock and then marks it as Done after the instance stops and the devices have been cleaned up.
+	// However if the operation has failed for another reason we will collect the error here.
 	err = op.Wait()
-	if err != nil && d.IsRunning() {
-		return err
+	status := d.statusCode()
+	if status != api.Stopped {
+		errPrefix := fmt.Errorf("Failed shutting down instance, status is %q", status)
+
+		if err != nil {
+			return fmt.Errorf("%s: %w", errPrefix.Error(), err)
+		}
+
+		return errPrefix
+	} else if op.Action() == "stop" {
+		// If instance stopped, send lifecycle event (even if there has been an error cleaning up).
+		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceShutdown.Event(d, nil))
 	}
 
-	if op.Action() == "stop" {
-		d.logger.Info("Shut down container", ctxMap)
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceShutdown.Event(d, nil))
+	// Now handle errors from shutdown sequence and return to caller if wasn't completed cleanly.
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2999,9 +2999,11 @@ func (d *lxc) onStop(args map[string]string) error {
 		}
 
 		// Stop the storage for this container
+		op.Reset()
 		_, err = d.unmount()
 		if err != nil {
-			op.Done(errors.Wrap(err, "Failed unmounting container"))
+			err = fmt.Errorf("Failed unmounting instance: %w", err)
+			op.Done(err)
 			return
 		}
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2751,22 +2751,27 @@ func (d *lxc) Stop(stateful bool) error {
 		return err
 	}
 
-	// Wait for onStop and liblxc to stop.
+	// Wait for operation lock to be Done. This is normally completed by onStop which picks up the same
+	// operation lock and then marks it as Done after the instance stops and the devices have been cleaned up.
+	// However if the operation has failed for another reason we will collect the error here.
 	err = op.Wait()
 	status := d.statusCode()
 	if status != api.Stopped {
 		errPrefix := fmt.Errorf("Failed stopping instance, status is %q", status)
 
 		if err != nil {
-			return errors.Wrap(err, errPrefix.Error())
+			return fmt.Errorf("%s: %w", errPrefix.Error(), err)
 		}
 
 		return errPrefix
+	} else if op.Action() == "stop" {
+		// If instance stopped, send lifecycle event (even if there has been an error cleaning up).
+		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceStopped.Event(d, nil))
 	}
 
-	if op.Action() == "stop" {
-		d.logger.Info("Stopped container", ctxMap)
-		d.state.Events.SendLifecycle(d.project, lifecycle.InstanceStopped.Event(d, nil))
+	// Now handle errors from stop sequence and return to caller if wasn't completed cleanly.
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -659,7 +659,15 @@ func (d *qemu) onStop(target string) error {
 	d.cleanupDevices() // Must be called before unmount.
 	os.Remove(d.pidFilePath())
 	os.Remove(d.monitorPath())
-	d.unmount()
+
+	// Stop the storage for the instance.
+	op.Reset()
+	_, err = d.unmount()
+	if err != nil {
+		err = fmt.Errorf("Failed unmounting instance: %w", err)
+		op.Done(err)
+		return err
+	}
 
 	// Unload the apparmor profile
 	err = apparmor.InstanceUnload(d.state, d)


### PR DESCRIPTION
Sometimes when ZFS has a lot of data to flush (something @stgraber has experienced when using LXD VMs with MAAS), the unmount sequence can take a long time, and currently LXD is only waiting 5s for it to complete. Not waiting for it complete means that a subsequent restart of the instance can be interfered with by the ongoing unmount process.

We can't increase the ZFS unmount wait time beyond the operation lock timeout of 30s, as we don't want to be keeping the operation lock alive without knowing that LXD is still trying to unmount the ZFS volume (and right now the storage drivers don't have access to the instance lock instance to allow them to reset it, and that is outside of the scope of this change). Increasing the ZFs unmount wait time beyond the operation lock timeout would mean that a go routine would be left repeatedly trying to unmount the ZFS volume up to its internal timeout, whilst the operation lock had already been released, meaning that an instance could be restarted whilst the unmount sequence was still ongoing. This sounds like a recipe for bad times to me.

So for now, we increase the ZFS unmount wait timeout from 5s to 30s (and tightly couple it to the operation lock timeout constant to show the relationship), and reset the operation lock to 30s just before starting the unmount step to give the storage driver the maximum amount of time.

We also ensure that should the unmount sequence fail that this is reported back to the caller, as this should cause a restart sequence to fail, and right now for VMs it does not.
