### PR TITLE
Added link for installing.md

### DIFF
--- a/installing.md
+++ b/installing.md
@@ -1,0 +1,1 @@
+doc/installing.md


### PR DESCRIPTION
Small fix to address #9623 
Simply created a link from installing.md to doc/installing.md (as is the current practice for files moved into /doc).