### PR TITLE
Instance: Use "default" profile when creating instance from image that has no associated profiles

### DIFF
--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -92,7 +92,7 @@ func instanceCreateFromImage(d *Daemon, r *http.Request, args db.InstanceArgs, h
 		return nil, errors.Wrapf(err, "Fetch image %s from database", hash)
 	}
 
-	// Set the default profiles if necessary.
+	// Use default profiles from image if request doesn't specify profiles to use.
 	if args.Profiles == nil {
 		args.Profiles = img.Profiles
 	}


### PR DESCRIPTION
If a project has `features.profiles=true` but `features.images=false` the even if there is a valid `default` profile in the project with a `root` disk device, new instances will fail to be created if they don't specify which profile(s) to use manually, due to trying to find image profiles in a project that cannot have its own images. 
This results in an empty (but importantly not nil) slice of image profiles being considered, which then prevents instance root disk detection.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>