### PR TITLE
Network: OVN instance peer route bug fix

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -740,8 +740,8 @@ func (n *ovn) getLoadBalancerName(listenAddress string) openvswitch.OVNLoadBalan
 	return openvswitch.OVNLoadBalancer(fmt.Sprintf("%s-lb-%s", n.getNetworkPrefix(), listenAddress))
 }
 
-// getLogicRouterPeerPortName returns OVN logical router port name to use for a peer connection.
-func (n *ovn) getLogicRouterPeerPortName(peerNetworkID int64) openvswitch.OVNRouterPort {
+// getLogicalRouterPeerPortName returns OVN logical router port name to use for a peer connection.
+func (n *ovn) getLogicalRouterPeerPortName(peerNetworkID int64) openvswitch.OVNRouterPort {
 	return openvswitch.OVNRouterPort(fmt.Sprintf("%s-lrp-peer-net%d", n.getRouterName(), peerNetworkID))
 }
 
@@ -2227,7 +2227,7 @@ func (n *ovn) logicalRouterPolicySetup(client *openvswitch.OVN, excludePeers ...
 		targetAddrSetPrefix := acl.OVNIntSwitchPortGroupAddressSetPrefix(targetOVNNet.ID())
 
 		// Associate the rules with the local peering port so we can identify them later if needed.
-		comment := n.getLogicRouterPeerPortName(targetOVNNet.ID())
+		comment := n.getLogicalRouterPeerPortName(targetOVNNet.ID())
 		policies = append(policies, openvswitch.OVNRouterPolicy{
 			Priority: ovnRouterPolicyPeerDropPriority,
 			Match:    fmt.Sprintf(`(inport == "%s" && ip6 && ip6.src == $%s_ip6) // %s`, extRouterPort, targetAddrSetPrefix, comment),
@@ -3276,7 +3276,7 @@ func (n *ovn) InstanceDevicePortSetup(opts *OVNInstanceNICSetupOpts, securityACL
 		// Add routes to peer routers, and security policies for each peer port on local router.
 		err = n.forPeers(func(targetOVNNet *ovn) error {
 			targetRouterName := targetOVNNet.getRouterName()
-			targetRouterPort := targetOVNNet.getLogicRouterPeerPortName(n.ID())
+			targetRouterPort := targetOVNNet.getLogicalRouterPeerPortName(n.ID())
 			targetRouterRoutes := make([]openvswitch.OVNRouterRoute, 0, len(routes))
 			for _, route := range routes {
 				nexthop := routerIntPortIPv4
@@ -4375,9 +4375,9 @@ func (n *ovn) peerSetup(client *openvswitch.OVN, targetOVNNet *ovn, opts openvsw
 	}
 
 	// Populate config based on target network.
-	opts.LocalRouterPort = n.getLogicRouterPeerPortName(targetOVNNet.ID())
+	opts.LocalRouterPort = n.getLogicalRouterPeerPortName(targetOVNNet.ID())
 	opts.TargetRouter = targetOVNNet.getRouterName()
-	opts.TargetRouterPort = targetOVNNet.getLogicRouterPeerPortName(n.ID())
+	opts.TargetRouterPort = targetOVNNet.getLogicalRouterPeerPortName(n.ID())
 	opts.TargetRouterPortMAC = targetRouterMAC
 
 	if validate.IsOneOf("none", "")(targetOVNNet.getRouterIntPortIPv4Net()) != nil {
@@ -4522,9 +4522,9 @@ func (n *ovn) PeerDelete(peerName string) error {
 
 		opts := openvswitch.OVNRouterPeering{
 			LocalRouter:      n.getRouterName(),
-			LocalRouterPort:  n.getLogicRouterPeerPortName(targetOVNNet.ID()),
+			LocalRouterPort:  n.getLogicalRouterPeerPortName(targetOVNNet.ID()),
 			TargetRouter:     targetOVNNet.getRouterName(),
-			TargetRouterPort: targetOVNNet.getLogicRouterPeerPortName(n.ID()),
+			TargetRouterPort: targetOVNNet.getLogicalRouterPeerPortName(n.ID()),
 		}
 
 		client, err := openvswitch.NewOVN(n.state)

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3284,7 +3284,7 @@ func (n *ovn) InstanceDevicePortSetup(opts *OVNInstanceNICSetupOpts, securityACL
 					nexthop = routerIntPortIPv6
 				}
 
-				if nexthop != nil {
+				if nexthop == nil {
 					continue // Skip routes that cannot be supported by local router.
 				}
 
@@ -3295,7 +3295,7 @@ func (n *ovn) InstanceDevicePortSetup(opts *OVNInstanceNICSetupOpts, securityACL
 				})
 			}
 
-			err = client.LogicalRouterRouteAdd(targetRouterName, true, routes...)
+			err = client.LogicalRouterRouteAdd(targetRouterName, true, targetRouterRoutes...)
 			if err != nil {
 				return fmt.Errorf("Failed adding static routes to peer network %q in project %q: %w", targetOVNNet.Name(), targetOVNNet.Project(), err)
 			}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3262,14 +3262,14 @@ func (n *ovn) InstanceDevicePortSetup(opts *OVNInstanceNICSetupOpts, securityACL
 		if validate.IsOneOf("none", "")(n.getRouterIntPortIPv4Net()) != nil {
 			routerIntPortIPv4, _, err = net.ParseCIDR(n.getRouterIntPortIPv4Net())
 			if err != nil {
-				return "", errors.Wrapf(err, "Failed parsing local router's peering port IPv4 Net")
+				return "", fmt.Errorf("Failed parsing local router's peering port IPv4 Net: %w", err)
 			}
 		}
 
 		if validate.IsOneOf("none", "")(n.getRouterIntPortIPv6Net()) != nil {
 			routerIntPortIPv6, _, err = net.ParseCIDR(n.getRouterIntPortIPv6Net())
 			if err != nil {
-				return "", errors.Wrapf(err, "Failed parsing local router's peering port IPv6 Net")
+				return "", fmt.Errorf("Failed parsing local router's peering port IPv6 Net: %w", err)
 			}
 		}
 


### PR DESCRIPTION
Fixes an issue @stgraber experience where restarting an instance with an OVN NIC that had `ipv{n}.routes` or `ipv{n}.routes.external` set would cause routes to be added to the network's peers with the incorrect nexthop IP and target port names.

Routes on a peer network after restarting instance with `ipv4.routes.external=10.0.0.1/32` before:

```
sudo ovn-nbctl lr-route-list lxd-net27-lr
IPv4 Routes
                 10.0.0.1               10.124.13.2 dst-ip lxd-net26-lr-lrp-int
           10.124.13.0/24               10.124.13.1 dst-ip lxd-net27-lr-lrp-peer-net26
                0.0.0.0/0               10.250.73.1 dst-ip lxd-net27-lr-lrp-ext
```

It should be going to `10.124.13.1 dst-ip lxd-net27-lr-lrp-peer-net26` same as `10.124.13.0/24 `

After fix:

```
sudo ovn-nbctl lr-route-list lxd-net27-lr
IPv4 Routes
                 10.0.0.1               10.124.13.1 dst-ip lxd-net27-lr-lrp-peer-net26
           10.124.13.0/24               10.124.13.1 dst-ip lxd-net27-lr-lrp-peer-net26
                0.0.0.0/0               10.250.73.1 dst-ip lxd-net27-lr-lrp-ext
```