### PR TITLE
Increases recommended subuid and subgid ranges in machine setup.

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -124,7 +124,7 @@ Now, the `lxd` and `lxc` binaries will be available to you and can be used to se
 You'll need sub{u,g}ids for root, so that LXD can create the unprivileged containers:
 
 ```bash
-echo "root:1000000:65536" | sudo tee -a /etc/subuid /etc/subgid
+echo "root:1000000:1000000000" | sudo tee -a /etc/subuid /etc/subgid
 ```
 
 Now you can run the daemon (the `--group sudo` bit allows everyone in the `sudo`


### PR DESCRIPTION
With the existing recommended range the `container_devices_disk` integration test fails to launch an isolated container because it runs out of uids. The new range allows this test to pass.