### PR TITLE
WIP: Uses single rule for SNAT with iptables.

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1518,3 +1518,6 @@ This introduces `network.nat` as a config option on network zones (DNS).
 It defaults to the current behavior of generating records for all
 instances NICs but if set to `false`, it will instruct LXD to only
 generate records for externally reachable addreses.
+
+## database\_leader
+Adds new "database-leader" role which is assigned to cluster leader.

--- a/installing.md
+++ b/installing.md
@@ -1,0 +1,1 @@
+doc/installing.md

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -160,7 +160,11 @@ func (c *cmdClusterList) Run(cmd *cobra.Command, args []string) error {
 	data := [][]string{}
 	for _, member := range members {
 		roles := member.ClusterMemberPut.Roles
-		line := []string{member.ServerName, member.URL, strings.Join(roles, "\n"), member.Architecture, member.FailureDomain, member.Description, strings.ToUpper(member.Status), member.Message}
+		rolesDelimiter := "\n"
+		if c.flagFormat == "csv" {
+			rolesDelimiter = ","
+		}
+		line := []string{member.ServerName, member.URL, strings.Join(roles, rolesDelimiter), member.Architecture, member.FailureDomain, member.Description, strings.ToUpper(member.Status), member.Message}
 		data = append(data, line)
 	}
 	sort.Sort(byName(data))

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1075,10 +1075,15 @@ func clusterNodesGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	leader, err := d.gateway.LeaderAddress()
+	if err != nil {
+		return response.InternalError(err)
+	}
+
 	if recursion {
 		result := []api.ClusterMember{}
 		for _, node := range nodes {
-			member, err := node.ToAPI(state.Cluster, state.Node)
+			member, err := node.ToAPI(state.Cluster, state.Node, leader)
 			if err != nil {
 				return response.InternalError(err)
 			}
@@ -1304,12 +1309,17 @@ func clusterNodeGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	leader, err := d.gateway.LeaderAddress()
+	if err != nil {
+		return response.InternalError(err)
+	}
+
 	for _, node := range nodes {
 		if node.Name != name {
 			continue
 		}
 
-		member, err := node.ToAPI(state.Cluster, state.Node)
+		member, err := node.ToAPI(state.Cluster, state.Node, leader)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -1406,7 +1416,12 @@ func updateClusterNode(d *Daemon, r *http.Request, isPatch bool) response.Respon
 		return response.SmartError(err)
 	}
 
-	member, err := node.ToAPI(state.Cluster, state.Node)
+	leader, err := d.gateway.LeaderAddress()
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	member, err := node.ToAPI(state.Cluster, state.Node, leader)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -30,6 +30,9 @@ const ClusterRoleDatabase = ClusterRole("database")
 // ClusterRoleDatabaseStandBy represents the database stand-by role in a cluster.
 const ClusterRoleDatabaseStandBy = ClusterRole("database-standby")
 
+// ClusterRoleDatabaseLeader represents the database leader role in a cluster.
+const ClusterRoleDatabaseLeader = ClusterRole("database-leader")
+
 // ClusterRoles maps role ids into human-readable names.
 //
 // Note: the database role is currently stored directly in the raft
@@ -66,7 +69,7 @@ func (n NodeInfo) IsOffline(threshold time.Duration) bool {
 }
 
 // ToAPI returns a LXD API entry.
-func (n NodeInfo) ToAPI(cluster *Cluster, node *Node) (*api.ClusterMember, error) {
+func (n NodeInfo) ToAPI(cluster *Cluster, node *Node, leader string) (*api.ClusterMember, error) {
 	// Load some needed data.
 	var err error
 	var offlineThreshold time.Duration
@@ -138,6 +141,13 @@ func (n NodeInfo) ToAPI(cluster *Cluster, node *Node) (*api.ClusterMember, error
 	result.Database = false
 	result.Config = n.Config
 	result.Roles = n.Roles
+
+	// Check if node is the leader node
+	if leader == n.Address {
+		result.Roles = append(result.Roles, string(ClusterRoleDatabaseLeader))
+		result.Database = true
+	}
+
 	if raftNode != nil && raftNode.Role == RaftVoter {
 		result.Roles = append(result.Roles, string(ClusterRoleDatabase))
 		result.Database = true
@@ -654,7 +664,7 @@ func (c *ClusterTx) UpdateNodeRoles(id int64, roles []ClusterRole) error {
 	roleIDs := []int{}
 	for _, role := range roles {
 		// Skip internal-only roles.
-		if role == ClusterRoleDatabase || role == ClusterRoleDatabaseStandBy {
+		if role == ClusterRoleDatabase || role == ClusterRoleDatabaseStandBy || role == ClusterRoleDatabaseLeader {
 			continue
 		}
 

--- a/lxd/firewall/drivers/drivers_util.go
+++ b/lxd/firewall/drivers/drivers_util.go
@@ -1,0 +1,26 @@
+package drivers
+
+
+// PortRangesFromSlice checks if adjacent indices in the given slice contain consecutive
+// numbers and returns a slice of port ranges ([startNumber, rangeSize]) accordingly.
+//
+// Note that if the input slice was parsed from multiple ranges (e.g. "80-81,5000") then 
+// this function will normalise the given ranges (e.g. "80-81,82,5000" will become "80-82-5000").
+func PortRangesFromSlice(ports []uint64) [][2]uint64 {
+	if len(ports) == 0 {
+		return nil
+	}
+
+	portRanges := make([][2]uint64, 0, len(ports))
+	startIdx := 0
+	size := uint64(0)
+	for i := range ports {
+		if i == len(ports)-1 || ports[i+1] != ports[i]+1 {
+			size = ports[i] - ports[startIdx] + 1
+			portRanges = append(portRanges, [2]uint64{ports[startIdx], size})
+			startIdx = i + 1
+		}
+	}
+
+	return portRanges
+}

--- a/lxd/firewall/drivers/drivers_util.go
+++ b/lxd/firewall/drivers/drivers_util.go
@@ -1,10 +1,11 @@
 package drivers
 
+import "fmt"
 
 // PortRangesFromSlice checks if adjacent indices in the given slice contain consecutive
 // numbers and returns a slice of port ranges ([startNumber, rangeSize]) accordingly.
 //
-// Note that if the input slice was parsed from multiple ranges (e.g. "80-81,5000") then 
+// Note that if the input slice was parsed from multiple ranges (e.g. "80-81,5000") then
 // this function will normalise the given ranges (e.g. "80-81,82,5000" will become "80-82-5000").
 func PortRangesFromSlice(ports []uint64) [][2]uint64 {
 	if len(ports) == 0 {
@@ -23,4 +24,22 @@ func PortRangesFromSlice(ports []uint64) [][2]uint64 {
 	}
 
 	return portRanges
+}
+
+func destinationStr(ipVersion uint, addr string, port string) string {
+	dest := fmt.Sprintf("%s:%s", addr, port)
+	if ipVersion == 6 {
+		dest = fmt.Sprintf("[%s]:%s", addr, port)
+	}
+
+	return dest
+}
+
+func portRangeStr(portRange [2]uint64) string {
+	if portRange[1] < 1 {
+		return ""
+	} else if portRange[1] == 1 {
+		return fmt.Sprintf("%d", portRange[0])
+	}
+	return fmt.Sprintf("%d:%d", portRange[0], portRange[0]+portRange[1]-1)
 }

--- a/lxd/firewall/drivers/drivers_util_test.go
+++ b/lxd/firewall/drivers/drivers_util_test.go
@@ -1,0 +1,62 @@
+package drivers
+
+import (
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPortRangesFromSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		ports    []uint64
+		expected [][2]uint64
+	}{
+		{
+			name:     "Single port",
+			ports:    []uint64{80},
+			expected: [][2]uint64{{80, 1}},
+		},
+		{
+			name:     "Single range",
+			ports:    []uint64{80, 81, 82, 83},
+			expected: [][2]uint64{{80, 4}},
+		},
+		{
+			name:  "Multiple (single) ports",
+			ports: []uint64{80, 90, 100},
+			expected: [][2]uint64{
+				{80, 1},
+				{90, 1},
+				{100, 1},
+			},
+		},
+		{
+			name:  "Multiple ranges",
+			ports: []uint64{80, 81, 82, 90, 91, 92, 100, 101, 102},
+			expected: [][2]uint64{
+				{80, 3},
+				{90, 3},
+				{100, 3},
+			},
+		},
+		{
+			name:  "Mixed ranges and single ports",
+			ports: []uint64{80, 81, 82, 87, 90, 91, 92, 88, 100, 101, 102, 89},
+			expected: [][2]uint64{
+				{80, 3},
+				{87, 1},
+				{90, 3},
+				{88, 1},
+				{100, 3},
+				{89, 1},
+			},
+		},
+	}
+	for i, tt := range tests {
+		log.Printf("Running test #%d: %s", i, tt.name)
+		ranges := PortRangesFromSlice(tt.ports)
+		require.ElementsMatch(t, ranges, tt.expected)
+	}
+}

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -936,6 +936,22 @@ func (d Xtables) InstanceSetupProxyNAT(projectName string, instanceName string, 
 
 	comment := d.instanceDeviceIPTablesComment(projectName, instanceName, deviceName)
 
+	targetPortRanges := PortRangesFromSlice(forward.TargetPorts)
+	for _, targetPortRange := range targetPortRanges {
+		targetPortStr := fmt.Sprintf("%d", targetPortRange[0])
+		if targetPortRange[1] > 1 {
+			targetPortStr = fmt.Sprintf("%d:%d", targetPortRange[0], targetPortRange[0]+targetPortRange[1]-1)
+		}
+
+		// Apply MASQUERADE rule for each target range
+		// instance <-> instance.
+		// Requires instance's bridge port has hairpin mode enabled when br_netfilter is loaded.
+		err := d.iptablesPrepend(ipVersion, comment, "nat", "POSTROUTING", "-p", forward.Protocol, "--source", targetAddressStr, "--destination", targetAddressStr, "--dport", targetPortStr, "-j", "MASQUERADE")
+		if err != nil {
+			return err
+		}
+	}
+
 	for i := range forward.ListenPorts {
 		// Use the target port that corresponds to the listen port (unless only 1 is specified, in which
 		// case use the same target port for all listen ports).
@@ -963,15 +979,6 @@ func (d Xtables) InstanceSetupProxyNAT(projectName string, instanceName string, 
 		err = d.iptablesPrepend(ipVersion, comment, "nat", "OUTPUT", "-p", forward.Protocol, "--destination", listenAddressStr, "--dport", listenPortStr, "-j", "DNAT", "--to-destination", targetDest)
 		if err != nil {
 			return err
-		}
-
-		if targetIndex == i {
-			// instance <-> instance.
-			// Requires instance's bridge port has hairpin mode enabled when br_netfilter is loaded.
-			err = d.iptablesPrepend(ipVersion, comment, "nat", "POSTROUTING", "-p", forward.Protocol, "--source", targetAddressStr, "--destination", targetAddressStr, "--dport", targetPortStr, "-j", "MASQUERADE")
-			if err != nil {
-				return err
-			}
 		}
 	}
 

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -296,6 +296,7 @@ var APIExtensions = []string{
 	"storage_volume_project_move",
 	"cloud_init",
 	"network_dns_nat",
+	"database_leader",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -243,7 +243,7 @@ test_clustering_membership() {
   # List all nodes, using clients points to different nodes and
   # checking which are database nodes and which are database-standby nodes.
   LXD_DIR="${LXD_THREE_DIR}" lxc cluster list
-  LXD_DIR="${LXD_THREE_DIR}" lxc cluster show node1 | grep -q "\- database$"
+  LXD_DIR="${LXD_THREE_DIR}" lxc cluster show node1 | grep -q "\- database-leader$"
   LXD_DIR="${LXD_FOUR_DIR}" lxc cluster show node2 | grep -q "\- database$"
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node3 | grep -q "\- database$"
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster show node4 | grep -q "\- database-standby$"
@@ -2359,7 +2359,7 @@ test_clustering_remove_raft_node() {
 
   # There are only 2 database nodes.
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster list
-  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node1 | grep -q "\- database$"
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node1 | grep -q "\- database-leader$"
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node3 | grep -q "\- database$"
 
   # The second node is still in the raft_nodes table.
@@ -2373,7 +2373,7 @@ test_clustering_remove_raft_node() {
 
   # We're back to 3 database nodes.
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster list
-  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node1 | grep -q "\- database$"
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node1 | grep -q "\- database-leader$"
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node3 | grep -q "\- database$"
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node4 | grep -q "\- database$"
 


### PR DESCRIPTION
This PR uses port ranges to configure `iptables` / `nftables` with fewer rules when adding a NAT enabled proxy device to an instance.

Fixes #9073 
