### PR TITLE
Generator: Accept sql.NullTime as a valid type in the generator

### DIFF
--- a/lxd/db/generate/db/mapping.go
+++ b/lxd/db/generate/db/mapping.go
@@ -274,4 +274,5 @@ var columnarTypeNames = []string{
 	"CertificateType",
 	"string",
 	"time.Time",
+	"sql.NullTime",
 }


### PR DESCRIPTION
Running `make update-schema` has been broken since the the usage of `sql.NullTime` was introduced into the db package to support nullable datetimes.