### PR TITLE
doc: add redirect to index.html

### DIFF
--- a/.sphinx/conf.py
+++ b/.sphinx/conf.py
@@ -48,6 +48,6 @@ html_sidebars = {
 source_suffix = ".md"
 
 # Setup redirects (https://documatt.gitlab.io/sphinx-reredirects/usage.html)
-# redirects = {
-#     "redirect/index": "../configuration/",
-# }
+redirects = {
+    "index/index": "../index.html",
+}


### PR DESCRIPTION
For the Sphinx build, add a redirect from index/index to the
index.html in the root folder, to ensure that both
https://linuxcontainers.org/lxd/docs/master/index and
https://linuxcontainers.org/lxd/docs/master/index/ work.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>