### PR TITLE
Instance: Require control socket for signal relay during non-interactive exec session

### DIFF
--- a/lxc/exec.go
+++ b/lxc/exec.go
@@ -153,11 +153,8 @@ func (c *cmdExec) Run(cmd *cobra.Command, args []string) error {
 		defer termios.Restore(stdinFd, oldttystate)
 	}
 
-	// Setup interactive console handler
+	// Setup signal and console handler
 	handler := c.controlSocketHandler
-	if !interactive {
-		handler = nil
-	}
 
 	// Grab current terminal dimensions
 	var width, height int

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6725,6 +6725,7 @@ func (d *lxc) DevptsFd() (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer d.release()
 
 	if !liblxc.HasApiExtension("devpts_fd") {
 		return nil, fmt.Errorf("Missing devpts_fd extension")

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5748,6 +5748,7 @@ func (d *lxc) Exec(req api.InstanceExecPost, stdin *os.File, stdout *os.File, st
 	if err != nil {
 		return nil, err
 	}
+	defer logFile.Close()
 
 	// Prepare the subcommand
 	cname := project.Instance(d.Project(), d.Name())

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1870,7 +1870,6 @@ func (d *lxc) DeviceEventHandler(runConf *deviceConfig.RunConfig) error {
 
 	// Generate uevent inside container if requested.
 	if len(runConf.Uevents) > 0 {
-
 		pidFdNr, pidFd := d.inheritInitPidFd()
 		if pidFdNr >= 0 {
 			defer pidFd.Close()

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -596,7 +596,6 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 			ws.conns[2] = nil
 		}
 		ws.allConnected = make(chan struct{})
-		ws.controlConnected = make(chan struct{})
 		for i := -1; i < len(ws.conns)-1; i++ {
 			ws.fds[i], err = shared.RandomCryptoString()
 			if err != nil {

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -42,13 +42,10 @@ type execWs struct {
 	req api.InstanceExecPost
 
 	instance     instance.Instance
-	rootUid      int64
-	rootGid      int64
 	conns        map[int]*websocket.Conn
 	connsLock    sync.Mutex
 	allConnected chan struct{}
 	fds          map[int]string
-	devptsFd     *os.File
 	s            *state.State
 }
 
@@ -155,12 +152,32 @@ func (s *execWs) Do(op *operations.Operation) error {
 		ttys = make([]*os.File, 1)
 		ptys = make([]*os.File, 1)
 
-		if s.devptsFd != nil && s.s.OS.NativeTerminals {
-			ptys[0], ttys[0], err = shared.OpenPtyInDevpts(int(s.devptsFd.Fd()), s.rootUid, s.rootGid)
-			s.devptsFd.Close()
-			s.devptsFd = nil
+		var devptsFd *os.File
+		var rootUID, rootGID int64
+
+		if s.instance.Type() == instancetype.Container {
+			c := s.instance.(instance.Container)
+			idmapset, err := c.CurrentIdmap()
+			if err != nil {
+				return err
+			}
+
+			if idmapset != nil {
+				rootUID, rootGID = idmapset.ShiftIntoNs(0, 0)
+			}
+
+			devptsFd, _ = c.DevptsFd()
+		}
+
+		if devptsFd != nil {
+			if s.s.OS.NativeTerminals {
+				ptys[0], ttys[0], err = shared.OpenPtyInDevpts(int(devptsFd.Fd()), rootUID, rootGID)
+			}
+
+			devptsFd.Close()
+			devptsFd = nil
 		} else {
-			ptys[0], ttys[0], err = shared.OpenPty(s.rootUid, s.rootGid)
+			ptys[0], ttys[0], err = shared.OpenPty(rootUID, rootGID)
 		}
 		if err != nil {
 			return err
@@ -565,23 +582,6 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 		ws := &execWs{}
 		ws.s = d.State()
 		ws.fds = map[int]string{}
-
-		if inst.Type() == instancetype.Container {
-			c := inst.(instance.Container)
-			idmapset, err := c.CurrentIdmap()
-			if err != nil {
-				return response.InternalError(err)
-			}
-
-			if idmapset != nil {
-				ws.rootUid, ws.rootGid = idmapset.ShiftIntoNs(0, 0)
-			}
-
-			devptsFd, err := c.DevptsFd()
-			if err == nil {
-				ws.devptsFd = devptsFd
-			}
-		}
 
 		ws.conns = map[int]*websocket.Conn{}
 		ws.conns[execWSControl] = nil

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -596,7 +596,8 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 			ws.conns[2] = nil
 		}
 		ws.allConnected = make(chan struct{})
-		for i := -1; i < len(ws.conns)-1; i++ {
+
+		for i := range ws.conns {
 			ws.fds[i], err = shared.RandomCryptoString()
 			if err != nil {
 				return response.InternalError(err)

--- a/shared/netutils/network_linux.go
+++ b/shared/netutils/network_linux.go
@@ -4,6 +4,7 @@
 package netutils
 
 import (
+	"context"
 	"io"
 
 	"github.com/gorilla/websocket"
@@ -13,14 +14,14 @@ import (
 )
 
 // WebsocketExecMirror mirrors a websocket connection with a set of Writer/Reader.
-func WebsocketExecMirror(conn *websocket.Conn, w io.WriteCloser, r io.ReadCloser, exited chan struct{}, fd int) (chan bool, chan bool) {
+func WebsocketExecMirror(ctx context.Context, conn *websocket.Conn, w io.WriteCloser, r io.ReadCloser, fd int) (chan bool, chan bool) {
 	readDone := make(chan bool, 1)
 	writeDone := make(chan bool, 1)
 
 	go shared.DefaultWriter(conn, w, writeDone)
 
 	go func(conn *websocket.Conn, r io.ReadCloser) {
-		in := shared.ExecReaderToChannel(r, -1, exited, fd)
+		in := shared.ExecReaderToChannel(ctx, r, -1, fd)
 		for {
 			buf, ok := <-in
 			if !ok {

--- a/shared/network.go
+++ b/shared/network.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -197,7 +198,7 @@ func WebsocketSendStream(conn *websocket.Conn, r io.Reader, bufferSize int) chan
 
 			err := conn.WriteMessage(websocket.BinaryMessage, buf)
 			if err != nil {
-				logger.Debugf("Got err writing %s", err)
+				logger.Debug("Got err writing", log.Ctx{"err": err})
 				break
 			}
 		}
@@ -215,23 +216,23 @@ func WebsocketRecvStream(w io.Writer, conn *websocket.Conn) chan bool {
 		for {
 			mt, r, err := conn.NextReader()
 			if mt == websocket.CloseMessage {
-				logger.Debugf("Got close message for reader")
+				logger.Debug("Got close message for reader")
 				break
 			}
 
 			if mt == websocket.TextMessage {
-				logger.Debugf("Got message barrier")
+				logger.Debug("Got message barrier")
 				break
 			}
 
 			if err != nil {
-				logger.Debugf("Got error getting next reader %s", err)
+				logger.Debug("Got error getting next reader", log.Ctx{"err": err})
 				break
 			}
 
 			buf, err := ioutil.ReadAll(r)
 			if err != nil {
-				logger.Debugf("Got error writing to writer %s", err)
+				logger.Debug("Got error writing to writer", log.Ctx{"err": err})
 				break
 			}
 
@@ -241,11 +242,11 @@ func WebsocketRecvStream(w io.Writer, conn *websocket.Conn) chan bool {
 
 			i, err := w.Write(buf)
 			if i != len(buf) {
-				logger.Debugf("Didn't write all of buf")
+				logger.Debug("Didn't write all of buf")
 				break
 			}
 			if err != nil {
-				logger.Debugf("Error writing buf %s", err)
+				logger.Debug("Error writing buf", log.Ctx{"err": err})
 				break
 			}
 		}
@@ -313,7 +314,7 @@ func defaultReader(conn *websocket.Conn, r io.ReadCloser, readDone chan<- bool) 
 		buf, ok := <-in
 		if !ok {
 			r.Close()
-			logger.Debugf("Sending write barrier")
+			logger.Debug("Sending write barrier")
 			conn.WriteMessage(websocket.TextMessage, []byte{})
 			readDone <- true
 			return
@@ -321,7 +322,7 @@ func defaultReader(conn *websocket.Conn, r io.ReadCloser, readDone chan<- bool) 
 
 		err := conn.WriteMessage(websocket.BinaryMessage, buf)
 		if err != nil {
-			logger.Debugf("Got err writing %s", err)
+			logger.Debug("Got err writing", log.Ctx{"err": err})
 			break
 		}
 	}
@@ -335,32 +336,32 @@ func DefaultWriter(conn *websocket.Conn, w io.WriteCloser, writeDone chan<- bool
 	for {
 		mt, r, err := conn.NextReader()
 		if err != nil {
-			logger.Debugf("Got error getting next reader %s", err)
+			logger.Debug("Got error getting next reader", log.Ctx{"err": err})
 			break
 		}
 
 		if mt == websocket.CloseMessage {
-			logger.Debugf("Got close message for reader")
+			logger.Debug("Got close message for reader")
 			break
 		}
 
 		if mt == websocket.TextMessage {
-			logger.Debugf("Got message barrier, resetting stream")
+			logger.Debug("Got message barrier, resetting stream")
 			break
 		}
 
 		buf, err := ioutil.ReadAll(r)
 		if err != nil {
-			logger.Debugf("Got error writing to writer %s", err)
+			logger.Debug("Got error writing to writer", log.Ctx{"err": err})
 			break
 		}
 		i, err := w.Write(buf)
 		if i != len(buf) {
-			logger.Debugf("Didn't write all of buf")
+			logger.Debug("Didn't write all of buf")
 			break
 		}
 		if err != nil {
-			logger.Debugf("Error writing buf %s", err)
+			logger.Debug("Error writing buf", log.Ctx{"err": err})
 			break
 		}
 	}

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -5,6 +5,7 @@ package shared
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -445,7 +446,7 @@ func OpenPty(uid, gid int64) (*os.File, *os.File, error) {
 // Extensively commented directly in the code. Please leave the comments!
 // Looking at this in a couple of months noone will know why and how this works
 // anymore.
-func ExecReaderToChannel(r io.Reader, bufferSize int, exited <-chan struct{}, fd int) <-chan []byte {
+func ExecReaderToChannel(ctx context.Context, r io.Reader, bufferSize int, fd int) <-chan []byte {
 	if bufferSize <= (128 * 1024) {
 		bufferSize = (128 * 1024)
 	}
@@ -474,7 +475,7 @@ func ExecReaderToChannel(r io.Reader, bufferSize int, exited <-chan struct{}, fd
 	// that there's nothing buffered on stdout and exit.
 	var attachedChildIsDead int32 = 0
 	go func() {
-		<-exited
+		<-ctx.Done()
 
 		atomic.StoreInt32(&attachedChildIsDead, 1)
 

--- a/test/main.sh
+++ b/test/main.sh
@@ -238,6 +238,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_image_auto_update "image auto-update"
     run_test test_image_prefer_cached "image prefer cached"
     run_test test_image_import_dir "import image from directory"
+    run_test test_exec "exec"
     run_test test_concurrent_exec "concurrent exec"
     run_test test_concurrent "concurrent startup"
     run_test test_snapshots "container snapshots"

--- a/test/suites/exec.sh
+++ b/test/suites/exec.sh
@@ -1,3 +1,30 @@
+test_exec() {
+  ensure_import_testimage
+
+  name=x1
+  lxc launch testimage x1
+  lxc list ${name} | grep RUNNING
+
+  exec_container_noninteractive() {
+    echo "abc${1}" | lxc exec "${name}" --force-noninteractive -- cat | grep abc
+  }
+
+  exec_container_interactive() {
+    echo "abc${1}" | lxc exec "${name}" -- cat | grep abc
+  }
+
+  for i in $(seq 1 25); do
+    exec_container_interactive "${i}" > "${LXD_DIR}/exec-${i}.out" 2>&1
+  done
+
+  for i in $(seq 1 25); do
+    exec_container_noninteractive "${i}" > "${LXD_DIR}/exec-${i}.out" 2>&1
+  done
+
+  lxc stop "${name}" --force
+  lxc delete "${name}"
+}
+
 test_concurrent_exec() {
   if [ -z "${LXD_CONCURRENT:-}" ]; then
     echo "==> SKIP: LXD_CONCURRENT isn't set"

--- a/test/suites/exec.sh
+++ b/test/suites/exec.sh
@@ -10,13 +10,22 @@ test_concurrent_exec() {
   lxc launch testimage x1
   lxc list ${name} | grep RUNNING
 
-  exec_container() {
+  exec_container_noninteractive() {
+    echo "abc${1}" | lxc exec "${name}" --force-noninteractive -- cat | grep abc
+  }
+
+  exec_container_interactive() {
     echo "abc${1}" | lxc exec "${name}" -- cat | grep abc
   }
 
   PIDS=""
-  for i in $(seq 1 50); do
-    exec_container "${i}" > "${LXD_DIR}/exec-${i}.out" 2>&1 &
+  for i in $(seq 1 25); do
+    exec_container_interactive "${i}" > "${LXD_DIR}/exec-${i}.out" 2>&1 &
+    PIDS="${PIDS} $!"
+  done
+
+  for i in $(seq 1 25); do
+    exec_container_noninteractive "${i}" > "${LXD_DIR}/exec-${i}.out" 2>&1 &
     PIDS="${PIDS} $!"
   done
 


### PR DESCRIPTION
Previously in non-interactive mode LXD still created a slot for the control socket to be connected and returned its secret to the client in non-interactive mode, but the lxc client never connected to it.

This meant two things:

1. That LXD had to have some logic to cater for "allConnected" actually meaning "all-but-the-control-socket", which was quite confusing to the reader.
2. Signals from the caller did not get propagated to the command being run and so would leave orphaned processes and go routines until the command exited (which might never happen without a signal).

By fixing 2 (requiring the control socket be connected for non-interactive commands), this also allows simplification of 1, by making "allConnected" actually mean "all connected".

- Expects all websockets to connect before starting command.
- Removes special treatment of control socket during setup.
- Adds timeout if websockets not connect within 5s.
- Use revert for cleanup.
- Fixes several file handle leaks.
- Adds tests for non-interactive exec.

Fixes #9578