### PR TITLE
Instance: Detect disconnect of non-interactive exec stdout websocket and kill command

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5748,6 +5748,7 @@ func (d *lxc) Exec(req api.InstanceExecPost, stdin *os.File, stdout *os.File, st
 	if err != nil {
 		return nil, err
 	}
+	defer logFile.Close()
 
 	// Prepare the subcommand
 	cname := project.Instance(d.Project(), d.Name())

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6726,6 +6726,7 @@ func (d *lxc) DevptsFd() (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer d.release()
 
 	if !liblxc.HasApiExtension("devpts_fd") {
 		return nil, fmt.Errorf("Missing devpts_fd extension")

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1870,7 +1870,6 @@ func (d *lxc) DeviceEventHandler(runConf *deviceConfig.RunConfig) error {
 
 	// Generate uevent inside container if requested.
 	if len(runConf.Uevents) > 0 {
-
 		pidFdNr, pidFd := d.inheritInitPidFd()
 		if pidFdNr >= 0 {
 			defer pidFd.Close()

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -254,11 +254,11 @@ func (s *execWs) Do(op *operations.Operation) error {
 				return
 			}
 
-			for {
-				s.connsLock.Lock()
-				conn := s.conns[execWSControl]
-				s.connsLock.Unlock()
+			s.connsLock.Lock()
+			conn := s.conns[execWSControl]
+			s.connsLock.Unlock()
 
+			for {
 				mt, r, err := conn.NextReader()
 				if mt == websocket.CloseMessage {
 					break

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -334,12 +334,13 @@ func (s *execWs) Do(op *operations.Operation) error {
 		go func() {
 			defer wgEOF.Done()
 
+			logger.Debug("Exec mirror websocket started", log.Ctx{"number": 0})
+			defer logger.Debug("Exec mirror websocket finished", log.Ctx{"number": 0})
+
 			s.connsLock.Lock()
 			conn := s.conns[0]
 			s.connsLock.Unlock()
 
-			logger.Debug("Started mirroring websocket")
-			defer logger.Debug("Finished mirroring websocket")
 			readDone, writeDone := netutils.WebsocketExecMirror(conn, ptys[0], ptys[0], attachedChildIsDead, int(ptys[0].Fd()))
 
 			<-readDone
@@ -350,6 +351,9 @@ func (s *execWs) Do(op *operations.Operation) error {
 		wgEOF.Add(len(ttys) - 1)
 		for i := 0; i < len(ttys); i++ {
 			go func(i int) {
+				logger.Debug("Exec mirror websocket started", log.Ctx{"number": i})
+				defer logger.Debug("Exec mirror websocket finished", log.Ctx{"number": i})
+
 				if i == execWSStdin {
 					s.connsLock.Lock()
 					conn := s.conns[i]

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -598,7 +598,7 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 		ws.requiredConnectedCtx, ws.requiredConnectedDone = context.WithCancel(context.Background())
 		ws.controlConnectedCtx, ws.controlConnectedDone = context.WithCancel(context.Background())
 
-		for i := -1; i < len(ws.conns)-1; i++ {
+		for i := range ws.conns {
 			ws.fds[i], err = shared.RandomCryptoString()
 			if err != nil {
 				return response.InternalError(err)

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -354,18 +354,14 @@ func (s *execWs) Do(op *operations.Operation) error {
 				logger.Debug("Exec mirror websocket started", log.Ctx{"number": i})
 				defer logger.Debug("Exec mirror websocket finished", log.Ctx{"number": i})
 
-				if i == execWSStdin {
-					s.connsLock.Lock()
-					conn := s.conns[i]
-					s.connsLock.Unlock()
+				s.connsLock.Lock()
+				conn := s.conns[i]
+				s.connsLock.Unlock()
 
+				if i == execWSStdin {
 					<-shared.WebsocketRecvStream(ttys[i], conn)
 					ttys[i].Close()
 				} else {
-					s.connsLock.Lock()
-					conn := s.conns[i]
-					s.connsLock.Unlock()
-
 					<-shared.WebsocketSendStream(conn, ptys[i], -1)
 					ptys[i].Close()
 					wgEOF.Done()

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -412,7 +412,7 @@ func (s *execWs) Do(op *operations.Operation) error {
 	}
 
 	exitCode, err := cmd.Wait()
-	logger.Debug("Instance process stopped")
+	logger.Debug("Instance process stopped", log.Ctx{"exitCode": exitCode})
 	return finisher(exitCode, err)
 }
 

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -527,19 +527,21 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 	if !ok {
 		post.Environment["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
-		// Add some additional paths. This directly looks through /proc
-		// rather than use FileExists as none of those paths are expected to be
-		// symlinks and this is much faster than forking a sub-process and
-		// attaching to the instance.
+		if inst.Type() == instancetype.Container {
+			// Add some additional paths. This directly looks through /proc
+			// rather than use FileExists as none of those paths are expected to be
+			// symlinks and this is much faster than forking a sub-process and
+			// attaching to the instance.
+			extraPaths := map[string]string{
+				"/snap":      "/snap/bin",
+				"/etc/NIXOS": "/run/current-system/sw/bin",
+			}
 
-		extraPaths := map[string]string{
-			"/snap":      "/snap/bin",
-			"/etc/NIXOS": "/run/current-system/sw/bin",
-		}
-
-		for k, v := range extraPaths {
-			if shared.PathExists(fmt.Sprintf("/proc/%d/root%s", inst.InitPID(), k)) {
-				post.Environment["PATH"] = fmt.Sprintf("%s:%s", post.Environment["PATH"], v)
+			instPID := inst.InitPID()
+			for k, v := range extraPaths {
+				if shared.PathExists(fmt.Sprintf("/proc/%d/root%s", instPID, k)) {
+					post.Environment["PATH"] = fmt.Sprintf("%s:%s", post.Environment["PATH"], v)
+				}
 			}
 		}
 	}

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -250,7 +250,6 @@ func (s *execWs) Do(op *operations.Operation) error {
 			select {
 			case <-s.controlConnectedCtx.Done():
 				break
-
 			case <-controlExit:
 				return
 			}

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -129,6 +129,17 @@ func (s *execWs) Connect(op *operations.Operation, r *http.Request, w http.Respo
 }
 
 func (s *execWs) Do(op *operations.Operation) error {
+	// Once this function ends ensure that any connected websockets are closed.
+	defer func() {
+		s.connsLock.Lock()
+		for i := range s.conns {
+			if s.conns[i] != nil {
+				s.conns[i].Close()
+			}
+		}
+		s.connsLock.Unlock()
+	}()
+
 	// As this function only gets called when the exec request has WaitForWS enabled, we expect the client to
 	// connect to all of the required websockets within a short period of time and we won't proceed until then.
 	logger.Debug("Waiting for exec websockets to connect")

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -237,7 +237,7 @@ func (s *execWs) Do(op *operations.Operation) error {
 		return finisher(-1, err)
 	}
 
-	logger := logging.AddContext(logger.Log, log.Ctx{"instance": s.instance.Name(), "PID": cmd.PID()})
+	logger := logging.AddContext(logger.Log, log.Ctx{"project": s.instance.Project(), "instance": s.instance.Name(), "PID": cmd.PID(), "interactive": s.req.Interactive})
 	logger.Debug("Instance process started")
 
 	// Now that process has started, we can start the mirroring of the process channels and websockets.

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
@@ -128,7 +129,15 @@ func (s *execWs) Connect(op *operations.Operation, r *http.Request, w http.Respo
 }
 
 func (s *execWs) Do(op *operations.Operation) error {
-	<-s.requiredConnectedCtx.Done()
+	// As this function only gets called when the exec request has WaitForWS enabled, we expect the client to
+	// connect to all of the required websockets within a short period of time and we won't proceed until then.
+	logger.Debug("Waiting for exec websockets to connect")
+	select {
+	case <-s.requiredConnectedCtx.Done():
+		break
+	case <-time.After(time.Second * 5):
+		return fmt.Errorf("Timed out waiting for websockets to connect")
+	}
 
 	var err error
 	var ttys []*os.File

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -589,7 +589,7 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 
 		ws.conns = map[int]*websocket.Conn{}
 		ws.conns[execWSControl] = nil
-		ws.conns[0] = nil
+		ws.conns[0] = nil // This is used for either TTY or Stdin.
 		if !post.Interactive {
 			ws.conns[execWSStdout] = nil
 			ws.conns[execWSStderr] = nil

--- a/shared/network.go
+++ b/shared/network.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -197,7 +198,7 @@ func WebsocketSendStream(conn *websocket.Conn, r io.Reader, bufferSize int) chan
 
 			err := conn.WriteMessage(websocket.BinaryMessage, buf)
 			if err != nil {
-				logger.Debugf("Got err writing %s", err)
+				logger.Debug("Got err writing", log.Ctx{"err": err})
 				break
 			}
 		}
@@ -215,23 +216,23 @@ func WebsocketRecvStream(w io.Writer, conn *websocket.Conn) chan bool {
 		for {
 			mt, r, err := conn.NextReader()
 			if mt == websocket.CloseMessage {
-				logger.Debugf("Got close message for reader")
+				logger.Debug("Got close message for reader")
 				break
 			}
 
 			if mt == websocket.TextMessage {
-				logger.Debugf("Got message barrier")
+				logger.Debug("Got message barrier")
 				break
 			}
 
 			if err != nil {
-				logger.Debugf("Got error getting next reader %s", err)
+				logger.Debug("Got error getting next reader", log.Ctx{"err": err})
 				break
 			}
 
 			buf, err := ioutil.ReadAll(r)
 			if err != nil {
-				logger.Debugf("Got error writing to writer %s", err)
+				logger.Debug("Got error writing to writer", log.Ctx{"err": err})
 				break
 			}
 
@@ -241,11 +242,11 @@ func WebsocketRecvStream(w io.Writer, conn *websocket.Conn) chan bool {
 
 			i, err := w.Write(buf)
 			if i != len(buf) {
-				logger.Debugf("Didn't write all of buf")
+				logger.Debug("Didn't write all of buf")
 				break
 			}
 			if err != nil {
-				logger.Debugf("Error writing buf %s", err)
+				logger.Debug("Error writing buf", log.Ctx{"err": err})
 				break
 			}
 		}
@@ -313,7 +314,7 @@ func defaultReader(conn *websocket.Conn, r io.ReadCloser, readDone chan<- bool) 
 		buf, ok := <-in
 		if !ok {
 			r.Close()
-			logger.Debugf("Sending write barrier")
+			logger.Debug("Sending write barrier")
 			conn.WriteMessage(websocket.TextMessage, []byte{})
 			readDone <- true
 			return
@@ -321,7 +322,7 @@ func defaultReader(conn *websocket.Conn, r io.ReadCloser, readDone chan<- bool) 
 
 		err := conn.WriteMessage(websocket.BinaryMessage, buf)
 		if err != nil {
-			logger.Debugf("Got err writing %s", err)
+			logger.Debug("Got err writing", log.Ctx{"err": err})
 			break
 		}
 	}
@@ -335,32 +336,32 @@ func DefaultWriter(conn *websocket.Conn, w io.WriteCloser, writeDone chan<- bool
 	for {
 		mt, r, err := conn.NextReader()
 		if err != nil {
-			logger.Debugf("Got error getting next reader %s", err)
+			logger.Debug("Got error getting next reader", log.Ctx{"err": err})
 			break
 		}
 
 		if mt == websocket.CloseMessage {
-			logger.Debugf("Got close message for reader")
+			logger.Debug("Got close message for reader")
 			break
 		}
 
 		if mt == websocket.TextMessage {
-			logger.Debugf("Got message barrier, resetting stream")
+			logger.Debug("Got message barrier, resetting stream")
 			break
 		}
 
 		buf, err := ioutil.ReadAll(r)
 		if err != nil {
-			logger.Debugf("Got error writing to writer %s", err)
+			logger.Debug("Got error writing to writer", log.Ctx{"err": err})
 			break
 		}
 		i, err := w.Write(buf)
 		if i != len(buf) {
-			logger.Debugf("Didn't write all of buf")
+			logger.Debug("Didn't write all of buf")
 			break
 		}
 		if err != nil {
-			logger.Debugf("Error writing buf %s", err)
+			logger.Debug("Error writing buf", log.Ctx{"err": err})
 			break
 		}
 	}

--- a/test/main.sh
+++ b/test/main.sh
@@ -238,6 +238,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_image_auto_update "image auto-update"
     run_test test_image_prefer_cached "image prefer cached"
     run_test test_image_import_dir "import image from directory"
+    run_test test_exec "exec"
     run_test test_concurrent_exec "concurrent exec"
     run_test test_concurrent "concurrent startup"
     run_test test_snapshots "container snapshots"

--- a/test/suites/exec.sh
+++ b/test/suites/exec.sh
@@ -1,3 +1,30 @@
+test_exec() {
+  ensure_import_testimage
+
+  name=x1
+  lxc launch testimage x1
+  lxc list ${name} | grep RUNNING
+
+  exec_container_noninteractive() {
+    echo "abc${1}" | lxc exec "${name}" --force-noninteractive -- cat | grep abc
+  }
+
+  exec_container_interactive() {
+    echo "abc${1}" | lxc exec "${name}" -- cat | grep abc
+  }
+
+  for i in $(seq 1 25); do
+    exec_container_interactive "${i}" > "${LXD_DIR}/exec-${i}.out" 2>&1
+  done
+
+  for i in $(seq 1 25); do
+    exec_container_noninteractive "${i}" > "${LXD_DIR}/exec-${i}.out" 2>&1
+  done
+
+  lxc stop "${name}" --force
+  lxc delete "${name}"
+}
+
 test_concurrent_exec() {
   if [ -z "${LXD_CONCURRENT:-}" ]; then
     echo "==> SKIP: LXD_CONCURRENT isn't set"

--- a/test/suites/exec.sh
+++ b/test/suites/exec.sh
@@ -10,13 +10,22 @@ test_concurrent_exec() {
   lxc launch testimage x1
   lxc list ${name} | grep RUNNING
 
-  exec_container() {
+  exec_container_noninteractive() {
+    echo "abc${1}" | lxc exec "${name}" --force-noninteractive -- cat | grep abc
+  }
+
+  exec_container_interactive() {
     echo "abc${1}" | lxc exec "${name}" -- cat | grep abc
   }
 
   PIDS=""
-  for i in $(seq 1 50); do
-    exec_container "${i}" > "${LXD_DIR}/exec-${i}.out" 2>&1 &
+  for i in $(seq 1 25); do
+    exec_container_interactive "${i}" > "${LXD_DIR}/exec-${i}.out" 2>&1 &
+    PIDS="${PIDS} $!"
+  done
+
+  for i in $(seq 1 25); do
+    exec_container_noninteractive "${i}" > "${LXD_DIR}/exec-${i}.out" 2>&1 &
     PIDS="${PIDS} $!"
   done
 


### PR DESCRIPTION
Thus preventing leaving the command running in the background (potentially indefinitely until the instance or LXD was stopped).

We cannot require that the client provide a control socket for non-interactive exec sessions as otherwise this would break older clients from using exec on newer servers. Instead we have to detect the client disconnecting by the stdout channel being closed.

Also:

- Makes the control connection required for interactive exec sessions.
- Removes duplication of interactive/non-interactive control connection handlers.
- Uses more structured logging.
- Fixes several file handle leaks.

Fixes #9578