### PR TITLE
Instance: Adds ExitStatus() to properly extract exit status when a command is signaled from interactive session

### DIFF
--- a/lxd/instance/drivers/driver_lxc_cmd.go
+++ b/lxd/instance/drivers/driver_lxc_cmd.go
@@ -33,16 +33,9 @@ func (c *lxcCmd) Signal(sig unix.Signal) error {
 
 // Wait for the command to end and returns its exit code and any error.
 func (c *lxcCmd) Wait() (int, error) {
-	err := c.cmd.Wait()
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return exitErr.ExitCode(), nil
-		}
+	exitStatus, err := shared.ExitStatus(c.cmd.Wait())
 
-		return -1, err // Unknown error.
-	}
-
-	return 0, nil
+	return exitStatus, err
 }
 
 // WindowResize resizes the running command's window.

--- a/lxd/instance/drivers/driver_qemu_cmd.go
+++ b/lxd/instance/drivers/driver_qemu_cmd.go
@@ -55,9 +55,9 @@ func (c *qemuCmd) Wait() (int, error) {
 
 	opAPI := c.cmd.Get()
 	<-c.dataDone
-	exitCode := int(opAPI.Metadata["return"].(float64))
+	exitStatus := int(opAPI.Metadata["return"].(float64))
 
-	return exitCode, nil
+	return exitStatus, nil
 }
 
 // WindowResize resizes the running command's window.

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -411,9 +411,9 @@ func (s *execWs) Do(op *operations.Operation) error {
 		}
 	}
 
-	exitCode, err := cmd.Wait()
-	logger.Debug("Instance process stopped", log.Ctx{"exitCode": exitCode})
-	return finisher(exitCode, err)
+	exitStatus, err := cmd.Wait()
+	logger.Debug("Instance process stopped", log.Ctx{"exitStatus": exitStatus})
+	return finisher(exitStatus, err)
 }
 
 // swagger:operation POST /1.0/instances/{name}/exec instances instance_exec_post
@@ -631,13 +631,13 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 				return err
 			}
 
-			exitCode, err := cmd.Wait()
+			exitStatus, err := cmd.Wait()
 			if err != nil {
 				return err
 			}
 
 			// Update metadata with the right URLs
-			metadata["return"] = exitCode
+			metadata["return"] = exitStatus
 			metadata["output"] = shared.Jmap{
 				"1": fmt.Sprintf("/%s/instances/%s/logs/%s", version.APIVersion, inst.Name(), filepath.Base(stdout.Name())),
 				"2": fmt.Sprintf("/%s/instances/%s/logs/%s", version.APIVersion, inst.Name(), filepath.Base(stderr.Name())),
@@ -648,12 +648,12 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 				return err
 			}
 
-			exitCode, err := cmd.Wait()
+			exitStatus, err := cmd.Wait()
 			if err != nil {
 				return err
 			}
 
-			metadata["return"] = exitCode
+			metadata["return"] = exitStatus
 		}
 
 		err = op.UpdateMetadata(metadata)

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -644,4 +645,29 @@ again:
 	}
 
 	return n, int(pollFds[0].Revents), err
+}
+
+// ExitStatus extracts the exit status from the error returned by exec.Cmd.
+// If a nil err is provided then an exist status of 0 is returned along with the nil error.
+// If a valid exit status can be extracted from err then it is returned along with a nil error.
+// If no valid exit status can be extracted then a -1 exit status is returned along with the err provided.
+func ExitStatus(err error) (int, error) {
+	if err == nil {
+		return 0, err // No error exit status.
+	}
+
+	exitErr, isExitError := err.(*exec.ExitError)
+	if isExitError {
+		// If the process was signaled, extract the signal.
+		status, isWaitStatus := exitErr.Sys().(syscall.WaitStatus)
+		if isWaitStatus && status.Signaled() {
+			return 128 + int(status.Signal()), nil // 128 + n == Fatal error signal "n"
+		}
+
+		// Otherwise capture the exit status from the command.
+		return exitErr.ExitCode(), nil
+
+	}
+
+	return -1, err // Not able to extract an exit status.
 }


### PR DESCRIPTION
Builds on change from https://github.com/lxc/lxd/pull/9598 by properly using `syscall.WaitStatus.Signaled()` to detect when a command is killed by ctrl+c during an interactive session.

This will now return the exit status 130 as documented by https://tldp.org/LDP/abs/html/exitcodes.html