### PR TITLE
Instance: Rework VM exec to always expect control connection for websocket sessions

### DIFF
--- a/lxd-agent/exec.go
+++ b/lxd-agent/exec.go
@@ -21,7 +21,9 @@ import (
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/logging"
 	"github.com/lxc/lxd/shared/netutils"
 )
 
@@ -483,11 +485,15 @@ func (s *execWs) Do(op *operations.Operation) error {
 		return finisher(-1, err)
 	}
 
+	logger := logging.AddContext(logger.Log, log.Ctx{"PID": cmd.Process.Pid, "interactive": s.interactive})
+	logger.Debug("Instance process started")
+
 	if s.interactive {
 		attachedChildIsBorn <- cmd.Process.Pid
 	}
 
 	err = cmd.Wait()
+	logger.Debug("Instance process stopped")
 	if err == nil {
 		return finisher(0, nil)
 	}

--- a/lxd-agent/exec.go
+++ b/lxd-agent/exec.go
@@ -108,7 +108,8 @@ func execPost(d *Daemon, r *http.Request) response.Response {
 	ws.requiredConnectedCtx, ws.requiredConnectedDone = context.WithCancel(context.Background())
 	ws.controlConnected = make(chan bool, 1)
 	ws.interactive = post.Interactive
-	for i := -1; i < len(ws.conns)-1; i++ {
+
+	for i := range ws.conns {
 		ws.fds[i], err = shared.RandomCryptoString()
 		if err != nil {
 			return response.InternalError(err)

--- a/lxd-agent/exec.go
+++ b/lxd-agent/exec.go
@@ -277,7 +277,6 @@ func (s *execWs) Do(op *operations.Operation) error {
 		stderr = ttys[execWSStderr]
 	}
 
-	controlExit := make(chan bool, 1)
 	attachedChildIsDead := make(chan struct{})
 	var wgEOF sync.WaitGroup
 
@@ -290,12 +289,8 @@ func (s *execWs) Do(op *operations.Operation) error {
 		conn := s.conns[-1]
 		s.connsLock.Unlock()
 
-		if conn == nil {
-			if s.interactive {
-				controlExit <- true
-			}
-		} else {
-			conn.Close()
+		if conn != nil {
+			conn.Close() // Close control connection (will cause control go routine to end).
 		}
 
 		close(attachedChildIsDead)

--- a/lxd-agent/exec.go
+++ b/lxd-agent/exec.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -355,7 +356,14 @@ func (s *execWs) Do(op *operations.Operation) error {
 
 	err = cmd.Start()
 	if err != nil {
-		return finisher(-1, err)
+		exitCode := -1
+
+		if errors.Is(err, exec.ErrNotFound) {
+			exitCode = 127
+			err = nil // Allow the exit code to be returned.
+		}
+
+		return finisher(exitCode, err)
 	}
 
 	logger := logging.AddContext(logger.Log, log.Ctx{"PID": cmd.Process.Pid, "interactive": s.interactive})

--- a/lxd-agent/exec.go
+++ b/lxd-agent/exec.go
@@ -291,7 +291,6 @@ func (s *execWs) Do(op *operations.Operation) error {
 			select {
 			case <-s.controlConnected:
 				break
-
 			case <-controlExit:
 				return
 			}

--- a/lxd-agent/exec.go
+++ b/lxd-agent/exec.go
@@ -217,6 +217,17 @@ func (s *execWs) Connect(op *operations.Operation, r *http.Request, w http.Respo
 }
 
 func (s *execWs) Do(op *operations.Operation) error {
+	// Once this function ends ensure that any connected websockets are closed.
+	defer func() {
+		s.connsLock.Lock()
+		for i := range s.conns {
+			if s.conns[i] != nil {
+				s.conns[i].Close()
+			}
+		}
+		s.connsLock.Unlock()
+	}()
+
 	// As this function only gets called when the exec request has WaitForWS enabled, we expect the client to
 	// connect to all of the required websockets within a short period of time and we won't proceed until then.
 	logger.Debug("Waiting for exec websockets to connect")

--- a/lxd-agent/exec.go
+++ b/lxd-agent/exec.go
@@ -100,7 +100,7 @@ func execPost(d *Daemon, r *http.Request) response.Response {
 
 	ws.conns = map[int]*websocket.Conn{}
 	ws.conns[execWSControl] = nil
-	ws.conns[0] = nil
+	ws.conns[0] = nil // This is used for either TTY or Stdin.
 	if !post.Interactive {
 		ws.conns[execWSStdout] = nil
 		ws.conns[execWSStderr] = nil

--- a/lxd-agent/main_agent.go
+++ b/lxd-agent/main_agent.go
@@ -46,7 +46,7 @@ func (c *cmdAgent) Command() *cobra.Command {
 
 func (c *cmdAgent) Run(cmd *cobra.Command, args []string) error {
 	// Setup logger.
-	log, err := logging.GetLogger("lxd-agent", "", c.global.flagLogVerbose, c.global.flagLogDebug, nil)
+	log, err := logging.GetLogger("", "", c.global.flagLogVerbose, c.global.flagLogDebug, nil)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5029,7 +5029,6 @@ func (d *qemu) Exec(req api.InstanceExecPost, stdin *os.File, stdout *os.File, s
 	}
 	revert.Add(agent.Disconnect)
 
-	req.WaitForWS = true
 	if req.Interactive {
 		// Set console to raw.
 		oldttystate, err := termios.MakeRaw(int(stdin.Fd()))


### PR DESCRIPTION
Even if the `lxc` client doesn't connect to the control socket, we expect LXD to open a control socket, so that LXD can instruct the lxd-agent to kill the process if needed.