### PR TITLE
Instance: Make VM WaitForWS for lxd-agent exec explicit

### DIFF
--- a/lxd-agent/exec.go
+++ b/lxd-agent/exec.go
@@ -52,6 +52,10 @@ func execPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
+	if !post.WaitForWS {
+		return response.BadRequest(fmt.Errorf("Websockets are required for VM exec"))
+	}
+
 	env := map[string]string{}
 
 	if post.Environment != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5055,6 +5055,10 @@ func (d *qemu) Exec(req api.InstanceExecPost, stdin *os.File, stdout *os.File, s
 		Control:  controlHandler,
 	}
 
+	// Always needed for VM exec, as even for non-websocket requests from the client we need to connect the
+	// websockets for control and for capturing output to a file on the LXD server.
+	req.WaitForWS = true
+
 	op, err := agent.ExecInstance("", req, &args)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Non-websocket exec requests for VMs were working, but only by chance. Lets tighten up what is required and explain why.