### PR TITLE
NIC: Routed NIC rework and VM support backport (stable-4.0)

### DIFF
--- a/doc/instances.md
+++ b/doc/instances.md
@@ -541,12 +541,17 @@ name                    | string  | kernel assigned   | no       | The name of t
 host\_name              | string  | randomly assigned | no       | The name of the interface inside the host
 mtu                     | integer | parent MTU        | no       | The MTU of the new interface
 hwaddr                  | string  | randomly assigned | no       | The MAC address of the new interface
+limits.ingress          | string  | -                 | no       | I/O limit in bit/s for incoming traffic (various suffixes supported, see below)
+limits.egress           | string  | -                 | no       | I/O limit in bit/s for outgoing traffic (various suffixes supported, see below)
+limits.max              | string  | -                 | no       | Same as modifying both limits.ingress and limits.egress
 ipv4.address            | string  | -                 | no       | Comma delimited list of IPv4 static addresses to add to the instance
 ipv4.gateway            | string  | auto              | no       | Whether to add an automatic default IPv4 gateway, can be "auto" or "none"
 ipv4.host\_address      | string  | 169.254.0.1       | no       | The IPv4 address to add to the host-side veth interface.
+ipv4.host\_table        | integer | -                 | no       | The custom policy routing table ID to add IPv4 static routes to (in addition to main routing table).
 ipv6.address            | string  | -                 | no       | Comma delimited list of IPv6 static addresses to add to the instance
 ipv6.gateway            | string  | auto              | no       | Whether to add an automatic default IPv6 gateway, can be "auto" or "none"
 ipv6.host\_address      | string  | fe80::1           | no       | The IPv6 address to add to the host-side veth interface.
+ipv6.host\_table        | integer | -                 | no       | The custom policy routing table ID to add IPv6 static routes to (in addition to main routing table).
 vlan                    | integer | -                 | no       | The VLAN ID to attach to
 
 ##### bridged, macvlan or ipvlan for connection to physical network

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -546,12 +546,12 @@ limits.egress           | string  | -                 | no       | I/O limit in 
 limits.max              | string  | -                 | no       | Same as modifying both limits.ingress and limits.egress
 ipv4.address            | string  | -                 | no       | Comma delimited list of IPv4 static addresses to add to the instance
 ipv4.gateway            | string  | auto              | no       | Whether to add an automatic default IPv4 gateway, can be "auto" or "none"
-ipv4.host\_address      | string  | 169.254.0.1       | no       | The IPv4 address to add to the host-side veth interface.
-ipv4.host\_table        | integer | -                 | no       | The custom policy routing table ID to add IPv4 static routes to (in addition to main routing table).
+ipv4.host\_address      | string  | 169.254.0.1       | no       | The IPv4 address to add to the host-side veth interface
+ipv4.host\_table        | integer | -                 | no       | The custom policy routing table ID to add IPv4 static routes to (in addition to main routing table)
 ipv6.address            | string  | -                 | no       | Comma delimited list of IPv6 static addresses to add to the instance
 ipv6.gateway            | string  | auto              | no       | Whether to add an automatic default IPv6 gateway, can be "auto" or "none"
-ipv6.host\_address      | string  | fe80::1           | no       | The IPv6 address to add to the host-side veth interface.
-ipv6.host\_table        | integer | -                 | no       | The custom policy routing table ID to add IPv6 static routes to (in addition to main routing table).
+ipv6.host\_address      | string  | fe80::1           | no       | The IPv6 address to add to the host-side veth interface
+ipv6.host\_table        | integer | -                 | no       | The custom policy routing table ID to add IPv6 static routes to (in addition to main routing table)
 vlan                    | integer | -                 | no       | The VLAN ID to attach to
 
 ##### bridged, macvlan or ipvlan for connection to physical network

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -13,13 +13,16 @@ import (
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/ip"
 	"github.com/lxc/lxd/lxd/network"
+	"github.com/lxc/lxd/lxd/revert"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/validate"
 )
 
-const nicRoutedIPv4GW = "169.254.0.1"
-const nicRoutedIPv6GW = "fe80::1"
+var nicRoutedIPGateway = map[string]string{
+	"ipv4": "169.254.0.1",
+	"ipv6": "fe80::1",
+}
 
 type nicRouted struct {
 	deviceCommon
@@ -32,12 +35,18 @@ func (d *nicRouted) CanHotPlug() bool {
 
 // UpdatableFields returns a list of fields that can be updated without triggering a device remove & add.
 func (d *nicRouted) UpdatableFields(oldDevice Type) []string {
-	return []string{}
+	// Check old and new device types match.
+	_, match := oldDevice.(*nicRouted)
+	if !match {
+		return []string{}
+	}
+
+	return []string{"limits.ingress", "limits.egress", "limits.max"}
 }
 
 // validateConfig checks the supplied config for correctness.
 func (d *nicRouted) validateConfig(instConf instance.ConfigReader) error {
-	if !instanceSupported(instConf.Type(), instancetype.Container) {
+	if !instanceSupported(instConf.Type(), instancetype.Container, instancetype.VM) {
 		return ErrUnsupportedDevType
 	}
 
@@ -54,10 +63,15 @@ func (d *nicRouted) validateConfig(instConf instance.ConfigReader) error {
 		"hwaddr",
 		"host_name",
 		"vlan",
+		"limits.ingress",
+		"limits.egress",
+		"limits.max",
 		"ipv4.gateway",
 		"ipv6.gateway",
 		"ipv4.host_address",
 		"ipv6.host_address",
+		"ipv4.host_table",
+		"ipv6.host_table",
 	}
 
 	rules := nicValidationRules(requiredFields, optionalFields, instConf)
@@ -197,7 +211,6 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 	parentName := ""
 	if d.config["parent"] != "" {
 		parentName = network.GetHostDevice(d.config["parent"], d.config["vlan"])
-
 		statusDev, err := networkCreateVlanDeviceIfNeeded(d.state, d.config["parent"], parentName, d.config["vlan"])
 		if err != nil {
 			return nil, err
@@ -215,68 +228,181 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 		}
 	}
 
-	hostName := d.config["host_name"]
-	if hostName == "" {
-		hostName = network.RandomDevName("veth")
+	revert := revert.New()
+	defer revert.Fail()
+
+	saveData["host_name"] = d.config["host_name"]
+
+	var peerName string
+
+	// Create veth pair and configure the peer end with custom hwaddr and mtu if supplied.
+	if d.inst.Type() == instancetype.Container {
+		if saveData["host_name"] == "" {
+			saveData["host_name"] = network.RandomDevName("veth")
+		}
+		peerName, err = networkCreateVethPair(saveData["host_name"], d.config)
+	} else if d.inst.Type() == instancetype.VM {
+		if saveData["host_name"] == "" {
+			saveData["host_name"] = network.RandomDevName("tap")
+		}
+		peerName = saveData["host_name"] // VMs use the host_name to link to the TAP FD.
+		err = networkCreateTap(saveData["host_name"], d.config)
 	}
-	saveData["host_name"] = hostName
+	if err != nil {
+		return nil, err
+	}
+
+	revert.Add(func() { network.InterfaceRemove(saveData["host_name"]) })
+
+	// Populate device config with volatile fields if needed.
+	networkVethFillFromVolatile(d.config, saveData)
+
+	// Apply host-side limits.
+	err = networkSetupHostVethLimits(d.config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Attempt to disable IPv6 router advertisement acceptance from instance.
+	err = util.SysctlSet(fmt.Sprintf("net/ipv6/conf/%s/accept_ra", saveData["host_name"]), "0")
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	// Prevent source address spoofing by requiring a return path.
+	err = util.SysctlSet(fmt.Sprintf("net/ipv4/conf/%s/rp_filter", saveData["host_name"]), "1")
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	// Apply firewall rules for reverse path filtering of IPv4 and IPv6.
+	err = d.state.Firewall.InstanceSetupRPFilter(d.inst.Project(), d.inst.Name(), d.name, saveData["host_name"])
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error setting up reverse path filter")
+	}
+
+	// Perform host-side address configuration.
+	for _, keyPrefix := range []string{"ipv4", "ipv6"} {
+		subnetSize := 32
+		ipFamilyArg := ip.FamilyV4
+		if keyPrefix == "ipv6" {
+			subnetSize = 128
+			ipFamilyArg = ip.FamilyV6
+		}
+
+		addresses := util.SplitNTrimSpace(d.config[fmt.Sprintf("%s.address", keyPrefix)], ",", -1, true)
+
+		// Add host-side gateway addresses.
+		if len(addresses) > 0 {
+			// Add gateway IPs to the host end of the veth pair. This ensures that liveness detection
+			// of the gateways inside the instance work and ensure that traffic doesn't periodically
+			// halt whilst ARP/NDP is re-detected (which is what happens with just neighbour proxies).
+			addr := &ip.Addr{
+				DevName: saveData["host_name"],
+				Address: fmt.Sprintf("%s/%d", d.ipHostAddress(keyPrefix), subnetSize),
+				Family:  ipFamilyArg,
+			}
+			err = addr.Add()
+			if err != nil {
+				return nil, fmt.Errorf("Failed adding host gateway IP %q: %w", addr.Address, err)
+			}
+		}
+
+		// Perform per-address host-side configuration (static routes and neighbour proxy entries).
+		for _, addrStr := range addresses {
+			// Apply host-side static routes to main routing table.
+			r := ip.Route{
+				DevName: saveData["host_name"],
+				Route:   fmt.Sprintf("%s/%d", addrStr, subnetSize),
+				Table:   "main",
+				Family:  ipFamilyArg,
+			}
+			err = r.Add()
+			if err != nil {
+				return nil, fmt.Errorf("Failed adding host route %q: %w", r.Route, err)
+			}
+
+			// Add host-side static routes to instance IPs to custom routing table if specified.
+			// This is in addition to the static route added to the main routing table, which is still
+			// critical to ensure that reverse path filtering doesn't kick in blocking traffic from
+			// the instance.
+			if d.config[fmt.Sprintf("%s.host_table", keyPrefix)] != "" {
+				r := ip.Route{
+					DevName: saveData["host_name"],
+					Route:   fmt.Sprintf("%s/%d", addrStr, subnetSize),
+					Table:   d.config[fmt.Sprintf("%s.host_table", keyPrefix)],
+					Family:  ipFamilyArg,
+				}
+				err = r.Add()
+				if err != nil {
+					return nil, fmt.Errorf("Failed adding host route %q to table %q: %w", r.Route, r.Table, err)
+				}
+			}
+
+			// If there is a parent interface, add neighbour proxy entry.
+			if parentName != "" {
+				np := ip.NeighProxy{
+					DevName: parentName,
+					Addr:    net.ParseIP(addrStr),
+				}
+				err = np.Add()
+				if err != nil {
+					return nil, fmt.Errorf("Failed adding neighbour proxy %q to %q: %w", np.Addr.String(), np.DevName, err)
+				}
+
+				revert.Add(func() { np.Delete() })
+			}
+		}
+	}
 
 	err = d.volatileSet(saveData)
 	if err != nil {
 		return nil, err
 	}
 
-	runConf := deviceConfig.RunConfig{}
-	nic := []deviceConfig.RunConfigItem{
-		{Key: "type", Value: "veth"},
-		{Key: "name", Value: d.config["name"]},
-		{Key: "flags", Value: "up"},
-		{Key: "veth.mode", Value: "router"},
-		{Key: "veth.pair", Value: saveData["host_name"]},
-	}
+	// Perform instance NIC configuration.
+	var nic []deviceConfig.RunConfigItem
 
-	// If there is a designated parent interface, activate the layer2 proxy mode to advertise
-	// the instance's IPs over that interface using proxy APR/NDP.
-	if parentName != "" {
-		nic = append(nic,
-			deviceConfig.RunConfigItem{Key: "l2proxy", Value: "1"},
-			deviceConfig.RunConfigItem{Key: "link", Value: parentName},
-		)
-	}
+	if d.inst.Type() == instancetype.Container {
+		nic = append(nic, []deviceConfig.RunConfigItem{
+			{Key: "type", Value: "phys"},
+			{Key: "link", Value: peerName},
+			{Key: "name", Value: d.config["name"]},
+			{Key: "flags", Value: "up"},
+		}...)
 
-	if d.config["mtu"] != "" {
-		nic = append(nic, deviceConfig.RunConfigItem{Key: "mtu", Value: d.config["mtu"]})
-	}
+		for _, keyPrefix := range []string{"ipv4", "ipv6"} {
+			if nicHasAutoGateway(d.config[fmt.Sprintf("%s.gateway", keyPrefix)]) {
+				// Use a fixed address as the next-hop default gateway.
+				nic = append(nic, deviceConfig.RunConfigItem{Key: fmt.Sprintf("%s.gateway", keyPrefix), Value: d.ipHostAddress(keyPrefix)})
+			}
 
-	if d.config["ipv4.address"] != "" {
-		for _, addr := range strings.Split(d.config["ipv4.address"], ",") {
-			addr = strings.TrimSpace(addr)
-			// Specify the broadcast address as 0.0.0.0 as there is no broadcast address on this link.
-			// This stops liblxc from trying to calculate a broadcast address (and getting it wrong)
-			// which can prevent instances communicating with each other using adjacent IP addresses.
-			nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv4.address", Value: fmt.Sprintf("%s/32 0.0.0.0", addr)})
+			for _, addrStr := range util.SplitNTrimSpace(d.config[fmt.Sprintf("%s.address", keyPrefix)], ",", -1, true) {
+				// Add addresses to instance NIC.
+				if keyPrefix == "ipv6" {
+					nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv6.address", Value: fmt.Sprintf("%s/128", addrStr)})
+				} else {
+					// Specify the broadcast address as 0.0.0.0 as there is no broadcast address on
+					// this link. This stops liblxc from trying to calculate a broadcast address
+					// (and getting it wrong) which can prevent instances communicating with each other
+					// using adjacent IP addresses.
+					nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv4.address", Value: fmt.Sprintf("%s/32 0.0.0.0", addrStr)})
+				}
+			}
 		}
-
-		if nicHasAutoGateway(d.config["ipv4.gateway"]) {
-			// Use a fixed link-local address as the next-hop default gateway.
-			nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv4.gateway", Value: d.ipv4HostAddress()})
-		}
+	} else if d.inst.Type() == instancetype.VM {
+		nic = append(nic, []deviceConfig.RunConfigItem{
+			{Key: "devName", Value: d.name},
+			{Key: "link", Value: peerName},
+			{Key: "hwaddr", Value: d.config["hwaddr"]},
+		}...)
 	}
 
-	if d.config["ipv6.address"] != "" {
-		for _, addr := range strings.Split(d.config["ipv6.address"], ",") {
-			addr = strings.TrimSpace(addr)
-			nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv6.address", Value: fmt.Sprintf("%s/128", addr)})
-		}
-
-		if nicHasAutoGateway(d.config["ipv6.gateway"]) {
-			// Use a fixed link-local address as the next-hop default gateway.
-			nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv6.gateway", Value: d.ipv6HostAddress()})
-		}
+	runConf := deviceConfig.RunConfig{
+		NetworkInterface: nic,
 	}
 
-	runConf.NetworkInterface = nic
-	runConf.PostHooks = append(runConf.PostHooks, d.postStart)
+	revert.Success()
 	return &runConf, nil
 }
 
@@ -311,62 +437,22 @@ func (d *nicRouted) setupParentSysctls(parentName string) error {
 	return nil
 }
 
-// postStart is run after the instance is started.
-func (d *nicRouted) postStart() error {
+// Update returns an error as most devices do not support live updates without being restarted.
+func (d *nicRouted) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 	v := d.volatileGet()
 
-	// Populate device config with volatile fields if needed.
-	networkVethFillFromVolatile(d.config, v)
-
-	// Apply host-side limits.
-	err := networkSetupHostVethLimits(d.config)
-	if err != nil {
-		return err
-	}
-
-	// Attempt to disable IPv6 router advertisement acceptance.
-	err = util.SysctlSet(fmt.Sprintf("net/ipv6/conf/%s/accept_ra", d.config["host_name"]), "0")
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	// Prevent source address spoofing by requiring a return path.
-	err = util.SysctlSet(fmt.Sprintf("net/ipv4/conf/%s/rp_filter", d.config["host_name"]), "1")
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	// Apply firewall rules for reverse path filtering of IPv4 and IPv6.
-	err = d.state.Firewall.InstanceSetupRPFilter(d.inst.Project(), d.inst.Name(), d.name, d.config["host_name"])
-	if err != nil {
-		return errors.Wrapf(err, "Error setting up reverse path filter")
-	}
-
-	if d.config["ipv4.address"] != "" {
-		// Add link-local gateway IPs to the host end of the veth pair. This ensures that
-		// liveness detection of the gateways inside the instance work and ensure that traffic
-		// doesn't periodically halt whilst ARP is re-detected.
-		addr := &ip.Addr{
-			DevName: d.config["host_name"],
-			Address: fmt.Sprintf("%s/32", d.ipv4HostAddress()),
-			Family:  ip.FamilyV4,
-		}
-		err := addr.Add()
+	// If instance is running, apply host side limits.
+	if isRunning {
+		err := d.validateEnvironment()
 		if err != nil {
 			return err
 		}
-	}
 
-	if d.config["ipv6.address"] != "" {
-		// Add link-local gateway IPs to the host end of the veth pair. This ensures that
-		// liveness detection of the gateways inside the instance work and ensure that traffic
-		// doesn't periodically halt whilst NDP is re-detected.
-		addr := &ip.Addr{
-			DevName: d.config["host_name"],
-			Address: fmt.Sprintf("%s/128", d.ipv6HostAddress()),
-			Family:  ip.FamilyV6,
-		}
-		err := addr.Add()
+		// Populate device config with volatile fields if needed.
+		networkVethFillFromVolatile(d.config, v)
+
+		// Apply host-side limits.
+		err = networkSetupHostVethLimits(d.config)
 		if err != nil {
 			return err
 		}
@@ -391,13 +477,18 @@ func (d *nicRouted) postStop() error {
 		"host_name":          "",
 	})
 
+	errs := []error{}
+
 	v := d.volatileGet()
 
 	networkVethFillFromVolatile(d.config, v)
 
-	errs := []error{}
+	parentName := ""
+	if d.config["parent"] != "" {
+		parentName = network.GetHostDevice(d.config["parent"], d.config["vlan"])
+	}
 
-	// Delete host-side end of veth pair if not removed by liblxc.
+	// Delete host-side interface.
 	if network.InterfaceExists(d.config["host_name"]) {
 		// Removing host-side end of veth pair will delete the peer end too.
 		err := network.InterfaceRemove(d.config["host_name"])
@@ -406,12 +497,12 @@ func (d *nicRouted) postStop() error {
 		}
 	}
 
-	// Delete IP neighbour proxy entries on the parent if they haven't been removed by liblxc.
-	for _, key := range []string{"ipv4.address", "ipv6.address"} {
-		if d.config[key] != "" {
+	// Delete IP neighbour proxy entries on the parent.
+	if parentName != "" {
+		for _, key := range []string{"ipv4.address", "ipv6.address"} {
 			for _, addr := range util.SplitNTrimSpace(d.config[key], ",", -1, true) {
 				neighProxy := &ip.NeighProxy{
-					DevName: d.config["parent"],
+					DevName: parentName,
 					Addr:    net.ParseIP(addr),
 				}
 
@@ -422,7 +513,6 @@ func (d *nicRouted) postStop() error {
 
 	// This will delete the parent interface if we created it for VLAN parent.
 	if shared.IsTrue(v["last_state.created"]) {
-		parentName := network.GetHostDevice(d.config["parent"], d.config["vlan"])
 		err := networkRemoveInterfaceIfNeeded(d.state, parentName, d.inst, d.config["parent"], d.config["vlan"])
 		if err != nil {
 			errs = append(errs, err)
@@ -442,20 +532,13 @@ func (d *nicRouted) postStop() error {
 	return nil
 }
 
-func (d *nicRouted) ipv4HostAddress() string {
-	if d.config["ipv4.host_address"] != "" {
-		return d.config["ipv4.host_address"]
+func (d *nicRouted) ipHostAddress(ipFamily string) string {
+	key := fmt.Sprintf("%s.host_address", ipFamily)
+	if d.config[key] != "" {
+		return d.config[key]
 	}
 
-	return nicRoutedIPv4GW
-}
-
-func (d *nicRouted) ipv6HostAddress() string {
-	if d.config["ipv6.host_address"] != "" {
-		return d.config["ipv6.host_address"]
-	}
-
-	return nicRoutedIPv6GW
+	return nicRoutedIPGateway[ipFamily]
 }
 
 func (d *nicRouted) isUniqueWithGatewayAutoMode(instConf instance.ConfigReader) error {

--- a/test/suites/container_devices_nic_routed.sh
+++ b/test/suites/container_devices_nic_routed.sh
@@ -132,14 +132,10 @@ test_container_devices_nic_routed() {
 
   # Check comms between containers.
   lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.1"
-  lxc exec "${ctName}" -- ping6 -c3 -W5 "2001:db8::1"
-  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.1"
-  lxc exec "${ctName}" -- ping6 -c3 -W5 "2001:db8::1"
+  lxc exec "${ctName}" -- ping6 -c2 -W5 "2001:db8::1"
 
   lxc exec "${ctName}2" -- ping -c2 -W5 "192.0.2.1"
-  lxc exec "${ctName}2" -- ping6 -c3 -W5 "2001:db8::1"
-  lxc exec "${ctName}2" -- ping -c2 -W5 "192.0.2.1"
-  lxc exec "${ctName}2" -- ping6 -c3 -W5 "2001:db8::1"
+  lxc exec "${ctName}2" -- ping6 -c2 -W5 "2001:db8::1"
 
   lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.2${ipRand}"
   lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.3${ipRand}"

--- a/test/suites/container_devices_nic_routed.sh
+++ b/test/suites/container_devices_nic_routed.sh
@@ -11,6 +11,7 @@ test_container_devices_nic_routed() {
   ipRand=$(shuf -i 0-9 -n 1)
 
   # These special values are needed to be enabled in kernel.
+  sysctl net.ipv4.conf.all.forwarding=1
   sysctl net.ipv6.conf.all.forwarding=1
   sysctl net.ipv6.conf.all.proxy_ndp=1
 


### PR DESCRIPTION
Backports the work done in (but without gvrp support as needed wider function changes outside of routed NIC):

- https://github.com/lxc/lxd/pull/9528
- https://github.com/lxc/lxd/pull/9529