### PR TITLE
Optimise proxy device driver nat rules

### DIFF
--- a/lxd/firewall/drivers/drivers_nftables_templates.go
+++ b/lxd/firewall/drivers/drivers_nftables_templates.go
@@ -103,7 +103,7 @@ table {{.family}} {{.namespace}} {
 	chain {{.chainPrefix}}pstrt{{.chainSeparator}}{{.label}} {
 		type nat hook postrouting priority 100; policy accept;
 		{{- range .snatRules}}
-		{{.ipFamily}} saddr {{.targetHost}} {{.ipFamily}} daddr {{.targetHost}} {{if .protocol}}{{.protocol}} dport {{.targetPort}}{{end}} masquerade
+		{{.ipFamily}} saddr {{.targetHost}} {{.ipFamily}} daddr {{.targetHost}} {{if .protocol}}{{.protocol}} dport {{.targetPorts}}{{end}} masquerade
 		{{- end}}
 	}
 }

--- a/lxd/firewall/drivers/drivers_nftables_templates.go
+++ b/lxd/firewall/drivers/drivers_nftables_templates.go
@@ -89,14 +89,14 @@ table {{.family}} {{.namespace}} {
 	chain {{.chainPrefix}}prert{{.chainSeparator}}{{.label}} {
 		type nat hook prerouting priority -100; policy accept;
 		{{- range .dnatRules}}
-		{{.ipFamily}} daddr {{.listenAddress}} {{if .protocol}}{{.protocol}} dport {{.listenPort}}{{end}} dnat to {{.targetDest}}
+		{{.ipFamily}} daddr {{.listenAddress}} {{if .protocol}}{{.protocol}} dport {{.listenPorts}}{{end}} dnat to {{.targetDest}}
 		{{- end}}
 	}
 
 	chain {{.chainPrefix}}out{{.chainSeparator}}{{.label}} {
 		type nat hook output priority -100; policy accept;
 		{{- range .dnatRules}}
-		{{.ipFamily}} daddr {{.listenAddress}} {{if .protocol}}{{.protocol}} dport {{.listenPort}}{{end}} dnat to {{.targetDest}}
+		{{.ipFamily}} daddr {{.listenAddress}} {{if .protocol}}{{.protocol}} dport {{.listenPorts}}{{end}} dnat to {{.targetDest}}
 		{{- end}}
 	}
 

--- a/lxd/firewall/drivers/drivers_util.go
+++ b/lxd/firewall/drivers/drivers_util.go
@@ -1,5 +1,7 @@
 package drivers
 
+import "fmt"
+
 // portRangesFromSlice checks if adjacent indices in the given slice contain consecutive
 // numbers and returns a slice of port ranges ([startNumber, rangeSize]) accordingly.
 //
@@ -23,4 +25,13 @@ func portRangesFromSlice(ports []uint64) [][2]uint64 {
 	}
 
 	return portRanges
+}
+
+func portRangeStr(portRange [2]uint64, delimiter string) string {
+	if portRange[1] < 1 {
+		return ""
+	} else if portRange[1] == 1 {
+		return fmt.Sprintf("%d", portRange[0])
+	}
+	return fmt.Sprintf("%d%s%d", portRange[0], delimiter, portRange[0]+portRange[1]-1)
 }

--- a/lxd/firewall/drivers/drivers_util.go
+++ b/lxd/firewall/drivers/drivers_util.go
@@ -1,0 +1,26 @@
+package drivers
+
+// portRangesFromSlice checks if adjacent indices in the given slice contain consecutive
+// numbers and returns a slice of port ranges ([startNumber, rangeSize]) accordingly.
+//
+// Note that this function cannot differentiate ranges from adjacent ports e.g. if the given
+// slice is "[80,81,82]" then the returned range will be "80-82", regardless of whether the
+// user input was parsed from "80-82" or "80,81,82".
+func portRangesFromSlice(ports []uint64) [][2]uint64 {
+	if len(ports) == 0 {
+		return nil
+	}
+
+	portRanges := make([][2]uint64, 0, len(ports))
+	startIdx := 0
+	size := uint64(0)
+	for i := range ports {
+		if i == len(ports)-1 || ports[i+1] != ports[i]+1 {
+			size = ports[i] - ports[startIdx] + 1
+			portRanges = append(portRanges, [2]uint64{ports[startIdx], size})
+			startIdx = i + 1
+		}
+	}
+
+	return portRanges
+}

--- a/lxd/firewall/drivers/drivers_util.go
+++ b/lxd/firewall/drivers/drivers_util.go
@@ -35,3 +35,73 @@ func portRangeStr(portRange [2]uint64, delimiter string) string {
 	}
 	return fmt.Sprintf("%d%s%d", portRange[0], delimiter, portRange[0]+portRange[1]-1)
 }
+
+// getOptimisedDNATRanges returns a map of listen port ranges to target port ranges that can be
+// applied in any order.
+//
+// Both Xtables and Nftables are able to apply rules for multiple listen ports at a time when a
+// listen port range exactly matches the corresponding target port range (e.g. "80-85" to "80-85")
+// or when there is a single target port (e.g. "80-85" to "80"). This function checks when these
+// conditions are met and returns a map of listen and target port ranges to be applied by the loaded
+// driver.
+func getOptimisedDNATRanges(forward *AddressForward) map[[2]uint64][2]uint64 {
+	targetPortsLen := len(forward.TargetPorts)
+	listenPortsLen := len(forward.ListenPorts)
+
+	snatRules := make(map[[2]uint64][2]uint64, listenPortsLen)
+	listenPortRanges := portRangesFromSlice(forward.ListenPorts)
+
+	// If there is only one target port, DNAT rules can be optimised for all listen ranges.
+	if targetPortsLen == 1 {
+		targetPort := forward.TargetPorts[0]
+		for _, listenPortRange := range listenPortRanges {
+			snatRules[listenPortRange] = [2]uint64{targetPort, 1}
+		}
+
+		return snatRules
+	}
+
+	// For a given listen range, the corresponding target range may not simply be targetRange[i] (where "i"
+	// is the index of the listen range). For example, "100-101,300" to "100-102" would be valid config
+	// because the number of listen and target ports are equal, but there are two listen ranges and one
+	// target range. Instead, to check if there is a target range we create a map of port range starting
+	// values and check if the current target port is in the map.
+	targetPortRanges := portRangesFromSlice(forward.TargetPorts)
+	targetPortRangeMap := make(map[uint64]uint64, len(targetPortRanges))
+	for _, targetPortRange := range targetPortRanges {
+		targetPortRangeMap[targetPortRange[0]] = targetPortRange[1]
+	}
+
+	nProcessedPorts := 0
+	for _, listenPortRange := range listenPortRanges {
+		rangeEndIdx := nProcessedPorts + int(listenPortRange[1])
+
+		currentTargetPort := forward.TargetPorts[nProcessedPorts]
+		targetPortRangeSize, ok := targetPortRangeMap[currentTargetPort]
+
+		// Check that we have a target port range and that the listen and target port ranges start
+		// at the same value.
+		if ok && listenPortRange[0] == currentTargetPort {
+			targetPortRange := [2]uint64{currentTargetPort, targetPortRangeSize}
+
+			// Check if the listen and target ranges are the same size.
+			if listenPortRange[1] == targetPortRangeSize {
+				// Port ranges are identical. One to one mapping.
+				snatRules[listenPortRange] = targetPortRange
+				nProcessedPorts += int(listenPortRange[1])
+			} else {
+				// Port ranges are identical until the end of the target range.
+				// Rules can be optimised for a portion of ports in the listen range.
+				snatRules[[2]uint64{listenPortRange[0], targetPortRangeSize}] = targetPortRange
+				nProcessedPorts += int(targetPortRangeSize)
+			}
+		}
+
+		// Remaining ports in the listen range cannot be optimised.
+		for ; nProcessedPorts < rangeEndIdx; nProcessedPorts++ {
+			snatRules[[2]uint64{forward.ListenPorts[nProcessedPorts], 1}] = [2]uint64{forward.TargetPorts[nProcessedPorts], 1}
+		}
+	}
+
+	return snatRules
+}

--- a/lxd/firewall/drivers/drivers_util_test.go
+++ b/lxd/firewall/drivers/drivers_util_test.go
@@ -1,0 +1,62 @@
+package drivers
+
+import (
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_portRangesFromSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		ports    []uint64
+		expected [][2]uint64
+	}{
+		{
+			name:     "Single port",
+			ports:    []uint64{80},
+			expected: [][2]uint64{{80, 1}},
+		},
+		{
+			name:     "Single range",
+			ports:    []uint64{80, 81, 82, 83},
+			expected: [][2]uint64{{80, 4}},
+		},
+		{
+			name:  "Multiple (single) ports",
+			ports: []uint64{80, 90, 100},
+			expected: [][2]uint64{
+				{80, 1},
+				{90, 1},
+				{100, 1},
+			},
+		},
+		{
+			name:  "Multiple ranges",
+			ports: []uint64{80, 81, 82, 90, 91, 92, 100, 101, 102},
+			expected: [][2]uint64{
+				{80, 3},
+				{90, 3},
+				{100, 3},
+			},
+		},
+		{
+			name:  "Mixed ranges and single ports",
+			ports: []uint64{80, 81, 82, 87, 90, 91, 92, 88, 100, 101, 102, 89},
+			expected: [][2]uint64{
+				{80, 3},
+				{87, 1},
+				{90, 3},
+				{88, 1},
+				{100, 3},
+				{89, 1},
+			},
+		},
+	}
+	for i, tt := range tests {
+		log.Printf("Running test #%d: %s", i, tt.name)
+		ranges := portRangesFromSlice(tt.ports)
+		assert.ElementsMatch(t, ranges, tt.expected)
+	}
+}

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -949,31 +949,28 @@ func (d Xtables) InstanceSetupProxyNAT(projectName string, instanceName string, 
 		}
 	}
 
-	for i := range forward.ListenPorts {
-		// Use the target port that corresponds to the listen port (unless only 1 is specified, in which
-		// case use the same target port for all listen ports).
-		targetIndex := 0
-		if targetPortsLen > 1 {
-			targetIndex = i
-		}
+	dnatRanges := getOptimisedDNATRanges(forward)
+	for listenPortRange, targetPortRange := range dnatRanges {
 
-		listenPortStr := fmt.Sprintf("%d", forward.ListenPorts[i])
-		targetPortStr := fmt.Sprintf("%d", forward.TargetPorts[targetIndex])
+		listenPortRangeStr := portRangeStr(listenPortRange, ":")
+		targetDest := targetAddressStr
 
-		// Format the destination host/port as appropriate.
-		targetDest := fmt.Sprintf("%s:%s", targetAddressStr, targetPortStr)
-		if ipVersion == 6 {
-			targetDest = fmt.Sprintf("[%s]:%s", targetAddressStr, targetPortStr)
+		if targetPortRange[1] == 1 {
+			targetPortStr := portRangeStr(targetPortRange, ":")
+			targetDest = fmt.Sprintf("%s:%s", targetAddressStr, targetPortStr)
+			if ipVersion == 6 {
+				targetDest = fmt.Sprintf("[%s]:%s", targetAddressStr, targetPortStr)
+			}
 		}
 
 		// outbound <-> instance.
-		err := d.iptablesPrepend(ipVersion, comment, "nat", "PREROUTING", "-p", forward.Protocol, "--destination", listenAddressStr, "--dport", listenPortStr, "-j", "DNAT", "--to-destination", targetDest)
+		err := d.iptablesPrepend(ipVersion, comment, "nat", "PREROUTING", "-p", forward.Protocol, "--destination", listenAddressStr, "--dport", listenPortRangeStr, "-j", "DNAT", "--to-destination", targetDest)
 		if err != nil {
 			return err
 		}
 
 		// host <-> instance.
-		err = d.iptablesPrepend(ipVersion, comment, "nat", "OUTPUT", "-p", forward.Protocol, "--destination", listenAddressStr, "--dport", listenPortStr, "-j", "DNAT", "--to-destination", targetDest)
+		err = d.iptablesPrepend(ipVersion, comment, "nat", "OUTPUT", "-p", forward.Protocol, "--destination", listenAddressStr, "--dport", listenPortRangeStr, "-j", "DNAT", "--to-destination", targetDest)
 		if err != nil {
 			return err
 		}

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -936,6 +936,19 @@ func (d Xtables) InstanceSetupProxyNAT(projectName string, instanceName string, 
 
 	comment := d.instanceDeviceIPTablesComment(projectName, instanceName, deviceName)
 
+	targetPortRanges := portRangesFromSlice(forward.TargetPorts)
+	for _, targetPortRange := range targetPortRanges {
+		targetPortRangeStr := portRangeStr(targetPortRange, ":")
+
+		// Apply MASQUERADE rule for each target range.
+		// instance <-> instance.
+		// Requires instance's bridge port has hairpin mode enabled when br_netfilter is loaded.
+		err := d.iptablesPrepend(ipVersion, comment, "nat", "POSTROUTING", "-p", forward.Protocol, "--source", targetAddressStr, "--destination", targetAddressStr, "--dport", targetPortRangeStr, "-j", "MASQUERADE")
+		if err != nil {
+			return err
+		}
+	}
+
 	for i := range forward.ListenPorts {
 		// Use the target port that corresponds to the listen port (unless only 1 is specified, in which
 		// case use the same target port for all listen ports).
@@ -963,15 +976,6 @@ func (d Xtables) InstanceSetupProxyNAT(projectName string, instanceName string, 
 		err = d.iptablesPrepend(ipVersion, comment, "nat", "OUTPUT", "-p", forward.Protocol, "--destination", listenAddressStr, "--dport", listenPortStr, "-j", "DNAT", "--to-destination", targetDest)
 		if err != nil {
 			return err
-		}
-
-		if targetIndex == i {
-			// instance <-> instance.
-			// Requires instance's bridge port has hairpin mode enabled when br_netfilter is loaded.
-			err = d.iptablesPrepend(ipVersion, comment, "nat", "POSTROUTING", "-p", forward.Protocol, "--source", targetAddressStr, "--destination", targetAddressStr, "--dport", targetPortStr, "-j", "MASQUERADE")
-			if err != nil {
-				return err
-			}
 		}
 	}
 

--- a/test/suites/container_devices_proxy.sh
+++ b/test/suites/container_devices_proxy.sh
@@ -199,10 +199,8 @@ container_devices_proxy_tcp() {
   if [ "$firewallDriver" = "xtables" ]; then
     [ "$(iptables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 5 ]
   else
-    [ "$(nft -nn list chain inet lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat ip to ${v4_addr}:1234")" -eq 1 ]
-    [ "$(nft -nn list chain inet lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1235 dnat ip to ${v4_addr}:1234")" -eq 1 ]
-    [ "$(nft -nn list chain inet lxd out.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat ip to ${v4_addr}:1234")" -eq 1 ]
-    [ "$(nft -nn list chain inet lxd out.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1235 dnat ip to ${v4_addr}:1234")" -eq 1 ]
+    [ "$(nft -nn list chain inet lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234-1235 dnat ip to ${v4_addr}:1234")" -eq 1 ]
+    [ "$(nft -nn list chain inet lxd out.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234-1235 dnat ip to ${v4_addr}:1234")" -eq 1 ]
   fi
 
   lxc config device remove nattest validNAT
@@ -217,10 +215,8 @@ container_devices_proxy_tcp() {
   if [ "$firewallDriver" = "xtables" ]; then
     [ "$(iptables -w -t nat -S | grep -c "generated for LXD container nattest (validNAT)")" -eq 6 ]
   else
-    [ "$(nft -nn list chain inet lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat ip to ${v4_addr}:1234")" -eq 1 ]
-    [ "$(nft -nn list chain inet lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1235 dnat ip to ${v4_addr}:1235")" -eq 1 ]
-    [ "$(nft -nn list chain inet lxd out.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234 dnat ip to ${v4_addr}:1234")" -eq 1 ]
-    [ "$(nft -nn list chain inet lxd out.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1235 dnat ip to ${v4_addr}:1235")" -eq 1 ]
+    [ "$(nft -nn list chain inet lxd prert.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234-1235 dnat ip to ${v4_addr}")" -eq 1 ]
+    [ "$(nft -nn list chain inet lxd out.nattest.validNAT | grep -c "ip daddr 127.0.0.1 tcp dport 1234-1235 dnat ip to ${v4_addr}")" -eq 1 ]
   fi
 
   lxc config device remove nattest validNAT


### PR DESCRIPTION
Currently, proxy device drivers add NAT rules for every listen port (e.g. given a listen range of `1000-1999` the driver will add 1000 NAT rules). This change optimises the number of rules added by the drivers by examining whether the given ports are part of a range.

Fixes #9073.