### PR TITLE
Generator: Use api.NewURL for URL generation

### DIFF
--- a/lxd/db/certificates.mapper.go
+++ b/lxd/db/certificates.mapper.go
@@ -8,7 +8,6 @@ package db
 import (
 	"database/sql"
 	"fmt"
-	"strings"
 
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/query"
@@ -110,13 +109,12 @@ func (c *ClusterTx) GetCertificates(filter CertificateFilter) ([]Certificate, er
 					return nil, err
 				}
 
-				for i, uri := range projectURIs {
-					if strings.HasPrefix(uri, "/1.0/") {
-						uri = strings.Split(uri, "/1.0/projects/")[1]
-						uri = strings.Split(uri, "?")[0]
-						projectURIs[i] = uri
-					}
+				uris, err := urlsToResourceNames("/projects", projectURIs...)
+				if err != nil {
+					return nil, err
 				}
+
+				projectURIs = uris
 				objects[i].Projects = append(objects[i].Projects, projectURIs...)
 			}
 		}

--- a/lxd/db/cluster/constants.go
+++ b/lxd/db/cluster/constants.go
@@ -1,9 +1,6 @@
 package cluster
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/lxc/lxd/shared/version"
 )
 
@@ -74,66 +71,6 @@ var EntityURIs = map[int]string{
 	TypeStorageVolumeSnapshot: "/" + version.APIVersion + "/storage-pools/%s/volumes/%s/%s/snapshots/%s?project=%s",
 	TypeWarning:               "/" + version.APIVersion + "/warnings/%s",
 	TypeClusterGroup:          "/" + version.APIVersion + "/cluster/groups/%s",
-}
-
-// EntityFormatURIs associates an entity code to a formatter function that can be
-// used to format its URI.
-var EntityFormatURIs = map[int]func(a ...interface{}) string{
-	TypeContainer: func(a ...interface{}) string {
-		uri := fmt.Sprintf(EntityURIs[TypeContainer], a[1], a[0])
-		if a[0] == "default" {
-			return strings.Split(uri, fmt.Sprintf("?project=%s", a[0]))[0]
-		}
-
-		return uri
-	},
-	TypeInstance: func(a ...interface{}) string {
-		uri := fmt.Sprintf(EntityURIs[TypeInstance], a[1], a[0])
-		if a[0] == "default" {
-			return strings.Split(uri, fmt.Sprintf("?project=%s", a[0]))[0]
-		}
-
-		return uri
-	},
-	TypeProfile: func(a ...interface{}) string {
-		uri := fmt.Sprintf(EntityURIs[TypeProfile], a[1], a[0])
-		if a[0] == "default" {
-			return strings.Split(uri, fmt.Sprintf("?project=%s", a[0]))[0]
-		}
-
-		return uri
-	},
-	TypeProject: func(a ...interface{}) string {
-		uri := fmt.Sprintf(EntityURIs[TypeProject], a[0])
-		return uri
-	},
-	TypeNetwork: func(a ...interface{}) string {
-		uri := fmt.Sprintf(EntityURIs[TypeNetwork], a[1], a[0])
-		if a[0] == "default" {
-			return strings.Split(uri, fmt.Sprintf("?project=%s", a[0]))[0]
-		}
-
-		return uri
-	},
-	TypeNetworkACL: func(a ...interface{}) string {
-		uri := fmt.Sprintf(EntityURIs[TypeNetworkACL], a[1], a[0])
-		if a[0] == "default" {
-			return strings.Split(uri, fmt.Sprintf("?project=%s", a[0]))[0]
-		}
-
-		return uri
-	},
-	TypeImage: func(a ...interface{}) string {
-		uri := fmt.Sprintf(EntityURIs[TypeImage], a[1], a[0])
-		if a[0] == "default" {
-			return strings.Split(uri, fmt.Sprintf("?project=%s", a[0]))[0]
-		}
-
-		return uri
-	},
-	TypeClusterGroup: func(a ...interface{}) string {
-		return fmt.Sprintf(EntityURIs[TypeClusterGroup], a[0])
-	},
 }
 
 func init() {

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -618,4 +619,27 @@ func exec(c *Cluster, q string, args ...interface{}) error {
 		})
 	})
 	return err
+}
+
+// urlsToResourceNames returns a list of resource names extracted from one or more URLs of the same resource type.
+// The resource type path prefix to match is provided by the matchPathPrefix argument.
+// TODO: Duplicated method from client/util.go. Remove with decoupling of URL generation from db package.
+func urlsToResourceNames(matchPathPrefix string, urls ...string) ([]string, error) {
+	resourceNames := make([]string, 0, len(urls))
+
+	for _, urlRaw := range urls {
+		u, err := url.Parse(urlRaw)
+		if err != nil {
+			return nil, fmt.Errorf("Failed parsing URL %q: %w", urlRaw, err)
+		}
+
+		fields := strings.Split(u.Path, fmt.Sprintf("%s/", matchPathPrefix))
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("Unexpected URL path %q", u)
+		}
+
+		resourceNames = append(resourceNames, fields[len(fields)-1])
+	}
+
+	return resourceNames, nil
 }

--- a/lxd/db/generate/db/mapping.go
+++ b/lxd/db/generate/db/mapping.go
@@ -59,6 +59,17 @@ func (m *Mapping) NaturalKey() []*Field {
 	return key
 }
 
+// Identifier returns the field that uniquely identifies this entity.
+func (m *Mapping) Identifier() *Field {
+	for _, field := range m.NaturalKey() {
+		if field.Name == "Name" || field.Name == "Fingerprint" {
+			return field
+		}
+	}
+
+	return nil
+}
+
 // ContainsFields checks that the mapping contains fields with the same type
 // and name of given ones.
 func (m *Mapping) ContainsFields(fields []*Field) bool {

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -22,8 +22,6 @@ import (
 //go:generate -command mapper lxd-generate db mapper -t images.mapper.go
 //go:generate mapper reset
 //
-//go:generate mapper stmt -p db -e image names
-//go:generate mapper stmt -p db -e image names-by-Project
 //go:generate mapper stmt -p db -e image objects
 //go:generate mapper stmt -p db -e image objects-by-Project
 //go:generate mapper stmt -p db -e image objects-by-Project-and-Cached

--- a/lxd/db/images.mapper.go
+++ b/lxd/db/images.mapper.go
@@ -12,21 +12,10 @@ import (
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/version"
 )
 
 var _ = api.ServerEnvironment{}
-
-var imageNames = cluster.RegisterStmt(`
-SELECT projects.name AS project, images.fingerprint
-  FROM images JOIN projects ON images.project_id = projects.id
-  ORDER BY projects.id, images.fingerprint
-`)
-
-var imageNamesByProject = cluster.RegisterStmt(`
-SELECT projects.name AS project, images.fingerprint
-  FROM images JOIN projects ON images.project_id = projects.id
-  WHERE project = ? ORDER BY projects.id, images.fingerprint
-`)
 
 var imageObjects = cluster.RegisterStmt(`
 SELECT images.id, projects.name AS project, images.fingerprint, images.type, images.filename, images.size, images.public, images.architecture, images.creation_date, images.expiry_date, images.upload_date, images.cached, images.last_use_date, images.auto_update
@@ -176,22 +165,88 @@ func (c *ClusterTx) GetImage(project string, fingerprint string) (*Image, error)
 // GetImageURIs returns all available image URIs.
 // generator: image URIs
 func (c *ClusterTx) GetImageURIs(filter ImageFilter) ([]string, error) {
-	var args []interface{}
+	var err error
+
+	// Result slice.
+	objects := make([]Image, 0)
+
+	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
-	if filter.Project != nil && filter.Fingerprint == nil && filter.Public == nil && filter.Cached == nil && filter.AutoUpdate == nil {
-		stmt = c.stmt(imageNamesByProject)
+	var args []interface{}
+
+	if filter.Project != nil && filter.Public != nil && filter.Fingerprint == nil && filter.Cached == nil && filter.AutoUpdate == nil {
+		stmt = c.stmt(imageObjectsByProjectAndPublic)
+		args = []interface{}{
+			filter.Project,
+			filter.Public,
+		}
+	} else if filter.Project != nil && filter.Cached != nil && filter.Fingerprint == nil && filter.Public == nil && filter.AutoUpdate == nil {
+		stmt = c.stmt(imageObjectsByProjectAndCached)
+		args = []interface{}{
+			filter.Project,
+			filter.Cached,
+		}
+	} else if filter.Project != nil && filter.Fingerprint == nil && filter.Public == nil && filter.Cached == nil && filter.AutoUpdate == nil {
+		stmt = c.stmt(imageObjectsByProject)
 		args = []interface{}{
 			filter.Project,
 		}
+	} else if filter.Fingerprint != nil && filter.Project == nil && filter.Public == nil && filter.Cached == nil && filter.AutoUpdate == nil {
+		stmt = c.stmt(imageObjectsByFingerprint)
+		args = []interface{}{
+			filter.Fingerprint,
+		}
+	} else if filter.Cached != nil && filter.Project == nil && filter.Fingerprint == nil && filter.Public == nil && filter.AutoUpdate == nil {
+		stmt = c.stmt(imageObjectsByCached)
+		args = []interface{}{
+			filter.Cached,
+		}
+	} else if filter.AutoUpdate != nil && filter.Project == nil && filter.Fingerprint == nil && filter.Public == nil && filter.Cached == nil {
+		stmt = c.stmt(imageObjectsByAutoUpdate)
+		args = []interface{}{
+			filter.AutoUpdate,
+		}
 	} else if filter.Project == nil && filter.Fingerprint == nil && filter.Public == nil && filter.Cached == nil && filter.AutoUpdate == nil {
-		stmt = c.stmt(imageNames)
+		stmt = c.stmt(imageObjects)
 		args = []interface{}{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
-	code := cluster.EntityTypes["image"]
-	formatter := cluster.EntityFormatURIs[code]
+	// Dest function for scanning a row.
+	dest := func(i int) []interface{} {
+		objects = append(objects, Image{})
+		return []interface{}{
+			&objects[i].ID,
+			&objects[i].Project,
+			&objects[i].Fingerprint,
+			&objects[i].Type,
+			&objects[i].Filename,
+			&objects[i].Size,
+			&objects[i].Public,
+			&objects[i].Architecture,
+			&objects[i].CreationDate,
+			&objects[i].ExpiryDate,
+			&objects[i].UploadDate,
+			&objects[i].Cached,
+			&objects[i].LastUseDate,
+			&objects[i].AutoUpdate,
+		}
+	}
 
-	return query.SelectURIs(stmt, formatter, args...)
+	// Select.
+	err = query.SelectObjects(stmt, dest, args...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch from \"images\" table: %w", err)
+	}
+
+	uris := make([]string, len(objects))
+	for i := range objects {
+		uri := api.NewURL().Path(version.APIVersion, "images", objects[i].Fingerprint)
+		uri.Project(objects[i].Project)
+
+		uris[i] = uri.String()
+	}
+
+	return uris, nil
 }

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -23,10 +23,8 @@ import (
 //go:generate -command mapper lxd-generate db mapper -t instances.mapper.go
 //go:generate mapper reset
 //
-//go:generate mapper stmt -p db -e instance names
-//go:generate mapper stmt -p db -e instance names-by-Project
-//go:generate mapper stmt -p db -e instance names-by-ID
 //go:generate mapper stmt -p db -e instance objects
+//go:generate mapper stmt -p db -e instance objects-by-ID
 //go:generate mapper stmt -p db -e instance objects-by-Project
 //go:generate mapper stmt -p db -e instance objects-by-Project-and-Type
 //go:generate mapper stmt -p db -e instance objects-by-Project-and-Type-and-Node
@@ -63,7 +61,7 @@ type Instance struct {
 	ID           int
 	Project      string `db:"primary=yes&join=projects.name"`
 	Name         string `db:"primary=yes"`
-	Node         string `db:"join=nodes.name&omit=URIs"` // TODO: Implement multiple joins for URI generation.
+	Node         string `db:"join=nodes.name"`
 	Type         instancetype.Type
 	Snapshot     bool `db:"ignore"`
 	Architecture int
@@ -83,7 +81,7 @@ type InstanceFilter struct {
 	ID      *int
 	Project *string
 	Name    *string
-	Node    *string `db:"omit=URIs"` // TODO: Implement multiple joins for URI generation.
+	Node    *string
 	Type    *instancetype.Type
 }
 

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/version"
 )
 
 // GetNetworksLocalConfig returns a map associating each network name to its
@@ -475,21 +475,16 @@ func (c *ClusterTx) NetworkNodes(networkID int64) (map[int64]NetworkNode, error)
 }
 
 // GetNetworkURIs returns the URIs for the networks with the given project.
-func (c *ClusterTx) GetNetworkURIs(projectID int) ([]string, error) {
-	stmt, err := c.prepare(`
-SELECT projects.name, networks.name from networks
-JOIN projects ON networks.project_id = projects.id
-WHERE networks.project_id = ?`)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to prepare statement for network: %w", err)
-	}
+func (c *ClusterTx) GetNetworkURIs(projectID int, project string) ([]string, error) {
+	sql := `SELECT networks.name from networks WHERE networks.project_id = ?`
 
-	code := cluster.EntityTypes["network"]
-	formatter := cluster.EntityFormatURIs[code]
-
-	uris, err := query.SelectURIs(stmt, formatter, projectID)
+	names, err := query.SelectStrings(c.tx, sql, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to get URIs for network: %w", err)
+	}
+	uris := make([]string, len(names))
+	for i := range names {
+		uris[i] = api.NewURL().Path(version.APIVersion, "networks", names[i]).Project(project).String()
 	}
 
 	return uris, nil

--- a/lxd/db/profiles.go
+++ b/lxd/db/profiles.go
@@ -16,10 +16,8 @@ import (
 //go:generate -command mapper lxd-generate db mapper -t profiles.mapper.go
 //go:generate mapper reset
 //
-//go:generate mapper stmt -p db -e profile names
-//go:generate mapper stmt -p db -e profile names-by-Project
-//go:generate mapper stmt -p db -e profile names-by-ID
 //go:generate mapper stmt -p db -e profile objects
+//go:generate mapper stmt -p db -e profile objects-by-ID
 //go:generate mapper stmt -p db -e profile objects-by-Project
 //go:generate mapper stmt -p db -e profile objects-by-Project-and-Name
 //go:generate mapper stmt -p db -e profile id

--- a/lxd/db/profiles.mapper.go
+++ b/lxd/db/profiles.mapper.go
@@ -12,32 +12,21 @@ import (
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/version"
 )
 
 var _ = api.ServerEnvironment{}
-
-var profileNames = cluster.RegisterStmt(`
-SELECT projects.name AS project, profiles.name
-  FROM profiles JOIN projects ON profiles.project_id = projects.id
-  ORDER BY projects.id, profiles.name
-`)
-
-var profileNamesByProject = cluster.RegisterStmt(`
-SELECT projects.name AS project, profiles.name
-  FROM profiles JOIN projects ON profiles.project_id = projects.id
-  WHERE project = ? ORDER BY projects.id, profiles.name
-`)
-
-var profileNamesByID = cluster.RegisterStmt(`
-SELECT projects.name AS project, profiles.name
-  FROM profiles JOIN projects ON profiles.project_id = projects.id
-  WHERE profiles.id = ? ORDER BY projects.id, profiles.name
-`)
 
 var profileObjects = cluster.RegisterStmt(`
 SELECT profiles.id, profiles.project_id, projects.name AS project, profiles.name, coalesce(profiles.description, '')
   FROM profiles JOIN projects ON profiles.project_id = projects.id
   ORDER BY projects.id, profiles.name
+`)
+
+var profileObjectsByID = cluster.RegisterStmt(`
+SELECT profiles.id, profiles.project_id, projects.name AS project, profiles.name, coalesce(profiles.description, '')
+  FROM profiles JOIN projects ON profiles.project_id = projects.id
+  WHERE profiles.id = ? ORDER BY projects.id, profiles.name
 `)
 
 var profileObjectsByProject = cluster.RegisterStmt(`
@@ -79,29 +68,65 @@ UPDATE profiles
 // GetProfileURIs returns all available profile URIs.
 // generator: profile URIs
 func (c *ClusterTx) GetProfileURIs(filter ProfileFilter) ([]string, error) {
-	var args []interface{}
+	var err error
+
+	// Result slice.
+	objects := make([]Profile, 0)
+
+	// Pick the prepared statement and arguments to use based on active criteria.
 	var stmt *sql.Stmt
-	if filter.Project != nil && filter.ID == nil && filter.Name == nil {
-		stmt = c.stmt(profileNamesByProject)
+	var args []interface{}
+
+	if filter.Project != nil && filter.Name != nil && filter.ID == nil {
+		stmt = c.stmt(profileObjectsByProjectAndName)
+		args = []interface{}{
+			filter.Project,
+			filter.Name,
+		}
+	} else if filter.Project != nil && filter.ID == nil && filter.Name == nil {
+		stmt = c.stmt(profileObjectsByProject)
 		args = []interface{}{
 			filter.Project,
 		}
 	} else if filter.ID != nil && filter.Project == nil && filter.Name == nil {
-		stmt = c.stmt(profileNamesByID)
+		stmt = c.stmt(profileObjectsByID)
 		args = []interface{}{
 			filter.ID,
 		}
 	} else if filter.ID == nil && filter.Project == nil && filter.Name == nil {
-		stmt = c.stmt(profileNames)
+		stmt = c.stmt(profileObjects)
 		args = []interface{}{}
 	} else {
 		return nil, fmt.Errorf("No statement exists for the given Filter")
 	}
 
-	code := cluster.EntityTypes["profile"]
-	formatter := cluster.EntityFormatURIs[code]
+	// Dest function for scanning a row.
+	dest := func(i int) []interface{} {
+		objects = append(objects, Profile{})
+		return []interface{}{
+			&objects[i].ID,
+			&objects[i].ProjectID,
+			&objects[i].Project,
+			&objects[i].Name,
+			&objects[i].Description,
+		}
+	}
 
-	return query.SelectURIs(stmt, formatter, args...)
+	// Select.
+	err = query.SelectObjects(stmt, dest, args...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch from \"profiles\" table: %w", err)
+	}
+
+	uris := make([]string, len(objects))
+	for i := range objects {
+		uri := api.NewURL().Path(version.APIVersion, "profiles", objects[i].Name)
+		uri.Project(objects[i].Project)
+
+		uris[i] = uri.String()
+	}
+
+	return uris, nil
 }
 
 // GetProfiles returns all available profiles.
@@ -126,6 +151,11 @@ func (c *ClusterTx) GetProfiles(filter ProfileFilter) ([]Profile, error) {
 		stmt = c.stmt(profileObjectsByProject)
 		args = []interface{}{
 			filter.Project,
+		}
+	} else if filter.ID != nil && filter.Project == nil && filter.Name == nil {
+		stmt = c.stmt(profileObjectsByID)
+		args = []interface{}{
+			filter.ID,
 		}
 	} else if filter.ID == nil && filter.Project == nil && filter.Name == nil {
 		stmt = c.stmt(profileObjects)

--- a/lxd/db/projects.go
+++ b/lxd/db/projects.go
@@ -219,12 +219,12 @@ func (c *ClusterTx) GetProjectUsedBy(project Project) ([]string, error) {
 		return nil, err
 	}
 
-	networks, err := c.GetNetworkURIs(project.ID)
+	networks, err := c.GetNetworkURIs(project.ID, project.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	networkACLs, err := c.GetNetworkACLURIs(project.ID)
+	networkACLs, err := c.GetNetworkACLURIs(project.ID, project.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/db/projects.go
+++ b/lxd/db/projects.go
@@ -19,8 +19,6 @@ import (
 //go:generate -command mapper lxd-generate db mapper -t projects.mapper.go
 //go:generate mapper reset
 //
-//go:generate mapper stmt -p db -e project names
-//go:generate mapper stmt -p db -e project names-by-ID
 //go:generate mapper stmt -p db -e project objects
 //go:generate mapper stmt -p db -e project objects-by-Name
 //go:generate mapper stmt -p db -e project create struct=Project

--- a/lxd/db/projects.go
+++ b/lxd/db/projects.go
@@ -21,6 +21,7 @@ import (
 //
 //go:generate mapper stmt -p db -e project objects
 //go:generate mapper stmt -p db -e project objects-by-Name
+//go:generate mapper stmt -p db -e project objects-by-ID
 //go:generate mapper stmt -p db -e project create struct=Project
 //go:generate mapper stmt -p db -e project id
 //go:generate mapper stmt -p db -e project rename

--- a/lxd/db/query/slices.go
+++ b/lxd/db/query/slices.go
@@ -4,54 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
-
-// SelectURIs returns a list of LXD API URI strings for the resource yielded by
-// the given query.
-//
-// The f argument must be a function that formats the entity URI using the
-// columns yielded by the query.
-func SelectURIs(stmt *sql.Stmt, f func(a ...interface{}) string, args ...interface{}) ([]string, error) {
-	rows, err := stmt.Query(args...)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to query URIs")
-	}
-	defer rows.Close()
-
-	columns, err := rows.Columns()
-	if err != nil {
-		return nil, errors.Wrap(err, "Rows columns")
-	}
-
-	params := make([]interface{}, len(columns))
-
-	dest := make([]interface{}, len(params))
-	for i := range params {
-		params[i] = ""
-		dest[i] = &params[i]
-	}
-
-	uris := []string{}
-
-	for rows.Next() {
-		err := rows.Scan(dest...)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Failed to scan URI params")
-		}
-
-		uri := f(params...)
-		uris = append(uris, uri)
-	}
-
-	err = rows.Err()
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to close URI result set")
-	}
-
-	return uris, nil
-}
 
 // SelectStrings executes a statement which must yield rows with a single string
 // column. It returns the list of column values.

--- a/lxd/db/query/slices_test.go
+++ b/lxd/db/query/slices_test.go
@@ -2,7 +2,6 @@ package query_test
 
 import (
 	"database/sql"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,22 +9,6 @@ import (
 
 	"github.com/lxc/lxd/lxd/db/query"
 )
-
-func TestSelectURIs(t *testing.T) {
-	tx := newTxForSlices(t)
-	defer tx.Rollback()
-
-	stmt, err := tx.Prepare("SELECT id, name FROM test ORDER BY name")
-	require.NoError(t, err)
-	defer stmt.Close()
-
-	uris, err := query.SelectURIs(stmt, func(a ...interface{}) string {
-		return fmt.Sprintf("/1.0/test/%s/%d", a[1], a[0])
-	})
-	require.NoError(t, err)
-
-	assert.Equal(t, []string{"/1.0/test/bar/1", "/1.0/test/foo/0"}, uris)
-}
 
 // Exercise possible failure modes.
 func TestStrings_Error(t *testing.T) {

--- a/shared/api/url.go
+++ b/shared/api/url.go
@@ -57,7 +57,7 @@ func (u *URL) Project(projectName string) *URL {
 
 // Target sets the "target" query parameter in the URL if the clusterMemberName is not empty or "default".
 func (u *URL) Target(clusterMemberName string) *URL {
-	if clusterMemberName != "" {
+	if clusterMemberName != "" && clusterMemberName != "none" {
 		queryArgs := u.Query()
 		queryArgs.Add("target", clusterMemberName)
 		u.RawQuery = queryArgs.Encode()


### PR DESCRIPTION
Cleaning up URLs from #9364, I've made some changes to consolidate URL generation to always use the methods in `shared/api/url.go`.

Main changes:
* Remove generation of prepared statements for getting names and projects of entities, preferring instead to just use the pre-existing prepared statements for getting whole entities, but just returning name and project via go.
* Omit `target=none` from URLs with `target` form values.
* Move `urlsToResourceNames` to `shared/api/url.go` to have all URL conversion methods in one place.
* Remove db package `EntityFormatURIs` and `SelectURIs` in favour of using `api.NewURL` to create URLs.