### PR TITLE
doc: css: temporary fixes for theme issues

### DIFF
--- a/.sphinx/_static/custom.css
+++ b/.sphinx/_static/custom.css
@@ -1,0 +1,73 @@
+
+/** Fix for issue #28 **/
+footer {
+    color: #666
+}
+
+footer::before {
+    border-top: 1px #ebebeb solid;
+    content: "";
+    display: inherit;
+    padding-bottom: 10px;
+}
+
+/** Fix for issue #26 **/
+
+td p:first-child, th p:first-child {
+    padding-top: 0
+}
+
+td p:last-child, th p:last-child {
+    margin-bottom: 0
+}
+
+/** Fix for issue #24 **/
+.caption[role="heading"] {
+    font-size: 2rem;
+    line-height: 2.5rem;
+    font-weight: 100;
+}
+
+/** Some tweaks for issue #16 **/
+
+[role="tablist"] {
+    border-bottom: 1px solid #d9d9d9;
+}
+
+.sphinx-tabs-tab[aria-selected="true"] {
+    border: 0;
+    border-bottom: 2px solid #111;
+    background-color: #ebebeb;
+    font-weight:300;
+}
+
+.sphinx-tabs-tab{
+    color: #111;
+    font-weight:300;
+    border-radius: 0;
+}
+
+.sphinx-tabs-panel {
+    border: 0;
+    border-bottom: 1px solid #d9d9d9;
+    border-radius: 0;
+}
+
+button.sphinx-tabs-tab:hover {
+    background-color: #f7f7f7;
+}
+
+/** Fix for issue #14 **/
+
+ol.lowerroman li {
+    list-style: lower-roman;
+}
+ol.upperroman li {
+    list-style: upper-roman;
+}
+ol.loweralpha li {
+    list-style: lower-alpha;
+}
+ol.upperalpha li {
+    list-style: upper-alpha;
+}

--- a/.sphinx/conf.py
+++ b/.sphinx/conf.py
@@ -34,6 +34,9 @@ html_show_sphinx = False
 html_last_updated_fmt = ""
 html_favicon = "https://linuxcontainers.org/static/img/favicon.ico"
 html_logo = "https://linuxcontainers.org/static/img/containers.small.png"
+html_static_path = ['_static']
+html_css_files = ['custom.css']
+
 
 # Uses global TOC for side nav instead of default local TOC.
 html_sidebars = {


### PR DESCRIPTION
Add a custom style sheet that can be used to tweak the CSS
of the Sphinx theme.
The current version of the style sheet fixes some of the low-
priority issues.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>