### PR TITLE
Ability to retrieve instances for all projects through API

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -143,8 +143,11 @@ type InstanceServer interface {
 
 	// Instance functions.
 	GetInstanceNames(instanceType api.InstanceType) (names []string, err error)
+	GetInstanceNamesAllProjects(instanceType api.InstanceType) (names map[string][]string, err error)
 	GetInstances(instanceType api.InstanceType) (instances []api.Instance, err error)
 	GetInstancesFull(instanceType api.InstanceType) (instances []api.InstanceFull, err error)
+	GetInstancesAllProjects(instanceType api.InstanceType) (instances []api.Instance, err error)
+	GetInstancesFullAllProjects(instanceType api.InstanceType) (instances []api.InstanceFull, err error)
 	GetInstance(name string) (instance *api.Instance, ETag string, err error)
 	CreateInstance(instance api.InstancesPost) (op Operation, err error)
 	CreateInstanceFromImage(source ImageServer, image api.Image, req api.InstancesPost) (op RemoteOperation, err error)

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1521,3 +1521,6 @@ generate records for externally reachable addreses.
 
 ## database\_leader
 Adds new "database-leader" role which is assigned to cluster leader.
+
+## instance\_all\_projects
+This adds support for displaying instances from all projects.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -986,6 +986,11 @@ definitions:
           type: string
         type: array
         x-go-name: Profiles
+      project:
+        description: Instance project name
+        example: foo
+        type: string
+        x-go-name: Project
       restore:
         description: If set, instance will be restored to the provided snapshot name
         example: snap0
@@ -1281,6 +1286,11 @@ definitions:
           type: string
         type: array
         x-go-name: Profiles
+      project:
+        description: Instance project name
+        example: foo
+        type: string
+        x-go-name: Project
       restore:
         description: If set, instance will be restored to the provided snapshot name
         example: snap0
@@ -7022,6 +7032,10 @@ paths:
         in: query
         name: filter
         type: string
+      - description: Retrieve instances from all projects
+        in: query
+        name: all-projects
+        type: boolean
       produces:
       - application/json
       responses:
@@ -8474,6 +8488,10 @@ paths:
         in: query
         name: filter
         type: string
+      - description: Retrieve instances from all projects
+        in: query
+        name: all-projects
+        type: boolean
       produces:
       - application/json
       responses:
@@ -8527,6 +8545,10 @@ paths:
         in: query
         name: filter
         type: string
+      - description: Retrieve instances from all projects
+        in: query
+        name: all-projects
+        type: boolean
       produces:
       - application/json
       responses:

--- a/lxc/list_test.go
+++ b/lxc/list_test.go
@@ -153,7 +153,7 @@ func TestShouldShow(t *testing.T) {
 }
 
 // Used by TestColumns and TestInvalidColumns
-const shorthand = "46abcdDfFlmMnNpPsStuL"
+const shorthand = "46abcdDefFlmMnNpPsStuL"
 const alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 func TestColumns(t *testing.T) {

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -252,7 +252,7 @@ SELECT nodes.id, nodes.address
 // string, to distinguish it from remote nodes.
 //
 // Containers whose node is down are addeded to the special address "0.0.0.0".
-func (c *ClusterTx) GetInstanceNamesByNodeAddress(project string, filter InstanceFilter) (map[string][]string, error) {
+func (c *ClusterTx) GetInstanceNamesByNodeAddress(projects []string, filter InstanceFilter) (map[string][]string, error) {
 	offlineThreshold, err := c.GetNodeOfflineThreshold()
 	if err != nil {
 		return nil, err
@@ -262,8 +262,10 @@ func (c *ClusterTx) GetInstanceNamesByNodeAddress(project string, filter Instanc
 	var filters strings.Builder
 
 	// Project filter.
-	filters.WriteString("projects.name = ?")
-	args = append(args, project)
+	filters.WriteString(fmt.Sprintf("projects.name IN (%s)", generateInClauseParams(len(projects))))
+	for _, project := range projects {
+		args = append(args, project)
+	}
 
 	// Instance type filter.
 	if filter.Type != nil {
@@ -394,14 +396,16 @@ func (c *Cluster) InstanceList(filter *InstanceFilter, instanceFunc func(inst In
 }
 
 // GetInstanceToNodeMap returns a map associating the name of each
-// instance in the given project to the name of the node hosting the instance.
-func (c *ClusterTx) GetInstanceToNodeMap(project string, filter InstanceFilter) (map[string]string, error) {
+// instance in the given projects to the name of the node hosting the instance.
+func (c *ClusterTx) GetInstanceToNodeMap(projects []string, filter InstanceFilter) (map[string]string, error) {
 	args := make([]interface{}, 0, 2) // Expect up to 2 filters.
 	var filters strings.Builder
 
 	// Project filter.
-	filters.WriteString("projects.name = ?")
-	args = append(args, project)
+	filters.WriteString(fmt.Sprintf("projects.name IN (%s)", generateInClauseParams(len(projects))))
+	for _, project := range projects {
+		args = append(args, project)
+	}
 
 	// Instance type filter.
 	if filter.Type != nil {
@@ -964,4 +968,13 @@ func UpdateInstance(tx *sql.Tx, id int, description string, architecture int, ep
 	}
 
 	return nil
+}
+
+// Generates '?' signs for sql IN clause.
+func generateInClauseParams(length int) string {
+	result := []string{}
+	for i := 0; i < length; i++ {
+		result = append(result, "?")
+	}
+	return strings.Join(result, ",")
 }

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -361,7 +361,7 @@ func TestGetInstanceNamesByNodeAddress(t *testing.T) {
 	addContainer(t, tx, nodeID3, "c3")
 	addContainer(t, tx, nodeID2, "c4")
 
-	result, err := tx.GetInstanceNamesByNodeAddress("default", db.InstanceTypeFilter(instancetype.Container))
+	result, err := tx.GetInstanceNamesByNodeAddress([]string{"default"}, db.InstanceTypeFilter(instancetype.Container))
 	require.NoError(t, err)
 	assert.Equal(
 		t,
@@ -385,7 +385,7 @@ func TestGetInstanceToNodeMap(t *testing.T) {
 	addContainer(t, tx, nodeID2, "c1")
 	addContainer(t, tx, nodeID1, "c2")
 
-	result, err := tx.GetInstanceToNodeMap("default", db.InstanceTypeFilter(instancetype.Container))
+	result, err := tx.GetInstanceToNodeMap([]string{"default"}, db.InstanceTypeFilter(instancetype.Container))
 	require.NoError(t, err)
 	assert.Equal(
 		t,

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3279,6 +3279,7 @@ func (d *lxc) Render(options ...func(response interface{}) error) (interface{}, 
 	instState.LastUsedAt = d.lastUsedDate
 	instState.Profiles = d.profiles
 	instState.Stateful = d.stateful
+	instState.Project = d.project
 
 	for _, option := range options {
 		err := option(&instState)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5140,6 +5140,7 @@ func (d *qemu) Render(options ...func(response interface{}) error) (interface{},
 	instState.LastUsedAt = d.lastUsedDate
 	instState.Profiles = d.profiles
 	instState.Stateful = d.stateful
+	instState.Project = d.project
 
 	for _, option := range options {
 		err := option(&instState)

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: 2020-04-27 19:48+0000\n"
 "Last-Translator: Predatorix Phoenix <predatorix@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -622,7 +622,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
@@ -822,7 +822,7 @@ msgstr "automatisches Update: %s"
 msgid "Available projects:"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -905,7 +905,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr " Prozessorauslastung:"
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -928,7 +928,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "ERSTELLT AM"
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr "ERSTELLT AM"
 
@@ -976,15 +976,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1059,7 +1063,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Spalten"
@@ -1341,7 +1345,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1349,7 +1353,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1464,7 +1468,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1630,6 +1634,11 @@ msgstr " Prozessorauslastung:"
 msgid "Disks:"
 msgstr " Prozessorauslastung:"
 
+#: lxc/list.go:136
+#, fuzzy
+msgid "Display instances from all projects"
+msgstr "Herunterfahren des Containers erzwingen."
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1643,7 +1652,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1731,7 +1740,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1912,7 +1921,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1980,7 +1989,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -2144,11 +2153,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -2297,12 +2306,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2322,17 +2331,17 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2384,7 +2393,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2396,7 +2405,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2548,12 +2557,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "List instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 #, fuzzy
 msgid "List instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, fuzzy, c-format
 msgid ""
 "List instances\n"
@@ -2609,6 +2618,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2763,11 +2773,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3157,7 +3167,7 @@ msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -3408,7 +3418,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3421,15 +3431,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3918,7 +3928,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3930,7 +3940,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3943,7 +3953,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -4475,7 +4485,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4716,7 +4726,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4998,7 +5008,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -6052,7 +6062,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -402,7 +402,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -589,7 +589,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "  Χρήση CPU:"
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -693,7 +693,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -732,15 +732,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -810,7 +814,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1069,7 +1073,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1077,7 +1081,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1187,7 +1191,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1344,6 +1348,10 @@ msgstr "  Χρήση CPU:"
 msgid "Disks:"
 msgstr "  Χρήση CPU:"
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1357,7 +1365,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1437,7 +1445,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1602,7 +1610,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1666,7 +1674,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1823,11 +1831,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1971,12 +1979,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1996,17 +2004,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2053,7 +2061,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2065,7 +2073,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2212,11 +2220,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2272,6 +2280,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2405,11 +2414,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2765,7 +2774,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -3013,7 +3022,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3026,15 +3035,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3496,7 +3505,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3508,7 +3517,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3521,7 +3530,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -4025,7 +4034,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4255,7 +4264,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4483,7 +4492,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5076,7 +5085,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -596,7 +596,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
@@ -785,7 +785,7 @@ msgstr "Auto actualización: %s"
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -868,7 +868,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "Uso de CPU:"
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -889,7 +889,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "CREADO"
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr "CREADO EN"
 
@@ -929,8 +929,12 @@ msgstr "No se peude leer desde stdin: %s"
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
@@ -938,7 +942,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1009,7 +1013,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Columnas"
@@ -1276,7 +1280,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1395,7 +1399,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1552,6 +1556,11 @@ msgstr "Uso del disco:"
 msgid "Disks:"
 msgstr "Uso del disco:"
 
+#: lxc/list.go:136
+#, fuzzy
+msgid "Display instances from all projects"
+msgstr "No se puede proveer el nombre del container a la lista"
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1565,7 +1574,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1645,7 +1654,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1815,7 +1824,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1879,7 +1888,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -2038,11 +2047,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr "Expira: %s"
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -2189,12 +2198,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2214,17 +2223,17 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2271,7 +2280,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2283,7 +2292,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2433,12 +2442,12 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 #, fuzzy
 msgid "List instances"
 msgstr "Aliases:"
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2494,6 +2503,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2629,11 +2639,11 @@ msgstr "Cacheado: %s"
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2998,7 +3008,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -3244,7 +3254,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3257,15 +3267,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3735,7 +3745,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3747,7 +3757,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3760,7 +3770,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -4265,7 +4275,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4499,7 +4509,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4736,7 +4746,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] <name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5435,7 +5445,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -612,7 +612,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -811,7 +811,7 @@ msgstr "Mise à jour auto. : %s"
 msgid "Available projects:"
 msgstr "Rendre l'image publique"
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "CPU utilisé :"
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -916,7 +916,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "CRÉÉ À"
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr "CRÉÉ À"
 
@@ -958,15 +958,19 @@ msgstr "Impossible de lire depuis stdin : %s"
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1039,7 +1043,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonnes"
@@ -1345,7 +1349,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1353,7 +1357,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1473,7 +1477,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1633,6 +1637,11 @@ msgstr "  Disque utilisé :"
 msgid "Disks:"
 msgstr "  Disque utilisé :"
 
+#: lxc/list.go:136
+#, fuzzy
+msgid "Display instances from all projects"
+msgstr "Forcer le conteneur à s'arrêter"
+
 #: lxc/cluster.go:428
 #, fuzzy
 msgid "Don't require user confirmation for using --force"
@@ -1647,7 +1656,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr "ÉPHÉMÈRE"
 
@@ -1736,7 +1745,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1928,7 +1937,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 #, fuzzy
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Mode rapide (identique à --columns=nsacPt"
@@ -1996,7 +2005,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -2163,11 +2172,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr "Expire : %s"
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr "IPv4"
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr "IPv6"
 
@@ -2323,12 +2332,12 @@ msgstr "Schème d'URL invalide \"%s\" in \"%s\""
 msgid "Invalid certificate"
 msgstr "Certificat invalide"
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, fuzzy, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr "Clé de configuration invalide"
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2348,17 +2357,17 @@ msgstr "Cible invalide %s"
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2407,7 +2416,7 @@ msgstr "Garder l'image à jour après la copie initiale"
 msgid "LAST SEEN"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
@@ -2419,7 +2428,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2571,12 +2580,12 @@ msgstr "Création du conteneur"
 msgid "List instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 #, fuzzy
 msgid "List instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, fuzzy, c-format
 msgid ""
 "List instances\n"
@@ -2632,6 +2641,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2827,11 +2837,11 @@ msgstr "Créé : %s"
 msgid "MANAGED"
 msgstr "GÉRÉ"
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3225,7 +3235,7 @@ msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -3488,7 +3498,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr "PID"
 
@@ -3501,15 +3511,15 @@ msgstr "Pid : %d"
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -4018,7 +4028,7 @@ msgstr ""
 msgid "SIZE"
 msgstr "TAILLE"
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr "INSTANTANÉS"
 
@@ -4030,7 +4040,7 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr "ÉTAT"
@@ -4044,7 +4054,7 @@ msgstr "STATIQUE"
 msgid "STATUS"
 msgstr "ÉTAT"
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
@@ -4588,7 +4598,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr "TYPE"
@@ -4834,7 +4844,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5122,7 +5132,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -6280,7 +6290,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -586,7 +586,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
@@ -775,7 +775,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -857,7 +857,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "Utilizzo CPU:"
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "CREATO IL"
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr "CREATO IL"
 
@@ -918,15 +918,19 @@ msgstr "Impossible leggere da stdin: %s"
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -997,7 +1001,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonne"
@@ -1263,7 +1267,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1271,7 +1275,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1382,7 +1386,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1539,6 +1543,11 @@ msgstr "Utilizzo disco:"
 msgid "Disks:"
 msgstr "Utilizzo disco:"
 
+#: lxc/list.go:136
+#, fuzzy
+msgid "Display instances from all projects"
+msgstr "Creazione del container in corso"
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1552,7 +1561,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1632,7 +1641,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1800,7 +1809,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1865,7 +1874,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -2022,11 +2031,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -2173,12 +2182,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2198,17 +2207,17 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2256,7 +2265,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2268,7 +2277,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2419,12 +2428,12 @@ msgstr "Creazione del container in corso"
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 #, fuzzy
 msgid "List instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2480,6 +2489,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2614,11 +2624,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2985,7 +2995,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -3231,7 +3241,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3244,15 +3254,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3723,7 +3733,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3735,7 +3745,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3748,7 +3758,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -4253,7 +4263,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4486,7 +4496,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4723,7 +4733,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] <name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -5422,7 +5432,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: 2021-08-06 08:35+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -590,7 +590,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -794,7 +794,7 @@ msgstr "自動更新: %s"
 msgid "Available projects:"
 msgstr "利用可能なプロジェクト:"
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr "BASE IMAGE"
 
@@ -877,7 +877,7 @@ msgstr "COUNT"
 msgid "CPU (%s):"
 msgstr "CPU (%s):"
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr "CPU USAGE"
 
@@ -898,7 +898,7 @@ msgstr "CPUs (%s):"
 msgid "CREATED"
 msgstr "CREATED"
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr "CREATED AT"
 
@@ -938,15 +938,20 @@ msgstr "標準入力から読み込めません: %s"
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr "--fast と --columns は同時に指定できません"
+
+#: lxc/list.go:399
+#, fuzzy
+msgid "Can't specify --project with --all-projects"
 msgstr "--fast と --columns は同時に指定できません"
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
@@ -1016,7 +1021,7 @@ msgstr "クラスタメンバ名"
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "カラムレイアウト"
@@ -1289,7 +1294,7 @@ msgstr "現在の VF 数: %d"
 msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1297,7 +1302,7 @@ msgstr "DEFAULT TARGET ADDRESS"
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr "DISK USAGE"
 
@@ -1408,7 +1413,7 @@ msgstr "警告を削除します"
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1568,6 +1573,11 @@ msgstr "ディスク:"
 msgid "Disks:"
 msgstr "ディスク:"
 
+#: lxc/list.go:136
+#, fuzzy
+msgid "Display instances from all projects"
+msgstr "すべてのプロジェクトのイベントを表示します"
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr "--force を使う際にユーザーの確認を必要としない"
@@ -1581,7 +1591,7 @@ msgstr "進捗情報を表示しません"
 msgid "Driver: %v (%v)"
 msgstr "ドライバ: %v (%v)"
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr "EPHEMERAL"
 
@@ -1663,7 +1673,7 @@ msgstr "ストレージボリュームの設定をYAMLで編集します"
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1854,7 +1864,7 @@ msgstr "エイリアス %s の削除に失敗しました"
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Fast モード (--columns=nsacPt と同じ)"
 
@@ -1933,7 +1943,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -2089,11 +2099,11 @@ msgstr "IP ADDRESS"
 msgid "IP addresses"
 msgstr "IP アドレス"
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr "IPV6"
 
@@ -2246,12 +2256,12 @@ msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
 msgid "Invalid certificate"
 msgstr "不正な証明書です"
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr "'%s' は正しくない設定項目 (key) です (%s 中の)"
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2272,19 +2282,19 @@ msgstr "不正なフォーマット %s"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 "'%s' は最大幅の値として不正です (-1 もしくは 0 もしくは正の整数でなくてはなり"
 "ません) ('%s' 中の)"
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr "'%s' は最大幅の値として不正です (整数でなくてはなりません) ('%s' 中の)"
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2332,7 +2342,7 @@ msgstr "最初にコピーした後も常にイメージを最新の状態に保
 msgid "LAST SEEN"
 msgstr "LAST SEEN"
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr "LAST USED AT"
 
@@ -2344,7 +2354,7 @@ msgstr "LIMIT"
 msgid "LISTEN ADDRESS"
 msgstr "LISTEN ADDRESS"
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr "LOCATION"
@@ -2524,12 +2534,12 @@ msgstr "インスタンスのデバイスを一覧表示します"
 msgid "List instance file templates"
 msgstr "インスタンスのファイルテンプレートを一覧表示します"
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/list.go:49
-#, c-format
+#: lxc/list.go:50
+#, fuzzy, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -2584,6 +2594,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2827,11 +2838,11 @@ msgstr "MAD: %s (%s)"
 msgid "MANAGED"
 msgstr "MANAGED"
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr "MEMORY USAGE"
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr "MEMORY USAGE%"
@@ -3211,7 +3222,7 @@ msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -3458,7 +3469,7 @@ msgstr "PCI アドレス: %v"
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr "PID"
 
@@ -3471,15 +3482,15 @@ msgstr "PID: %d"
 msgid "PORTS"
 msgstr "PORTS"
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr "PROCESSES"
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr "PROJECT"
 
@@ -3950,7 +3961,7 @@ msgstr "SEVERITY"
 msgid "SIZE"
 msgstr "SIZE"
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr "SNAPSHOTS"
 
@@ -3962,7 +3973,7 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr "STATE"
@@ -3975,7 +3986,7 @@ msgstr "STATIC"
 msgid "STATUS"
 msgstr "STATUS"
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr "STORAGE POOL"
 
@@ -4528,7 +4539,7 @@ msgid "TOKEN"
 msgstr "TOKEN"
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr "TYPE"
@@ -4786,7 +4797,7 @@ msgstr "UUID: %v"
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5020,7 +5031,7 @@ msgstr "[<remote>:] <fingerprint>"
 msgid "[<remote>:] <name>"
 msgstr "[<remote>:] <name>"
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
@@ -5682,7 +5693,7 @@ msgstr ""
 "lxc launch ubuntu:18.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成し、起動します"
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2021-12-06 16:11-0500\n"
+        "POT-Creation-Date: 2021-12-07 16:58-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -380,7 +380,7 @@ msgstr  ""
 msgid   "ALIASES"
 msgstr  ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid   "ARCHITECTURE"
 msgstr  ""
 
@@ -562,7 +562,7 @@ msgstr  ""
 msgid   "Available projects:"
 msgstr  ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid   "BASE IMAGE"
 msgstr  ""
 
@@ -642,7 +642,7 @@ msgstr  ""
 msgid   "CPU (%s):"
 msgstr  ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid   "CPU USAGE"
 msgstr  ""
 
@@ -663,7 +663,7 @@ msgstr  ""
 msgid   "CREATED"
 msgstr  ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid   "CREATED AT"
 msgstr  ""
 
@@ -702,15 +702,19 @@ msgstr  ""
 msgid   "Can't remove the default remote"
 msgstr  ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid   "Can't specify --fast with --columns"
+msgstr  ""
+
+#: lxc/list.go:399
+msgid   "Can't specify --project with --all-projects"
 msgstr  ""
 
 #: lxc/rename.go:51
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
@@ -764,7 +768,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213 lxc/warning.go:93
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213 lxc/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -1014,11 +1018,11 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490 lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145 lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577 lxc/storage_volume.go:1308
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507 lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145 lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163 lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577 lxc/storage_volume.go:1308
 msgid   "DESCRIPTION"
 msgstr  ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid   "DISK USAGE"
 msgstr  ""
 
@@ -1102,7 +1106,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196 lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373 lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742 lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087 lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79 lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368 lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476 lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288 lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80 lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005 lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187 lxc/network_acl.go:30 lxc/network_acl.go:91 lxc/network_acl.go:161 lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346 lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564 lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677 lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:82 lxc/network_zone.go:152 lxc/network_zone.go:205 lxc/network_zone.go:254 lxc/network_zone.go:335 lxc/network_zone.go:395 lxc/network_zone.go:422 lxc/network_zone.go:541 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166 lxc/storage_volume.go:241 lxc/storage_volume.go:332 lxc/storage_volume.go:521 lxc/storage_volume.go:600 lxc/storage_volume.go:676 lxc/storage_volume.go:758 lxc/storage_volume.go:839 lxc/storage_volume.go:1039 lxc/storage_volume.go:1127 lxc/storage_volume.go:1214 lxc/storage_volume.go:1398 lxc/storage_volume.go:1431 lxc/storage_volume.go:1544 lxc/storage_volume.go:1620 lxc/storage_volume.go:1719 lxc/storage_volume.go:1753 lxc/storage_volume.go:1851 lxc/storage_volume.go:1918 lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:31 lxc/cluster.go:114 lxc/cluster.go:196 lxc/cluster.go:245 lxc/cluster.go:292 lxc/cluster.go:344 lxc/cluster.go:373 lxc/cluster.go:423 lxc/cluster.go:506 lxc/cluster.go:591 lxc/cluster.go:742 lxc/cluster.go:804 lxc/cluster.go:902 lxc/cluster.go:981 lxc/cluster.go:1087 lxc/cluster.go:1106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:363 lxc/config.go:455 lxc/config.go:613 lxc/config.go:733 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:196 lxc/config_device.go:274 lxc/config_device.go:345 lxc/config_device.go:438 lxc/config_device.go:535 lxc/config_device.go:542 lxc/config_device.go:651 lxc/config_device.go:723 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:177 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:239 lxc/config_template.go:298 lxc/config_trust.go:34 lxc/config_trust.go:79 lxc/config_trust.go:176 lxc/config_trust.go:288 lxc/config_trust.go:368 lxc/config_trust.go:411 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:40 lxc/export.go:32 lxc/file.go:75 lxc/file.go:111 lxc/file.go:160 lxc/file.go:223 lxc/file.go:418 lxc/image.go:38 lxc/image.go:144 lxc/image.go:300 lxc/image.go:351 lxc/image.go:476 lxc/image.go:635 lxc/image.go:855 lxc/image.go:990 lxc/image.go:1288 lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80 lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33 lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360 lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703 lxc/network.go:761 lxc/network.go:841 lxc/network.go:936 lxc/network.go:1005 lxc/network.go:1055 lxc/network.go:1125 lxc/network.go:1187 lxc/network_acl.go:30 lxc/network_acl.go:91 lxc/network_acl.go:161 lxc/network_acl.go:214 lxc/network_acl.go:263 lxc/network_acl.go:346 lxc/network_acl.go:406 lxc/network_acl.go:433 lxc/network_acl.go:564 lxc/network_acl.go:613 lxc/network_acl.go:662 lxc/network_acl.go:677 lxc/network_acl.go:798 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:628 lxc/network_forward.go:690 lxc/network_forward.go:705 lxc/network_forward.go:770 lxc/network_peer.go:30 lxc/network_peer.go:83 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:82 lxc/network_zone.go:152 lxc/network_zone.go:205 lxc/network_zone.go:254 lxc/network_zone.go:335 lxc/network_zone.go:395 lxc/network_zone.go:422 lxc/network_zone.go:541 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:640 lxc/profile.go:716 lxc/profile.go:766 lxc/profile.go:825 lxc/profile.go:879 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:342 lxc/project.go:392 lxc/project.go:491 lxc/project.go:546 lxc/project.go:606 lxc/project.go:635 lxc/project.go:688 lxc/project.go:747 lxc/publish.go:34 lxc/query.go:32 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:491 lxc/remote.go:527 lxc/remote.go:613 lxc/remote.go:683 lxc/remote.go:737 lxc/remote.go:775 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:336 lxc/storage.go:396 lxc/storage.go:516 lxc/storage.go:596 lxc/storage.go:670 lxc/storage.go:754 lxc/storage_volume.go:44 lxc/storage_volume.go:166 lxc/storage_volume.go:241 lxc/storage_volume.go:332 lxc/storage_volume.go:521 lxc/storage_volume.go:600 lxc/storage_volume.go:676 lxc/storage_volume.go:758 lxc/storage_volume.go:839 lxc/storage_volume.go:1039 lxc/storage_volume.go:1127 lxc/storage_volume.go:1214 lxc/storage_volume.go:1398 lxc/storage_volume.go:1431 lxc/storage_volume.go:1544 lxc/storage_volume.go:1620 lxc/storage_volume.go:1719 lxc/storage_volume.go:1753 lxc/storage_volume.go:1851 lxc/storage_volume.go:1918 lxc/storage_volume.go:2059 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:260 lxc/warning.go:301 lxc/warning.go:355
 msgid   "Description"
 msgstr  ""
 
@@ -1204,6 +1208,10 @@ msgstr  ""
 msgid   "Disks:"
 msgstr  ""
 
+#: lxc/list.go:136
+msgid   "Display instances from all projects"
+msgstr  ""
+
 #: lxc/cluster.go:428
 msgid   "Don't require user confirmation for using --force"
 msgstr  ""
@@ -1217,7 +1225,7 @@ msgstr  ""
 msgid   "Driver: %v (%v)"
 msgstr  ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid   "EPHEMERAL"
 msgstr  ""
 
@@ -1293,7 +1301,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330 lxc/warning.go:234
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330 lxc/warning.go:234
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1449,7 +1457,7 @@ msgstr  ""
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid   "Fast mode (same as --columns=nsacPt)"
 msgstr  ""
 
@@ -1505,7 +1513,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805 lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016 lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938 lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518 lxc/storage_volume.go:1232 lxc/warning.go:94
+#: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805 lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016 lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938 lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86 lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584 lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518 lxc/storage_volume.go:1232 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
@@ -1654,11 +1662,11 @@ msgstr  ""
 msgid   "IP addresses"
 msgstr  ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid   "IPV4"
 msgstr  ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid   "IPV6"
 msgstr  ""
 
@@ -1799,12 +1807,12 @@ msgstr  ""
 msgid   "Invalid certificate"
 msgstr  ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid   "Invalid config key '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid   "Invalid config key column format (too many fields): '%s'"
 msgstr  ""
@@ -1824,17 +1832,17 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid   "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid   "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
@@ -1880,7 +1888,7 @@ msgstr  ""
 msgid   "LAST SEEN"
 msgstr  ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid   "LAST USED AT"
 msgstr  ""
 
@@ -1892,7 +1900,7 @@ msgstr  ""
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151 lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151 lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid   "LOCATION"
 msgstr  ""
 
@@ -2036,11 +2044,11 @@ msgstr  ""
 msgid   "List instance file templates"
 msgstr  ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid   "List instances"
 msgstr  ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid   "List instances\n"
         "\n"
@@ -2090,6 +2098,7 @@ msgid   "List instances\n"
         "  c - Creation date\n"
         "  d - Description\n"
         "  D - disk usage\n"
+        "  e - Project name\n"
         "  l - Last used date\n"
         "  m - Memory usage\n"
         "  M - Memory usage (%)\n"
@@ -2219,11 +2228,11 @@ msgstr  ""
 msgid   "MANAGED"
 msgstr  ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid   "MEMORY USAGE"
 msgstr  ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid   "MEMORY USAGE%"
 msgstr  ""
@@ -2538,7 +2547,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346 lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143 lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623 lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570 lxc/storage_volume.go:1307
+#: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346 lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143 lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623 lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570 lxc/storage_volume.go:1307
 msgid   "NAME"
 msgstr  ""
 
@@ -2778,7 +2787,7 @@ msgstr  ""
 msgid   "PEER"
 msgstr  ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid   "PID"
 msgstr  ""
 
@@ -2791,15 +2800,15 @@ msgstr  ""
 msgid   "PORTS"
 msgstr  ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid   "PROCESSES"
 msgstr  ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid   "PROJECT"
 msgstr  ""
 
@@ -3252,7 +3261,7 @@ msgstr  ""
 msgid   "SIZE"
 msgstr  ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid   "SNAPSHOTS"
 msgstr  ""
 
@@ -3264,7 +3273,7 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918 lxc/network_peer.go:143 lxc/storage.go:580
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918 lxc/network_peer.go:143 lxc/storage.go:580
 msgid   "STATE"
 msgstr  ""
 
@@ -3276,7 +3285,7 @@ msgstr  ""
 msgid   "STATUS"
 msgstr  ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid   "STORAGE POOL"
 msgstr  ""
 
@@ -3749,7 +3758,7 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236 lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162 lxc/storage_volume.go:1306 lxc/warning.go:214
+#: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236 lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162 lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid   "TYPE"
 msgstr  ""
 
@@ -3965,7 +3974,7 @@ msgstr  ""
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337 lxc/warning.go:241
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337 lxc/warning.go:241
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -4175,7 +4184,7 @@ msgstr  ""
 msgid   "[<remote>:] <name>"
 msgstr  ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid   "[<remote>:] [<filter>...]"
 msgstr  ""
 
@@ -4734,7 +4743,7 @@ msgid   "lxc launch ubuntu:20.04 u1\n"
         "    Create and start a virtual machine"
 msgstr  ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid   "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
         "  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", \"IPV6\" and \"MAC\" columns.\n"
         "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from instance configuration keys.\n"

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -576,7 +576,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -905,15 +905,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -983,7 +987,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1242,7 +1246,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1250,7 +1254,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1359,7 +1363,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1512,6 +1516,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1525,7 +1533,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1603,7 +1611,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1768,7 +1776,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1832,7 +1840,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1985,11 +1993,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -2133,12 +2141,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2158,17 +2166,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2215,7 +2223,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2227,7 +2235,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2374,11 +2382,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2434,6 +2442,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2567,11 +2576,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2924,7 +2933,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -3170,7 +3179,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3183,15 +3192,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3653,7 +3662,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3665,7 +3674,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3678,7 +3687,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -4176,7 +4185,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4406,7 +4415,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4628,7 +4637,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5221,7 +5230,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -602,7 +602,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -789,7 +789,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -871,7 +871,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -892,7 +892,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -931,15 +931,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1009,7 +1013,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1268,7 +1272,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1276,7 +1280,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1538,6 +1542,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1551,7 +1559,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1629,7 +1637,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1794,7 +1802,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1858,7 +1866,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -2011,11 +2019,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -2159,12 +2167,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2184,17 +2192,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2241,7 +2249,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2253,7 +2261,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2400,11 +2408,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2460,6 +2468,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2593,11 +2602,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2950,7 +2959,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -3196,7 +3205,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3209,15 +3218,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3679,7 +3688,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3691,7 +3700,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3704,7 +3713,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -4202,7 +4211,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4432,7 +4441,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4654,7 +4663,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5247,7 +5256,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -604,7 +604,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
@@ -802,7 +802,7 @@ msgstr "Atualização automática: %s"
 msgid "Available projects:"
 msgstr "Criar projetos"
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr "IMAGEM BASE"
 
@@ -884,7 +884,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "Utilização do CPU:"
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -905,7 +905,7 @@ msgstr "CPUs:"
 msgid "CREATED"
 msgstr "CRIADO"
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr "CRIADO EM"
 
@@ -945,15 +945,20 @@ msgstr "Não é possível ler stdin: %s"
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr "Não é possível especificar --fast com --columns"
+
+#: lxc/list.go:399
+#, fuzzy
+msgid "Can't specify --project with --all-projects"
 msgstr "Não é possível especificar --fast com --columns"
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
@@ -1024,7 +1029,7 @@ msgstr "Nome de membro do cluster"
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colunas"
@@ -1305,7 +1310,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1313,7 +1318,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1431,7 +1436,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1590,6 +1595,10 @@ msgstr "Uso de disco:"
 msgid "Disks:"
 msgstr "Uso de disco:"
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1603,7 +1612,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr "EFÊMERO"
 
@@ -1692,7 +1701,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1858,7 +1867,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1922,7 +1931,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -2084,11 +2093,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr "IPV6"
 
@@ -2234,12 +2243,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2259,17 +2268,17 @@ msgstr "Editar arquivos no container"
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2316,7 +2325,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2328,7 +2337,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2477,11 +2486,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2537,6 +2546,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2670,11 +2680,11 @@ msgstr "Em cache: %s"
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3046,7 +3056,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -3292,7 +3302,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3305,15 +3315,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3792,7 +3802,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3804,7 +3814,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3817,7 +3827,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -4336,7 +4346,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4571,7 +4581,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4810,7 +4820,7 @@ msgstr "Criar perfis"
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5436,7 +5446,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: 2020-10-08 08:16+0000\n"
 "Last-Translator: Artem <KovalevArtem.ru@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -614,7 +614,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
@@ -806,7 +806,7 @@ msgstr "Авто-обновление: %s"
 msgid "Available projects:"
 msgstr "Доступные команды:"
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -888,7 +888,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr " Использование ЦП:"
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "CREATED"
 msgstr "СОЗДАН"
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr "СОЗДАН"
 
@@ -950,15 +950,19 @@ msgstr "Невозможно прочитать из стандартного в
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1029,7 +1033,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Столбцы"
@@ -1302,7 +1306,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1424,7 +1428,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1582,6 +1586,11 @@ msgstr " Использование диска:"
 msgid "Disks:"
 msgstr " Использование диска:"
 
+#: lxc/list.go:136
+#, fuzzy
+msgid "Display instances from all projects"
+msgstr "Копирование образа: %s"
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1595,7 +1604,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1677,7 +1686,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1851,7 +1860,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -2073,11 +2082,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -2227,12 +2236,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2252,17 +2261,17 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2309,7 +2318,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2321,7 +2330,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2473,12 +2482,12 @@ msgstr "Копирование образа: %s"
 msgid "List instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 #, fuzzy
 msgid "List instances"
 msgstr "Псевдонимы:"
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2534,6 +2543,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2669,11 +2679,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -3049,7 +3059,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -3298,7 +3308,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3311,15 +3321,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3792,7 +3802,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3804,7 +3814,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3817,7 +3827,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -4331,7 +4341,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4562,7 +4572,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4823,7 +4833,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -5844,7 +5854,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: 2020-11-05 02:45+0000\n"
 "Last-Translator: wdggg <wdggg7@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -482,7 +482,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -669,7 +669,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -811,15 +811,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -889,7 +893,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1148,7 +1152,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1156,7 +1160,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1265,7 +1269,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1418,6 +1422,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1431,7 +1439,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1509,7 +1517,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1674,7 +1682,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1738,7 +1746,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1891,11 +1899,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -2039,12 +2047,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -2064,17 +2072,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2121,7 +2129,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2133,7 +2141,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2280,11 +2288,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2340,6 +2348,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2473,11 +2482,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2830,7 +2839,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -3076,7 +3085,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3089,15 +3098,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3559,7 +3568,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3571,7 +3580,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3584,7 +3593,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -4082,7 +4091,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4312,7 +4321,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4534,7 +4543,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5127,7 +5136,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2021-12-06 16:11-0500\n"
+"POT-Creation-Date: 2021-12-07 16:58-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -399,7 +399,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:487
+#: lxc/cluster.go:176 lxc/image.go:1030 lxc/list.go:504
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: lxc/list.go:492 lxc/list.go:493
+#: lxc/list.go:510 lxc/list.go:511
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:522
 msgid "CPU USAGE"
 msgstr ""
 
@@ -689,7 +689,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:489
+#: lxc/list.go:506
 msgid "CREATED AT"
 msgstr ""
 
@@ -728,15 +728,19 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:510
+#: lxc/list.go:528
 msgid "Can't specify --fast with --columns"
+msgstr ""
+
+#: lxc/list.go:399
+msgid "Can't specify --project with --all-projects"
 msgstr ""
 
 #: lxc/rename.go:51
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:522 lxc/storage_volume.go:1319 lxc/warning.go:223
+#: lxc/list.go:548 lxc/storage_volume.go:1319 lxc/warning.go:223
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1015 lxc/list.go:131 lxc/storage_volume.go:1213
+#: lxc/image.go:1015 lxc/list.go:133 lxc/storage_volume.go:1213
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:490
+#: lxc/cluster.go:178 lxc/image.go:1029 lxc/image_alias.go:237 lxc/list.go:507
 #: lxc/network.go:914 lxc/network_acl.go:144 lxc/network_forward.go:145
 #: lxc/network_peer.go:141 lxc/network_zone.go:135 lxc/operation.go:163
 #: lxc/profile.go:624 lxc/project.go:473 lxc/storage.go:577
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:508
 msgid "DISK USAGE"
 msgstr ""
 
@@ -1182,7 +1186,7 @@ msgstr ""
 #: lxc/image.go:1367 lxc/image.go:1426 lxc/image.go:1478 lxc/image.go:1534
 #: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
 #: lxc/image_alias.go:153 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:49 lxc/main.go:80
+#: lxc/info.go:35 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:80
 #: lxc/manpage.go:22 lxc/monitor.go:32 lxc/move.go:37 lxc/network.go:33
 #: lxc/network.go:128 lxc/network.go:213 lxc/network.go:286 lxc/network.go:360
 #: lxc/network.go:410 lxc/network.go:495 lxc/network.go:580 lxc/network.go:703
@@ -1335,6 +1339,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/list.go:136
+msgid "Display instances from all projects"
+msgstr ""
+
 #: lxc/cluster.go:428
 msgid "Don't require user confirmation for using --force"
 msgstr ""
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:772
+#: lxc/list.go:802
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1426,7 +1434,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1041 lxc/list.go:534 lxc/storage_volume.go:1330
+#: lxc/image.go:1041 lxc/list.go:560 lxc/storage_volume.go:1330
 #: lxc/warning.go:234
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:133
+#: lxc/list.go:135
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1655,7 +1663,7 @@ msgstr ""
 
 #: lxc/alias.go:105 lxc/cluster.go:116 lxc/cluster.go:805
 #: lxc/config_template.go:241 lxc/config_trust.go:290 lxc/image.go:1016
-#: lxc/image_alias.go:158 lxc/list.go:132 lxc/network.go:845 lxc/network.go:938
+#: lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:845 lxc/network.go:938
 #: lxc/network_acl.go:94 lxc/network_forward.go:90 lxc/network_peer.go:86
 #: lxc/network_zone.go:85 lxc/operation.go:107 lxc/profile.go:584
 #: lxc/project.go:394 lxc/project.go:749 lxc/remote.go:531 lxc/storage.go:518
@@ -1808,11 +1816,11 @@ msgstr ""
 msgid "IP addresses"
 msgstr ""
 
-#: lxc/list.go:485 lxc/network.go:912
+#: lxc/list.go:502 lxc/network.go:912
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:486 lxc/network.go:913
+#: lxc/list.go:503 lxc/network.go:913
 msgid "IPV6"
 msgstr ""
 
@@ -1956,12 +1964,12 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:566
+#: lxc/list.go:592
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:560
+#: lxc/list.go:586
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
@@ -1981,17 +1989,17 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/list.go:585
+#: lxc/list.go:611
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:582
+#: lxc/list.go:608
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:573
+#: lxc/list.go:599
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -2038,7 +2046,7 @@ msgstr ""
 msgid "LAST SEEN"
 msgstr ""
 
-#: lxc/list.go:494
+#: lxc/list.go:512
 msgid "LAST USED AT"
 msgstr ""
 
@@ -2050,7 +2058,7 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:518 lxc/network.go:988 lxc/network_forward.go:151
+#: lxc/list.go:544 lxc/network.go:988 lxc/network_forward.go:151
 #: lxc/operation.go:168 lxc/storage_volume.go:1315 lxc/warning.go:219
 msgid "LOCATION"
 msgstr ""
@@ -2197,11 +2205,11 @@ msgstr ""
 msgid "List instance file templates"
 msgstr ""
 
-#: lxc/list.go:48
+#: lxc/list.go:49
 msgid "List instances"
 msgstr ""
 
-#: lxc/list.go:49
+#: lxc/list.go:50
 #, c-format
 msgid ""
 "List instances\n"
@@ -2257,6 +2265,7 @@ msgid ""
 "  c - Creation date\n"
 "  d - Description\n"
 "  D - disk usage\n"
+"  e - Project name\n"
 "  l - Last used date\n"
 "  m - Memory usage\n"
 "  M - Memory usage (%)\n"
@@ -2390,11 +2399,11 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/list.go:495
+#: lxc/list.go:513
 msgid "MEMORY USAGE"
 msgstr ""
 
-#: lxc/list.go:496
+#: lxc/list.go:514
 #, c-format
 msgid "MEMORY USAGE%"
 msgstr ""
@@ -2747,7 +2756,7 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/cluster.go:173 lxc/cluster.go:885 lxc/config_trust.go:346
-#: lxc/list.go:497 lxc/network.go:909 lxc/network_acl.go:143
+#: lxc/list.go:515 lxc/network.go:909 lxc/network_acl.go:143
 #: lxc/network_peer.go:140 lxc/network_zone.go:134 lxc/profile.go:623
 #: lxc/project.go:468 lxc/remote.go:590 lxc/storage.go:570
 #: lxc/storage_volume.go:1307
@@ -2993,7 +3002,7 @@ msgstr ""
 msgid "PEER"
 msgstr ""
 
-#: lxc/list.go:499
+#: lxc/list.go:517
 msgid "PID"
 msgstr ""
 
@@ -3006,15 +3015,15 @@ msgstr ""
 msgid "PORTS"
 msgstr ""
 
-#: lxc/list.go:498
+#: lxc/list.go:516
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:500 lxc/project.go:470
+#: lxc/list.go:518 lxc/project.go:470
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/list.go:509 lxc/warning.go:211
 msgid "PROJECT"
 msgstr ""
 
@@ -3476,7 +3485,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:501
+#: lxc/list.go:519
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -3488,7 +3497,7 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:179 lxc/list.go:502 lxc/network.go:918
+#: lxc/cluster.go:179 lxc/list.go:520 lxc/network.go:918
 #: lxc/network_peer.go:143 lxc/storage.go:580
 msgid "STATE"
 msgstr ""
@@ -3501,7 +3510,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:488
+#: lxc/list.go:505
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -3999,7 +4008,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:345 lxc/image.go:1033 lxc/image_alias.go:236
-#: lxc/list.go:503 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
+#: lxc/list.go:521 lxc/network.go:910 lxc/network.go:985 lxc/operation.go:162
 #: lxc/storage_volume.go:1306 lxc/warning.go:214
 msgid "TYPE"
 msgstr ""
@@ -4229,7 +4238,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:1048 lxc/list.go:548 lxc/storage_volume.go:1337
+#: lxc/image.go:1048 lxc/list.go:574 lxc/storage_volume.go:1337
 #: lxc/warning.go:241
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -4451,7 +4460,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: lxc/image.go:987 lxc/list.go:46
+#: lxc/image.go:987 lxc/list.go:47
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -5044,7 +5053,7 @@ msgid ""
 "    Create and start a virtual machine"
 msgstr ""
 
-#: lxc/list.go:121
+#: lxc/list.go:123
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"

--- a/shared/api/instance.go
+++ b/shared/api/instance.go
@@ -193,6 +193,12 @@ type Instance struct {
 	// The type of instance (container or virtual-machine)
 	// Example: container
 	Type string `json:"type" yaml:"type"`
+
+	// Instance project name
+	// Example: foo
+	//
+	// API extension: instance_all_projects
+	Project string `json:"project" yaml:"project"`
 }
 
 // InstanceFull is a combination of Instance, InstanceBackup, InstanceState and InstanceSnapshot.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -297,6 +297,7 @@ var APIExtensions = []string{
 	"cloud_init",
 	"network_dns_nat",
 	"database_leader",
+	"instance_all_projects",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR allows for retrieving instances from all projects by using command `lxc list --all-projects`.

1. New functions was introduced: `GetInstancesAllProjects` and `GetInstancesFullAllProjects`,
so I didn't have to change current functions(`GetInstances`, `GetInstancesFull`) signature.
2. New url parameter was added: `all-projects`. It would be not convenient to handle this with recursion parameter
because then we should add recursion=3 and recursion=4 for `GetInstance` and `GetInstanceFull` respectively.
3. `GetInstanceNamesByNodeAddress` and `GetInstanceToNodeMap` was modified to handle multiple projects.
4. Colum 'PROJECT' is not displayed by default. We need to add `-c e`.

Closes #7559