### PR TITLE
lxc/exec: Always connect control websocket

### DIFF
--- a/lxc/exec.go
+++ b/lxc/exec.go
@@ -155,9 +155,6 @@ func (c *cmdExec) Run(cmd *cobra.Command, args []string) error {
 
 	// Setup interactive console handler
 	handler := c.controlSocketHandler
-	if !interactive {
-		handler = nil
-	}
 
 	// Grab current terminal dimensions
 	var width, height int


### PR DESCRIPTION
This way signals can be relayed to non-interactive commands, and if the lxc command disconnects this can be detected
and used to clean up the running command.

Fixes #9578

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>