### PR TITLE
Network: Ensures OVN networks only consider only compatible networks for use as uplink

### DIFF
--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -76,6 +76,17 @@ func (c *ClusterTx) GetCreatedNetworks() (map[string]map[int64]api.Network, erro
 	return c.getCreatedNetworks("")
 }
 
+// GetCreatedNetworksByProject returns a map of api.Network in a project associated to network ID.
+// Only networks that have are in state networkCreated are returned.
+func (c *ClusterTx) GetCreatedNetworksByProject(projectName string) (map[int64]api.Network, error) {
+	nets, err := c.getCreatedNetworks(projectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return nets[projectName], nil
+}
+
 // getCreatedNetworks returns a map of api.Network associated to project and network ID.
 // Supports an optional projectName filter. If projectName is empty, all networks in created state are returned.
 func (c *ClusterTx) getCreatedNetworks(projectName string) (map[string]map[int64]api.Network, error) {

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -73,17 +73,27 @@ func (c *ClusterTx) GetNonPendingNetworkIDs() (map[string]int64, error) {
 // GetCreatedNetworks returns a map of api.Network associated to project and network ID.
 // Only networks that have are in state networkCreated are returned.
 func (c *ClusterTx) GetCreatedNetworks() (map[string]map[int64]api.Network, error) {
-	stmt, err := c.tx.Prepare(`SELECT projects.name, networks.id, networks.name, coalesce(networks.description, ''), networks.type, networks.state
-		FROM networks
-		JOIN projects on projects.id = networks.project_id
-		WHERE networks.state = ?
-	`)
-	if err != nil {
-		return nil, err
-	}
-	defer stmt.Close()
+	return c.getCreatedNetworks("")
+}
 
-	rows, err := stmt.Query(networkCreated)
+// getCreatedNetworks returns a map of api.Network associated to project and network ID.
+// Supports an optional projectName filter. If projectName is empty, all networks in created state are returned.
+func (c *ClusterTx) getCreatedNetworks(projectName string) (map[string]map[int64]api.Network, error) {
+	var sb strings.Builder
+	sb.WriteString(`SELECT projects.name, networks.id, networks.name, coalesce(networks.description, ''), networks.type, networks.state
+	FROM networks
+	JOIN projects on projects.id = networks.project_id
+	WHERE networks.state = ?
+	`)
+
+	args := []interface{}{networkCreated}
+
+	if projectName != "" {
+		sb.WriteString(" AND projects.name = ?")
+		args = append(args, projectName)
+	}
+
+	rows, err := c.tx.Query(sb.String(), args...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes an issue seen in https://www.youtube.com/watch?v=1M__Rm9iZb8 where LXD did not auto select the only viable uplink network for use with a new OVN network because it was incorrectly considering another OVN network in the default project as a potential uplink, even though only `bridge` and `physical` networks types can be used as uplinks. 