### PR TITLE
lxd: log basic idmapped mount support

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -939,6 +939,12 @@ func (d *Daemon) init() error {
 		}
 	}
 
+	if kernelSupportsIdmappedMounts() {
+		logger.Info("- idmapped mounts kernel support: yes")
+	} else {
+		logger.Info("- idmapped mounts kernel support: no")
+	}
+
 	// Detect and cached available instance types from operational drivers.
 	_, instanceTypesWarnings := instanceDrivers.SupportedInstanceTypes()
 	dbWarnings = append(dbWarnings, instanceTypesWarnings...)


### PR DESCRIPTION
Add a helper that we're only using during daemon startup to give an
indication whether the underlying kernel has the necessary
infrastructure to support idmapped mounts. This check does not give any
indication whether the relevant filesystem used for a container does
have this support.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>